### PR TITLE
chore: CodexSDKとGitHubCopilotSDKのバージョン更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.4",
       "license": "ISC",
       "dependencies": {
-        "@github/copilot-sdk": "^0.2.0",
-        "@openai/codex-sdk": "^0.114.0",
+        "@github/copilot-sdk": "^0.2.1",
+        "@openai/codex-sdk": "^0.115.0",
         "ignore": "^7.0.5",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
@@ -1232,26 +1232,26 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.10.tgz",
-      "integrity": "sha512-RpHYMXYpyAgQLYQ3MB8ubV8zMn/zDatwaNmdxcC8ws7jqM+Ojy7Dz4KFKzyT0rCrWoUCAEBXsXoPbP0LY0FgLw==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.24.tgz",
+      "integrity": "sha512-/nZ2GwhaGq0HeI3W+6LE0JGw25/bipC6tYVa+oQ5tIvAafBazuNt10CXkeaor+u9oBWLZtPbdTyAzE2tjy9NpQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.10",
-        "@github/copilot-darwin-x64": "1.0.10",
-        "@github/copilot-linux-arm64": "1.0.10",
-        "@github/copilot-linux-x64": "1.0.10",
-        "@github/copilot-win32-arm64": "1.0.10",
-        "@github/copilot-win32-x64": "1.0.10"
+        "@github/copilot-darwin-arm64": "1.0.24",
+        "@github/copilot-darwin-x64": "1.0.24",
+        "@github/copilot-linux-arm64": "1.0.24",
+        "@github/copilot-linux-x64": "1.0.24",
+        "@github/copilot-win32-arm64": "1.0.24",
+        "@github/copilot-win32-x64": "1.0.24"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.10.tgz",
-      "integrity": "sha512-MNlzwkTQ9iUgHQ+2Z25D0KgYZDEl4riEa1Z4/UCNpHXmmBiIY8xVRbXZTNMB69cnagjQ5Z8D2QM2BjI0kqeFPg==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.24.tgz",
+      "integrity": "sha512-lejn6KV+09rZEICX3nRx9a58DQFQ2kK3NJ3EICfVLngUCWIUmwn1BLezjeTQc9YNasHltA1hulvfsWqX+VjlMw==",
       "cpu": [
         "arm64"
       ],
@@ -1265,9 +1265,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.10.tgz",
-      "integrity": "sha512-zAQBCbEue/n4xHBzE9T03iuupVXvLtu24MDMeXXtIC0d4O+/WV6j1zVJrp9Snwr0MBWYH+wUrV74peDDdd1VOQ==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.24.tgz",
+      "integrity": "sha512-r2F3keTvr4Bunz3V+waRAvsHgqsVQGyIZFBebsNPWxBX1eh3IXgtBqxCR7vXTFyZonQ8VaiJH3YYEfAhyKsk9g==",
       "cpu": [
         "x64"
       ],
@@ -1281,9 +1281,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.10.tgz",
-      "integrity": "sha512-7mJ3uLe7ITyRi2feM1rMLQ5d0bmUGTUwV1ZxKZwSzWCYmuMn05pg4fhIUdxZZZMkLbOl3kG/1J7BxMCTdS2w7A==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.24.tgz",
+      "integrity": "sha512-B3oANXKKKLhnKYozXa/W+DxfCQAHJCs0QKR5rBwNrwJbf656twNgALSxWTSJk+1rEP6MrHCswUAcwjwZL7Q+FQ==",
       "cpu": [
         "arm64"
       ],
@@ -1297,9 +1297,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.10.tgz",
-      "integrity": "sha512-66NPaxroRScNCs6TZGX3h1RSKtzew0tcHBkj4J1AHkgYLjNHMdjjBwokGtKeMxzYOCAMBbmJkUDdNGkqsKIKUA==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.24.tgz",
+      "integrity": "sha512-NGTldizY54B+4Sfhu/GWoEQNMwqqUNgMwbSgBshFv+Hqy1EwuvNWKVov1Y0Vzhp4qAHc6ZxBk/OPIW8Ato9FUg==",
       "cpu": [
         "x64"
       ],
@@ -1313,12 +1313,12 @@
       }
     },
     "node_modules/@github/copilot-sdk": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.2.0.tgz",
-      "integrity": "sha512-fCEpD9W9xqcaCAJmatyNQ1PkET9P9liK2P4Vk0raDFoMXcvpIdqewa5JQeKtWCBUsN/HCz7ExkkFP8peQuo+DA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.2.2.tgz",
+      "integrity": "sha512-VZCqS08YlUM90bUKJ7VLeIxgTTEHtfXBo84T1IUMNvXRREX2csjPH6Z+CPw3S2468RcCLvzBXcc9LtJJTLIWFw==",
       "license": "MIT",
       "dependencies": {
-        "@github/copilot": "^1.0.10",
+        "@github/copilot": "^1.0.21",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
       },
@@ -1327,9 +1327,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.10.tgz",
-      "integrity": "sha512-WC5M+M75sxLn4lvZ1wPA1Lrs/vXFisPXJPCKbKOMKqzwMLX/IbuybTV4dZDIyGEN591YmOdRIylUF0tVwO8Zmw==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.24.tgz",
+      "integrity": "sha512-/pd/kgef7/HIIg1SQq4q8fext39pDSC44jHB10KkhfgG1WaDFhQbc/aSSMQfxeldkRbQh6VANp8WtGQdwtMCBA==",
       "cpu": [
         "arm64"
       ],
@@ -1343,9 +1343,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.10.tgz",
-      "integrity": "sha512-tUfIwyamd0zpm9DVTtbjIWF6j3zrA5A5IkkiuRgsy0HRJPQpeAV7ZYaHEZteHrynaULpl1Gn/Dq0IB4hYc4QtQ==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.24.tgz",
+      "integrity": "sha512-RDvOiSvyEJwELqErwANJTrdRuMIHkwPE4QK7Le7WsmaSKxiuS4H1Pa8Yxnd2FWrMsCHEbase23GJlymbnGYLXQ==",
       "cpu": [
         "x64"
       ],
@@ -2191,9 +2191,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.114.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.114.0.tgz",
-      "integrity": "sha512-HMo8LRR6CtfKkaa28xvFK6eOarmBFTDfsrS9GJtEoaspGGemFok494CpafDspiTZaHZZGHfSUe5SWTUxYq7OaA==",
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.115.0.tgz",
+      "integrity": "sha512-uu689DHUzvuPcb39hJ+7fqy++TAvY32w9VggDpcz3HS0Sx0WadWoAPPcMK547P2T6AqfMsAtA8kspkR3tqErOg==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -2202,19 +2202,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.114.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.114.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.114.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.114.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.114.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.114.0-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.115.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.115.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.115.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.115.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.115.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.115.0-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.114.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.114.0-darwin-arm64.tgz",
-      "integrity": "sha512-c9dlgo9O+66alr3s3G36fKE3KaO2+xrLZ/QcU3oujDruV86pqgVSEK2njHi+WIyyOa6m2AyWxdaHLEbKxPCNRg==",
+      "version": "0.115.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.115.0-darwin-arm64.tgz",
+      "integrity": "sha512-wTWV+YlDTL0y0mL+FMmbzhilm+dPkbIZTe/lH3LwBzcEMhgSGLsPdZLfAiMND4wFE21HS7H0pjMogNQEMLQmqg==",
       "cpu": [
         "arm64"
       ],
@@ -2229,9 +2229,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.114.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.114.0-darwin-x64.tgz",
-      "integrity": "sha512-oPAPeZSaJZ1AQneFPSJu44uqbZr63Bxut9FOTWZwuSqYx4YEees7i0HJmJcqQc0XnCbYtHJdqo/i07Uv374NLw==",
+      "version": "0.115.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.115.0-darwin-x64.tgz",
+      "integrity": "sha512-EPzgymU4CFp83qjv29wXFwhWib3zC8g6SLTJGh2OpcJiOYyLY0bO53FB+QchL1jC9gm1uLyD5j5F3ddI0AbjIg==",
       "cpu": [
         "x64"
       ],
@@ -2246,9 +2246,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.114.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.114.0-linux-arm64.tgz",
-      "integrity": "sha512-oUFZGZgMiEqmo85C+dfhckpVApH25alLWfwBgfKr2IRgdx/tovy8vN101f6kj01E6nDDe4LfJdNSZGtZht4fRA==",
+      "version": "0.115.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.115.0-linux-arm64.tgz",
+      "integrity": "sha512-40+SCyI+LvVx/iX30qH7dTQzWt9MZxDaK2E6YRB4hoYej5UALrhkFNzweHa5uvqvhmqGZCuagZOYB8285eGCgw==",
       "cpu": [
         "arm64"
       ],
@@ -2263,9 +2263,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.114.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.114.0-linux-x64.tgz",
-      "integrity": "sha512-MF6RhxfBoccccd5CYII2C7TL2TvYzombBQhanDZfQAajr6n7IuoazCmoHDlrFHS4AcSw9bYA4MRlrwEjbEjgsw==",
+      "version": "0.115.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.115.0-linux-x64.tgz",
+      "integrity": "sha512-+6eRd2p4KMrhQvuF7XpjYIdCA2Ok2LbhOq+ywZdLpHbmwQ/Yynd0gJ/Q90xCeo2vloCwl9WsbsiVVSahG5FyWg==",
       "cpu": [
         "x64"
       ],
@@ -2279,12 +2279,12 @@
       }
     },
     "node_modules/@openai/codex-sdk": {
-      "version": "0.114.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.114.0.tgz",
-      "integrity": "sha512-28tV+pvoQhhoRADBCtlg24fR6LDTyeUA6C65NBTvYFnDoQVPJcHcAwRrbuWmUMcXdLrXwY2bmiMxyfXlUWQzgw==",
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.115.0.tgz",
+      "integrity": "sha512-BPoPhim0uUm3rzugY7JFaFJ+rPG/wMRhvKNFii//Dp3kTb+gFy3jrip7ijXqhswsnqXM3nwTiv7kYHt1+TMUPg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openai/codex": "0.114.0"
+        "@openai/codex": "0.115.0"
       },
       "engines": {
         "node": ">=18"
@@ -2292,9 +2292,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.114.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.114.0-win32-arm64.tgz",
-      "integrity": "sha512-CnRMHopj3en9aqQ2UaDW7EgpEGkxHdZVLLRq2cOy5D0HyuzF6Qb6595ADoFVJHEmPeN5Iz/KUbiGs5GLDjUwOA==",
+      "version": "0.115.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.115.0-win32-arm64.tgz",
+      "integrity": "sha512-yaYhQ0kPL9Kithmrr1vh5A4c+gqAMhMZeA/htTtkpWW8RQkmwgcYYpX/Ky2cEzu0w51pvxQQy63LgHftc+pg1Q==",
       "cpu": [
         "arm64"
       ],
@@ -2309,9 +2309,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.114.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.114.0-win32-x64.tgz",
-      "integrity": "sha512-ztRsH5Z+gPVZ5ZInx6HzXsTFFkuEdjk3Ay0UGVOhRRCWvevXQi/SL4eU8hwysCYrs8K/WRq3mo4c95w9zQ2wLw==",
+      "version": "0.115.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.115.0-win32-x64.tgz",
+      "integrity": "sha512-wtYf2HJCB+p+Uj7o1W08fRgZMzKCVGRQ4YdSfLRNfF4wwPqX5XsK9blsv7brukn5J9lclYxagiR6qGvbfHbD7w==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
-    "@github/copilot-sdk": "^0.2.0",
-    "@openai/codex-sdk": "^0.114.0",
+    "@github/copilot-sdk": "^0.2.1",
+    "@openai/codex-sdk": "^0.115.0",
     "ignore": "^7.0.5",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"


### PR DESCRIPTION
### Motivation
- 依存する SDK を最新安定版に上げてバグ修正や機能改善を取り込むために `@openai/codex-sdk` と `@github/copilot-sdk` のバージョンを更新しました。
- `package.json` のみを先に更新し、依存解決は別環境で行う前提の変更です。

### Description
- `package.json` の `dependencies` で `@openai/codex-sdk` を `^0.115.0` に更新しました。
- `package.json` の `dependencies` で `@github/copilot-sdk` を `^0.2.1` に更新しました。
- 変更は当該バージョン行のみでコミット済みです。
- 注意: 現環境では npm レジストリアクセスが 403 となるため `package-lock.json` の更新や実際のパッケージインストールは行っていません; ネットワーク制約を解消した環境で `npm install` を実行してください。

### Testing
- `npm run typecheck` を実行しましたが、既存コード起因の多数の TypeScript エラーにより失敗しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc5398653883228909a2244f477434)