### PR TITLE
承認応答後の stale live run 反映を防ぐ

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1816,9 +1816,22 @@ export default function AgentSessionWindowApp() {
       return;
     }
 
+    const sessionId = selectedSession.id;
     setApprovalActionRequestId(request.requestId);
     try {
-      await withmateApi.resolveLiveApproval(selectedSession.id, request.requestId, decision);
+      await withmateApi.resolveLiveApproval(sessionId, request.requestId, decision);
+      const latestLiveRun = await withmateApi.getLiveSessionRun(sessionId);
+      setLiveRunState((current) => {
+        if (
+          current.ownerSessionId !== sessionId
+          || current.state?.approvalRequest?.requestId !== request.requestId
+        ) {
+          return current;
+        }
+
+        return { ownerSessionId: sessionId, state: latestLiveRun };
+      });
+      setApprovalActionRequestId(null);
     } catch (error) {
       window.alert(error instanceof Error ? error.message : "承認要求の処理に失敗したよ。");
       setApprovalActionRequestId(null);
@@ -1833,9 +1846,22 @@ export default function AgentSessionWindowApp() {
       return;
     }
 
+    const sessionId = selectedSession.id;
     setElicitationActionRequestId(request.requestId);
     try {
-      await withmateApi.resolveLiveElicitation(selectedSession.id, request.requestId, response);
+      await withmateApi.resolveLiveElicitation(sessionId, request.requestId, response);
+      const latestLiveRun = await withmateApi.getLiveSessionRun(sessionId);
+      setLiveRunState((current) => {
+        if (
+          current.ownerSessionId !== sessionId
+          || current.state?.elicitationRequest?.requestId !== request.requestId
+        ) {
+          return current;
+        }
+
+        return { ownerSessionId: sessionId, state: latestLiveRun };
+      });
+      setElicitationActionRequestId(null);
     } catch (error) {
       window.alert(error instanceof Error ? error.message : "入力要求の処理に失敗したよ。");
       setElicitationActionRequestId(null);

--- a/src/CompanionReviewApp.tsx
+++ b/src/CompanionReviewApp.tsx
@@ -668,6 +668,12 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
   const stagedFileTree = useMemo(() => buildChangedFileTree(stagedChangedFiles), [stagedChangedFiles]);
   const selectedSessionLiveRun =
     snapshot && liveRunState.ownerSessionId === snapshot.session.id ? liveRunState.state : null;
+  useEffect(() => {
+    setApprovalActionRequestId(null);
+  }, [selectedSessionLiveRun?.approvalRequest?.requestId]);
+  useEffect(() => {
+    setElicitationActionRequestId(null);
+  }, [selectedSessionLiveRun?.elicitationRequest?.requestId]);
   const companionAuditLogApi = useMemo(() => withmateApi ? ({
     listSessionAuditLogSummaryPage: withmateApi.listCompanionAuditLogSummaryPage,
     getSessionAuditLogDetailSection: withmateApi.getCompanionAuditLogDetailSection,
@@ -1931,9 +1937,22 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
       return;
     }
 
+    const sessionId = snapshot.session.id;
     setApprovalActionRequestId(request.requestId);
     try {
-      await withmateApi.resolveLiveApproval(snapshot.session.id, request.requestId, decision);
+      await withmateApi.resolveLiveApproval(sessionId, request.requestId, decision);
+      const latestLiveRun = await withmateApi.getLiveSessionRun(sessionId);
+      setLiveRunState((current) => {
+        if (
+          current.ownerSessionId !== sessionId
+          || current.state?.approvalRequest?.requestId !== request.requestId
+        ) {
+          return current;
+        }
+
+        return { ownerSessionId: sessionId, state: latestLiveRun };
+      });
+      setApprovalActionRequestId(null);
     } catch (error) {
       window.alert(error instanceof Error ? error.message : "承認要求の処理に失敗したよ。");
       setApprovalActionRequestId(null);
@@ -1949,9 +1968,22 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
       return;
     }
 
+    const sessionId = snapshot.session.id;
     setElicitationActionRequestId(request.requestId);
     try {
-      await withmateApi.resolveLiveElicitation(snapshot.session.id, request.requestId, response);
+      await withmateApi.resolveLiveElicitation(sessionId, request.requestId, response);
+      const latestLiveRun = await withmateApi.getLiveSessionRun(sessionId);
+      setLiveRunState((current) => {
+        if (
+          current.ownerSessionId !== sessionId
+          || current.state?.elicitationRequest?.requestId !== request.requestId
+        ) {
+          return current;
+        }
+
+        return { ownerSessionId: sessionId, state: latestLiveRun };
+      });
+      setElicitationActionRequestId(null);
     } catch (error) {
       window.alert(error instanceof Error ? error.message : "入力要求の処理に失敗したよ。");
       setElicitationActionRequestId(null);


### PR DESCRIPTION
## 概要
- live approval / elicitation の解決後に live run を明示 refresh し、イベント取り逃がしでボタンが disabled のまま残る経路を防止
- refresh 応答は現在 state が同じ requestId を保持している場合だけ反映し、購読イベントや次 turn の状態を古い snapshot で上書きしないように guard
- Companion chat 側の同じ approval / elicitation 経路も同じ扱いに統一

## 検証
- npm run typecheck
- npx tsx --test scripts/tests/session-approval-service.test.ts scripts/tests/session-message-column.test.ts scripts/tests/chat-window-adapter.test.ts scripts/tests/main-ipc-registration.test.ts scripts/tests/preload-api.test.ts