### PR TITLE
66 message render crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^0.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/scripts/tests/message-rich-text.test.ts
+++ b/scripts/tests/message-rich-text.test.ts
@@ -1,14 +1,9 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
-import path from "node:path";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { MessageRichText } from "../../src/MessageRichText.js";
-
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
 test("MessageRichText は **bold** を strong として render する", () => {
   const html = renderToStaticMarkup(
@@ -32,29 +27,18 @@ test("MessageRichText は inline code と link を優先しつつ bold を併用
   assert.match(html, /<button class="message-inline-link" type="button" title="src\/App\.tsx">file<\/button>/);
 });
 
-test("MessageRichText は先頭空白付き Markdown 行でも停止せずに render できる", () => {
+test("MessageRichText は先頭空白付き Markdown 行でも停止せずに render できる", { timeout: 2_000 }, () => {
   const input = ["  # title", "", "  - item", "  1. first", "", "  ```ts", "const answer = 42;", "  ```"].join("\n");
-  const script = `
-    import React from "react";
-    import { renderToStaticMarkup } from "react-dom/server";
-    import { MessageRichText } from "./src/MessageRichText.tsx";
+  const html = renderToStaticMarkup(
+    React.createElement(MessageRichText, {
+      text: input,
+    }),
+  );
 
-    const html = renderToStaticMarkup(React.createElement(MessageRichText, { text: ${JSON.stringify(input)} }));
-    console.log(html);
-  `;
-  const result = spawnSync(process.execPath, ["--import", "tsx", "--eval", script], {
-    cwd: repoRoot,
-    encoding: "utf8",
-    timeout: 2_000,
-  });
-
-  assert.equal(result.error, undefined);
-  assert.equal(result.signal, null);
-  assert.equal(result.status, 0, result.stderr);
-  assert.match(result.stdout, /<h3 class="message-heading level-1">title<\/h3>/);
-  assert.match(result.stdout, /<ul class="message-list"><li>item<\/li><\/ul>/);
-  assert.match(result.stdout, /<ol class="message-list ordered"><li>first<\/li><\/ol>/);
-  assert.match(result.stdout, /<pre class="message-code-block"><code>const answer = 42;<\/code><\/pre>/);
+  assert.match(html, /<h3 class="message-heading level-1">title<\/h3>/);
+  assert.match(html, /<ul class="message-list"><li>item<\/li><\/ul>/);
+  assert.match(html, /<ol class="message-list ordered"><li>first<\/li><\/ol>/);
+  assert.match(html, /<pre class="message-code-block"><code>const answer = 42;<\/code><\/pre>/);
 });
 
 test("MessageRichText は先頭空白付き Markdown を既存 block と inline のまま扱う", () => {

--- a/scripts/tests/message-rich-text.test.ts
+++ b/scripts/tests/message-rich-text.test.ts
@@ -1,9 +1,14 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { MessageRichText } from "../../src/MessageRichText.js";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
 test("MessageRichText は **bold** を strong として render する", () => {
   const html = renderToStaticMarkup(
@@ -25,4 +30,47 @@ test("MessageRichText は inline code と link を優先しつつ bold を併用
   assert.match(html, /<code class="message-inline-code">\*\*literal\*\*<\/code>/);
   assert.match(html, /<strong class="message-inline-strong">/);
   assert.match(html, /<button class="message-inline-link" type="button" title="src\/App\.tsx">file<\/button>/);
+});
+
+test("MessageRichText は先頭空白付き Markdown 行でも停止せずに render できる", () => {
+  const input = ["  # title", "", "  - item", "  1. first", "", "  ```ts", "const answer = 42;", "  ```"].join("\n");
+  const script = `
+    import React from "react";
+    import { renderToStaticMarkup } from "react-dom/server";
+    import { MessageRichText } from "./src/MessageRichText.tsx";
+
+    const html = renderToStaticMarkup(React.createElement(MessageRichText, { text: ${JSON.stringify(input)} }));
+    console.log(html);
+  `;
+  const result = spawnSync(process.execPath, ["--import", "tsx", "--eval", script], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    timeout: 2_000,
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.signal, null);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /<h3 class="message-heading level-1">title<\/h3>/);
+  assert.match(result.stdout, /<ul class="message-list"><li>item<\/li><\/ul>/);
+  assert.match(result.stdout, /<ol class="message-list ordered"><li>first<\/li><\/ol>/);
+  assert.match(result.stdout, /<pre class="message-code-block"><code>const answer = 42;<\/code><\/pre>/);
+});
+
+test("MessageRichText は先頭空白付き Markdown を既存 block と inline のまま扱う", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(MessageRichText, {
+      text: ["  # **title**", "", "  - [file](src/App.tsx)", "  - `literal`", "", "  1. **step**", "", "tail paragraph"].join(
+        "\n",
+      ),
+    }),
+  );
+
+  assert.match(html, /<h3 class="message-heading level-1"><strong class="message-inline-strong">title<\/strong><\/h3>/);
+  assert.match(
+    html,
+    /<ul class="message-list"><li><button class="message-inline-link" type="button" title="src\/App\.tsx">file<\/button><\/li><li><code class="message-inline-code">literal<\/code><\/li><\/ul>/,
+  );
+  assert.match(html, /<ol class="message-list ordered"><li><strong class="message-inline-strong">step<\/strong><\/li><\/ol>/);
+  assert.match(html, /<p class="message-paragraph">tail paragraph<\/p>/);
 });

--- a/scripts/tests/message-rich-text.test.ts
+++ b/scripts/tests/message-rich-text.test.ts
@@ -74,3 +74,20 @@ test("MessageRichText は先頭空白付き Markdown を既存 block と inline 
   assert.match(html, /<ol class="message-list ordered"><li><strong class="message-inline-strong">step<\/strong><\/li><\/ol>/);
   assert.match(html, /<p class="message-paragraph">tail paragraph<\/p>/);
 });
+
+test("MessageRichText は 4 文字以上インデントされた block marker を段落として扱う", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(MessageRichText, {
+      text: ["    # not heading", "    - not list", "    1. not ordered", "    ```ts"].join("\n"),
+    }),
+  );
+
+  assert.doesNotMatch(html, /message-heading/);
+  assert.doesNotMatch(html, /<ul class="message-list">/);
+  assert.doesNotMatch(html, /<ol class="message-list ordered">/);
+  assert.doesNotMatch(html, /message-code-block/);
+  assert.match(
+    html,
+    /<p class="message-paragraph">    # not heading<br\/>    - not list<br\/>    1\. not ordered<br\/>    ```ts<\/p>/,
+  );
+});

--- a/scripts/tests/session-memory-storage.test.ts
+++ b/scripts/tests/session-memory-storage.test.ts
@@ -10,6 +10,28 @@ import { DEFAULT_APPROVAL_MODE } from "../../src/approval-mode.js";
 import { SessionMemoryStorage } from "../../src-electron/session-memory-storage.js";
 import { SessionStorage } from "../../src-electron/session-storage.js";
 
+const REMOVABLE_DIRECTORY_RETRY_ERROR_CODES = new Set(["EBUSY", "EPERM", "ENOTEMPTY"]);
+
+async function removeDirectoryWithRetry(targetPath: string, attempts = 15): Promise<void> {
+  for (let index = 0; index < attempts; index += 1) {
+    try {
+      await rm(targetPath, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      const errorCode =
+        typeof error === "object" && error !== null && "code" in error && typeof error.code === "string"
+          ? error.code
+          : null;
+      const shouldRetry = errorCode !== null && REMOVABLE_DIRECTORY_RETRY_ERROR_CODES.has(errorCode);
+      if (!shouldRetry || index === attempts - 1) {
+        throw error;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, Math.min(2_000, 100 * (index + 1))));
+    }
+  }
+}
+
 function createSession() {
   return buildNewSession({
     taskTitle: "Memory foundation",
@@ -43,7 +65,7 @@ describe("SessionMemoryStorage", () => {
       memoryStorage.close();
       sessionStorage.close();
     } finally {
-      await rm(tempDirectory, { recursive: true, force: true });
+      await removeDirectoryWithRetry(tempDirectory);
     }
   });
 
@@ -70,7 +92,7 @@ describe("SessionMemoryStorage", () => {
       memoryStorage.close();
       sessionStorage.close();
     } finally {
-      await rm(tempDirectory, { recursive: true, force: true });
+      await removeDirectoryWithRetry(tempDirectory);
     }
   });
 
@@ -91,7 +113,7 @@ describe("SessionMemoryStorage", () => {
       memoryStorage.close();
       sessionStorage.close();
     } finally {
-      await rm(tempDirectory, { recursive: true, force: true });
+      await removeDirectoryWithRetry(tempDirectory);
     }
   });
 
@@ -120,7 +142,7 @@ describe("SessionMemoryStorage", () => {
       memoryStorage.close();
       sessionStorage.close();
     } finally {
-      await rm(tempDirectory, { recursive: true, force: true });
+      await removeDirectoryWithRetry(tempDirectory);
     }
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -818,6 +818,10 @@ export default function App() {
     () => removeActivePathReference(draft, activePathReference),
     [activePathReference, draft],
   );
+  const previewUserMessage = useMemo(
+    () => (isEditingPathReference ? previewDraft : draft),
+    [draft, isEditingPathReference, previewDraft],
+  );
   const previewPathReferenceCandidates = useMemo(
     () => extractTextReferenceCandidates(previewDraft),
     [previewDraft],
@@ -1609,7 +1613,6 @@ export default function App() {
       };
     }
 
-    const previewUserMessage = isEditingPathReference ? previewDraft : draft;
     const timeoutId = window.setTimeout(() => {
       void withmateApi.previewComposerInput(selectedSessionId, previewUserMessage).then((preview) => {
         if (active) {
@@ -1634,6 +1637,7 @@ export default function App() {
     isComposerImeComposing,
     isEditingPathReference,
     previewPathReferenceSignature,
+    previewUserMessage,
     selectedSessionId,
   ]);
   useEffect(() => {

--- a/src/MessageRichText.tsx
+++ b/src/MessageRichText.tsx
@@ -15,6 +15,10 @@ function isOrderedListLine(line: string): boolean {
   return /^\d+\.\s+/.test(line);
 }
 
+function normalizeBlockMarkerLine(line: string): string {
+  return line.trimStart().trimEnd();
+}
+
 function parseBlocks(text: string): Block[] {
   const lines = text.replace(/\r\n/g, "\n").split("\n");
   const blocks: Block[] = [];
@@ -23,13 +27,14 @@ function parseBlocks(text: string): Block[] {
   while (index < lines.length) {
     const rawLine = lines[index] ?? "";
     const line = rawLine.trimEnd();
+    const markerLine = normalizeBlockMarkerLine(rawLine);
 
     if (!line.trim()) {
       index += 1;
       continue;
     }
 
-    const codeFence = line.match(/^```(.*)$/);
+    const codeFence = markerLine.match(/^```(.*)$/);
     if (codeFence) {
       const codeLines: string[] = [];
       const language = codeFence[1]?.trim() ?? "";
@@ -45,7 +50,7 @@ function parseBlocks(text: string): Block[] {
       continue;
     }
 
-    const heading = line.match(/^(#{1,3})\s+(.*)$/);
+    const heading = markerLine.match(/^(#{1,3})\s+(.*)$/);
     if (heading) {
       blocks.push({
         type: "heading",
@@ -56,20 +61,20 @@ function parseBlocks(text: string): Block[] {
       continue;
     }
 
-    if (isUnorderedListLine(line)) {
+    if (isUnorderedListLine(markerLine)) {
       const items: string[] = [];
-      while (index < lines.length && isUnorderedListLine((lines[index] ?? "").trim())) {
-        items.push((lines[index] ?? "").trim().replace(/^[-*]\s+/, ""));
+      while (index < lines.length && isUnorderedListLine(normalizeBlockMarkerLine(lines[index] ?? ""))) {
+        items.push(normalizeBlockMarkerLine(lines[index] ?? "").replace(/^[-*]\s+/, ""));
         index += 1;
       }
       blocks.push({ type: "unordered-list", items });
       continue;
     }
 
-    if (isOrderedListLine(line)) {
+    if (isOrderedListLine(markerLine)) {
       const items: string[] = [];
-      while (index < lines.length && isOrderedListLine((lines[index] ?? "").trim())) {
-        items.push((lines[index] ?? "").trim().replace(/^\d+\.\s+/, ""));
+      while (index < lines.length && isOrderedListLine(normalizeBlockMarkerLine(lines[index] ?? ""))) {
+        items.push(normalizeBlockMarkerLine(lines[index] ?? "").replace(/^\d+\.\s+/, ""));
         index += 1;
       }
       blocks.push({ type: "ordered-list", items });
@@ -78,17 +83,29 @@ function parseBlocks(text: string): Block[] {
 
     const paragraphLines: string[] = [];
     while (index < lines.length) {
-      const next = (lines[index] ?? "").trimEnd();
+      const next = lines[index] ?? "";
       const trimmed = next.trim();
+      const nextMarkerLine = normalizeBlockMarkerLine(next);
       if (!trimmed) {
         break;
       }
-      if (trimmed.startsWith("```") || /^(#{1,3})\s+/.test(trimmed) || isUnorderedListLine(trimmed) || isOrderedListLine(trimmed)) {
+      if (
+        nextMarkerLine.startsWith("```") ||
+        /^(#{1,3})\s+/.test(nextMarkerLine) ||
+        isUnorderedListLine(nextMarkerLine) ||
+        isOrderedListLine(nextMarkerLine)
+      ) {
         break;
       }
-      paragraphLines.push(lines[index] ?? "");
+      paragraphLines.push(next);
       index += 1;
     }
+
+    if (paragraphLines.length === 0) {
+      paragraphLines.push(rawLine);
+      index += 1;
+    }
+
     blocks.push({ type: "paragraph", lines: paragraphLines });
   }
 

--- a/src/MessageRichText.tsx
+++ b/src/MessageRichText.tsx
@@ -18,7 +18,17 @@ function isOrderedListLine(line: string): boolean {
 function normalizeBlockMarkerLine(line: string): string {
   const trimmedEnd = line.trimEnd();
   const leadingWhitespace = trimmedEnd.match(/^[\t ]*/)?.[0] ?? "";
-  if (leadingWhitespace.length >= 4) {
+  let indentationColumns = 0;
+
+  for (const char of leadingWhitespace) {
+    if (char === "\t") {
+      indentationColumns += 4 - (indentationColumns % 4);
+    } else {
+      indentationColumns += 1;
+    }
+  }
+
+  if (indentationColumns >= 4) {
     return trimmedEnd;
   }
   return trimmedEnd.slice(leadingWhitespace.length);

--- a/src/MessageRichText.tsx
+++ b/src/MessageRichText.tsx
@@ -16,7 +16,12 @@ function isOrderedListLine(line: string): boolean {
 }
 
 function normalizeBlockMarkerLine(line: string): string {
-  return line.trimStart().trimEnd();
+  const trimmedEnd = line.trimEnd();
+  const leadingWhitespace = trimmedEnd.match(/^[\t ]*/)?.[0] ?? "";
+  if (leadingWhitespace.length >= 4) {
+    return trimmedEnd;
+  }
+  return trimmedEnd.slice(leadingWhitespace.length);
 }
 
 function parseBlocks(text: string): Block[] {
@@ -39,7 +44,7 @@ function parseBlocks(text: string): Block[] {
       const codeLines: string[] = [];
       const language = codeFence[1]?.trim() ?? "";
       index += 1;
-      while (index < lines.length && !lines[index]?.trimStart().startsWith("```")) {
+      while (index < lines.length && !normalizeBlockMarkerLine(lines[index] ?? "").startsWith("```")) {
         codeLines.push(lines[index] ?? "");
         index += 1;
       }

--- a/src/settings-ui.ts
+++ b/src/settings-ui.ts
@@ -23,7 +23,7 @@ export const SETTINGS_MEMORY_GENERATION_LABEL = "Memory Generation";
 export const SETTINGS_MEMORY_GENERATION_HELP =
   "OFF にすると、turn 完了後の Generate Memory を実行しない。";
 export const SETTINGS_MEMORY_EXTRACTION_HELP =
-  "turn 完了後に Generate Memory を実行する設定。timeout に達したらその回は中断する。";
+  "Generate Memory で使う memory extraction の設定。timeout に達したらその回の抽出は中断する。";
 export const SETTINGS_ACTION_DOCK_AUTO_CLOSE_LABEL = "送信後に Action Dock を自動で閉じる";
 export const SETTINGS_CHARACTER_REFLECTION_MODEL_LABEL = "Model";
 export const SETTINGS_CHARACTER_REFLECTION_REASONING_LABEL = "Reasoning Depth";

--- a/src/settings-ui.ts
+++ b/src/settings-ui.ts
@@ -7,11 +7,23 @@ import {
 
 export const SETTINGS_SKILL_ROOT_LABEL = "Skill Root";
 export const SETTINGS_SKILL_ROOT_PLACEHOLDER = "skill folder の親ディレクトリを入力";
+export const SETTINGS_API_KEY_LABEL = "OpenAI API Key (Coding Agent)";
+export const SETTINGS_API_KEY_PLACEHOLDER = "Coding Agent 用 OpenAI API Key を入力";
+export const SETTINGS_CODING_CREDENTIALS_HELP =
+  "Coding Agent が Character Stream を使うための OpenAI API Key を設定する。";
+export const SETTINGS_CODING_CREDENTIALS_FUTURE_NOTE =
+  "他 provider 対応は future scope として、いまは OpenAI 前提で扱う。";
+export const SETTINGS_RELEASE_COMPATIBILITY_NOTE =
+  "初回リリース前のため、設定 schema の後方互換性は考慮しない。";
 export const SETTINGS_MEMORY_EXTRACTION_MODEL_LABEL = "Model";
 export const SETTINGS_MEMORY_EXTRACTION_REASONING_LABEL = "Reasoning Depth";
 export const SETTINGS_MEMORY_EXTRACTION_THRESHOLD_LABEL = "Output Tokens Threshold";
 export const SETTINGS_MEMORY_EXTRACTION_TIMEOUT_LABEL = "Timeout Seconds";
 export const SETTINGS_MEMORY_GENERATION_LABEL = "Memory Generation";
+export const SETTINGS_MEMORY_GENERATION_HELP =
+  "OFF にすると、turn 完了後の Generate Memory を実行しない。";
+export const SETTINGS_MEMORY_EXTRACTION_HELP =
+  "turn 完了後に Generate Memory を実行する設定。timeout に達したらその回は中断する。";
 export const SETTINGS_ACTION_DOCK_AUTO_CLOSE_LABEL = "送信後に Action Dock を自動で閉じる";
 export const SETTINGS_CHARACTER_REFLECTION_MODEL_LABEL = "Model";
 export const SETTINGS_CHARACTER_REFLECTION_REASONING_LABEL = "Reasoning Depth";
@@ -19,6 +31,11 @@ export const SETTINGS_CHARACTER_REFLECTION_TIMEOUT_LABEL = "Timeout Seconds";
 export const SETTINGS_CHARACTER_REFLECTION_COOLDOWN_LABEL = "Cooldown Seconds";
 export const SETTINGS_CHARACTER_REFLECTION_CHAR_DELTA_LABEL = "Min Char Delta";
 export const SETTINGS_CHARACTER_REFLECTION_MESSAGE_DELTA_LABEL = "Min Message Delta";
+export const SETTINGS_CHARACTER_REFLECTION_HELP =
+  "app-wide な character reflection を SessionStart などで評価する設定。timeout に達したらその回は中断する。";
+export const SETTINGS_RESET_DATABASE_LABEL = "DB を初期化";
+export const SETTINGS_RESET_DATABASE_HELP =
+  "Danger Zone: app settings などの DB 内容を初期化する。characters は DB 外ファイルなので保持される。";
 
 export const SETTINGS_RESET_DATABASE_TARGET_LABELS: Record<ResetAppDatabaseTarget, string> = {
   sessions: "sessions",


### PR DESCRIPTION
This pull request introduces improvements to the `MessageRichText` Markdown parser to better handle lines with leading whitespace, adds more robust directory cleanup logic to test utilities, and includes some minor optimizations and new settings UI labels. The most significant changes are grouped below.

**Markdown Parsing Enhancements (`MessageRichText`):**

* Improved the `parseBlocks` function in `src/MessageRichText.tsx` to correctly interpret Markdown block elements (headings, lists, code fences) even when lines are indented with up to three spaces. Lines with four or more leading spaces are now treated as plain paragraphs. This prevents rendering issues when users paste or write Markdown with leading spaces. [[1]](diffhunk://#diff-a03a8f2ac541e1af1005c14f7e14fa14179d10319ec047d55e5bc70840f63701R18-R26) [[2]](diffhunk://#diff-a03a8f2ac541e1af1005c14f7e14fa14179d10319ec047d55e5bc70840f63701R35-R47) [[3]](diffhunk://#diff-a03a8f2ac541e1af1005c14f7e14fa14179d10319ec047d55e5bc70840f63701L48-R58) [[4]](diffhunk://#diff-a03a8f2ac541e1af1005c14f7e14fa14179d10319ec047d55e5bc70840f63701L59-R82) [[5]](diffhunk://#diff-a03a8f2ac541e1af1005c14f7e14fa14179d10319ec047d55e5bc70840f63701L81-R113)
* Added new and expanded test cases in `scripts/tests/message-rich-text.test.ts` to verify correct rendering of indented Markdown input, ensuring headings, lists, and code blocks are parsed as expected, or as paragraphs if over-indented. [[1]](diffhunk://#diff-409ce1de04442ef4c9b750d3d62f525af84758c41a2b843aa2d24683163b09a2R2-R12) [[2]](diffhunk://#diff-409ce1de04442ef4c9b750d3d62f525af84758c41a2b843aa2d24683163b09a2R34-R93)

**Test Utilities Robustness:**

* Introduced `removeDirectoryWithRetry` in `scripts/tests/session-memory-storage.test.ts` to make directory cleanup in tests more reliable, handling transient filesystem errors (like `EBUSY`, `EPERM`, `ENOTEMPTY`) by retrying the removal operation. Updated all relevant tests to use this helper. [[1]](diffhunk://#diff-79ac1b65d5f8481d479780929f0fe34da95341b00f72daf56ee550b23918cb22R13-R34) [[2]](diffhunk://#diff-79ac1b65d5f8481d479780929f0fe34da95341b00f72daf56ee550b23918cb22L46-R68) [[3]](diffhunk://#diff-79ac1b65d5f8481d479780929f0fe34da95341b00f72daf56ee550b23918cb22L73-R95) [[4]](diffhunk://#diff-79ac1b65d5f8481d479780929f0fe34da95341b00f72daf56ee550b23918cb22L94-R116) [[5]](diffhunk://#diff-79ac1b65d5f8481d479780929f0fe34da95341b00f72daf56ee550b23918cb22L123-R145)

**Performance and Code Quality Improvements:**

* Refactored the computation of `previewUserMessage` in `src/App.tsx` to use `useMemo`, preventing unnecessary recalculations and improving component performance. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R821-R824) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L1612) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R1640)

**Settings UI Additions:**

* Added new constants for settings labels and help texts in `src/settings-ui.ts`, including fields for OpenAI API keys, memory extraction, character reflection, and a database reset feature. These are preparatory changes for future settings UI enhancements.