### PR TITLE
fix(copilot): Sandbox selector を非表示にする

### DIFF
--- a/scripts/tests/provider-runtime-options.test.ts
+++ b/scripts/tests/provider-runtime-options.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { getSandboxOptionsForProvider } from "../../src/provider-runtime-options.js";
+import {
+  getSandboxOptionsForProvider,
+  getSandboxOptionsForProviderSelection,
+} from "../../src/provider-runtime-options.js";
 
 test("getSandboxOptionsForProvider は Codex provider に Sandbox 選択肢を返す", () => {
   const codexOptions = getSandboxOptionsForProvider("codex");
@@ -12,4 +15,14 @@ test("getSandboxOptionsForProvider は Codex provider に Sandbox 選択肢を�
 test("getSandboxOptionsForProvider は非 Codex provider では Sandbox 選択肢を返さない", () => {
   assert.deepEqual(getSandboxOptionsForProvider("copilot"), []);
   assert.deepEqual(getSandboxOptionsForProvider(null), []);
+});
+
+test("getSandboxOptionsForProviderSelection は非 Codex provider で保存済み値を補完しない", () => {
+  assert.deepEqual(getSandboxOptionsForProviderSelection("copilot", "workspace-write"), []);
+});
+
+test("getSandboxOptionsForProviderSelection は Codex provider で保存済み値を選択肢に含める", () => {
+  const options = getSandboxOptionsForProviderSelection("codex", "workspace-write");
+
+  assert.ok(options.some((option) => option.value === "workspace-write"));
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ import {
 import {
   getApprovalOptionsForProvider,
   getSandboxOptionsForProvider,
+  getSandboxOptionsForProviderSelection,
 } from "./provider-runtime-options.js";
 import {
   buildContextPaneProjection,
@@ -1528,14 +1529,9 @@ export default function AgentSessionWindowApp() {
     [selectedSession?.approvalMode, selectedSession?.provider],
   );
   const sandboxChoiceOptions = useMemo(
-    () => {
-      const options = getSandboxOptionsForProvider(selectedSession?.provider);
-      if (!selectedSession || options.some((option) => option.value === selectedSession.codexSandboxMode)) {
-        return options;
-      }
-
-      return [{ value: selectedSession.codexSandboxMode, label: selectedSession.codexSandboxMode }, ...options];
-    },
+    () => selectedSession
+      ? getSandboxOptionsForProviderSelection(selectedSession.provider, selectedSession.codexSandboxMode)
+      : getSandboxOptionsForProvider(undefined),
     [selectedSession?.codexSandboxMode, selectedSession?.provider],
   );
   const modelSelectOptions = useMemo(

--- a/src/CompanionReviewApp.tsx
+++ b/src/CompanionReviewApp.tsx
@@ -94,6 +94,7 @@ import { fileKindLabel, modelOptionLabel, reasoningDepthLabel } from "./ui-utils
 import {
   getApprovalOptionsForProvider,
   getSandboxOptionsForProvider,
+  getSandboxOptionsForProviderSelection,
 } from "./provider-runtime-options.js";
 import { extractTextReferenceCandidates } from "./path-reference.js";
 import type { WorkspacePathCandidate } from "./workspace-path-candidate.js";
@@ -892,14 +893,9 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
     [selectedApprovalMode, snapshot?.session.provider],
   );
   const sandboxSelectOptions = useMemo(
-    () => {
-      const options = getSandboxOptionsForProvider(snapshot?.session.provider);
-      if (!snapshot || options.some((option) => option.value === selectedCodexSandboxMode)) {
-        return options;
-      }
-
-      return [{ value: selectedCodexSandboxMode, label: selectedCodexSandboxMode }, ...options];
-    },
+    () => snapshot
+      ? getSandboxOptionsForProviderSelection(snapshot.session.provider, selectedCodexSandboxMode)
+      : getSandboxOptionsForProvider(undefined),
     [selectedCodexSandboxMode, snapshot?.session.provider],
   );
   const companionComposerBlockedReason = snapshot?.session.status !== "active"

--- a/src/provider-runtime-options.ts
+++ b/src/provider-runtime-options.ts
@@ -27,3 +27,15 @@ export function getSandboxOptionsForProvider(
 
   return codexSandboxModeOptions.map((option) => ({ value: option.id, label: option.label }));
 }
+
+export function getSandboxOptionsForProviderSelection(
+  providerId: string | null | undefined,
+  selectedValue: CodexSandboxMode,
+): RuntimeSelectOption<CodexSandboxMode>[] {
+  const options = getSandboxOptionsForProvider(providerId);
+  if (options.length === 0 || options.some((option) => option.value === selectedValue)) {
+    return options;
+  }
+
+  return [{ value: selectedValue, label: selectedValue }, ...options];
+}


### PR DESCRIPTION
## 概要
- Copilot など非 Codex provider では Sandbox 選択肢を表示しないように修正
- 保存済みの codexSandboxMode があっても、非 Codex provider では UI 選択肢として補完しない共通 helper を追加
- AgentMode と Companion Review の Sandbox options 生成を同じ helper に統一

## 検証
- node --import tsx scripts\\tests\\provider-runtime-options.test.ts
- npm run typecheck