### PR TITLE
fix(session): Explorer起動のWindows fallbackを追加

### DIFF
--- a/scripts/tests/open-path.test.ts
+++ b/scripts/tests/open-path.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { resolveOpenPathTarget } from "../../src-electron/open-path.js";
+import { buildDirectoryOpenFallbackCommand, resolveOpenPathTarget } from "../../src-electron/open-path.js";
 
 describe("resolveOpenPathTarget", () => {
   it("http url はそのまま外部 URL として扱う", () => {
@@ -30,5 +30,16 @@ describe("resolveOpenPathTarget", () => {
       type: "local-path",
       targetPath: "C:\\workspace\\project\\docs\\spec.md",
     });
+  });
+
+  it("Windows の directory open fallback は explorer.exe を使う", () => {
+    assert.deepEqual(buildDirectoryOpenFallbackCommand("C:\\workspace\\project", "win32"), {
+      command: "explorer.exe",
+      args: ["C:\\workspace\\project"],
+    });
+  });
+
+  it("Windows 以外では directory open fallback を持たない", () => {
+    assert.equal(buildDirectoryOpenFallbackCommand("/workspace/project", "linux"), null);
   });
 });

--- a/src-electron/main.ts
+++ b/src-electron/main.ts
@@ -1,4 +1,5 @@
-import { readFile, rm, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { readFile, rm, stat, writeFile } from "node:fs/promises";
 import { mkdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -67,7 +68,7 @@ import { CopilotAdapter } from "./copilot-adapter.js";
 import { getMateTalkBackgroundStructuredPromptCapability } from "./provider-runtime.js";
 import { resolveComposerPreview } from "./composer-attachments.js";
 import { ModelCatalogStorage } from "./model-catalog-storage.js";
-import { resolveOpenPathTarget } from "./open-path.js";
+import { buildDirectoryOpenFallbackCommand, resolveOpenPathTarget } from "./open-path.js";
 import { launchTerminalAtPath } from "./open-terminal.js";
 import { SessionStorage } from "./session-storage.js";
 import { SessionMemoryStorage } from "./session-memory-storage.js";
@@ -3660,6 +3661,39 @@ async function openSessionFilesTerminal(sessionId: string): Promise<void> {
   await launchTerminalAtPath(directoryPath);
 }
 
+async function openDirectoryWithExplorerFallback(directoryPath: string): Promise<boolean> {
+  let directoryStat;
+  try {
+    directoryStat = await stat(directoryPath);
+  } catch {
+    return false;
+  }
+
+  if (!directoryStat.isDirectory()) {
+    return false;
+  }
+
+  const fallbackCommand = buildDirectoryOpenFallbackCommand(directoryPath);
+  if (!fallbackCommand) {
+    return false;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(fallbackCommand.command, fallbackCommand.args, {
+      detached: true,
+      stdio: "ignore",
+      windowsHide: false,
+    });
+
+    child.once("error", reject);
+    child.once("spawn", () => {
+      child.unref();
+      resolve();
+    });
+  });
+  return true;
+}
+
 async function openPathTarget(target: string, options?: OpenPathOptions): Promise<void> {
   const resolved = resolveOpenPathTarget(target, options);
   if (resolved.type === "external-url") {
@@ -3669,6 +3703,9 @@ async function openPathTarget(target: string, options?: OpenPathOptions): Promis
 
   const errorMessage = await shell.openPath(resolved.targetPath);
   if (errorMessage) {
+    if (await openDirectoryWithExplorerFallback(resolved.targetPath)) {
+      return;
+    }
     throw new Error(errorMessage);
   }
 }

--- a/src-electron/main.ts
+++ b/src-electron/main.ts
@@ -701,10 +701,7 @@ function writeRendererLog(input: RendererLogInput, windowId?: number): void {
 
 async function openDirectory(directoryPath: string): Promise<void> {
   mkdirSync(directoryPath, { recursive: true });
-  const errorMessage = await shell.openPath(directoryPath);
-  if (errorMessage) {
-    throw new Error(errorMessage);
-  }
+  await openLocalPath(directoryPath);
 }
 
 function createBaseWindow(options: ConstructorParameters<typeof BrowserWindow>[0]): BrowserWindow {
@@ -3694,6 +3691,19 @@ async function openDirectoryWithExplorerFallback(directoryPath: string): Promise
   return true;
 }
 
+async function openLocalPath(targetPath: string): Promise<void> {
+  const errorMessage = await shell.openPath(targetPath);
+  if (!errorMessage) {
+    return;
+  }
+
+  if (await openDirectoryWithExplorerFallback(targetPath)) {
+    return;
+  }
+
+  throw new Error(errorMessage);
+}
+
 async function openPathTarget(target: string, options?: OpenPathOptions): Promise<void> {
   const resolved = resolveOpenPathTarget(target, options);
   if (resolved.type === "external-url") {
@@ -3701,13 +3711,7 @@ async function openPathTarget(target: string, options?: OpenPathOptions): Promis
     return;
   }
 
-  const errorMessage = await shell.openPath(resolved.targetPath);
-  if (errorMessage) {
-    if (await openDirectoryWithExplorerFallback(resolved.targetPath)) {
-      return;
-    }
-    throw new Error(errorMessage);
-  }
+  await openLocalPath(resolved.targetPath);
 }
 
 async function createHomeWindow(): Promise<BrowserWindow> {

--- a/src-electron/open-path.ts
+++ b/src-electron/open-path.ts
@@ -13,6 +13,11 @@ export type ResolvedOpenPathTarget =
       targetPath: string;
     };
 
+export type OpenPathFallbackCommand = {
+  command: string;
+  args: string[];
+};
+
 function stripLocalPathFragment(target: string): string {
   const hashIndex = target.indexOf("#");
   const withoutFragment = hashIndex >= 0 ? target.slice(0, hashIndex) : target;
@@ -92,5 +97,19 @@ export function resolveOpenPathTarget(target: string, options: OpenPathOptions =
   return {
     type: "local-path",
     targetPath: normalizedTarget,
+  };
+}
+
+export function buildDirectoryOpenFallbackCommand(
+  targetPath: string,
+  platform: NodeJS.Platform = process.platform,
+): OpenPathFallbackCommand | null {
+  if (platform !== "win32") {
+    return null;
+  }
+
+  return {
+    command: "explorer.exe",
+    args: [targetPath],
   };
 }


### PR DESCRIPTION
## 概要
- Windows で workspace directory の shell.openPath が失敗した場合、実在ディレクトリなら explorer.exe で開く fallback を追加
- fallback command の生成を open-path helper として分離
- open-path の targeted test に Windows fallback / 非 Windows no-op を追加

## 検証
- npx tsx --test scripts/tests/open-path.test.ts
- npm run typecheck