### PR TITLE
Command history order fix

### DIFF
--- a/docs/design/session-live-activity-monitor.md
+++ b/docs/design/session-live-activity-monitor.md
@@ -26,9 +26,9 @@
 - `Latest Command` は次の優先順で決める
   - 実行中なら `liveRun.steps` の最後の `command_execution`
   - 待機中なら直近 terminal Audit Log に含まれる最後の `command_execution`
-- run 中は `Latest Command` の下に、確定済み live step のうち直近数件だけを `Details` 面として補助表示してよい
+- run 中は `Latest Command` の上に、確定済み live step のうち直近数件だけを `Details` 面として補助表示してよい
   - 対象は `completed / failed / canceled` の step
-  - 直近の in-progress command と full timeline は常設しない
+  - 直近の in-progress command は面の最下段で常に追えるようにし、full timeline は常設しない
 - `Memory生成` は専用 background activity state を main process から受ける
 - `独り言` は background activity と recent monologue stream を表示する
 - それ以外の step list や詳細な実況履歴は right pane 常設から外し、確定後は artifact timeline / Audit Log を見る
@@ -67,7 +67,7 @@ flowchart TB
   - source label (`live` / `last run`)
   - 危険度の rough badge (`DELETE / WRITE / NETWORK`)
   - 必要時だけ開く `details`
-- run 中に確定した step があれば、同じ面の下段に `CONFIRMED Details` として数件だけ補助表示してよい
+- run 中に確定した step があれば、同じ面の上段に `CONFIRMED Details` として数件だけ補助表示してよい
   - `command_execution` は command block を維持する
   - `mcp_tool_call` / `todo_list` / `file_change` / `reasoning` などは summary + optional `details` を出す
 - `liveRun.errorMessage` がある時は card 内の alert として併記する

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -1019,6 +1019,48 @@ export function SessionContextPane({
 
         <div ref={contentRef} className="command-monitor-content">
           <div className="command-monitor-stack">
+            {activeContextPaneTab === "latest-command" && runningDetailsEntries.length > 0 ? (
+              <div className="command-monitor-card">
+                <div className="command-monitor-card-head">
+                  <div className="command-monitor-meta">
+                    <span className="live-run-step-type">Details</span>
+                    <span className="command-monitor-source">CONFIRMED</span>
+                  </div>
+                </div>
+
+                <div className="command-monitor-confirmed-list">
+                  {runningDetailsEntries.map((entry) => (
+                    <article key={entry.id} className="command-monitor-confirmed-item">
+                      <div className="command-monitor-card-head compact">
+                        <div className="command-monitor-meta">
+                          <span className={`live-run-step-status ${liveRunStepToneClassName(entry.status)}`}>
+                            {liveRunStepStatusLabel(entry.status)}
+                          </span>
+                          <span className="live-run-step-type">{operationTypeLabel(entry.type)}</span>
+                        </div>
+                      </div>
+
+                      {entry.type === "command_execution" ? (
+                        <div className="live-run-command-summary compact" aria-label="確定した command">
+                          <span className="live-run-command-prefix" aria-hidden="true">$</span>
+                          <code className="live-run-command-text">{entry.summary}</code>
+                        </div>
+                      ) : (
+                        <p className="command-monitor-confirmed-summary">{entry.summary}</p>
+                      )}
+
+                      {entry.details ? (
+                        <details className="command-monitor-details live-run-step-details">
+                          <summary>{liveRunStepDetailsLabel(entry.type)}</summary>
+                          <pre>{entry.details}</pre>
+                        </details>
+                      ) : null}
+                    </article>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
             {activeContextPaneTab === "latest-command" ? (
               latestCommandView ? (
                 <div className="command-monitor-card">
@@ -1070,48 +1112,6 @@ export function SessionContextPane({
                   ) : null}
                 </div>
               )
-            ) : null}
-
-            {activeContextPaneTab === "latest-command" && runningDetailsEntries.length > 0 ? (
-              <div className="command-monitor-card">
-                <div className="command-monitor-card-head">
-                  <div className="command-monitor-meta">
-                    <span className="live-run-step-type">Details</span>
-                    <span className="command-monitor-source">CONFIRMED</span>
-                  </div>
-                </div>
-
-                <div className="command-monitor-confirmed-list">
-                  {runningDetailsEntries.map((entry) => (
-                    <article key={entry.id} className="command-monitor-confirmed-item">
-                      <div className="command-monitor-card-head compact">
-                        <div className="command-monitor-meta">
-                          <span className={`live-run-step-status ${liveRunStepToneClassName(entry.status)}`}>
-                            {liveRunStepStatusLabel(entry.status)}
-                          </span>
-                          <span className="live-run-step-type">{operationTypeLabel(entry.type)}</span>
-                        </div>
-                      </div>
-
-                      {entry.type === "command_execution" ? (
-                        <div className="live-run-command-summary compact" aria-label="確定した command">
-                          <span className="live-run-command-prefix" aria-hidden="true">$</span>
-                          <code className="live-run-command-text">{entry.summary}</code>
-                        </div>
-                      ) : (
-                        <p className="command-monitor-confirmed-summary">{entry.summary}</p>
-                      )}
-
-                      {entry.details ? (
-                        <details className="command-monitor-details live-run-step-details">
-                          <summary>{liveRunStepDetailsLabel(entry.type)}</summary>
-                          <pre>{entry.details}</pre>
-                        </details>
-                      ) : null}
-                    </article>
-                  ))}
-                </div>
-              </div>
             ) : null}
 
             {activeContextPaneTab === "tasks" ? (
@@ -1357,6 +1357,48 @@ export function CharacterUpdateContextPane({
 
         <div ref={contentRef} className="command-monitor-content">
           <div className="command-monitor-stack">
+            {activePaneTab === "latest-command" && runningDetailsEntries.length > 0 ? (
+              <div className="command-monitor-card">
+                <div className="command-monitor-card-head">
+                  <div className="command-monitor-meta">
+                    <span className="live-run-step-type">Details</span>
+                    <span className="command-monitor-source">CONFIRMED</span>
+                  </div>
+                </div>
+
+                <div className="command-monitor-confirmed-list">
+                  {runningDetailsEntries.map((entry) => (
+                    <article key={entry.id} className="command-monitor-confirmed-item">
+                      <div className="command-monitor-card-head compact">
+                        <div className="command-monitor-meta">
+                          <span className={`live-run-step-status ${liveRunStepToneClassName(entry.status)}`}>
+                            {liveRunStepStatusLabel(entry.status)}
+                          </span>
+                          <span className="live-run-step-type">{operationTypeLabel(entry.type)}</span>
+                        </div>
+                      </div>
+
+                      {entry.type === "command_execution" ? (
+                        <div className="live-run-command-summary compact" aria-label="確定した command">
+                          <span className="live-run-command-prefix" aria-hidden="true">$</span>
+                          <code className="live-run-command-text">{entry.summary}</code>
+                        </div>
+                      ) : (
+                        <p className="command-monitor-confirmed-summary">{entry.summary}</p>
+                      )}
+
+                      {entry.details ? (
+                        <details className="command-monitor-details live-run-step-details">
+                          <summary>{liveRunStepDetailsLabel(entry.type)}</summary>
+                          <pre>{entry.details}</pre>
+                        </details>
+                      ) : null}
+                    </article>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
             {activePaneTab === "latest-command" ? (
               latestCommandView ? (
                 <div className="command-monitor-card">
@@ -1418,48 +1460,6 @@ export function CharacterUpdateContextPane({
                 />
               </div>
             )}
-
-            {activePaneTab === "latest-command" && runningDetailsEntries.length > 0 ? (
-              <div className="command-monitor-card">
-                <div className="command-monitor-card-head">
-                  <div className="command-monitor-meta">
-                    <span className="live-run-step-type">Details</span>
-                    <span className="command-monitor-source">CONFIRMED</span>
-                  </div>
-                </div>
-
-                <div className="command-monitor-confirmed-list">
-                  {runningDetailsEntries.map((entry) => (
-                    <article key={entry.id} className="command-monitor-confirmed-item">
-                      <div className="command-monitor-card-head compact">
-                        <div className="command-monitor-meta">
-                          <span className={`live-run-step-status ${liveRunStepToneClassName(entry.status)}`}>
-                            {liveRunStepStatusLabel(entry.status)}
-                          </span>
-                          <span className="live-run-step-type">{operationTypeLabel(entry.type)}</span>
-                        </div>
-                      </div>
-
-                      {entry.type === "command_execution" ? (
-                        <div className="live-run-command-summary compact" aria-label="確定した command">
-                          <span className="live-run-command-prefix" aria-hidden="true">$</span>
-                          <code className="live-run-command-text">{entry.summary}</code>
-                        </div>
-                      ) : (
-                        <p className="command-monitor-confirmed-summary">{entry.summary}</p>
-                      )}
-
-                      {entry.details ? (
-                        <details className="command-monitor-details live-run-step-details">
-                          <summary>{liveRunStepDetailsLabel(entry.type)}</summary>
-                          <pre>{entry.details}</pre>
-                        </details>
-                      ) : null}
-                    </article>
-                  ))}
-                </div>
-              </div>
-            ) : null}
           </div>
         </div>
       </section>


### PR DESCRIPTION
コマンドのログが最上段につまれているのを、最下段に追加して常に最新のものが表示されるように修正します。