### PR TITLE
Reasoning live表示を右ペインに追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/scripts/tests/codex-adapter.test.ts
+++ b/scripts/tests/codex-adapter.test.ts
@@ -15,6 +15,7 @@ import {
   buildCodexStableRawItems,
   collectCodexAssistantTextSnapshotsFromEventsForTesting,
   collectCodexAssistantTextFromEventsForTesting,
+  collectCodexReasoningTextFromEventsForTesting,
   resolveCodexThreadForSettings,
   type CodexThreadOptions,
 } from "../../src-electron/codex-adapter.js";
@@ -251,6 +252,36 @@ describe("CodexAdapter thread settings", () => {
         text: "done",
       },
     });
+  });
+
+  it("reasoning item は rawItems に残さず live reasoning text にだけ流す", () => {
+    const events = [
+      {
+        type: "item.updated",
+        item: {
+          id: "reasoning-1",
+          type: "reasoning",
+          text: "既存経路を確認する",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          id: "reasoning-1",
+          type: "reasoning",
+          text: "既存経路を確認してから UI に流す",
+        },
+      },
+    ] as never[];
+
+    assert.deepEqual(buildCodexStableRawItems([
+      {
+        id: "reasoning-1",
+        type: "reasoning",
+        text: "既存経路を確認してから UI に流す",
+      } as never,
+    ]), []);
+    assert.equal(collectCodexReasoningTextFromEventsForTesting(events), "既存経路を確認してから UI に流す");
   });
 
   it("model / reasoning 変更後の thread settings は新 options と settingsKey を反映する", () => {

--- a/scripts/tests/copilot-adapter.test.ts
+++ b/scripts/tests/copilot-adapter.test.ts
@@ -17,6 +17,9 @@ import {
   buildCopilotSessionSettings,
   buildCopilotMessageAttachments,
   buildCopilotProviderQuotaTelemetry,
+  collectCopilotAuditOperationsFromEventsForTesting,
+  collectCopilotLiveStepsFromEventsForTesting,
+  collectCopilotReasoningTextFromEventsForTesting,
   getCopilotPermissionCompletedLiveStatus,
   buildCopilotSessionContextTelemetry,
   buildCopilotSystemMessage,
@@ -622,6 +625,65 @@ describe("CopilotAdapter env", () => {
         },
       },
     ]);
+  });
+
+  it("assistant.reasoning / reasoning_delta は rawItems に残さない", () => {
+    const items = buildCopilotStableRawItems([
+      {
+        type: "assistant.reasoning_delta",
+        timestamp: "2026-03-23T00:00:00.000Z",
+        ephemeral: true,
+        data: {
+          reasoningId: "reasoning-1",
+          deltaContent: "調査",
+        },
+      } as never,
+      {
+        type: "assistant.reasoning",
+        timestamp: "2026-03-23T00:00:01.000Z",
+        data: {
+          reasoningId: "reasoning-1",
+          content: "調査してから実装する",
+        },
+      } as never,
+    ], "F:/repo");
+
+    assert.deepEqual(items, []);
+  });
+
+  it("assistant.reasoning_delta / assistant.reasoning は live reasoning text にだけ変換する", () => {
+    const events = [
+      {
+        type: "assistant.reasoning_delta",
+        timestamp: "2026-03-23T00:00:00.000Z",
+        ephemeral: true,
+        data: {
+          reasoningId: "reasoning-1",
+          deltaContent: "調査して",
+        },
+      },
+      {
+        type: "assistant.reasoning_delta",
+        timestamp: "2026-03-23T00:00:01.000Z",
+        ephemeral: true,
+        data: {
+          reasoningId: "reasoning-1",
+          deltaContent: "から実装する",
+        },
+      },
+      {
+        type: "assistant.reasoning",
+        timestamp: "2026-03-23T00:00:02.000Z",
+        data: {
+          reasoningId: "reasoning-1",
+          content: "調査してから実装する",
+        },
+      },
+    ] as never[];
+
+    assert.deepEqual(collectCopilotLiveStepsFromEventsForTesting(events, "F:/repo"), []);
+    assert.deepEqual(collectCopilotAuditOperationsFromEventsForTesting(events, "F:/repo"), []);
+    assert.equal(collectCopilotReasoningTextFromEventsForTesting(events, "F:/repo"), "調査してから実装する");
   });
 
   it("rawItems の大きな text payload は preview と metadata に畳み込む", () => {

--- a/scripts/tests/session-context-pane-style.test.ts
+++ b/scripts/tests/session-context-pane-style.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("Reasoning live details は内側 pre スクロールを作らない", async () => {
+  const [componentSource, stylesSource] = await Promise.all([
+    readFile("src/session-components.tsx", "utf8"),
+    readFile("src/styles.css", "utf8"),
+  ]);
+
+  assert.match(
+    componentSource,
+    /className="command-monitor-details live-run-step-details live-reasoning-details"/,
+  );
+  assert.match(
+    stylesSource,
+    /\.live-reasoning-details pre\s*{\s*max-height:\s*none;\s*overflow:\s*visible;\s*}/,
+  );
+});

--- a/scripts/tests/session-runtime-service.test.ts
+++ b/scripts/tests/session-runtime-service.test.ts
@@ -128,6 +128,7 @@ function createLiveRunState(overrides?: Partial<LiveSessionRunState>): LiveSessi
     sessionId: overrides?.sessionId ?? "session-1",
     threadId: overrides?.threadId ?? "",
     assistantText: overrides?.assistantText ?? "",
+    reasoningText: overrides?.reasoningText ?? "",
     steps: overrides?.steps ?? [],
     backgroundTasks: overrides?.backgroundTasks ?? [],
     usage: overrides?.usage ?? null,
@@ -780,6 +781,104 @@ describe("SessionRuntimeService", () => {
     assert.equal(storedSessions[1]?.threadId, "thread-new");
     assert.equal(liveStates.at(-1)?.threadId, "thread-new");
     assert.deepEqual(liveStates.at(-1)?.backgroundTasks, backgroundTasks);
+  });
+
+  it("成功後も Reasoning は live state に保持し、次の prompt 用 state で空にする", async () => {
+    const session = createSession({ provider: "codex", threadId: "thread-old" });
+    let liveState: LiveSessionRunState | null = null;
+    const liveStates: Array<LiveSessionRunState | null> = [];
+
+    const adapter: ProviderCodingAdapter = {
+      composePrompt() {
+        return {
+          systemBodyText: "system",
+          inputBodyText: "input",
+          logicalPrompt: { systemText: "system", inputText: "input", composedText: "system\ninput" },
+          imagePaths: [],
+          additionalDirectories: [],
+        };
+      },
+      async getProviderQuotaTelemetry() {
+        return null;
+      },
+      invalidateSessionThread() {},
+      invalidateAllSessionThreads() {},
+      async runSessionTurn(_input, onProgress) {
+        await onProgress?.(createLiveRunState({
+          sessionId: session.id,
+          threadId: "thread-new",
+          reasoningText: "既存経路を確認してから表示へ流す",
+        }));
+        return createPartialResult({
+          threadId: "thread-new",
+          assistantText: "完了したよ。",
+        });
+      },
+    };
+
+    const service = new SessionRuntimeService({
+      getSession(sessionId) {
+        return sessionId === session.id ? session : null;
+      },
+      upsertSession(next) {
+        return next;
+      },
+      async resolveComposerPreview() {
+        return { attachments: [], errors: [] } satisfies ComposerPreview;
+      },
+      async resolveSessionCharacter() {
+        return createCharacter();
+      },
+      getAppSettings() {
+        return normalizeAppSettings({});
+      },
+      resolveProviderCatalog() {
+        return { snapshot: { revision: 1, providers: [createProviderCatalog()] }, provider: createProviderCatalog() };
+      },
+      getProviderCodingAdapter() {
+        return adapter;
+      },
+      getSessionMemory(current) {
+        return createSessionMemory(current.id);
+      },
+      resolveProjectMemoryEntriesForPrompt(): ProjectMemoryEntry[] {
+        return [];
+      },
+      createAuditLog(input) {
+        return createAuditLogBase(input);
+      },
+      updateAuditLog() {},
+      setLiveSessionRun(_sessionId, next) {
+        liveState = next;
+        liveStates.push(next);
+      },
+      getLiveSessionRun() {
+        return liveState;
+      },
+      async waitForApprovalDecision(_sessionId, _request, _signal): Promise<LiveApprovalDecision> {
+        return "approve";
+      },
+      async waitForElicitationResponse() {
+        return { action: "cancel" } as const;
+      },
+      setProviderQuotaTelemetry() {},
+      setSessionContextTelemetry() {},
+      invalidateProviderSessionThread() {},
+      scheduleProviderQuotaTelemetryRefresh() {},
+      runSessionMemoryExtraction() {},
+      runCharacterReflection() {},
+      clearWorkspaceFileIndex() {},
+      broadcastLiveSessionRun() {},
+      resolvePendingApprovalRequest() {},
+      resolvePendingElicitationRequest() {},
+      currentTimestampLabel,
+    });
+
+    await service.runSessionTurn(session.id, { userMessage: "お願いします" });
+
+    assert.equal(liveStates[0]?.reasoningText, "");
+    assert.equal(liveStates.at(-1)?.threadId, "thread-new");
+    assert.equal(liveStates.at(-1)?.reasoningText, "既存経路を確認してから表示へ流す");
   });
 
   it("provider failure 時は error session を保存し、cancel 時は idle へ戻す", async () => {

--- a/scripts/tests/session-ui-projection.test.ts
+++ b/scripts/tests/session-ui-projection.test.ts
@@ -14,7 +14,6 @@ import {
   buildSessionContextTelemetryProjection,
   cycleContextPaneTab,
   resolveAvailableContextPaneTabs,
-  resolveAutoContextPaneTab,
 } from "../../src/session-ui-projection.js";
 
 function makeBackgroundTask(partial: Partial<LiveBackgroundTask> & Pick<LiveBackgroundTask, "id" | "kind" | "status" | "title" | "updatedAt">): LiveBackgroundTask {
@@ -75,53 +74,6 @@ describe("session-ui-projection", () => {
     assert.equal(projection.remainingPercentLabel, "40% left");
     assert.equal(projection.remainingRequestsLabel, "80 / 200 left");
     assert.match(projection.resetLabel, /\d{2}\/\d{2} \d{2}:\d{2}/);
-  });
-
-  it("実行中 session があれば LatestCommand を自動選択する", () => {
-    const tab = resolveAutoContextPaneTab({
-      isSelectedSessionRunning: true,
-      isCopilotSession: true,
-      backgroundTasks: [
-        makeBackgroundTask({
-          id: "agent:1",
-          kind: "agent",
-          status: "running",
-          title: "sub agent",
-          updatedAt: "2026-03-28T00:00:00.000Z",
-        }),
-      ],
-    });
-
-    assert.equal(tab, "latest-command");
-  });
-
-  it("Copilot background task が走っていれば Tasks を自動選択する", () => {
-    const tab = resolveAutoContextPaneTab({
-      isSelectedSessionRunning: false,
-      isCopilotSession: true,
-      backgroundTasks: [
-        makeBackgroundTask({
-          id: "shell:1",
-          kind: "shell",
-          status: "running",
-          title: "npm test",
-          updatedAt: "2026-03-28T00:00:00.000Z",
-        }),
-      ],
-    });
-
-    assert.equal(tab, "tasks");
-  });
-
-  it("CompanionGroup monitor があれば CompanionGroup を自動選択する", () => {
-    const tab = resolveAutoContextPaneTab({
-      isSelectedSessionRunning: false,
-      isCopilotSession: false,
-      backgroundTasks: [],
-      hasCompanionGroupMonitor: true,
-    });
-
-    assert.equal(tab, "companion-group");
   });
 
   it("ContextPaneProjection は LatestCommand tab の表示情報を作る", () => {
@@ -342,7 +294,7 @@ describe("session-ui-projection", () => {
   });
 
   it("cycleContextPaneTab は利用可能な command pane を循環する", () => {
-    assert.equal(cycleContextPaneTab("latest-command", 1), "tasks");
+    assert.equal(cycleContextPaneTab("latest-command", 1), "reasoning");
     assert.equal(cycleContextPaneTab("latest-command", -1), "companion-group");
   });
 
@@ -352,6 +304,11 @@ describe("session-ui-projection", () => {
     ]);
     assert.deepEqual(resolveAvailableContextPaneTabs({ isCopilotSession: true }), [
       "latest-command",
+      "tasks",
+    ]);
+    assert.deepEqual(resolveAvailableContextPaneTabs({ isCopilotSession: true, hasReasoningText: true }), [
+      "latest-command",
+      "reasoning",
       "tasks",
     ]);
     assert.deepEqual(resolveAvailableContextPaneTabs({ isCopilotSession: false, hasCompanionGroupMonitor: true }), [

--- a/src-electron/codex-adapter.ts
+++ b/src-electron/codex-adapter.ts
@@ -107,6 +107,7 @@ type CodexTurnStreamState = {
   threadId: string | null;
   streamedAssistantText: string;
   finalAssistantText: string;
+  reasoningText: string;
   usage: Usage | null;
   liveUsage: AuditLogUsage | null;
   streamErrorMessage: string;
@@ -459,11 +460,6 @@ function toActivitySummary(items: ThreadItem[]): string[] {
           summary.push(`todo: ${item.items.filter((entry) => entry.completed).length}/${item.items.length} completed`);
         }
         break;
-      case "reasoning":
-        if (item.text.trim()) {
-          summary.push(item.text.trim());
-        }
-        break;
       default:
         break;
     }
@@ -566,12 +562,6 @@ function toAuditOperations(items: ThreadItem[]): AuditLogOperation[] {
           details: toAuditTextPreview(item.items.map((entry) => `${entry.completed ? "[x]" : "[ ]"} ${entry.text}`).join("\n")),
         });
         break;
-      case "reasoning":
-        operations.push({
-          type: item.type,
-          summary: toAuditTextPreview(item.text) ?? item.text,
-        });
-        break;
       case "error":
         operations.push({
           type: item.type,
@@ -663,13 +653,6 @@ export function buildCodexStableRawItems(items: ThreadItem[]): BoundedAuditRawIt
         });
         break;
       case "reasoning":
-        pushCodexRawItem(rawItems, {
-          type: item.type,
-          data: {
-            id: item.id,
-            text: item.text,
-          },
-        });
         break;
       case "error":
         pushCodexRawItem(rawItems, {
@@ -760,12 +743,7 @@ function buildLiveStep(item: ThreadItem): LiveRunStep | null {
         status: "completed",
       };
     case "reasoning":
-      return {
-        id: item.id,
-        type: item.type,
-        summary: toAuditTextPreview(item.text) ?? item.text,
-        status: "completed",
-      };
+      return null;
     case "error":
       return {
         id: item.id,
@@ -786,6 +764,7 @@ async function emitLiveState(
   threadId: string | null,
   steps: Map<string, LiveRunStep>,
   assistantText: string,
+  reasoningText: string,
   usage: AuditLogUsage | null,
   errorMessage: string,
 ): Promise<void> {
@@ -797,6 +776,7 @@ async function emitLiveState(
     sessionId,
     threadId: threadId ?? "",
     assistantText: toAuditTextPreview(assistantText) ?? "",
+    reasoningText: toAuditTextPreview(reasoningText) ?? "",
     steps: Array.from(steps.values()),
     backgroundTasks: [],
     usage,
@@ -813,6 +793,7 @@ function createCodexTurnStreamState(threadId: string | null): CodexTurnStreamSta
     threadId,
     streamedAssistantText: "",
     finalAssistantText: "",
+    reasoningText: "",
     usage: null,
     liveUsage: null,
     streamErrorMessage: "",
@@ -900,6 +881,14 @@ function getLiveAssistantText(state: CodexTurnStreamState): string {
   return state.finalAssistantText || state.streamedAssistantText;
 }
 
+function collectReasoningText(items: Iterable<ThreadItem>): string {
+  return Array.from(items)
+    .filter((item): item is Extract<ThreadItem, { type: "reasoning" }> => item.type === "reasoning")
+    .map((item) => item.text.trim())
+    .filter((text) => text.length > 0)
+    .join("\n\n");
+}
+
 function applyCodexTurnEvent(state: CodexTurnStreamState, event: ThreadEvent): void {
   const assistantDelta = readCodexAssistantDelta(event);
   if (assistantDelta !== null) {
@@ -930,6 +919,9 @@ function applyCodexTurnEvent(state: CodexTurnStreamState, event: ThreadEvent): v
           state.finalAssistantText = itemAssistantText;
         }
       }
+      if (event.item.type === "reasoning") {
+        state.reasoningText = collectReasoningText(state.items.values());
+      }
 
       const liveStep = buildLiveStep(event.item);
       if (liveStep) {
@@ -958,6 +950,14 @@ export function collectCodexAssistantTextSnapshotsFromEventsForTesting(events: T
     snapshots.push(getLiveAssistantText(state));
   }
   return snapshots;
+}
+
+export function collectCodexReasoningTextFromEventsForTesting(events: ThreadEvent[]): string {
+  const state = createCodexTurnStreamState(null);
+  for (const event of events) {
+    applyCodexTurnEvent(state, event);
+  }
+  return state.reasoningText;
 }
 
 function buildCodexTransportPayload(prompt: ProviderPromptComposition): AuditTransportPayload {
@@ -1392,6 +1392,7 @@ export class CodexAdapter implements ProviderTurnAdapter {
       streamState.threadId,
       streamState.liveSteps,
       getLiveAssistantText(streamState),
+      streamState.reasoningText,
       streamState.liveUsage,
       streamState.streamErrorMessage,
     );
@@ -1409,6 +1410,7 @@ export class CodexAdapter implements ProviderTurnAdapter {
           streamState.threadId,
           streamState.liveSteps,
           getLiveAssistantText(streamState),
+          streamState.reasoningText,
           streamState.liveUsage,
           streamState.streamErrorMessage,
         );

--- a/src-electron/copilot-adapter.ts
+++ b/src-electron/copilot-adapter.ts
@@ -91,6 +91,8 @@ type CopilotTurnStreamState = {
   backgroundTasks: Map<string, LiveBackgroundTask>;
   permissionToStepId: Map<string, string>;
   toolNamesByCallId: Map<string, string>;
+  reasoningDraftsById: Map<string, string>;
+  reasoningText: string;
   rawItems: CopilotStableRawItem[];
   assistantText: string;
   assistantMessages: string[];
@@ -247,6 +249,8 @@ function createCopilotTurnStreamState(): CopilotTurnStreamState {
     backgroundTasks: new Map<string, LiveBackgroundTask>(),
     permissionToStepId: new Map<string, string>(),
     toolNamesByCallId: new Map<string, string>(),
+    reasoningDraftsById: new Map<string, string>(),
+    reasoningText: "",
     rawItems: [],
     assistantText: "",
     assistantMessages: [],
@@ -264,6 +268,13 @@ function updateCopilotCommandStep(state: CopilotTurnStreamState, nextState: Copi
     details: toAuditTextPreview(nextState.details),
     status: nextState.status,
   });
+}
+
+function refreshCopilotReasoningText(state: CopilotTurnStreamState): void {
+  state.reasoningText = Array.from(state.reasoningDraftsById.values())
+    .map((content) => content.trim())
+    .filter((content) => content.length > 0)
+    .join("\n\n");
 }
 
 const COPILOT_APPROVED_PERMISSION_COMPLETED_KINDS = new Set([
@@ -313,6 +324,17 @@ function applyCopilotTurnEvent(args: {
           void args.onProviderQuotaTelemetry(telemetry);
         }
       }
+      break;
+    case "assistant.reasoning_delta": {
+      const currentDraft = state.reasoningDraftsById.get(event.data.reasoningId) ?? "";
+      const nextDraft = currentDraft + event.data.deltaContent;
+      state.reasoningDraftsById.set(event.data.reasoningId, nextDraft);
+      refreshCopilotReasoningText(state);
+      break;
+    }
+    case "assistant.reasoning":
+      state.reasoningDraftsById.set(event.data.reasoningId, event.data.content);
+      refreshCopilotReasoningText(state);
       break;
     case "session.usage_info":
       if (args.onSessionContextTelemetry) {
@@ -417,6 +439,50 @@ function applyCopilotTurnEvent(args: {
   }
 
   appendCopilotStableRawItem(state.rawItems, event, workspacePath, state.toolNamesByCallId);
+}
+
+export function collectCopilotLiveStepsFromEventsForTesting(
+  events: SessionEvent[],
+  workspacePath = "C:/workspace",
+): LiveRunStep[] {
+  const state = createCopilotTurnStreamState();
+  for (const event of events) {
+    applyCopilotTurnEvent({
+      event,
+      state,
+      providerId: "copilot",
+      sessionId: "session-1",
+      workspacePath,
+    });
+  }
+
+  return Array.from(state.liveSteps.values());
+}
+
+export function collectCopilotAuditOperationsFromEventsForTesting(
+  events: SessionEvent[],
+  workspacePath = "C:/workspace",
+): AuditLogOperation[] {
+  const steps = collectCopilotLiveStepsFromEventsForTesting(events, workspacePath);
+  return toAuditOperations(new Map(steps.map((step) => [step.id, step])));
+}
+
+export function collectCopilotReasoningTextFromEventsForTesting(
+  events: SessionEvent[],
+  workspacePath = "C:/workspace",
+): string {
+  const state = createCopilotTurnStreamState();
+  for (const event of events) {
+    applyCopilotTurnEvent({
+      event,
+      state,
+      providerId: "copilot",
+      sessionId: "session-1",
+      workspacePath,
+    });
+  }
+
+  return state.reasoningText;
 }
 
 type CopilotQuotaSnapshotLike = {
@@ -1036,6 +1102,7 @@ function appendCopilotStableRawItem(
           inputTokens: event.data.inputTokens ?? null,
           cacheReadTokens: event.data.cacheReadTokens ?? null,
           outputTokens: event.data.outputTokens ?? null,
+          reasoningTokens: event.data.reasoningTokens ?? null,
         },
       });
       break;
@@ -1162,7 +1229,7 @@ function extractToolExecutionDetails(event: Extract<SessionEvent, { type: "tool.
   return normalized.length > 0 ? normalized.join("\n\n") : undefined;
 }
 
-function toCommandOperations(steps: Map<string, LiveRunStep>): AuditLogOperation[] {
+function toAuditOperations(steps: Map<string, LiveRunStep>): AuditLogOperation[] {
   return Array.from(steps.values())
     .filter((step) =>
       step.type === "command_execution"
@@ -1310,6 +1377,7 @@ async function emitLiveState(
   steps: Map<string, LiveRunStep>,
   backgroundTasks: Map<string, LiveBackgroundTask>,
   assistantText: string,
+  reasoningText: string,
   usage: AuditLogUsage | null,
   errorMessage: string,
 ): Promise<void> {
@@ -1321,6 +1389,7 @@ async function emitLiveState(
     sessionId,
     threadId: threadId ?? "",
     assistantText: toAuditTextPreview(assistantText) ?? "",
+    reasoningText: toAuditTextPreview(reasoningText) ?? "",
     steps: Array.from(steps.values()),
     backgroundTasks: sortLiveBackgroundTasks(backgroundTasks.values()),
     usage,
@@ -2133,7 +2202,7 @@ export class CopilotAdapter implements ProviderTurnAdapter {
       workspacePath,
       ...normalizeAllowedAdditionalDirectories(workspacePath, session.allowedAdditionalDirectories),
     ]);
-    const operations = toCommandOperations(steps);
+    const operations = toAuditOperations(steps);
     const artifact = buildArtifactFromOperations({
       session,
       operations,
@@ -2213,6 +2282,7 @@ export class CopilotAdapter implements ProviderTurnAdapter {
           streamState.liveSteps,
           streamState.backgroundTasks,
           streamState.assistantText,
+          streamState.reasoningText,
           streamState.usage,
           streamState.streamErrorMessage,
         ),
@@ -2227,6 +2297,7 @@ export class CopilotAdapter implements ProviderTurnAdapter {
       streamState.liveSteps,
       streamState.backgroundTasks,
       streamState.assistantText,
+      streamState.reasoningText,
       streamState.usage,
       streamState.streamErrorMessage,
     );

--- a/src-electron/session-runtime-service.ts
+++ b/src-electron/session-runtime-service.ts
@@ -221,6 +221,7 @@ function buildEmptyLiveSessionRunState(sessionId: string, threadId: string): Liv
     sessionId,
     threadId,
     assistantText: "",
+    reasoningText: "",
     steps: [],
     backgroundTasks: [],
     usage: null,
@@ -456,6 +457,7 @@ export class SessionRuntimeService {
     const initialLiveState: LiveSessionRunState = {
       ...buildEmptyLiveSessionRunState(sessionId, runningSession.threadId),
       backgroundTasks: this.deps.getLiveSessionRun(sessionId)?.backgroundTasks ?? [],
+      reasoningText: "",
     };
     this.deps.setLiveSessionRun(sessionId, initialLiveState);
 
@@ -611,10 +613,12 @@ export class SessionRuntimeService {
           return;
         }
 
+        const currentLiveState = this.deps.getLiveSessionRun(sessionId);
         const nextLiveState: LiveSessionRunState = {
           ...state,
-          approvalRequest: this.deps.getLiveSessionRun(sessionId)?.approvalRequest ?? null,
-          elicitationRequest: this.deps.getLiveSessionRun(sessionId)?.elicitationRequest ?? null,
+          reasoningText: state.reasoningText ?? currentLiveState?.reasoningText ?? "",
+          approvalRequest: currentLiveState?.approvalRequest ?? null,
+          elicitationRequest: currentLiveState?.elicitationRequest ?? null,
         };
         void syncRunningAuditFromLiveState(nextLiveState).catch((error) => {
           console.warn("Audit progress update failed", error);
@@ -845,11 +849,14 @@ export class SessionRuntimeService {
       this.deps.resolvePendingElicitationRequest(sessionId, { action: "cancel" });
       this.inFlightSessionRuns.delete(sessionId);
       this.sessionRunControllers.delete(sessionId);
-      const preservedBackgroundTasks = this.deps.getLiveSessionRun(sessionId)?.backgroundTasks ?? [];
-      if (preservedBackgroundTasks.length > 0) {
+      const currentLiveState = this.deps.getLiveSessionRun(sessionId);
+      const preservedBackgroundTasks = currentLiveState?.backgroundTasks ?? [];
+      const preservedReasoningText = currentLiveState?.reasoningText ?? "";
+      if (preservedBackgroundTasks.length > 0 || preservedReasoningText.trim().length > 0) {
         this.deps.setLiveSessionRun(sessionId, {
           ...buildEmptyLiveSessionRunState(sessionId, activeRunningSession.threadId),
           backgroundTasks: preservedBackgroundTasks,
+          reasoningText: preservedReasoningText,
         });
       } else {
         this.deps.setLiveSessionRun(sessionId, null);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,7 +57,6 @@ import {
   cycleContextPaneTab,
   type ContextPaneTabKey,
   resolveAvailableContextPaneTabs,
-  resolveAutoContextPaneTab,
 } from "./session-ui-projection.js";
 import { ChatWindow, ChatWindowStatusScreen } from "./chat/chat-window.js";
 import {
@@ -314,6 +313,7 @@ function buildLiveRunScrollSignature(liveRun: LiveSessionRunState | null): strin
 
   return [
     liveRun.assistantText,
+    liveRun.reasoningText ?? "",
     liveRun.errorMessage,
     liveRun.approvalRequest
       ? [
@@ -352,6 +352,7 @@ function createPendingLiveSessionRunState(
     sessionId: session.id,
     threadId: session.threadId,
     assistantText: "",
+    reasoningText: "",
     steps: [],
     backgroundTasks: previousState?.backgroundTasks ?? [],
     usage: null,
@@ -611,9 +612,8 @@ export default function AgentSessionWindowApp() {
     () => previewPathReferenceCandidates.join("\u001f"),
     [previewPathReferenceCandidates],
   );
-  const selectedSessionRunState: Session["runState"] | null = selectedSessionLiveRun
-    ? "running"
-    : selectedSession?.runState ?? null;
+  const selectedSessionRunState: Session["runState"] | null = selectedSession?.runState
+    ?? (selectedSessionLiveRun ? "running" : null);
 
   const selectedSessionCharacter = useMemo(
     () =>
@@ -1250,12 +1250,15 @@ export default function AgentSessionWindowApp() {
     () => selectedSessionLiveRun?.backgroundTasks ?? [],
     [selectedSessionLiveRun?.backgroundTasks],
   );
+  const liveRunReasoningText = selectedSessionLiveRun?.reasoningText ?? "";
+  const hasLiveRunReasoningText = liveRunReasoningText.trim().length > 0;
   const availableContextPaneTabs = useMemo(
     () => resolveAvailableContextPaneTabs({
       isCopilotSession,
       hasCompanionGroupMonitor: selectedCompanionGroupMonitorEntries.length > 0,
+      hasReasoningText: hasLiveRunReasoningText,
     }),
-    [isCopilotSession, selectedCompanionGroupMonitorEntries.length],
+    [hasLiveRunReasoningText, isCopilotSession, selectedCompanionGroupMonitorEntries.length],
   );
 
   const hasInProgressLiveRunStep = useMemo(
@@ -2473,21 +2476,18 @@ export default function AgentSessionWindowApp() {
       latestCommandView,
       backgroundTasks: selectedBackgroundTasks,
       companionGroupMonitorEntries: selectedCompanionGroupMonitorEntries,
-    }),
-    [activeContextPaneTab, latestCommandView, selectedBackgroundTasks, selectedCompanionGroupMonitorEntries],
-  );
-
-  useEffect(() => {
-    const nextTab = resolveAutoContextPaneTab({
+      hasReasoningText: hasLiveRunReasoningText,
       isSelectedSessionRunning,
-      isCopilotSession,
-      backgroundTasks: selectedBackgroundTasks,
-      hasCompanionGroupMonitor: selectedCompanionGroupMonitorEntries.length > 0,
-    });
-    if (nextTab) {
-      setActiveContextPaneTab(nextTab);
-    }
-  }, [isSelectedSessionRunning, isCopilotSession, selectedBackgroundTasks, selectedCompanionGroupMonitorEntries.length]);
+    }),
+    [
+      activeContextPaneTab,
+      hasLiveRunReasoningText,
+      isSelectedSessionRunning,
+      latestCommandView,
+      selectedBackgroundTasks,
+      selectedCompanionGroupMonitorEntries,
+    ],
+  );
 
   useEffect(() => {
     if (!availableContextPaneTabs.includes(activeContextPaneTab)) {
@@ -2570,6 +2570,7 @@ export default function AgentSessionWindowApp() {
         isContextRailResizing,
         latestCommandView,
         runningDetailsEntries,
+        liveRunReasoningText,
         activeContextPaneTab,
         availableContextPaneTabs,
         contextPaneProjection,

--- a/src/CompanionReviewApp.tsx
+++ b/src/CompanionReviewApp.tsx
@@ -85,7 +85,6 @@ import {
   buildRunningDetailsEntries,
   buildSessionContextTelemetryProjection,
   cycleContextPaneTab,
-  resolveAutoContextPaneTab,
   resolveAvailableContextPaneTabs,
   type ContextPaneTabKey,
 } from "./session-ui-projection.js";
@@ -697,7 +696,7 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
     liveRun: selectedSessionLiveRun,
     enabled: !isMergeView,
   });
-  const selectedSessionRunState = selectedSessionLiveRun ? "running" : snapshot?.session.runState ?? null;
+  const selectedSessionRunState = snapshot?.session.runState ?? (selectedSessionLiveRun ? "running" : null);
   const isSelectedSessionRunning = selectedSessionRunState === "running" || turnRunning;
   const activePathReference = useMemo(
     () => (snapshot ? getActivePathReference(composerText, composerCaret) : null),
@@ -839,10 +838,12 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
         snapshot?.session.runState ?? "",
         snapshot?.session.messages.map((message) => `${message.role}:${message.text.length}:${message.text}`).join("\u001d") ?? "",
         selectedSessionLiveRun?.assistantText ?? "",
+        selectedSessionLiveRun?.reasoningText ?? "",
         selectedSessionLiveRun?.errorMessage ?? "",
       ].join("\u001a"),
     [
       selectedSessionLiveRun?.assistantText,
+      selectedSessionLiveRun?.reasoningText,
       selectedSessionLiveRun?.errorMessage,
       snapshot?.session.id,
       snapshot?.session.messages,
@@ -1087,6 +1088,8 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
     () => selectedSessionLiveRun?.backgroundTasks ?? [],
     [selectedSessionLiveRun?.backgroundTasks],
   );
+  const liveRunReasoningText = selectedSessionLiveRun?.reasoningText ?? "";
+  const hasLiveRunReasoningText = liveRunReasoningText.trim().length > 0;
   const companionGroupMonitorEntries = useMemo(() => {
     if (!snapshot) {
       return [];
@@ -1101,26 +1104,17 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
     latestCommandView,
     backgroundTasks: selectedBackgroundTasks,
     companionGroupMonitorEntries,
+    hasReasoningText: hasLiveRunReasoningText,
+    isSelectedSessionRunning,
   });
   const availableContextPaneTabs = useMemo(
     () => resolveAvailableContextPaneTabs({
       isCopilotSession,
       hasCompanionGroupMonitor: companionGroupMonitorEntries.length > 0,
+      hasReasoningText: hasLiveRunReasoningText,
     }),
-    [isCopilotSession, companionGroupMonitorEntries.length],
+    [hasLiveRunReasoningText, isCopilotSession, companionGroupMonitorEntries.length],
   );
-
-  useEffect(() => {
-    const nextTab = resolveAutoContextPaneTab({
-      isSelectedSessionRunning,
-      isCopilotSession,
-      backgroundTasks: selectedBackgroundTasks,
-      hasCompanionGroupMonitor: companionGroupMonitorEntries.length > 0,
-    });
-    if (nextTab) {
-      setActiveContextPaneTab(nextTab);
-    }
-  }, [isSelectedSessionRunning, isCopilotSession, selectedBackgroundTasks, companionGroupMonitorEntries.length]);
 
   useEffect(() => {
     if (!availableContextPaneTabs.includes(activeContextPaneTab)) {
@@ -2197,6 +2191,7 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
         contextPaneProjection,
         latestCommandView,
         runningDetailsEntries,
+        liveRunReasoningText,
         backgroundTasks: selectedBackgroundTasks,
         companionGroupMonitorEntries,
         isCopilotSession,

--- a/src/chat/companion-chat-projection.tsx
+++ b/src/chat/companion-chat-projection.tsx
@@ -88,6 +88,7 @@ export type CompanionChatProjectionInput = {
   contextPaneProjection: SessionContextPaneProps["contextPaneProjection"];
   latestCommandView: SessionContextPaneProps["latestCommandView"];
   runningDetailsEntries: SessionContextPaneProps["runningDetailsEntries"];
+  liveRunReasoningText: SessionContextPaneProps["liveRunReasoningText"];
   backgroundTasks: SessionContextPaneProps["backgroundTasks"];
   companionGroupMonitorEntries: SessionContextPaneProps["companionGroupMonitorEntries"];
   isCopilotSession: boolean;
@@ -371,6 +372,7 @@ export function buildCompanionChatWindowProps(input: CompanionChatProjectionInpu
           contextPaneProjection={input.contextPaneProjection}
           latestCommandView={input.latestCommandView}
           runningDetailsEntries={input.runningDetailsEntries}
+          liveRunReasoningText={input.liveRunReasoningText}
           backgroundTasks={input.backgroundTasks}
           companionGroupMonitorEntries={input.companionGroupMonitorEntries}
           selectedSessionLiveRunErrorMessage={input.liveRunErrorMessage}

--- a/src/chat/session-chat-projection.tsx
+++ b/src/chat/session-chat-projection.tsx
@@ -87,6 +87,7 @@ export type AgentSessionChatProjectionInput = {
   isContextRailResizing: boolean;
   latestCommandView: SessionContextPaneProps["latestCommandView"];
   runningDetailsEntries: SessionContextPaneProps["runningDetailsEntries"];
+  liveRunReasoningText: SessionContextPaneProps["liveRunReasoningText"];
   activeContextPaneTab: ContextPaneTabKey;
   availableContextPaneTabs: ContextPaneTabKey[];
   contextPaneProjection: SessionContextPaneProps["contextPaneProjection"];
@@ -370,6 +371,7 @@ export function buildAgentSessionChatWindowProps(input: AgentSessionChatProjecti
           contextPaneProjection={input.contextPaneProjection}
           latestCommandView={input.latestCommandView}
           runningDetailsEntries={input.runningDetailsEntries}
+          liveRunReasoningText={input.liveRunReasoningText}
           backgroundTasks={input.selectedBackgroundTasks}
           companionGroupMonitorEntries={input.selectedCompanionGroupMonitorEntries}
           selectedSessionLiveRunErrorMessage={input.liveRunErrorMessage}

--- a/src/runtime-state.ts
+++ b/src/runtime-state.ts
@@ -235,6 +235,7 @@ export type LiveSessionRunState = {
   sessionId: string;
   threadId: string;
   assistantText: string;
+  reasoningText?: string;
   steps: LiveRunStep[];
   backgroundTasks: LiveBackgroundTask[];
   usage: AuditLogUsage | null;

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -1303,6 +1303,7 @@ export type SessionContextPaneProps = {
   contextPaneProjection: ContextPaneProjection;
   latestCommandView: LatestCommandView | null;
   runningDetailsEntries: RunningDetailsEntry[];
+  liveRunReasoningText: string;
   backgroundTasks: LiveBackgroundTask[];
   companionGroupMonitorEntries: HomeMonitorEntry[];
   selectedSessionLiveRunErrorMessage: string;
@@ -1414,6 +1415,7 @@ export function SessionContextPane({
   contextPaneProjection,
   latestCommandView,
   runningDetailsEntries,
+  liveRunReasoningText,
   backgroundTasks,
   companionGroupMonitorEntries,
   selectedSessionLiveRunErrorMessage,
@@ -1449,6 +1451,8 @@ export function SessionContextPane({
         return taskEntries
           .map((task) => `${task.id}:${task.kind}:${task.status}:${task.title}:${task.details?.length ?? 0}:${task.updatedAt}`)
           .join("|");
+      case "reasoning":
+        return `${isSelectedSessionRunning ? "running" : "idle"}:${liveRunReasoningText.length}`;
       case "companion-group":
         return companionGroupMonitorEntries
           .map((entry) => `${entry.kind}:${entry.session.id}:${entry.session.taskTitle}:${entry.state.kind}:${entry.state.label}:${entry.session.updatedAt}`)
@@ -1460,7 +1464,9 @@ export function SessionContextPane({
     activeContextPaneTab,
     companionGroupMonitorEntries,
     latestCommandView,
+    liveRunReasoningText,
     runningDetailsEntries,
+    isSelectedSessionRunning,
     taskEntries,
     selectedSessionLiveRunErrorMessage,
   ]);
@@ -1667,6 +1673,31 @@ export function SessionContextPane({
                 <div className="command-monitor-empty-shell">
                   <p className="command-monitor-empty">まだ background task はないよ。</p>
                   <p className="command-monitor-empty-subtle">Copilot の sub-agent や background shell がある時だけここへ出るよ。</p>
+                </div>
+              )
+            ) : null}
+
+            {activeContextPaneTab === "reasoning" ? (
+              liveRunReasoningText.trim().length > 0 ? (
+                <div className="command-monitor-card">
+                  <div className="command-monitor-card-head">
+                    <div className="command-monitor-meta">
+                      <span className={`live-run-step-status ${contextPaneProjection.reasoningToneClassName}`}>
+                        {isSelectedSessionRunning ? "実行中" : "保持中"}
+                      </span>
+                      <span className="live-run-step-type">Reasoning</span>
+                      <span className="command-monitor-source">
+                        {isSelectedSessionRunning ? "RUN LIVE" : "LAST RUN"}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="command-monitor-details live-run-step-details live-reasoning-details">
+                    <pre>{liveRunReasoningText}</pre>
+                  </div>
+                </div>
+              ) : (
+                <div className="command-monitor-empty-shell">
+                  <p className="command-monitor-empty">まだ Reasoning はないよ。</p>
                 </div>
               )
             ) : null}

--- a/src/session-ui-projection.ts
+++ b/src/session-ui-projection.ts
@@ -10,9 +10,9 @@ import type {
 import type { HomeMonitorEntry } from "./home/home-session-projection.js";
 import { liveRunStepStatusLabel } from "./ui-utils.js";
 
-export type ContextPaneTabKey = "latest-command" | "tasks" | "companion-group";
+export type ContextPaneTabKey = "latest-command" | "reasoning" | "tasks" | "companion-group";
 
-export const CONTEXT_PANE_TAB_ORDER: ContextPaneTabKey[] = ["latest-command", "tasks", "companion-group"];
+export const CONTEXT_PANE_TAB_ORDER: ContextPaneTabKey[] = ["latest-command", "reasoning", "tasks", "companion-group"];
 
 export type LatestCommandView = {
   status: string;
@@ -58,6 +58,7 @@ export type ContextPaneProjection = {
   latestCommandToneClassName: string;
   latestCommandStatusLabel: string;
   latestCommandSourceCopy: string;
+  reasoningToneClassName: string;
   tasksToneClassName: string;
 };
 
@@ -285,6 +286,8 @@ export function contextPaneTabLabel(tab: ContextPaneTabKey): string {
   switch (tab) {
     case "latest-command":
       return "LatestCommand";
+    case "reasoning":
+      return "Reasoning";
     case "tasks":
       return "Tasks";
     case "companion-group":
@@ -294,40 +297,20 @@ export function contextPaneTabLabel(tab: ContextPaneTabKey): string {
   }
 }
 
-export function resolveAutoContextPaneTab({
-  isSelectedSessionRunning,
-  isCopilotSession,
-  backgroundTasks,
-  hasCompanionGroupMonitor = false,
-}: {
-  isSelectedSessionRunning: boolean;
-  isCopilotSession: boolean;
-  backgroundTasks: LiveBackgroundTask[];
-  hasCompanionGroupMonitor?: boolean;
-}): ContextPaneTabKey | null {
-  if (isSelectedSessionRunning) {
-    return "latest-command";
-  }
-
-  if (isCopilotSession && backgroundTasks.some((task) => task.status === "running")) {
-    return "tasks";
-  }
-
-  if (hasCompanionGroupMonitor) {
-    return "companion-group";
-  }
-
-  return null;
-}
-
 export function resolveAvailableContextPaneTabs({
   isCopilotSession,
   hasCompanionGroupMonitor = false,
+  hasReasoningText = false,
 }: {
   isCopilotSession: boolean;
   hasCompanionGroupMonitor?: boolean;
+  hasReasoningText?: boolean;
 }): ContextPaneTabKey[] {
   return CONTEXT_PANE_TAB_ORDER.filter((tab) => {
+    if (tab === "reasoning") {
+      return hasReasoningText;
+    }
+
     if (tab === "tasks") {
       return isCopilotSession;
     }
@@ -357,16 +340,23 @@ export function buildContextPaneProjection({
   latestCommandView,
   backgroundTasks,
   companionGroupMonitorEntries = [],
+  hasReasoningText = false,
+  isSelectedSessionRunning = false,
 }: {
   activeContextPaneTab: ContextPaneTabKey;
   latestCommandView: LatestCommandView | null;
   backgroundTasks: LiveBackgroundTask[];
   companionGroupMonitorEntries?: HomeMonitorEntry[];
+  hasReasoningText?: boolean;
+  isSelectedSessionRunning?: boolean;
 }): ContextPaneProjection {
   const latestCommandToneClassName = latestCommandView ? liveRunStepToneClassName(latestCommandView.status) : "unknown";
   const latestCommandStatusLabel = latestCommandView ? liveRunStepStatusLabel(latestCommandView.status) : "待機";
   const latestCommandSourceCopy = latestCommandView?.sourceLabel === "live" ? "RUN LIVE" : "LAST RUN";
   const tasksToneClassName = summarizeBackgroundTasksStatus(backgroundTasks);
+  const reasoningToneClassName = hasReasoningText
+    ? (isSelectedSessionRunning ? "in_progress" : "completed")
+    : "unknown";
   const companionGroupToneClassName = companionGroupMonitorEntries.some((entry) => entry.state.kind === "running")
     ? "running"
     : companionGroupMonitorEntries.some((entry) => entry.state.kind === "error")
@@ -379,6 +369,9 @@ export function buildContextPaneProjection({
       badgeLabel = backgroundTasks.length > 0
         ? sessionBackgroundActivityStatusLabel(tasksToneClassName)
         : "";
+      break;
+    case "reasoning":
+      badgeLabel = hasReasoningText ? (isSelectedSessionRunning ? "Live" : "Hold") : "";
       break;
     case "companion-group":
       badgeLabel = companionGroupMonitorEntries.length > 0 ? String(companionGroupMonitorEntries.length) : "";
@@ -396,6 +389,9 @@ export function buildContextPaneProjection({
     case "tasks":
       toneClassName = tasksToneClassName;
       break;
+    case "reasoning":
+      toneClassName = reasoningToneClassName;
+      break;
     case "companion-group":
       toneClassName = companionGroupToneClassName;
       break;
@@ -411,6 +407,7 @@ export function buildContextPaneProjection({
     latestCommandToneClassName,
     latestCommandStatusLabel,
     latestCommandSourceCopy,
+    reasoningToneClassName,
     tasksToneClassName,
   };
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -4553,6 +4553,11 @@ button:disabled {
   white-space: pre-wrap;
 }
 
+.live-reasoning-details pre {
+  max-height: none;
+  overflow: visible;
+}
+
 .command-monitor-card-head.compact {
   margin-bottom: 8px;
 }


### PR DESCRIPTION
## 変更内容
- Codex / Copilot の Reasoning を live state として右ペインの Reasoning タブに表示
- Reasoning 本文は rawItems / audit operations に保存せず、live state だけで次のプロンプト送信まで保持
- CompanionReview 側にも reasoningText とタブ availability を配線
- 長い Reasoning の IPC payload を既存 live text と同じ 64KB preview 上限に制限
- 右ペインの自動タブ切り替えを廃止し、利用不可タブからの退避だけ維持
- アプリバージョンを 4.2.1 に更新

## 検証
- npx tsx --test scripts/tests/copilot-adapter.test.ts scripts/tests/codex-adapter.test.ts scripts/tests/session-ui-projection.test.ts scripts/tests/session-runtime-service.test.ts scripts/tests/session-context-pane-style.test.ts
- npm run typecheck
- npm run build
- git diff --check

## 補足
- npm run build は成功。Vite の既存 chunk size warning は継続。