### PR TITLE
HomeのSessionカードアイコン削除とCI分割

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,13 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  test:
-    name: Typecheck and test
+  typecheck:
+    name: Typecheck
     runs-on: windows-latest
 
     steps:
@@ -27,5 +31,41 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+  test:
+    name: Test shard ${{ matrix.shard }} / 3
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Test
-        run: npm test
+        run: npm run test:shard -- --shard=${{ matrix.shard }}/3
+
+  ci:
+    name: Typecheck and test
+    runs-on: ubuntu-latest
+    needs:
+      - typecheck
+      - test
+    if: ${{ always() }}
+
+    steps:
+      - name: Check required jobs
+        run: |
+          if [ "${{ needs.typecheck.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ]; then
+            exit 1
+          fi

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "preview": "vite preview",
     "benchmark:data-loading": "tsx scripts/benchmark-data-loading.ts",
     "test": "tsx --test scripts/tests/*.test.ts scripts/tests/*.test.tsx",
+    "test:shard": "node --import tsx scripts/run-test-shard.ts",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.electron.json --noEmit",
     "validate:snapshot-ignore": "tsx scripts/validate-snapshot-ignore.ts"
   },

--- a/scripts/run-test-shard.ts
+++ b/scripts/run-test-shard.ts
@@ -1,0 +1,123 @@
+import { spawnSync } from "node:child_process";
+import { readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+type TestFile = {
+  relativePath: string;
+  size: number;
+};
+
+type ShardOptions = {
+  index: number;
+  total: number;
+};
+
+function parsePositiveInteger(value: string | undefined, label: string): number {
+  const parsed = Number.parseInt(value ?? "", 10);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${label} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+function parseShardOptions(args: string[]): ShardOptions {
+  let indexValue = process.env.TEST_SHARD_INDEX;
+  let totalValue = process.env.TEST_SHARD_TOTAL;
+
+  for (let position = 0; position < args.length; position += 1) {
+    const arg = args[position];
+    if (arg.startsWith("--shard=")) {
+      const [, shardValue] = arg.split("=", 2);
+      const [index, total] = shardValue.split("/", 2);
+      indexValue = index;
+      totalValue = total;
+      continue;
+    }
+    if (arg === "--shard-index") {
+      indexValue = args[position + 1];
+      position += 1;
+      continue;
+    }
+    if (arg.startsWith("--shard-index=")) {
+      indexValue = arg.split("=", 2)[1];
+      continue;
+    }
+    if (arg === "--shard-total") {
+      totalValue = args[position + 1];
+      position += 1;
+      continue;
+    }
+    if (arg.startsWith("--shard-total=")) {
+      totalValue = arg.split("=", 2)[1];
+      continue;
+    }
+  }
+
+  const index = parsePositiveInteger(indexValue ?? "1", "shard index");
+  const total = parsePositiveInteger(totalValue ?? "1", "shard total");
+  if (index > total) {
+    throw new Error(`shard index must be <= shard total. Received ${index}/${total}.`);
+  }
+  return { index, total };
+}
+
+function listTestFiles(rootDirectory: string): TestFile[] {
+  const testsDirectory = path.join(rootDirectory, "scripts", "tests");
+  return readdirSync(testsDirectory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && /\.test\.tsx?$/.test(entry.name))
+    .map((entry) => {
+      const fullPath = path.join(testsDirectory, entry.name);
+      return {
+        relativePath: path.relative(rootDirectory, fullPath).replace(/\\/g, "/"),
+        size: statSync(fullPath).size,
+      };
+    })
+    .sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+}
+
+function selectShard(files: TestFile[], options: ShardOptions): TestFile[] {
+  const buckets = Array.from({ length: options.total }, () => ({
+    files: [] as TestFile[],
+    totalSize: 0,
+  }));
+  const largestFirst = [...files].sort((left, right) => {
+    const sizeDiff = right.size - left.size;
+    return sizeDiff === 0 ? left.relativePath.localeCompare(right.relativePath) : sizeDiff;
+  });
+
+  for (const file of largestFirst) {
+    const target = buckets.reduce((smallest, bucket) => (bucket.totalSize < smallest.totalSize ? bucket : smallest));
+    target.files.push(file);
+    target.totalSize += file.size;
+  }
+
+  return buckets[options.index - 1].files.sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+}
+
+function main(): void {
+  const options = parseShardOptions(process.argv.slice(2));
+  const rootDirectory = process.cwd();
+  const allFiles = listTestFiles(rootDirectory);
+  const shardFiles = selectShard(allFiles, options);
+
+  if (shardFiles.length === 0) {
+    throw new Error(`No test files selected for shard ${options.index}/${options.total}.`);
+  }
+
+  console.log(`Running test shard ${options.index}/${options.total}: ${shardFiles.length} of ${allFiles.length} files`);
+  for (const file of shardFiles) {
+    console.log(`- ${file.relativePath}`);
+  }
+
+  const result = spawnSync(process.execPath, ["--import", "tsx", "--test", ...shardFiles.map((file) => file.relativePath)], {
+    cwd: rootDirectory,
+    stdio: "inherit",
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+  process.exit(result.status ?? 1);
+}
+
+main();

--- a/src/home/HomeRecentSessionsPanel.tsx
+++ b/src/home/HomeRecentSessionsPanel.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { isLegacyReadOnlySession, type SessionSummary } from "../app-state.js";
 import type { CompanionSessionSummary } from "../companion-state.js";
 import { getHomeCompanionSessionState, type HomeSessionState } from "./home-session-projection.js";
-import { buildCardThemeStyle, CharacterAvatar } from "../ui-utils.js";
+import { buildCardThemeStyle } from "../ui-utils.js";
 
 export type HomeRecentSessionsPanelProps = {
   filteredSessionEntries: Array<{ session: SessionSummary; state: HomeSessionState }>;
@@ -121,7 +121,6 @@ export function HomeRecentSessionsPanel({
                 aria-disabled={!canUsePrimaryFeatures}
                 disabled={!canUsePrimaryFeatures}
               >
-                <CharacterAvatar character={{ name: session.character, iconPath: session.characterIconPath }} size="small" className="session-card-avatar" />
                 <div className="session-card-copy">
                   <div className="session-card-topline home-session-card-topline">
                     <strong>{session.taskTitle}</strong>
@@ -151,7 +150,6 @@ export function HomeRecentSessionsPanel({
               aria-disabled={!canUsePrimaryFeatures}
               disabled={!canUsePrimaryFeatures}
             >
-              <CharacterAvatar character={{ name: session.character, iconPath: session.characterIconPath }} size="small" className="session-card-avatar" />
               <div className="session-card-copy">
                 <div className="session-card-topline home-session-card-topline">
                   <strong>{session.taskTitle}</strong>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1089,6 +1089,7 @@ button:disabled {
 
 .home-page .home-session-card {
   align-items: start;
+  grid-template-columns: minmax(0, 1fr);
   min-height: 108px;
 }
 


### PR DESCRIPTION
概要: Home の Session 一覧から同一表示になっていたキャラクターアイコンを削除し、カードを 1 カラム化しました。あわせて CI の npm test を 3 shard に分割し、同一 PR/ref の古い run を自動キャンセルします。検証: npm run build:renderer / npm run typecheck / npm run test:shard -- --shard=1/3 / npm run test:shard -- --shard=2/3 / npm run test:shard -- --shard=3/3 / git diff --check