### PR TITLE
fix(session): keep live progress with streaming response

### DIFF
--- a/scripts/tests/session-message-column.test.ts
+++ b/scripts/tests/session-message-column.test.ts
@@ -203,7 +203,7 @@ test("SessionMessageColumn は pending と live approval\/elicitation を messag
   );
 });
 
-test("SessionMessageColumn は実行中の assistant text を通常 message slot に表示する", () => {
+test("SessionMessageColumn は実行中の assistant text を pending bubble 内に表示する", () => {
   const html = renderSessionMessageColumn({
     messages: createMessages(100),
     isRunning: true,
@@ -213,12 +213,16 @@ test("SessionMessageColumn は実行中の assistant text を通常 message slot
   assert.match(html, /pending-row/);
   assert.match(html, /ストリーミング中の返答/);
   assert.ok(
-    html.indexOf("message 100") < html.indexOf("ストリーミング中の返答"),
-    "streaming assistant text は既存メッセージの後に描画する",
+    html.indexOf("message 100") < html.indexOf("pending-row"),
+    "pending row は既存メッセージの後に描画する",
   );
   assert.ok(
-    html.indexOf("ストリーミング中の返答") < html.indexOf("pending-row"),
-    "streaming assistant text は pending row とは別の message slot に描画する",
+    html.indexOf("pending-row") < html.indexOf("ストリーミング中の返答"),
+    "streaming assistant text は pending row 内に描画する",
+  );
+  assert.ok(
+    html.indexOf("処理を実行中") < html.indexOf("ストリーミング中の返答"),
+    "progress 表示は streaming assistant text より前に描画する",
   );
 });
 

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -1901,24 +1901,13 @@ export function SessionMessageColumn({
     Math.max(0, messages.length - SESSION_MESSAGE_INITIAL_RENDER_COUNT),
   );
   const prependAnchorRef = useRef<{ scrollHeight: number; scrollTop: number } | null>(null);
-  const liveAssistantMessage = useMemo<Message | null>(
-    () => (isRunning && hasLiveRunAssistantText ? { role: "assistant", text: liveRunAssistantText } : null),
-    [hasLiveRunAssistantText, isRunning, liveRunAssistantText],
-  );
-  const displayedMessageCount = messages.length + (liveAssistantMessage ? 1 : 0);
   const latestMessageWindowStartIndex = Math.min(
     Math.max(0, messageWindowStartIndex),
-    Math.max(0, displayedMessageCount - SESSION_MESSAGE_INITIAL_RENDER_COUNT),
+    Math.max(0, messages.length - SESSION_MESSAGE_INITIAL_RENDER_COUNT),
   );
   const renderedMessages = useMemo(
-    () => {
-      const rendered = messages.slice(latestMessageWindowStartIndex);
-      if (liveAssistantMessage && latestMessageWindowStartIndex <= messages.length) {
-        rendered.push(liveAssistantMessage);
-      }
-      return rendered;
-    },
-    [latestMessageWindowStartIndex, liveAssistantMessage, messages],
+    () => messages.slice(latestMessageWindowStartIndex),
+    [latestMessageWindowStartIndex, messages],
   );
   const hasOlderMessages = latestMessageWindowStartIndex > 0;
 
@@ -2289,6 +2278,7 @@ export function SessionMessageColumn({
                         onOpenPath={onOpenPath}
                       />
                     ) : null}
+                    {hasLiveRunAssistantText ? <MessageRichText text={liveRunAssistantText} /> : null}
                     {liveRunErrorMessage ? (
                       <p className="pending-run-error-note" role="alert">{liveRunErrorMessage}</p>
                     ) : null}


### PR DESCRIPTION
## 概要
- 実行中の assistant streaming text を通常 message slot ではなく pending bubble 内に戻しました。
- Progress 表示がメッセージ本文の下に別 bubble として出る不自然な順序を解消しました。
- SessionMessageColumn の focused test を pending bubble 内表示の期待に更新しました。

## 検証
- npx tsx --test scripts/tests/session-message-column.test.ts
- npm run typecheck
- git diff --check