### PR TITLE
Home の新規 Session を一覧へ即時反映する

### DIFF
--- a/scripts/tests/home-launch-actions.test.ts
+++ b/scripts/tests/home-launch-actions.test.ts
@@ -9,6 +9,7 @@ import {
   type HomeLaunchDraft,
 } from "../../src/home/home-launch-state.js";
 import type { MateProfile } from "../../src/mate/mate-state.js";
+import type { SessionSummary } from "../../src/session-state.js";
 
 function createMateProfile(): MateProfile {
   return {
@@ -76,10 +77,40 @@ function createCompanionSession(): CompanionSession {
   };
 }
 
+function createSessionSummary(): SessionSummary {
+  return {
+    id: "session-1",
+    taskTitle: "Task",
+    status: "idle",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    provider: "codex",
+    catalogRevision: 1,
+    workspaceLabel: "demo",
+    workspacePath: "C:/work/demo",
+    branch: "main",
+    sessionKind: "default",
+    accessMode: "active",
+    sourceSchemaVersion: 4,
+    characterId: "mate-1",
+    character: "Mia",
+    characterIconPath: "avatar.png",
+    characterThemeColors: { main: "#111111", sub: "#f5f5f5" },
+    runState: "idle",
+    approvalMode: "on-request",
+    codexSandboxMode: "workspace-write",
+    model: "gpt-5.4-mini",
+    reasoningEffort: "medium",
+    customAgentName: "",
+    allowedAdditionalDirectories: [],
+    threadId: "",
+  };
+}
+
 function createStartHomeLaunchHarness(overrides: Partial<Parameters<typeof startHomeLaunch>[0]> = {}) {
   const feedback: string[] = [];
   const startingStates: boolean[] = [];
   const openedSessions: string[] = [];
+  const sessionSummaries: string[] = [];
   const openedCompanionSessions: string[] = [];
   const companionSummaries: string[] = [];
   let closeCount = 0;
@@ -88,6 +119,7 @@ function createStartHomeLaunchHarness(overrides: Partial<Parameters<typeof start
     feedback,
     startingStates,
     openedSessions,
+    sessionSummaries,
     openedCompanionSessions,
     companionSummaries,
     get closeCount() {
@@ -100,7 +132,7 @@ function createStartHomeLaunchHarness(overrides: Partial<Parameters<typeof start
       mateProfile: createMateProfile(),
       selectedProviderId: "codex",
       sessions: [],
-      createSession: async () => ({ id: "session-1" }),
+      createSession: async () => createSessionSummary(),
       createCompanionSession: async () => createCompanionSession(),
       openSessionWindow: async (sessionId: string) => {
         openedSessions.push(sessionId);
@@ -116,6 +148,9 @@ function createStartHomeLaunchHarness(overrides: Partial<Parameters<typeof start
       },
       setLaunchStarting: (launchStarting: boolean) => {
         startingStates.push(launchStarting);
+      },
+      upsertSessionSummary: (summary: SessionSummary) => {
+        sessionSummaries.push(summary.id);
       },
       upsertCompanionSessionSummary: (summary: CompanionSessionSummary) => {
         companionSummaries.push(summary.id);
@@ -155,6 +190,7 @@ describe("home-launch-actions", () => {
     assert.deepEqual(harness.feedback, ["Session を開始してるよ..."]);
     assert.deepEqual(harness.startingStates, [true, false]);
     assert.equal(harness.closeCount, 1);
+    assert.deepEqual(harness.sessionSummaries, ["session-1"]);
     assert.deepEqual(harness.openedSessions, ["session-1"]);
   });
 

--- a/src/HomeApp.tsx
+++ b/src/HomeApp.tsx
@@ -485,6 +485,12 @@ export default function HomeApp() {
     openMateTalkWindow,
     createSession: async (input) => await withWithMateApi((api) => api.createSession(input)),
     createCompanionSession: async (input) => await withWithMateApi((api) => api.createCompanionSession(input)),
+    upsertSessionSummary: (summary) => {
+      setSessions((current) => [
+        summary,
+        ...current.filter((session) => session.id !== summary.id),
+      ]);
+    },
     upsertCompanionSessionSummary: (summary) => {
       setCompanionSessions((current) => [
         summary,

--- a/src/home/home-launch-actions.ts
+++ b/src/home/home-launch-actions.ts
@@ -3,6 +3,7 @@ import type { CompanionSession, CompanionSessionSummary, CreateCompanionSessionI
 import { createCompanionSessionSummary } from "../companion-state.js";
 import type { MateProfile, MateStorageState } from "../mate/mate-state.js";
 import type { CreateSessionInput, SessionSummary } from "../session-state.js";
+import { projectSessionSummary } from "../session-state.js";
 import {
   buildCreateCompanionSessionInputFromLaunchDraft,
   buildCreateSessionInputFromLaunchDraft,
@@ -11,7 +12,7 @@ import {
   type HomeLaunchDraft,
 } from "./home-launch-state.js";
 
-export type HomeLaunchSessionCreator = (input: CreateSessionInput) => Promise<{ id: string } | null>;
+export type HomeLaunchSessionCreator = (input: CreateSessionInput) => Promise<SessionSummary | null>;
 
 export type HomeLaunchCompanionSessionCreator = (input: CreateCompanionSessionInput) => Promise<CompanionSession | null>;
 
@@ -30,6 +31,7 @@ export type StartHomeLaunchInput = {
   closeLaunchDialog: () => void;
   setLaunchFeedback: (message: string) => void;
   setLaunchStarting: (launchStarting: boolean) => void;
+  upsertSessionSummary: (summary: SessionSummary) => void;
   upsertCompanionSessionSummary: (summary: CompanionSessionSummary) => void;
 };
 
@@ -97,6 +99,7 @@ export async function startHomeLaunch(input: StartHomeLaunchInput): Promise<void
       return;
     }
 
+    input.upsertSessionSummary(projectSessionSummary(createdSession));
     input.closeLaunchDialog();
     await input.openSessionWindow(createdSession.id);
   } catch (error) {

--- a/src/home/home-launch-handlers.ts
+++ b/src/home/home-launch-handlers.ts
@@ -28,8 +28,9 @@ type HomeLaunchHandlersContext = {
   openSessionWindow: (sessionId: string) => Promise<void>;
   openCompanionReviewWindow: (sessionId: string) => Promise<void>;
   openMateTalkWindow: (input: ReturnType<typeof buildMateTalkLaunchInputFromLaunchDraft>) => Promise<void>;
-  createSession: (input: CreateSessionInput) => Promise<{ id: string } | null>;
+  createSession: (input: CreateSessionInput) => Promise<SessionSummary | null>;
   createCompanionSession: (input: CreateCompanionSessionInput) => Promise<CompanionSession | null>;
+  upsertSessionSummary: (summary: SessionSummary) => void;
   upsertCompanionSessionSummary: (summary: CompanionSessionSummary) => void;
 };
 
@@ -61,6 +62,7 @@ export function buildHomeLaunchHandlers({
   openMateTalkWindow,
   createSession,
   createCompanionSession,
+  upsertSessionSummary,
   upsertCompanionSessionSummary,
 }: HomeLaunchHandlersContext): HomeLaunchHandlers {
   const onBrowseWorkspace = async () => {
@@ -152,6 +154,7 @@ export function buildHomeLaunchHandlers({
       closeLaunchDialog: onCloseLaunchDialog,
       setLaunchFeedback,
       setLaunchStarting,
+      upsertSessionSummary,
       upsertCompanionSessionSummary,
     });
   };


### PR DESCRIPTION
## 概要
- Home の通常 Session 作成後に、作成結果の summary を Home の session 一覧 state へ即時反映
- Companion と同じく、broadcast を待たずにローカル一覧を更新
- home launch action の regression test を追加

## 検証
- npx tsx --test scripts/tests/home-launch-actions.test.ts
- git diff --check

## 補足
- npm run typecheck はこの checkout で tsc が見つからず未実行