### PR TITLE
Implement model change selection with fallback for unsupported depth

### DIFF
--- a/docs/plans/archive/2026/04/20260416-model-depth-switch-bug/decisions.md
+++ b/docs/plans/archive/2026/04/20260416-model-depth-switch-bug/decisions.md
@@ -1,0 +1,19 @@
+# 20260416 model-depth-switch-bug Decisions
+
+## Decision 1
+
+- 日付: 2026-04-16
+- 内容: Session の model 切り替えでは、切り替え先 model に current depth が無い場合でも切り替え失敗にせず、provider default depth、それも無ければ selected model の先頭 depth に fallback する。
+- 理由: Session UI の model select は有効な model だけを選ばせる一方、current depth は直前 model の値を保持しているため、そのまま strict validation に通すと model change 自体が失敗するため。
+
+## Decision 2
+
+- 日付: 2026-04-16
+- 内容: Depth を直接切り替える操作は従来どおり strict validation のまま維持する。
+- 理由: Depth UI は selected model の対応候補だけを表示しており、ここで fallback を混ぜる必要がないため。
+
+## Decision 3
+
+- 日付: 2026-04-16
+- 内容: 回帰 test は `scripts/tests/model-catalog-settings.test.ts` に追加する。
+- 理由: 今回の差分は model catalog の解決規約に近く、helper 単位で fallback の意図を固定するのが最小で分かりやすいため。

--- a/docs/plans/archive/2026/04/20260416-model-depth-switch-bug/plan.md
+++ b/docs/plans/archive/2026/04/20260416-model-depth-switch-bug/plan.md
@@ -1,0 +1,23 @@
+# 20260416 model-depth-switch-bug
+
+## 目的
+
+- Session などの model 切り替え時に、現在選択中の reasoning depth が切り替え先 model に存在しない場合でも切り替え失敗にせず、利用可能な depth へ安全に fallback させる。
+
+## 調査観点
+
+- `src/App.tsx` の session model / reasoning depth 更新フロー
+- `src/model-catalog.ts` の model 選択解決と fallback 規約
+- 既存 test で同系統の回帰を拾えているか
+
+## 実施方針
+
+1. model 切り替え時に選択解決がどう失敗するかをコード上で特定する。
+2. 切り替え先 model に非対応の reasoning depth を渡しても、利用可能な値へ補正して session 更新できるよう修正する。
+3. 回帰 test を追加し、必要なら design / context の更新要否も確認する。
+
+## 完了条件
+
+- model 切り替え時に unsupported な reasoning depth が残っていても session 更新が成功する。
+- reasoning depth 明示変更時の既存挙動は壊さない。
+- 関連 test と build が通る。

--- a/docs/plans/archive/2026/04/20260416-model-depth-switch-bug/questions.md
+++ b/docs/plans/archive/2026/04/20260416-model-depth-switch-bug/questions.md
@@ -1,0 +1,5 @@
+# 20260416 model-depth-switch-bug Questions
+
+## Status
+
+- 質問なし

--- a/docs/plans/archive/2026/04/20260416-model-depth-switch-bug/result.md
+++ b/docs/plans/archive/2026/04/20260416-model-depth-switch-bug/result.md
@@ -1,0 +1,33 @@
+# 20260416 model-depth-switch-bug Result
+
+## 状態
+
+- Closed
+
+## 実装結果
+
+- `src/App.tsx` の Session model 切り替えを、unsupported depth でも fallback 付きで保存できるよう変更した。
+- `src/model-catalog.ts` に model change 用の解決 helper を追加した。
+- `scripts/tests/model-catalog-settings.test.ts` に回帰 test を追加した。
+
+## 検証
+
+- `node .tmp-test-run/scripts/tests/model-catalog-settings.test.js`
+- `node .tmp-test-run/scripts/tests/session-state.test.js`
+- `npm run build`
+
+## 未完了
+
+- `docs/design/model-catalog.md` の更新
+- commit / push / PR
+
+## Blockers
+
+- local Git: worktree の Git 管理ディレクトリが repo 外にあり、`index.lock` 作成権限が無く commit できない
+- shell network: `github.com:443` 接続不可のため push できない
+- GitHub connector: write 系操作が `user cancelled MCP tool call` で拒否されるため remote 側で代替 commit / PR もできない
+
+## クローズ方針
+
+- 実装差分と検証結果は完了しているため、この plan は完了扱いで archive する
+- `docs/design/model-catalog.md` の更新と commit / push / PR はユーザー側の書き込み可能環境で継続する

--- a/docs/plans/archive/2026/04/20260416-model-depth-switch-bug/worklog.md
+++ b/docs/plans/archive/2026/04/20260416-model-depth-switch-bug/worklog.md
@@ -1,0 +1,21 @@
+# 20260416 model-depth-switch-bug Worklog
+
+## Status
+
+- Closed
+
+## 2026-04-16
+
+- `src/App.tsx` の model change handler が `resolveModelSelection()` を使っており、切り替え先 model に存在しない depth を持ったまま切り替えると例外になることを確認した。
+- `src/model-catalog.ts` に model change 専用の `resolveModelChangeSelection()` を追加し、model は exact match のまま depth だけ fallback させる方針で実装した。
+- `scripts/tests/model-catalog-settings.test.ts` に回帰 test を追加した。
+- `docs/design/model-catalog.md` は更新が必要と判断したが、この環境では `docs/design/` への書き込みが拒否されて未反映。
+- 検証再実行の前提として `node_modules` が存在しないことを確認した。
+- `npm ci` は install script 実行時の `spawn EPERM` で失敗したため、`npm ci --ignore-scripts` で依存だけ展開した。
+- `tsx` は `esbuild` child process 起動で `spawn EPERM` になるため、`tsc` で `scripts/tests/model-catalog-settings.test.ts` と `scripts/tests/session-state.test.ts` を `.tmp-test-run/` へ JS 出力してから `node` で実行する迂回に切り替えた。
+- `node .tmp-test-run/scripts/tests/model-catalog-settings.test.js` と `node .tmp-test-run/scripts/tests/session-state.test.js` は成功した。
+- `npm run build` は成功した。
+- local Git commit は worktree 実体の `.git/worktrees/73/index.lock` を repo 外に作ろうとして権限エラーになり失敗した。
+- `git ls-remote` は `github.com:443` 接続失敗で止まり、shell からの push 経路は使えなかった。
+- GitHub connector は read 系は動くが、`create_blob` など write 系操作は `user cancelled MCP tool call` で拒否され、remote commit / PR 作成も完了できなかった。
+- commit / push / PR はユーザー側で引き継ぐ前提に整理し、実装差分と検証結果だけを残して plan を close した。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/scripts/tests/model-catalog-settings.test.ts
+++ b/scripts/tests/model-catalog-settings.test.ts
@@ -9,7 +9,7 @@ import {
   getResolvedProviderSettingsBundle,
   normalizeAppSettings,
 } from "../../src/provider-settings-state.js";
-import { coerceModelSelection, type ModelCatalogProvider } from "../../src/model-catalog.js";
+import { coerceModelSelection, resolveModelChangeSelection, type ModelCatalogProvider } from "../../src/model-catalog.js";
 
 const providerCatalog: ModelCatalogProvider = {
   id: "codex",
@@ -44,6 +44,19 @@ describe("coerceModelSelection", () => {
 
     assert.equal(selection.resolvedModel, "gpt-5.1-mini");
     assert.equal(selection.resolvedReasoningEffort, "medium");
+  });
+});
+
+describe("resolveModelChangeSelection", () => {
+  it("model 切り替え時は非対応 depth を許容される値へ fallback する", () => {
+    const selection = resolveModelChangeSelection(providerCatalog, "gpt-5.1-mini", "high");
+
+    assert.equal(selection.resolvedModel, "gpt-5.1-mini");
+    assert.equal(selection.resolvedReasoningEffort, "medium");
+  });
+
+  it("model 自体が catalog に無い場合はエラーにする", () => {
+    assert.throws(() => resolveModelChangeSelection(providerCatalog, "missing-model", "high"));
   });
 });
 

--- a/scripts/tests/model-catalog-settings.test.ts
+++ b/scripts/tests/model-catalog-settings.test.ts
@@ -48,7 +48,7 @@ describe("coerceModelSelection", () => {
 });
 
 describe("resolveModelChangeSelection", () => {
-  it("model 切り替え時は非対応 depth を許容される値へ fallback する", () => {
+  it("model 切り替え時は非対応 depth は許容される値へ fallback する", () => {
     const selection = resolveModelChangeSelection(providerCatalog, "gpt-5.1-mini", "high");
 
     assert.equal(selection.resolvedModel, "gpt-5.1-mini");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import {
 import {
   getProviderCatalog,
   getReasoningEffortOptionsForModel,
+  resolveModelChangeSelection,
   resolveModelSelection,
   type ModelCatalogSnapshot,
 } from "./model-catalog.js";
@@ -2472,7 +2473,7 @@ export default function App() {
       return;
     }
 
-    const selection = resolveModelSelection(selectedProviderCatalog, model, selectedSession.reasoningEffort);
+    const selection = resolveModelChangeSelection(selectedProviderCatalog, model, selectedSession.reasoningEffort);
     const nextSession: Session = applySessionModelMetadataUpdate(
       selectedSession,
       selection,

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -245,6 +245,29 @@ export function coerceModelSelection(
   };
 }
 
+export function resolveModelChangeSelection(
+  providerCatalog: ModelCatalogProvider,
+  requestedModel: string,
+  requestedReasoningEffort: ModelReasoningEffort,
+): ResolvedModelSelection {
+  const normalizedModel = typeof requestedModel === "string" && requestedModel.trim()
+    ? requestedModel.trim()
+    : providerCatalog.defaultModelId;
+  const exactEntry = providerCatalog.models.find((entry) => entry.id === normalizedModel);
+  if (!exactEntry) {
+    throw new Error("selected model が model catalog に存在しないよ。");
+  }
+
+  return {
+    requestedModel: normalizedModel,
+    resolvedModel: exactEntry.id,
+    requestedReasoningEffort,
+    resolvedReasoningEffort: exactEntry.reasoningEfforts.includes(requestedReasoningEffort)
+      ? requestedReasoningEffort
+      : fallbackReasoningEffort(providerCatalog, exactEntry.reasoningEfforts),
+  };
+}
+
 export function resolveModelSelection(
   providerCatalog: ModelCatalogProvider,
   requestedModel: string,


### PR DESCRIPTION
This pull request documents and implements a fix for a bug where switching the model in a session could fail if the current reasoning depth was not supported by the new model. The solution introduces a fallback mechanism to allow safe model switching, updates the relevant code and tests, and archives the planning and decision process.

**Implementation of model switching fallback:**

* Added a new helper function `resolveModelChangeSelection` in `src/model-catalog.ts` to allow model switching to succeed by falling back to a supported reasoning depth if the requested depth is not available in the target model. (`src/model-catalog.ts`, [src/model-catalog.tsR248-R270](diffhunk://#diff-8b1758d690f427ce79ccdeecc4b1cc443a2a5a0ebe028b897e0a6f0c5411bb98R248-R270))
* Updated `src/App.tsx` to use `resolveModelChangeSelection` instead of `resolveModelSelection` when switching models in the session, ensuring the fallback logic is applied. (`src/App.tsx`, [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R40) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L2475-R2476)

**Test coverage:**

* Added regression tests for the fallback behavior in `scripts/tests/model-catalog-settings.test.ts` to ensure unsupported depths are handled correctly during model changes. (`scripts/tests/model-catalog-settings.test.ts`, [[1]](diffhunk://#diff-b1f1a8d8203ecb3e36cb13765201811bb7108bce060089250b80caaec6e6f67dL12-R12) [[2]](diffhunk://#diff-b1f1a8d8203ecb3e36cb13765201811bb7108bce060089250b80caaec6e6f67dR50-R62)

**Documentation and planning:**

* Archived a full set of planning documents detailing the purpose, decisions, implementation plan, worklog, and results of the fix, including blockers and next steps for documentation updates. (`docs/plans/archive/2026/04/20260416-model-depth-switch-bug/plan.md`, [[1]](diffhunk://#diff-8d7709b5897a9b956beb71379b1813683f4ff53dba1a6c96fa8420a5503873faR1-R23); `docs/plans/archive/2026/04/20260416-model-depth-switch-bug/decisions.md`, [[2]](diffhunk://#diff-e6fda09cbd253fd0b8bb6e86e44bab45cdfb40994ee7602e6c03ccc3319a0bfcR1-R19); `docs/plans/archive/2026/04/20260416-model-depth-switch-bug/worklog.md`, [[3]](diffhunk://#diff-f1adbe950ccfdda8ee507644118e1a44343d68abe72c70fc3191ef8163eb8a54R1-R21); `docs/plans/archive/2026/04/20260416-model-depth-switch-bug/result.md`, [[4]](diffhunk://#diff-31b0521d47937ec4a486ac78b168cfcf8a19448e55d617f6101c5ecc0e052d68R1-R33); `docs/plans/archive/2026/04/20260416-model-depth-switch-bug/questions.md`, [[5]](diffhunk://#diff-2efe6774d853a7ede9b9a0f564a4a6572a5d3bd6157a478b8c3a789c2cff17fbR1-R5)…epth