### PR TITLE
Reasoning タブを対応 provider で常時表示する

### DIFF
--- a/scripts/tests/session-ui-projection.test.ts
+++ b/scripts/tests/session-ui-projection.test.ts
@@ -298,12 +298,21 @@ describe("session-ui-projection", () => {
     assert.equal(cycleContextPaneTab("latest-command", -1), "companion-group");
   });
 
-  it("available tabs は non-Copilot で Tasks を除外する", () => {
+  it("available tabs は non-Copilot で Tasks を除外し、Reasoning は capability がある時点で表示する", () => {
     assert.deepEqual(resolveAvailableContextPaneTabs({ isCopilotSession: false }), [
       "latest-command",
     ]);
     assert.deepEqual(resolveAvailableContextPaneTabs({ isCopilotSession: true }), [
       "latest-command",
+      "tasks",
+    ]);
+    assert.deepEqual(resolveAvailableContextPaneTabs({ isCopilotSession: false, hasReasoningCapability: true }), [
+      "latest-command",
+      "reasoning",
+    ]);
+    assert.deepEqual(resolveAvailableContextPaneTabs({ isCopilotSession: true, hasReasoningCapability: true }), [
+      "latest-command",
+      "reasoning",
       "tasks",
     ]);
     assert.deepEqual(resolveAvailableContextPaneTabs({ isCopilotSession: true, hasReasoningText: true }), [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1252,13 +1252,16 @@ export default function AgentSessionWindowApp() {
   );
   const liveRunReasoningText = selectedSessionLiveRun?.reasoningText ?? "";
   const hasLiveRunReasoningText = liveRunReasoningText.trim().length > 0;
+  const hasReasoningCapability =
+    availableReasoningEfforts.length > 0 || Boolean(selectedSession?.reasoningEffort);
   const availableContextPaneTabs = useMemo(
     () => resolveAvailableContextPaneTabs({
       isCopilotSession,
       hasCompanionGroupMonitor: selectedCompanionGroupMonitorEntries.length > 0,
+      hasReasoningCapability,
       hasReasoningText: hasLiveRunReasoningText,
     }),
-    [hasLiveRunReasoningText, isCopilotSession, selectedCompanionGroupMonitorEntries.length],
+    [hasLiveRunReasoningText, hasReasoningCapability, isCopilotSession, selectedCompanionGroupMonitorEntries.length],
   );
 
   const hasInProgressLiveRunStep = useMemo(

--- a/src/CompanionReviewApp.tsx
+++ b/src/CompanionReviewApp.tsx
@@ -1090,6 +1090,8 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
   );
   const liveRunReasoningText = selectedSessionLiveRun?.reasoningText ?? "";
   const hasLiveRunReasoningText = liveRunReasoningText.trim().length > 0;
+  const hasReasoningCapability =
+    reasoningEffortOptions.length > 0 || Boolean(snapshot?.session.reasoningEffort);
   const companionGroupMonitorEntries = useMemo(() => {
     if (!snapshot) {
       return [];
@@ -1111,9 +1113,10 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
     () => resolveAvailableContextPaneTabs({
       isCopilotSession,
       hasCompanionGroupMonitor: companionGroupMonitorEntries.length > 0,
+      hasReasoningCapability,
       hasReasoningText: hasLiveRunReasoningText,
     }),
-    [hasLiveRunReasoningText, isCopilotSession, companionGroupMonitorEntries.length],
+    [hasLiveRunReasoningText, hasReasoningCapability, isCopilotSession, companionGroupMonitorEntries.length],
   );
 
   useEffect(() => {

--- a/src/session-ui-projection.ts
+++ b/src/session-ui-projection.ts
@@ -300,15 +300,17 @@ export function contextPaneTabLabel(tab: ContextPaneTabKey): string {
 export function resolveAvailableContextPaneTabs({
   isCopilotSession,
   hasCompanionGroupMonitor = false,
+  hasReasoningCapability = false,
   hasReasoningText = false,
 }: {
   isCopilotSession: boolean;
   hasCompanionGroupMonitor?: boolean;
+  hasReasoningCapability?: boolean;
   hasReasoningText?: boolean;
 }): ContextPaneTabKey[] {
   return CONTEXT_PANE_TAB_ORDER.filter((tab) => {
     if (tab === "reasoning") {
-      return hasReasoningText;
+      return hasReasoningCapability || hasReasoningText;
     }
 
     if (tab === "tasks") {


### PR DESCRIPTION
## 概要
- Reasoning タブの表示条件を reasoning text の有無ではなく provider/model の reasoning capability ベースに変更
- 通常 Session と CompanionReview の両方で同じ判定を適用
- capability がある場合は本文がまだ無くても Reasoning タブを表示する regression test を追加

## 検証
- npx tsx --test scripts/tests/session-ui-projection.test.ts scripts/tests/session-runtime-service.test.ts scripts/tests/session-context-pane-style.test.ts
- npm run typecheck
- git diff --check

## 補足
- 誤って npm test -- ... も実行したため、固定 glob により全体 test が走りました。3 回とも 1273 pass / 0 fail です。