### PR TITLE
fix(markdown): MarkdownリンクをOSのopenPath経路で開く

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/scripts/tests/companion-inline-path.test.ts
+++ b/scripts/tests/companion-inline-path.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { openCompanionInlinePath } from "../../src/chat/companion-inline-path.js";
+import type { WithMateWindowApi } from "../../src/withmate-window-api.js";
+
+test("openCompanionInlinePath は Companion worktree を baseDirectory として渡す", () => {
+  const calls: Array<{ target: string; baseDirectory?: string | null }> = [];
+  const api = {
+    openPath(target, options) {
+      calls.push({ target, baseDirectory: options?.baseDirectory });
+      return Promise.resolve();
+    },
+  } as Pick<WithMateWindowApi, "openPath"> as WithMateWindowApi;
+
+  openCompanionInlinePath(api, "src/App.tsx", "C:/repo/.withmate/companion/session-1");
+
+  assert.deepEqual(calls, [
+    {
+      target: "src/App.tsx",
+      baseDirectory: "C:/repo/.withmate/companion/session-1",
+    },
+  ]);
+});

--- a/scripts/tests/message-rich-text.test.ts
+++ b/scripts/tests/message-rich-text.test.ts
@@ -3,7 +3,28 @@ import test from "node:test";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { MessageRichText } from "../../src/MessageRichText.js";
+import { handleMarkdownLinkClick, MessageRichText } from "../../src/MessageRichText.js";
+
+function clickMarkdownLink(target: string) {
+  const opened: string[] = [];
+  let defaultPrevented = false;
+
+  handleMarkdownLinkClick(
+    {
+      button: 0,
+      defaultPrevented: false,
+      preventDefault: () => {
+        defaultPrevented = true;
+      },
+    },
+    target,
+    (openedTarget) => {
+      opened.push(openedTarget);
+    },
+  );
+
+  return { defaultPrevented, opened };
+}
 
 test("MessageRichText は **bold** を strong として render する", () => {
   const html = renderToStaticMarkup(
@@ -25,6 +46,97 @@ test("MessageRichText は inline code と link を優先しつつ bold を併用
   assert.match(html, /<code class="message-inline-code">\*\*literal\*\*<\/code>/);
   assert.match(html, /<strong class="message-inline-strong">/);
   assert.match(html, /<a href="src\/App\.tsx">file<\/a>/);
+});
+
+test("handleMarkdownLinkClick は Markdown link を既定ナビゲーションではなく openPath 経路へ流す", () => {
+  const { defaultPrevented, opened } = clickMarkdownLink("https://example.test/docs#intro");
+
+  assert.equal(defaultPrevented, true);
+  assert.deepEqual(opened, ["https://example.test/docs#intro"]);
+});
+
+test("handleMarkdownLinkClick は encoded HTTP URL を decode せず openPath 経路へ流す", () => {
+  const { defaultPrevented, opened } = clickMarkdownLink("https://example.test/docs/my%20file.md");
+
+  assert.equal(defaultPrevented, true);
+  assert.deepEqual(opened, ["https://example.test/docs/my%20file.md"]);
+});
+
+test("handleMarkdownLinkClick は encoded local link を decode せず openPath 経路へ流す", () => {
+  const { defaultPrevented, opened } = clickMarkdownLink("docs/my%20file-%E4%BB%95%E6%A7%98.md");
+
+  assert.equal(defaultPrevented, true);
+  assert.deepEqual(opened, ["docs/my%20file-%E4%BB%95%E6%A7%98.md"]);
+});
+
+test("MessageRichText は local/file href の encode を保持して render する", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(MessageRichText, {
+      text: [
+        "[relative](docs/my%20file.md)",
+        "[unicode](docs/%E4%BB%95%E6%A7%98.md)",
+        "[file](file:///C:/tmp/a%20b.txt)",
+        "[windows](C:/tmp/a%20b.txt)",
+      ].join("\n"),
+    }),
+  );
+
+  assert.match(html, /<a href="docs\/my%20file\.md">relative<\/a>/);
+  assert.match(html, /<a href="docs\/%E4%BB%95%E6%A7%98\.md">unicode<\/a>/);
+  assert.match(html, /<a href="file:\/\/\/C:\/tmp\/a%20b\.txt">file<\/a>/);
+  assert.match(html, /<a href="C:\/tmp\/a%20b\.txt">windows<\/a>/);
+});
+
+test("MessageRichText は unsafe href を render しない", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(MessageRichText, {
+      text: "[x](javascript:alert(1))",
+    }),
+  );
+
+  assert.doesNotMatch(html, /href="javascript:/i);
+});
+
+test("handleMarkdownLinkClick は footnote などの同一ページアンカーを既定動作に任せる", () => {
+  const { defaultPrevented, opened } = clickMarkdownLink("#message-footnote-example-fn-1");
+
+  assert.equal(defaultPrevented, false);
+  assert.deepEqual(opened, []);
+});
+
+test("handleMarkdownLinkClick は mailto を openPath 経路へ流す", () => {
+  const { defaultPrevented, opened } = clickMarkdownLink("mailto:alice@example.test");
+
+  assert.equal(defaultPrevented, true);
+  assert.deepEqual(opened, ["mailto:alice@example.test"]);
+});
+
+test("handleMarkdownLinkClick は encoded mailto を decode せず openPath 経路へ流す", () => {
+  const { defaultPrevented, opened } = clickMarkdownLink("mailto:alice@example.test?subject=hello%20world%0D%0A");
+
+  assert.equal(defaultPrevented, true);
+  assert.deepEqual(opened, ["mailto:alice@example.test?subject=hello%20world%0D%0A"]);
+});
+
+test("handleMarkdownLinkClick は protocol-relative URL を openPath 経路へ流す", () => {
+  const { defaultPrevented, opened } = clickMarkdownLink("//example.test/docs");
+
+  assert.equal(defaultPrevented, true);
+  assert.deepEqual(opened, ["//example.test/docs"]);
+});
+
+test("handleMarkdownLinkClick は forward-slash UNC path を local path として openPath 経路へ流す", () => {
+  const { defaultPrevented, opened } = clickMarkdownLink("//server/share/my%20file.txt");
+
+  assert.equal(defaultPrevented, true);
+  assert.deepEqual(opened, ["//server/share/my%20file.txt"]);
+});
+
+test("handleMarkdownLinkClick は Windows absolute path を scheme と誤判定せず openPath 経路へ流す", () => {
+  const { defaultPrevented, opened } = clickMarkdownLink("C:/workspace/project/src/App.tsx");
+
+  assert.equal(defaultPrevented, true);
+  assert.deepEqual(opened, ["C:/workspace/project/src/App.tsx"]);
 });
 
 test("MessageRichText は GFM table を table 要素として render する", () => {

--- a/scripts/tests/open-path.test.ts
+++ b/scripts/tests/open-path.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { buildDirectoryOpenFallbackCommand, resolveOpenPathTarget } from "../../src-electron/open-path.js";
+import {
+  buildDirectoryOpenFallbackCommand,
+  resolveForwardSlashUncPathCandidate,
+  resolveOpenPathTarget,
+  resolveProtocolRelativeExternalFallback,
+} from "../../src-electron/open-path.js";
 
 describe("resolveOpenPathTarget", () => {
   it("http url はそのまま外部 URL として扱う", () => {
@@ -11,10 +16,132 @@ describe("resolveOpenPathTarget", () => {
     });
   });
 
+  it("protocol-relative URL は https の外部 URL として扱う", () => {
+    assert.deepEqual(resolveOpenPathTarget("//example.com/docs"), {
+      type: "external-url",
+      target: "https://example.com/docs",
+    });
+  });
+
+  it("複数階層の protocol-relative URL も query と fragment を保った外部 URL として扱う", () => {
+    assert.deepEqual(resolveOpenPathTarget("//example.com/docs/page?x=a%20b#top"), {
+      type: "external-url",
+      target: "https://example.com/docs/page?x=a%20b#top",
+    });
+  });
+
+  it("拡張子付きの protocol-relative URL も UNC 候補にしない", () => {
+    assert.deepEqual(resolveOpenPathTarget("//example.com/docs/page.html"), {
+      type: "external-url",
+      target: "https://example.com/docs/page.html",
+    });
+    assert.equal(resolveForwardSlashUncPathCandidate("//example.com/docs/page.html"), null);
+  });
+
+  it("先頭空白付きの protocol-relative URL も UNC 候補にしない", () => {
+    assert.deepEqual(resolveOpenPathTarget(" //example.com/docs/page.html"), {
+      type: "external-url",
+      target: "https://example.com/docs/page.html",
+    });
+    assert.equal(resolveForwardSlashUncPathCandidate(" //example.com/docs/page.html"), null);
+  });
+
+  it("複数階層の protocol-relative URL は UNC 候補にしない", () => {
+    assert.equal(resolveForwardSlashUncPathCandidate("//example.com/docs/page?x=a%20b#top"), null);
+  });
+
+  it("ポート付き protocol-relative URL は external URL として扱う", () => {
+    assert.deepEqual(resolveOpenPathTarget("//localhost:5173/docs"), {
+      type: "external-url",
+      target: "https://localhost:5173/docs",
+    });
+    assert.equal(resolveForwardSlashUncPathCandidate("//localhost:5173/docs"), null);
+  });
+
+  it("localhost の protocol-relative URL は port なしでも external URL として扱う", () => {
+    assert.deepEqual(resolveOpenPathTarget("//localhost/docs"), {
+      type: "external-url",
+      target: "https://localhost/docs",
+    });
+    assert.equal(resolveForwardSlashUncPathCandidate("//localhost/docs"), null);
+  });
+
+  it("single-label host の protocol-relative URL は 1 segment path なら external URL として扱う", () => {
+    assert.deepEqual(resolveOpenPathTarget("//intranet/app"), {
+      type: "external-url",
+      target: "https://intranet/app",
+    });
+    assert.equal(resolveForwardSlashUncPathCandidate("//intranet/app"), null);
+  });
+
+  it("forward-slash UNC path は local path として扱う", () => {
+    assert.deepEqual(resolveOpenPathTarget("//server/share/file.txt"), {
+      type: "local-path",
+      targetPath: "//server/share/file.txt",
+    });
+  });
+
+  it("forward-slash UNC path は local open 失敗時の external fallback も持つ", () => {
+    assert.equal(resolveProtocolRelativeExternalFallback("//server/share/file.txt"), "https://server/share/file.txt");
+  });
+
+  it("single-label host の複数 segment protocol-relative URL は local open 失敗時の external fallback を持つ", () => {
+    assert.deepEqual(resolveOpenPathTarget("//intranet/app/page"), {
+      type: "local-path",
+      targetPath: "//intranet/app/page",
+    });
+    assert.equal(resolveForwardSlashUncPathCandidate("//intranet/app/page"), "//intranet/app/page");
+    assert.equal(resolveProtocolRelativeExternalFallback("//intranet/app/page"), "https://intranet/app/page");
+  });
+
+  it("FQDN の protocol-relative URL は UNC 候補にしない", () => {
+    assert.deepEqual(resolveOpenPathTarget("//fileserver.example.com/share/file.txt"), {
+      type: "external-url",
+      target: "https://fileserver.example.com/share/file.txt",
+    });
+    assert.equal(resolveForwardSlashUncPathCandidate("//fileserver.example.com/share/file.txt"), null);
+  });
+
+  it("IP address の protocol-relative URL は UNC 候補にしない", () => {
+    assert.deepEqual(resolveOpenPathTarget("//192.168.1.10/share/file.txt"), {
+      type: "external-url",
+      target: "https://192.168.1.10/share/file.txt",
+    });
+    assert.equal(resolveForwardSlashUncPathCandidate("//192.168.1.10/share/file.txt"), null);
+  });
+
+  it("mailto URL は外部 URL として扱う", () => {
+    assert.deepEqual(resolveOpenPathTarget("mailto:alice@example.test"), {
+      type: "external-url",
+      target: "mailto:alice@example.test",
+    });
+  });
+
+  it("encoded mailto URL は decode せず外部 URL として扱う", () => {
+    assert.deepEqual(resolveOpenPathTarget("mailto:alice@example.test?subject=hello%20world%0D%0A"), {
+      type: "external-url",
+      target: "mailto:alice@example.test?subject=hello%20world%0D%0A",
+    });
+  });
+
   it("workspace 相対 path は baseDirectory 基準で解決する", () => {
     assert.deepEqual(resolveOpenPathTarget("src/App.tsx#L10", { baseDirectory: "C:/workspace/project" }), {
       type: "local-path",
       targetPath: "C:\\workspace\\project\\src\\App.tsx",
+    });
+  });
+
+  it("encoded workspace 相対 path は fragment を外してから decode する", () => {
+    assert.deepEqual(resolveOpenPathTarget("docs/a%23b%3Fv.txt#section", { baseDirectory: "C:/workspace/project" }), {
+      type: "local-path",
+      targetPath: "C:\\workspace\\project\\docs\\a#b?v.txt",
+    });
+  });
+
+  it("encoded workspace 相対 path の空白と非 ASCII を decode する", () => {
+    assert.deepEqual(resolveOpenPathTarget("docs/my%20file-%E4%BB%95%E6%A7%98.md", { baseDirectory: "C:/workspace/project" }), {
+      type: "local-path",
+      targetPath: "C:\\workspace\\project\\docs\\my file-仕様.md",
     });
   });
 
@@ -29,6 +156,20 @@ describe("resolveOpenPathTarget", () => {
     assert.deepEqual(resolveOpenPathTarget("file:///C:/workspace/project/docs/spec.md#intro"), {
       type: "local-path",
       targetPath: "C:\\workspace\\project\\docs\\spec.md",
+    });
+  });
+
+  it("file url の encoded local path は fragment を外してから decode する", () => {
+    assert.deepEqual(resolveOpenPathTarget("file:///C:/workspace/docs/a%23b.txt#intro"), {
+      type: "local-path",
+      targetPath: "C:\\workspace\\docs\\a#b.txt",
+    });
+  });
+
+  it("file UNC url は host を含む local UNC path に変換する", () => {
+    assert.deepEqual(resolveOpenPathTarget("file://server/share/file.txt"), {
+      type: "local-path",
+      targetPath: "\\\\server\\share\\file.txt",
     });
   });
 

--- a/src-electron/main.ts
+++ b/src-electron/main.ts
@@ -56,7 +56,11 @@ import { CopilotAdapter } from "./copilot-adapter.js";
 import { getMateTalkBackgroundStructuredPromptCapability } from "./provider-runtime.js";
 import { resolveComposerPreview } from "./composer-attachments.js";
 import { ModelCatalogStorage } from "./model-catalog-storage.js";
-import { buildDirectoryOpenFallbackCommand, resolveOpenPathTarget } from "./open-path.js";
+import {
+  buildDirectoryOpenFallbackCommand,
+  resolveProtocolRelativeExternalFallback,
+  resolveOpenPathTarget,
+} from "./open-path.js";
 import { launchTerminalAtPath } from "./open-terminal.js";
 import { SessionStorage } from "./session-storage.js";
 import { SessionMemoryStorage } from "./session-memory-storage.js";
@@ -3517,13 +3521,22 @@ async function openLocalPath(targetPath: string): Promise<void> {
 }
 
 async function openPathTarget(target: string, options?: OpenPathOptions): Promise<void> {
+  const protocolRelativeExternalFallback = resolveProtocolRelativeExternalFallback(target);
   const resolved = resolveOpenPathTarget(target, options);
   if (resolved.type === "external-url") {
     await shell.openExternal(resolved.target);
     return;
   }
 
-  await openLocalPath(resolved.targetPath);
+  try {
+    await openLocalPath(resolved.targetPath);
+  } catch (error) {
+    if (protocolRelativeExternalFallback) {
+      await shell.openExternal(protocolRelativeExternalFallback);
+      return;
+    }
+    throw error;
+  }
 }
 
 async function createHomeWindow(): Promise<BrowserWindow> {

--- a/src-electron/open-path.ts
+++ b/src-electron/open-path.ts
@@ -37,13 +37,80 @@ function isWindowsFileUrl(url: URL): boolean {
   return /^\/[a-zA-Z]:\//.test(url.pathname);
 }
 
+function isSupportedExternalUrlScheme(scheme: string): boolean {
+  return scheme === "http" || scheme === "https" || scheme === "mailto" || scheme === "tel";
+}
+
+function isProtocolRelativeExternalUrl(target: string): boolean {
+  const match = /^\/\/([^/?#]+)(\/[^?#]*)?/.exec(target);
+  const authority = match?.[1] ?? "";
+  if (authority.includes(".") || authority.includes(":") || authority.toLowerCase() === "localhost") {
+    return true;
+  }
+
+  const pathSegments = (match?.[2] ?? "").split("/").filter(Boolean);
+  return pathSegments.length === 1;
+}
+
+function decodeLocalPathTarget(target: string): string {
+  try {
+    return decodeURIComponent(target);
+  } catch {
+    return target;
+  }
+}
+
+function isForwardSlashUncPath(target: string): boolean {
+  return /^\/\/[^/?#]+\/[^/?#]+(?:\/|$)/.test(target);
+}
+
+// Inputs that already look like protocol-relative URLs must not trigger UNC network probes.
+export function resolveForwardSlashUncPathCandidate(target: string): string | null {
+  const trimmed = target.trim();
+  if (isProtocolRelativeExternalUrl(trimmed)) {
+    return null;
+  }
+
+  const normalizedTarget = stripLocalPathFragment(trimmed).trim();
+  if (!normalizedTarget) {
+    return null;
+  }
+  const decodedTarget = decodeLocalPathTarget(normalizedTarget);
+  if (!isForwardSlashUncPath(decodedTarget)) {
+    return null;
+  }
+  return decodedTarget;
+}
+
+export function resolveProtocolRelativeExternalFallback(target: string): string | null {
+  const trimmed = target.trim();
+  return /^\/\/[^/?#]+/.test(trimmed) ? `https:${trimmed}` : null;
+}
+
 export function resolveOpenPathTarget(target: string, options: OpenPathOptions = {}): ResolvedOpenPathTarget {
   const trimmed = target.trim();
   if (!trimmed) {
     throw new Error("開く対象が空だよ。");
   }
 
-  if (/^https?:\/\//i.test(trimmed)) {
+  const normalizedTarget = stripLocalPathFragment(trimmed).trim();
+  const decodedTarget = normalizedTarget ? decodeLocalPathTarget(normalizedTarget) : "";
+  if (isForwardSlashUncPath(decodedTarget) && !isProtocolRelativeExternalUrl(trimmed)) {
+    return {
+      type: "local-path",
+      targetPath: decodedTarget,
+    };
+  }
+
+  if (isProtocolRelativeExternalUrl(trimmed)) {
+    return {
+      type: "external-url",
+      target: `https:${trimmed}`,
+    };
+  }
+
+  const externalUrlSchemeMatch = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(trimmed);
+  if (externalUrlSchemeMatch && isSupportedExternalUrlScheme(externalUrlSchemeMatch[1].toLowerCase())) {
     return {
       type: "external-url",
       target: trimmed,
@@ -56,7 +123,13 @@ export function resolveOpenPathTarget(target: string, options: OpenPathOptions =
     fileUrl.search = "";
     if (isWindowsFileUrl(fileUrl)) {
       const pathname = decodeURIComponent(fileUrl.pathname).replace(/\//g, "\\");
-      const targetPath = /^[\\][a-zA-Z]:\\/.test(pathname) ? pathname.slice(1) : pathname;
+      const hostname = fileUrl.hostname;
+      const targetPath =
+        hostname && hostname !== "localhost"
+          ? `\\\\${hostname}${pathname}`
+          : /^[\\][a-zA-Z]:\\/.test(pathname)
+            ? pathname.slice(1)
+            : pathname;
       return {
         type: "local-path",
         targetPath,
@@ -68,15 +141,14 @@ export function resolveOpenPathTarget(target: string, options: OpenPathOptions =
     };
   }
 
-  const normalizedTarget = stripLocalPathFragment(trimmed).trim();
   if (!normalizedTarget) {
     throw new Error("開く対象の path が空だよ。");
   }
 
-  if (path.isAbsolute(normalizedTarget) || isWindowsAbsolutePath(normalizedTarget)) {
+  if (path.isAbsolute(decodedTarget) || isWindowsAbsolutePath(decodedTarget)) {
     return {
       type: "local-path",
-      targetPath: normalizedTarget,
+      targetPath: decodedTarget,
     };
   }
 
@@ -85,18 +157,18 @@ export function resolveOpenPathTarget(target: string, options: OpenPathOptions =
     if (isWindowsAbsolutePath(baseDirectory)) {
       return {
         type: "local-path",
-        targetPath: path.win32.resolve(baseDirectory, normalizedTarget),
+        targetPath: path.win32.resolve(baseDirectory, decodedTarget),
       };
     }
     return {
       type: "local-path",
-      targetPath: path.resolve(baseDirectory, normalizedTarget),
+      targetPath: path.resolve(baseDirectory, decodedTarget),
     };
   }
 
   return {
     type: "local-path",
-    targetPath: normalizedTarget,
+    targetPath: decodedTarget,
   };
 }
 

--- a/src/CompanionReviewApp.tsx
+++ b/src/CompanionReviewApp.tsx
@@ -51,6 +51,7 @@ import { buildCompanionGroupMonitorEntries } from "./home/home-session-projectio
 import { SessionHeader } from "./session-components.js";
 import { ChatHeaderHandle, ChatWindow, ChatWindowStatusScreen } from "./chat/chat-window.js";
 import { buildCompanionChatWindowProps } from "./chat/companion-chat-projection.js";
+import { openCompanionInlinePath } from "./chat/companion-inline-path.js";
 import {
   buildComposerSendabilityState,
   getComposerSendButtonTitle,
@@ -2242,7 +2243,7 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
           }),
         onResolveLiveApproval: (request, decision) => void handleResolveCompanionLiveApproval(request, decision),
         onResolveLiveElicitation: (request, response) => void handleResolveCompanionLiveElicitation(request, response),
-        onOpenInlinePath: (target) => void getWithMateApi()?.openPath(target),
+        onOpenInlinePath: (target) => openCompanionInlinePath(getWithMateApi(), target, snapshot.session.worktreePath),
         onPickFile: () => void pickAndInsertPath("file"),
         onPickFolder: () => void pickAndInsertPath("folder"),
         onPickImage: () => void pickAndInsertPath("image"),

--- a/src/MessageRichText.tsx
+++ b/src/MessageRichText.tsx
@@ -1,12 +1,15 @@
-import { Children, isValidElement, useEffect, useId, useMemo, useState, type ReactNode } from "react";
-import ReactMarkdown, { type Components } from "react-markdown";
+import { Children, isValidElement, useEffect, useId, useMemo, useState, type MouseEvent, type ReactNode } from "react";
+import ReactMarkdown, { defaultUrlTransform, type Components, type UrlTransform } from "react-markdown";
 import rehypeKatex from "rehype-katex";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 
+import { getWithMateApi } from "./renderer-withmate-api.js";
+
 type MessageRichTextProps = {
   text: string;
   className?: string;
+  onOpenPath?: (target: string) => void;
 };
 
 type MermaidRenderState =
@@ -57,6 +60,66 @@ function resolveCodeLanguage(className?: string) {
 
 function mergeClassName(baseClassName: string, className?: string) {
   return className ? `${baseClassName} ${className}` : baseClassName;
+}
+
+function hasUnsupportedUrlScheme(target: string): boolean {
+  if (/^[a-zA-Z]:[\\/]/.test(target)) {
+    return false;
+  }
+
+  const schemeMatch = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(target);
+  if (!schemeMatch) {
+    return false;
+  }
+
+  const scheme = schemeMatch[1].toLowerCase();
+  return scheme !== "http" && scheme !== "https" && scheme !== "file" && scheme !== "mailto" && scheme !== "tel";
+}
+
+function isWindowsAbsolutePathTarget(target: string): boolean {
+  return /^[a-zA-Z]:[\\/]/.test(target) || /^\\\\[^\\]+\\[^\\]+/.test(target);
+}
+
+function isAllowedMarkdownHref(target: string): boolean {
+  if (!target || target.startsWith("#") || target.startsWith("//") || isWindowsAbsolutePathTarget(target)) {
+    return true;
+  }
+  return !hasUnsupportedUrlScheme(target);
+}
+
+const markdownUrlTransform: UrlTransform = (url, key) => {
+  if (key !== "href") {
+    return defaultUrlTransform(url);
+  }
+  return isAllowedMarkdownHref(url) ? url : "";
+};
+
+export function openMarkdownLink(target: string, onOpenPath?: (target: string) => void): void {
+  if (onOpenPath) {
+    onOpenPath(target);
+    return;
+  }
+
+  void getWithMateApi()?.openPath(target);
+}
+
+export function handleMarkdownLinkClick(
+  event: Pick<MouseEvent<HTMLAnchorElement>, "button" | "defaultPrevented" | "preventDefault">,
+  target: string,
+  onOpenPath?: (target: string) => void,
+): void {
+  if (
+    !target ||
+    target.startsWith("#") ||
+    hasUnsupportedUrlScheme(target) ||
+    event.defaultPrevented ||
+    event.button !== 0
+  ) {
+    return;
+  }
+
+  event.preventDefault();
+  openMarkdownLink(target, onOpenPath);
 }
 
 function replaceFootnoteLabelReference(value: unknown, footnoteLabelId: string) {
@@ -232,17 +295,37 @@ const markdownComponents: Components = {
   img: () => null,
 };
 
-export function MessageRichText({ text, className = "message-body" }: MessageRichTextProps) {
+function createMarkdownComponents(onOpenPath?: (target: string) => void): Components {
+  return {
+    ...markdownComponents,
+    a: ({ children, href, node, ...props }) => {
+      const target = href?.trim() ?? "";
+      const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+        handleMarkdownLinkClick(event, target, onOpenPath);
+      };
+
+      return (
+        <a {...props} href={href} onClick={handleClick}>
+          {children}
+        </a>
+      );
+    },
+  };
+}
+
+export function MessageRichText({ text, className = "message-body", onOpenPath }: MessageRichTextProps) {
   const reactId = useId();
   const footnotePrefix = useMemo(() => `message-footnote-${reactId.replace(/[^a-zA-Z0-9_-]/g, "")}-`, [reactId]);
   const footnoteLabelId = `${footnotePrefix}footnote-label`;
+  const components = useMemo(() => createMarkdownComponents(onOpenPath), [onOpenPath]);
   const rehypePlugins = useMemo(() => [rehypeKatex, createFootnoteLabelIdPlugin(footnoteLabelId)], [footnoteLabelId]);
 
   return (
     <div className={`${className} rich-text`.trim()}>
       <ReactMarkdown
-        components={markdownComponents}
+        components={components}
         rehypePlugins={rehypePlugins}
+        urlTransform={markdownUrlTransform}
         remarkPlugins={[remarkGfm, [remarkMath, { singleDollarTextMath: false }]]}
         remarkRehypeOptions={{ clobberPrefix: footnotePrefix }}
       >

--- a/src/chat/companion-inline-path.ts
+++ b/src/chat/companion-inline-path.ts
@@ -1,0 +1,9 @@
+import type { WithMateWindowApi } from "../withmate-window-api.js";
+
+export function openCompanionInlinePath(
+  api: WithMateWindowApi | null | undefined,
+  target: string,
+  worktreePath: string,
+): void {
+  void api?.openPath(target, { baseDirectory: worktreePath });
+}

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -1896,7 +1896,7 @@ export function SessionRetryBanner({
           </p>
           <div className="resume-banner-request">
             <span>前回の依頼</span>
-            <MessageRichText text={retryBanner.lastRequestText} />
+            <MessageRichText text={retryBanner.lastRequestText} onOpenPath={onOpenPath} />
           </div>
         </div>
       ) : null}
@@ -2146,7 +2146,7 @@ export function SessionMessageColumn({
                       {artifactExpanded ? "−" : "i"}
                     </button>
                   ) : null}
-                  <MessageRichText text={message.text} />
+                  <MessageRichText text={message.text} onOpenPath={onOpenPath} />
 
                   {artifact ? (
                     <section className="artifact-shell">
@@ -2257,7 +2257,7 @@ export function SessionMessageColumn({
                                         <div className="artifact-operation-body">
                                           {operation.type === "agent_message" ? (
                                             <div className="artifact-operation-message">
-                                              <MessageRichText text={operation.summary} />
+                                              <MessageRichText text={operation.summary} onOpenPath={onOpenPath} />
                                             </div>
                                           ) : (
                                             <p>{operation.summary}</p>
@@ -2330,7 +2330,7 @@ export function SessionMessageColumn({
                         onOpenPath={onOpenPath}
                       />
                     ) : null}
-                    {hasLiveRunAssistantText ? <MessageRichText text={liveRunAssistantText} /> : null}
+                    {hasLiveRunAssistantText ? <MessageRichText text={liveRunAssistantText} onOpenPath={onOpenPath} /> : null}
                     {liveRunErrorMessage ? (
                       <p className="pending-run-error-note" role="alert">{liveRunErrorMessage}</p>
                     ) : null}


### PR DESCRIPTION
## 概要
- Markdown リンクの通常クリックを Electron 内ナビゲーションではなく openPath 経路へ流す
- footnote / 同一ページ anchor は既定動作を維持する
- protocol-relative URL、mailto/tel、file URL、encoded local path、forward-slash UNC の扱いを整理する
- Companion Review の Markdown 相対リンクを worktree 基準で開く
- アプリバージョンを 4.2.2 に更新する

## 検証
- npx tsx --test scripts/tests/message-rich-text.test.ts scripts/tests/companion-inline-path.test.ts scripts/tests/open-path.test.ts
- npm run typecheck
- git diff --check