### PR TITLE
fix(companion): approval never の読み戻しを修正

### DIFF
--- a/scripts/tests/companion-storage-v3.test.ts
+++ b/scripts/tests/companion-storage-v3.test.ts
@@ -156,6 +156,7 @@ describe("CompanionStorageV3", () => {
       storage = new CompanionStorageV3(dbPath, blobPath);
       const group = await storage.ensureGroup(createGroup());
       const session = await storage.createSession(createSession(group.id, {
+        approvalMode: "never",
         messages: [
           { role: "user", text: "Companion user text" },
           {
@@ -180,6 +181,8 @@ describe("CompanionStorageV3", () => {
       const mergeRun = await storage.createMergeRun(createMergeRun(group.id));
 
       assert.equal(session.groupId, group.id);
+      assert.equal((await storage.getSession(session.id))?.approvalMode, "never");
+      assert.equal((await storage.listActiveSessionSummaries())[0]?.approvalMode, "never");
       assert.equal((await storage.getSession(session.id))?.messages[1]?.artifact?.changedFiles[0]?.diffRows.length, 0);
       assert.equal((await storage.getMessageArtifact(session.id, 1))?.changedFiles[0]?.diffRows[0]?.rightText, "hello");
       assert.deepEqual(await storage.listMergeRunsForSession(session.id), [mergeRun]);

--- a/scripts/tests/companion-storage.test.ts
+++ b/scripts/tests/companion-storage.test.ts
@@ -108,7 +108,9 @@ describe("CompanionStorage", () => {
     try {
       storage = new CompanionStorage(dbPath);
       const group = storage.ensureGroup(createGroup());
-      const session = storage.createSession(createSession(group.id));
+      const session = storage.createSession(createSession(group.id, {
+        approvalMode: "never",
+      }));
 
       assert.equal(session.groupId, group.id);
       assert.deepEqual(storage.listActiveSessionSummaries(), [
@@ -132,7 +134,7 @@ describe("CompanionStorage", () => {
           provider: "codex",
           model: DEFAULT_MODEL_ID,
           reasoningEffort: DEFAULT_REASONING_EFFORT,
-          approvalMode: DEFAULT_APPROVAL_MODE,
+          approvalMode: "never",
           codexSandboxMode: DEFAULT_CODEX_SANDBOX_MODE,
           character: "Mia",
           characterRoleMarkdown: "落ち着いて伴走する。",
@@ -145,6 +147,7 @@ describe("CompanionStorage", () => {
         },
       ]);
       assert.equal(storage.getSession("session-1")?.companionBranch, "withmate/companion/session-1");
+      assert.equal(storage.getSession("session-1")?.approvalMode, "never");
     } finally {
       storage?.close();
       await removeDirectoryWithRetry(tempDirectory);

--- a/src-electron/companion-storage-v3.ts
+++ b/src-electron/companion-storage-v3.ts
@@ -16,7 +16,7 @@ import {
 } from "../src/companion-state.js";
 import type { ChangedFile, DiffRow } from "../src/runtime-state.js";
 import { summarizeMessageArtifact, type Message, type MessageArtifact } from "../src/session-state.js";
-import { DEFAULT_APPROVAL_MODE } from "../src/approval-mode.js";
+import { DEFAULT_APPROVAL_MODE, normalizeApprovalMode } from "../src/approval-mode.js";
 import { DEFAULT_CODEX_SANDBOX_MODE } from "../src/codex-sandbox-mode.js";
 import { DEFAULT_CATALOG_REVISION, DEFAULT_MODEL_ID, DEFAULT_REASONING_EFFORT } from "../src/model-catalog.js";
 import {
@@ -442,10 +442,7 @@ async function rowToSession(row: CompanionSessionRow, blobStore: TextBlobStore):
         ? row.reasoning_effort
         : DEFAULT_REASONING_EFFORT,
     customAgentName: row.custom_agent_name,
-    approvalMode:
-      row.approval_mode === "untrusted" || row.approval_mode === "on-failure" || row.approval_mode === "on-request"
-        ? row.approval_mode
-        : DEFAULT_APPROVAL_MODE,
+    approvalMode: normalizeApprovalMode(row.approval_mode, DEFAULT_APPROVAL_MODE),
     codexSandboxMode:
       row.codex_sandbox_mode === "read-only" ||
       row.codex_sandbox_mode === "workspace-write" ||
@@ -579,10 +576,7 @@ function rowToSessionSummary(
       row.reasoning_effort === "xhigh"
       ? row.reasoning_effort
       : DEFAULT_REASONING_EFFORT,
-    approvalMode:
-      row.approval_mode === "untrusted" || row.approval_mode === "on-failure" || row.approval_mode === "on-request"
-        ? row.approval_mode
-        : DEFAULT_APPROVAL_MODE,
+    approvalMode: normalizeApprovalMode(row.approval_mode, DEFAULT_APPROVAL_MODE),
     codexSandboxMode: row.codex_sandbox_mode === "read-only" ||
       row.codex_sandbox_mode === "workspace-write" ||
       row.codex_sandbox_mode === "workspace-write-network" ||

--- a/src-electron/companion-storage.ts
+++ b/src-electron/companion-storage.ts
@@ -18,7 +18,7 @@ import type { ChangedFile, DiffRow } from "../src/runtime-state.js";
 import type { Message, MessageArtifact } from "../src/session-state.js";
 import { DEFAULT_CATALOG_REVISION, DEFAULT_MODEL_ID, DEFAULT_REASONING_EFFORT } from "../src/model-catalog.js";
 import { DEFAULT_CODEX_SANDBOX_MODE } from "../src/codex-sandbox-mode.js";
-import { DEFAULT_APPROVAL_MODE } from "../src/approval-mode.js";
+import { DEFAULT_APPROVAL_MODE, normalizeApprovalMode } from "../src/approval-mode.js";
 import { openAppDatabase } from "./sqlite-connection.js";
 
 type CompanionGroupRow = {
@@ -177,10 +177,7 @@ function rowToSession(row: CompanionSessionRow): CompanionSession {
         ? row.reasoning_effort
         : DEFAULT_REASONING_EFFORT,
     customAgentName: row.custom_agent_name,
-    approvalMode:
-      row.approval_mode === "untrusted" || row.approval_mode === "on-failure" || row.approval_mode === "on-request"
-        ? row.approval_mode
-        : DEFAULT_APPROVAL_MODE,
+    approvalMode: normalizeApprovalMode(row.approval_mode, DEFAULT_APPROVAL_MODE),
     codexSandboxMode:
       row.codex_sandbox_mode === "read-only" ||
       row.codex_sandbox_mode === "workspace-write" ||


### PR DESCRIPTION
## 概要
- Companion storage の approval_mode 読み戻しを normalizeApprovalMode に統一
- V3 blob-backed Companion storage の detail / summary 読み戻しも同じ正規化に統一
- approvalMode=never の保存・読み戻し回帰テストを追加

## 検証
- node --test --import tsx scripts/tests/companion-storage.test.ts scripts/tests/companion-storage-v3.test.ts scripts/tests/approval-mode.test.ts
- npm run typecheck