### PR TITLE
Windows パス処理の修正と workspace index 再検証の強化

### DIFF
--- a/scripts/tests/workspace-file-search.test.ts
+++ b/scripts/tests/workspace-file-search.test.ts
@@ -1,6 +1,6 @@
 import type { Stats } from "node:fs";
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readdir, rm, stat, utimes, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, it } from "node:test";
@@ -535,6 +535,8 @@ describe("workspace-file-search", () => {
 
       // TTL 超過前に 2 段目ディレクトリ配下へファイル追加
       await writeFile(path.join(workspacePath, "src", "components", "NewComp.tsx"), "", "utf8");
+      // 一部環境では短時間の作成だと directory mtime が更新されないため、明示的に更新する。
+      await utimes(path.join(workspacePath, "src", "components"), new Date(fakeNow), new Date(fakeNow));
       assert.deepEqual(await searchWorkspaceFilePaths(workspacePath, "NewComp"), []);
 
       // TTL 超過 → src/components の mtime が変化 → visitedDirectories で構造変化と判定 → 再走査
@@ -565,6 +567,8 @@ describe("workspace-file-search", () => {
       // TTL 超過 + ファイル追加（構造変化あり）→ 再走査
       fakeNow += DEFAULT_WORKSPACE_FILE_INDEX_TTL_MS + 100;
       await writeFile(path.join(workspacePath, "added.ts"), "", "utf8");
+      // 一部環境では短時間の作成だと directory mtime が更新されないため、明示的に更新する。
+      await utimes(workspacePath, new Date(fakeNow), new Date(fakeNow));
 
       // 再走査後は新ファイルが見え、contentVersion も更新される
       assert.deepEqual(await searchWorkspaceFilePaths(workspacePath, "added"), ["added.ts"]);

--- a/src-electron/open-path.ts
+++ b/src-electron/open-path.ts
@@ -20,6 +20,18 @@ function stripLocalPathFragment(target: string): string {
   return queryIndex >= 0 ? withoutFragment.slice(0, queryIndex) : withoutFragment;
 }
 
+function isWindowsAbsolutePath(targetPath: string): boolean {
+  return /^[a-zA-Z]:[\\/]/.test(targetPath) || /^\\\\[^\\]+\\[^\\]+/.test(targetPath);
+}
+
+function isWindowsFileUrl(url: URL): boolean {
+  const hostname = url.hostname;
+  if (hostname && hostname !== "localhost") {
+    return true;
+  }
+  return /^\/[a-zA-Z]:\//.test(url.pathname);
+}
+
 export function resolveOpenPathTarget(target: string, options: OpenPathOptions = {}): ResolvedOpenPathTarget {
   const trimmed = target.trim();
   if (!trimmed) {
@@ -37,6 +49,14 @@ export function resolveOpenPathTarget(target: string, options: OpenPathOptions =
     const fileUrl = new URL(trimmed);
     fileUrl.hash = "";
     fileUrl.search = "";
+    if (isWindowsFileUrl(fileUrl)) {
+      const pathname = decodeURIComponent(fileUrl.pathname).replace(/\//g, "\\");
+      const targetPath = /^[\\][a-zA-Z]:\\/.test(pathname) ? pathname.slice(1) : pathname;
+      return {
+        type: "local-path",
+        targetPath,
+      };
+    }
     return {
       type: "local-path",
       targetPath: fileURLToPath(fileUrl),
@@ -48,7 +68,7 @@ export function resolveOpenPathTarget(target: string, options: OpenPathOptions =
     throw new Error("開く対象の path が空だよ。");
   }
 
-  if (path.isAbsolute(normalizedTarget)) {
+  if (path.isAbsolute(normalizedTarget) || isWindowsAbsolutePath(normalizedTarget)) {
     return {
       type: "local-path",
       targetPath: normalizedTarget,
@@ -57,6 +77,12 @@ export function resolveOpenPathTarget(target: string, options: OpenPathOptions =
 
   const baseDirectory = options.baseDirectory?.trim();
   if (baseDirectory) {
+    if (isWindowsAbsolutePath(baseDirectory)) {
+      return {
+        type: "local-path",
+        targetPath: path.win32.resolve(baseDirectory, normalizedTarget),
+      };
+    }
     return {
       type: "local-path",
       targetPath: path.resolve(baseDirectory, normalizedTarget),

--- a/src-electron/project-scope.ts
+++ b/src-electron/project-scope.ts
@@ -12,7 +12,19 @@ export type ResolvedProjectScopeInput = {
   displayName: string;
 };
 
+function isWindowsAbsolutePath(targetPath: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(targetPath) || /^\\\\[^\\]+\\[^\\]+/.test(targetPath);
+}
+
 function normalizeProjectPath(targetPath: string): string {
+  if (isWindowsAbsolutePath(targetPath)) {
+    const normalizedWindowsPath = path.win32.normalize(targetPath).replace(/\\/g, "/");
+    if (/^[A-Za-z]:\/$/.test(normalizedWindowsPath)) {
+      return normalizedWindowsPath;
+    }
+    return normalizedWindowsPath.replace(/\/+$/, "");
+  }
+
   const resolved = path.resolve(targetPath).replace(/\\/g, "/");
   if (resolved === "/" || /^[A-Za-z]:\/$/.test(resolved)) {
     return resolved;
@@ -39,7 +51,7 @@ function readTextFile(targetPath: string): string | null {
 }
 
 export function findGitRootSync(startDirectory: string): string | null {
-  let currentDirectory = path.resolve(startDirectory);
+  let currentDirectory = normalizeProjectPath(startDirectory);
 
   while (true) {
     if (pathExists(path.join(currentDirectory, ".git"))) {
@@ -190,13 +202,25 @@ function resolveRepositoryIdentity(gitRemoteUrl: string | null, gitCommonDir: st
 }
 
 function toDisplayName(targetPath: string): string {
-  const resolvedPath = path.resolve(targetPath);
+  const resolvedPath = isWindowsAbsolutePath(targetPath)
+    ? path.win32.normalize(targetPath)
+    : path.resolve(targetPath);
   const baseName = path.basename(resolvedPath);
   return baseName || normalizeProjectPath(targetPath);
 }
 
 export function resolveProjectScope(workspacePath: string): ResolvedProjectScopeInput {
   const normalizedWorkspacePath = normalizeProjectPath(workspacePath);
+  if (isWindowsAbsolutePath(normalizedWorkspacePath) && process.platform !== "win32") {
+    return {
+      projectType: "directory",
+      projectKey: `directory:${normalizedWorkspacePath}`,
+      workspacePath: normalizedWorkspacePath,
+      gitRoot: null,
+      gitRemoteUrl: null,
+      displayName: toDisplayName(normalizedWorkspacePath),
+    };
+  }
   const gitRoot = findGitRootSync(normalizedWorkspacePath);
   const projectType: ProjectScopeType = gitRoot ? "git" : "directory";
   if (!gitRoot) {

--- a/src-electron/snapshot-ignore.ts
+++ b/src-electron/snapshot-ignore.ts
@@ -80,6 +80,7 @@ type IgnoreMatcher = {
 
 export type ObservedMtime = {
   mtimeMs: number;
+  size: number;
   observedAt: number;
 };
 
@@ -166,7 +167,7 @@ export type SnapshotScanResult = {
 };
 
 export type IgnoreFileState =
-  | { kind: "loaded"; mtimeMs: number; observedAt: number }
+  | { kind: "loaded"; mtimeMs: number; size: number; observedAt: number }
   | { kind: "unreadable"; mtimeMs: number | null; observedAt: number | null }
   | { kind: "race" };
 
@@ -249,7 +250,7 @@ async function collectIgnoreSourceDirectories(rootDirectory: string): Promise<st
 
 /** createIgnoreMatcher の戻り値。 */
 type CreateIgnoreMatcherResult =
-  | { kind: "loaded"; matcher: IgnoreMatcher; mtimeMs: number; observedAt: number }
+  | { kind: "loaded"; matcher: IgnoreMatcher; mtimeMs: number; size: number; observedAt: number }
   | { kind: "absent" } // ファイルが存在しない（最初の stat が失敗）
   | { kind: "unreadable"; mtimeMs: number | null; observedAt: number | null } // 安定したアクセス拒否・型不整合などで読めない
   | { kind: "race" }; // 全試行で読み取り中に変更が続いた
@@ -459,6 +460,7 @@ async function createIgnoreMatcher(baseDirectory: string, ignoreFilePath: string
           kind: "loaded",
           matcher: { baseDirectory, matcher: ignore().add(rules) },
           mtimeMs: statAfter.mtimeMs,
+          size: statAfter.size,
           observedAt: statAfterObserved.observedAt,
         };
       }
@@ -585,7 +587,12 @@ function applyIgnoreFileResult(
     if (directory !== null) {
       loadedDirectories.add(directory);
     }
-    ignoreFiles.set(ignoreFilePath, { kind: "loaded", mtimeMs: result.mtimeMs, observedAt: result.observedAt });
+    ignoreFiles.set(ignoreFilePath, {
+      kind: "loaded",
+      mtimeMs: result.mtimeMs,
+      size: result.size,
+      observedAt: result.observedAt,
+    });
     return result.matcher;
   }
   if (result.kind === "unreadable") {
@@ -791,6 +798,7 @@ async function walkWorkspace(
       const dirObserved = await statWalkDirectoryWithObservedAt(directory);
       visitedDirectories.set(relDir, {
         mtimeMs: dirObserved.stats.mtimeMs,
+        size: dirObserved.stats.size,
         observedAt: dirObserved.observedAt,
       });
     } catch {
@@ -1002,7 +1010,7 @@ async function hasIgnoreStateChanged(root: SnapshotRootIndex): Promise<boolean> 
 
     try {
       const current = await statIgnoreFile(ignoreFilePath);
-      if (current.mtimeMs !== state.mtimeMs) {
+      if (current.mtimeMs !== state.mtimeMs || current.size !== state.size) {
         return true;
       }
     } catch {
@@ -1029,7 +1037,7 @@ async function hasDirectoryStructureChanged(root: SnapshotRootIndex): Promise<bo
     const directoryPath = relativePath ? path.join(root.directory, relativePath) : root.directory;
     try {
       const current = await statWalkDirectory(directoryPath);
-      if (current.mtimeMs !== observed.mtimeMs) {
+      if (current.mtimeMs !== observed.mtimeMs || current.size !== observed.size) {
         return true;
       }
     } catch {

--- a/src-electron/window-entry-loader.ts
+++ b/src-electron/window-entry-loader.ts
@@ -43,7 +43,11 @@ export class WindowEntryLoader {
       return;
     }
 
-    const filePath = path.resolve(this.deps.rendererDistPath, entryFileName);
+    const rendererDistPath = this.deps.rendererDistPath.trim();
+    const filePath =
+      /^[a-zA-Z]:[\\/]/.test(rendererDistPath) || /^\\\\[^\\]+\\[^\\]+/.test(rendererDistPath)
+        ? path.win32.resolve(rendererDistPath, entryFileName)
+        : path.resolve(rendererDistPath, entryFileName);
     await window.loadFile(filePath, search ? { search } : undefined);
   }
 }

--- a/src-electron/workspace-file-search.ts
+++ b/src-electron/workspace-file-search.ts
@@ -266,7 +266,7 @@ async function checkStructureUnchanged(index: WorkspaceFileIndex, now = getNow()
       relativeDir === "" ? index.workspacePath : path.join(index.workspacePath, relativeDir);
     try {
       const s = await statPath(absoluteDir);
-      if (s.mtimeMs !== directoryState.mtimeMs) {
+      if (s.mtimeMs !== directoryState.mtimeMs || s.size !== directoryState.size) {
         return false;
       }
     } catch {
@@ -292,7 +292,7 @@ async function checkStructureUnchanged(index: WorkspaceFileIndex, now = getNow()
     }
     try {
       const s = await statPath(ignoreFilePath);
-      if (s.mtimeMs !== ignoreFileState.mtimeMs) {
+      if (s.mtimeMs !== ignoreFileState.mtimeMs || s.size !== ignoreFileState.size) {
         return false;
       }
     } catch {


### PR DESCRIPTION
### Motivation
- Windows 形式のパス（ドライブ文字や UNC、`file://` URL）が非 Windows 環境で誤解釈されてテストが失敗していたため、プラットフォーム非依存に正しく解決する必要があった。 
- workspace file index の TTL 再検証で mtime のみを比較していたため、ファイルシステムの粒度差で再走査検知が不安定だったので堅牢化が必要だった。

### Description
- `src-electron/open-path.ts` で `file://` の Windows 表現と Windows 絶対パスを検出して正しくローカルパスへ解決するロジックを追加しました。 
- `src-electron/window-entry-loader.ts` で `rendererDistPath` が Windows 形式のときに `path.win32.resolve` を使う分岐を追加して production の `loadFile` 出力を安定化しました。 
- `src-electron/project-scope.ts` に Windows パス判定を導入し、非 Windows 実行環境では Windows ドライブパス入力を誤って `path.resolve` せず `directory:` スコープとして扱うガードを追加しました。 
- `src-electron/snapshot-ignore.ts` と `src-electron/workspace-file-search.ts` でディレクトリ／ignore ファイルの差分判定に `size` を導入し、`ObservedMtime` / `IgnoreFileState` を拡張して `mtime` と `size` の両方で変化検知するようにしました。 
- 不安定だったテストを安定化するために `scripts/tests/workspace-file-search.test.ts` の該当ケースで `utimes` による明示的なディレクトリタイムスタンプ更新を追加しました。

### Testing
- 個別テストで修正箇所を検証するため `npx tsx --test scripts/tests/open-path.test.ts scripts/tests/workspace-file-search.test.ts` を実行して成功しました。 
- `npx tsx --test scripts/tests/window-entry-loader.test.ts scripts/tests/workspace-file-search.test.ts` を実行して成功しました。 
- `npx tsx --test scripts/tests/session-memory-support-service.test.ts` を実行して成功しました。 
- 最終的に `npm test` を実行して全テストが通過し、425 件のテストが合格で 0 件の失敗となりました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eedfb675488322b9a1dc0812f2c60e)