### PR TITLE
MateTalkのActionDock自動格納を反映

### DIFF
--- a/scripts/tests/mate-talk-state.test.ts
+++ b/scripts/tests/mate-talk-state.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { MateTalkTurnController, shouldSubmitMateTalkInputByKey } from "../../src/chat/mate-talk-state.js";
+import {
+  MateTalkTurnController,
+  resolveMateTalkActionDockExpandedAfterSubmit,
+  shouldSubmitMateTalkInputByKey,
+} from "../../src/chat/mate-talk-state.js";
 
 test("MateTalkTurnController は beginTurn で turnId と messageSequence を増やす", () => {
   const controller = new MateTalkTurnController();
@@ -90,6 +94,33 @@ test("shouldSubmitMateTalkInputByKey は composing 中は送信しない", () =>
       key: "Enter",
       ctrlKey: true,
       isComposing: true,
+    }),
+    false,
+  );
+});
+
+test("resolveMateTalkActionDockExpandedAfterSubmit は自動格納設定が有効なら送信時に閉じる", () => {
+  assert.equal(
+    resolveMateTalkActionDockExpandedAfterSubmit({
+      isActionDockExpanded: true,
+      appSettings: { autoCollapseActionDockOnSend: true },
+    }),
+    false,
+  );
+});
+
+test("resolveMateTalkActionDockExpandedAfterSubmit は自動格納設定が無効なら現在の状態を保つ", () => {
+  assert.equal(
+    resolveMateTalkActionDockExpandedAfterSubmit({
+      isActionDockExpanded: true,
+      appSettings: { autoCollapseActionDockOnSend: false },
+    }),
+    true,
+  );
+  assert.equal(
+    resolveMateTalkActionDockExpandedAfterSubmit({
+      isActionDockExpanded: false,
+      appSettings: { autoCollapseActionDockOnSend: false },
     }),
     false,
   );

--- a/src/chat/mate-talk-state.ts
+++ b/src/chat/mate-talk-state.ts
@@ -1,3 +1,5 @@
+import type { AppSettings } from "../provider-settings-state.js";
+
 export type MateTalkTurnState = {
   turnId: number;
   messageSequence: number;
@@ -43,3 +45,13 @@ export const shouldSubmitMateTalkInputByKey = (eventLike: {
   }
   return eventLike.ctrlKey === true || eventLike.metaKey === true;
 };
+
+export function resolveMateTalkActionDockExpandedAfterSubmit({
+  isActionDockExpanded,
+  appSettings,
+}: {
+  isActionDockExpanded: boolean;
+  appSettings: Pick<AppSettings, "autoCollapseActionDockOnSend">;
+}): boolean {
+  return appSettings.autoCollapseActionDockOnSend ? false : isActionDockExpanded;
+}

--- a/src/chat/use-mate-talk-window-state.ts
+++ b/src/chat/use-mate-talk-window-state.ts
@@ -27,7 +27,10 @@ import {
   isMateTalkReasoningEffortAllowed,
   resolveMateTalkModelChange,
 } from "./mate-talk-model-selection.js";
-import { MateTalkTurnController } from "./mate-talk-state.js";
+import {
+  MateTalkTurnController,
+  resolveMateTalkActionDockExpandedAfterSubmit,
+} from "./mate-talk-state.js";
 
 function getMateTalkLaunchParams(): { providerId: string; model: string; reasoningEffort: ModelReasoningEffort } {
   if (typeof window === "undefined") {
@@ -437,6 +440,12 @@ export function useMateTalkWindowState({
     setInput("");
     setInputCaret(0);
     setPathReferences([]);
+    setIsActionDockExpanded((current) =>
+      resolveMateTalkActionDockExpandedAfterSubmit({
+        isActionDockExpanded: current,
+        appSettings,
+      }),
+    );
 
     try {
       if (!withmateApi) {


### PR DESCRIPTION
## 概要
- MateTalk送信時にSettingsのActionDock自動格納設定を反映
- 自動格納の判定をstate helperに切り出し
- MateTalk stateの回帰テストを追加

## 検証
- npm exec -- tsx --test scripts/tests/mate-talk-state.test.ts scripts/tests/chat-window-mate-talk-mode.test.ts
- npm run typecheck