### PR TITLE
MonitorカードからMateアイコンを削除

### DIFF
--- a/scripts/tests/home-components.test.tsx
+++ b/scripts/tests/home-components.test.tsx
@@ -4,8 +4,10 @@ import React, { isValidElement, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { HomeLaunchDialog } from "../../src/home/HomeLaunchDialog.js";
+import { HomeMonitorContent } from "../../src/home/HomeMonitorContent.js";
 import { HomeRecentSessionsPanel } from "../../src/home/HomeRecentSessionsPanel.js";
 import { HomeRightPane } from "../../src/home/HomeRightPane.js";
+import type { HomeMonitorEntry } from "../../src/home/home-session-projection.js";
 import { HomeMateSetupPanel } from "../../src/mate/MateSetupPanel.js";
 import { HomeSettingsContent } from "../../src/settings/SettingsContent.js";
 import { createDefaultAppSettings } from "../../src/provider-settings-state.js";
@@ -1438,6 +1440,54 @@ describe("HomeRecentSessionsPanel", () => {
     const html = renderHomeRecentSessions();
     const newSessionButtons = html.match(/<button class="start-session-button"/g);
     assert.equal(newSessionButtons?.length, 1);
+  });
+});
+
+describe("HomeMonitorContent", () => {
+  const noOp = (..._args: unknown[]) => undefined;
+
+  it("Monitor カードは Mate アイコン画像なしでセッション情報を表示する", () => {
+    const entries: HomeMonitorEntry[] = [
+      {
+        kind: "agent",
+        session: {
+          id: "session-1",
+          taskTitle: "Agent task",
+          workspaceLabel: "workspace",
+          workspacePath: "C:/workspace",
+          character: "Solo Mate",
+          characterIconPath: "mate.png",
+        },
+        state: { kind: "running", label: "実行中" },
+      } as HomeMonitorEntry,
+      {
+        kind: "companion",
+        session: {
+          id: "companion-1",
+          groupId: "group-1",
+          taskTitle: "Companion task",
+          character: "Solo Mate",
+          characterIconPath: "mate.png",
+        },
+        state: { kind: "neutral", label: "待機" },
+        groupLabel: "demo",
+      } as HomeMonitorEntry,
+    ];
+    const html = renderToStaticMarkup(
+      <HomeMonitorContent
+        runningEntries={entries}
+        nonRunningEntries={[]}
+        onOpenSession={noOp}
+        onOpenCompanionReview={noOp}
+      />,
+    );
+
+    assert.ok(html.includes("Agent task"));
+    assert.ok(html.includes("workspace"));
+    assert.ok(html.includes("Companion task"));
+    assert.ok(html.includes("demo"));
+    assert.ok(!html.includes("character-avatar"));
+    assert.ok(!html.includes("<img"));
   });
 });
 

--- a/src/home/HomeMonitorContent.tsx
+++ b/src/home/HomeMonitorContent.tsx
@@ -1,5 +1,4 @@
 import type { HomeMonitorEntry } from "./home-session-projection.js";
-import { CharacterAvatar } from "../ui-utils.js";
 
 export type HomeMonitorContentProps = {
   runningEntries: HomeMonitorEntry[];
@@ -34,10 +33,9 @@ export function HomeMonitorContent({
             type="button"
             onClick={() => onOpenCompanionReview(session.id)}
           >
-            <CharacterAvatar character={{ name: session.character, iconPath: session.characterIconPath }} size="tiny" />
             <div className="home-monitor-row-copy">
               <strong>{session.taskTitle}</strong>
-              <span>{session.character}</span>
+              <span>{entry.groupLabel}</span>
             </div>
             <div className="home-monitor-row-badges">
               <span className="session-mode-badge companion">Companion</span>
@@ -56,7 +54,6 @@ export function HomeMonitorContent({
           type="button"
           onClick={() => onOpenSession(session.id)}
         >
-          <CharacterAvatar character={{ name: session.character, iconPath: session.characterIconPath }} size="tiny" />
           <div className="home-monitor-row-copy">
             <strong>{session.taskTitle}</strong>
             <span>{session.workspaceLabel || session.workspacePath || "workspace 未設定"}</span>

--- a/src/styles.css
+++ b/src/styles.css
@@ -919,13 +919,13 @@ button:disabled {
 
 .home-page .home-monitor-row {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   width: 100%;
-  padding: 10px 12px;
+  padding: 12px;
   border: 1px solid rgba(203, 213, 225, 0.1);
-  border-radius: 16px;
+  border-radius: 12px;
   background: rgba(255, 255, 255, 0.04);
   color: var(--ink);
   text-align: left;
@@ -938,6 +938,7 @@ button:disabled {
 }
 
 .home-page .home-monitor-row.companion {
+  border-left-color: color-mix(in srgb, var(--companion-group-accent, rgba(172, 139, 255, 0.72)) 72%, rgba(203, 213, 225, 0.1) 28%);
   box-shadow: inset 3px 0 0 var(--companion-group-accent, rgba(172, 139, 255, 0.72));
 }
 


### PR DESCRIPTION
## 概要
- SingleMate 化後の Monitor カードから Mate/キャラアイコン表示を削除
- Companion 行の補助情報をキャラ名から group label に変更
- アイコン画像が出力されないことを HomeMonitorContent の SSR test で検証

## 検証
- npm test -- scripts/tests/home-components.test.tsx
- npm run typecheck
- npm run build