### PR TITLE
feat(ui): microcopy default editing and runtime resolver

### DIFF
--- a/docs/design/session-character-copy.md
+++ b/docs/design/session-character-copy.md
@@ -1,61 +1,94 @@
-# Session Character Copy
+# Session Microcopy
 
 - 作成日: 2026-03-25
-- 対象: SessionWindow の固定文言を character ごとに差し替える仕組み
+- 更新日: 2026-05-24
+- 対象: SessionWindow の microcopy を system default / user default / character override で解決する仕組み
 
 ## Goal
 
-SessionWindow の固定文言を character 体験へ寄せつつ、character 未設定時は bland な default copy で運用できるようにする。
+SessionWindow の固定文言を system default で安定運用しつつ、ユーザーが default copy を編集できるようにする。複数 character 復帰後は character ごとの override を差分として重ね、character 未設定時や壊れた設定では system default へ fallback する。
 
 ## Position
 
 - 状態: supporting doc
 - current UI 全体の正本は `docs/design/desktop-ui.md`
-- この文書は Session copy slot の詳細仕様だけを扱う
+- この文書は Session microcopy slot の詳細仕様だけを扱う
+- character override の DB / UI 実装は複数 character 復帰時に扱う
 
 ## State Model
 
-`CharacterProfile` に session copy 設定を持たせる。
+microcopy は stable slot ID ごとの複数候補として持つ。1 slot 1 string にはしない。
 
 ```ts
-type CharacterSessionCopy = {
-  pendingApproval?: string[];
-  pendingWorking?: string[];
-  pendingResponding?: string[];
-  pendingPreparing?: string[];
-  retryInterruptedTitle?: string[];
-  retryFailedTitle?: string[];
-  retryCanceledTitle?: string[];
-  latestCommandWaiting?: string[];
-  latestCommandEmpty?: string[];
-  changedFilesEmpty?: string[];
-  contextEmpty?: string[];
-};
+type MicrocopySlot =
+  | "chat.pending.response_waiting"
+  | "dock.status.approval"
+  | "dock.status.working"
+  | "dock.status.responding"
+  | "dock.status.preparing"
+  | "retry.interrupted.title"
+  | "retry.failed.title"
+  | "retry.canceled.title"
+  | "empty.latest_command.waiting"
+  | "empty.latest_command"
+  | "empty.changed_files"
+  | "empty.context";
+
+type MicrocopyCatalog = Partial<Record<MicrocopySlot, string[]>>;
 ```
 
 - 値はすべて複数候補の配列
-- 未設定時は bland default copy を使う
+- 未設定時は system default copy を使う
+- 空文字、空配列、未知 slot は normalize 時に破棄または fallback する
 - `{name}` placeholder を許可し、描画時に character 名へ置換する
+
+## Storage Policy
+
+- built-in system default はコード同梱の復旧用正本として保持する
+- user default は `app_settings` の `user_microcopy_catalog_json` に JSON として保存する
+- この追加は既存 `app_settings` key/value の範囲なので V5 schema migration を要求しない
+- character override は将来 `CharacterProfile` 側に差分として持たせる
+- character override は user default 全体を複製せず、変更した slot だけを保存する
+
+将来の character 側 shape:
+
+```ts
+type CharacterMicrocopyOverrides = Partial<Record<MicrocopySlot, string[]>>;
+
+type CharacterProfile = {
+  id: string;
+  name: string;
+  microcopyOverrides?: CharacterMicrocopyOverrides;
+};
+```
+
+解決順:
+
+1. character override
+2. user default
+3. built-in system default
 
 ## Rendering Policy
 
-- session copy の lookup は Renderer 側で行う
-- truth source は `resolvedCharacter`
-- Session へ copy を複製しない
-- character 更新後は既存 session でも reopen なしで反映できる構成を維持する
+- microcopy の lookup は Renderer 側で `resolveMicrocopy()` を通す
+- Session へ microcopy を複製しない
+- user default 更新後は既存 session でも reopen なしで反映できる構成を維持する
 - 候補選択は slot ごとの stable seed から決め、同じ表示中に文言が揺れないようにする
+- chat message column と ActionDock は別 slot にする
+- message column は会話時系列の placeholder、ActionDock は状態表示と操作を担当する
 
 ## Default Copy Policy
 
 - default は短く、無味で、provider 非依存の wording を使う
-- character copy がある時だけ語尾や温度感を変える
+- character override がある時だけ語尾や温度感を変える
 
 初期 default の例:
 
-- pending approval: `承認を待機中`
-- pending working: `処理を実行中`
-- pending responding: `応答を生成中`
-- pending preparing: `応答を準備中`
+- chat pending response waiting: `応答を準備しています`, `出力を待機しています`
+- dock approval: `承認を待機中`
+- dock working: `処理を実行中`
+- dock responding: `応答を生成中`
+- dock preparing: `応答を準備中`
 - retry interrupted title: `前回の依頼は中断されたままです`
 - retry failed title: `前回の依頼は完了できませんでした`
 - retry canceled title: `この依頼は途中で停止しました`
@@ -66,14 +99,18 @@ type CharacterSessionCopy = {
 
 ## Editor
 
-- Character Editor に `Session Copy` 編集面を追加する
+- Settings に `Default Microcopy` 編集面を追加する
+- Character Editor には将来 `Character Microcopy Override` 編集面を追加する
 - 各 slot は 1 行 input の候補リストで編集する
 - `+` で候補行を追加し、`×` で候補行を削除する
+- slot ごとに `system default に戻す` / `user default を使う` を提供する
 - 候補リスト部分だけを card 内でスクロールさせ、footer や card 外へはみ出させない
 - helper text で `{name}` placeholder と複数候補運用を案内する
 
 ## Out Of Scope
 
+- character override の永続化 table 設計
+- character override 編集 UI
 - main process dialog
 - Home / monitor / settings copy
 - provider prompt / memory 連携

--- a/scripts/tests/app-settings-storage.test.ts
+++ b/scripts/tests/app-settings-storage.test.ts
@@ -18,6 +18,10 @@ describe("AppSettingsStorage", () => {
         ...createDefaultAppSettings(),
         memoryGenerationEnabled: false,
         autoCollapseActionDockOnSend: false,
+        userMicrocopyCatalog: {
+          ...createDefaultAppSettings().userMicrocopyCatalog,
+          "chat.pending.response_waiting": ["応答待機中", "出力待機中"],
+        },
         codingProviderSettings: {
           codex: {
             enabled: false,
@@ -96,6 +100,10 @@ describe("AppSettingsStorage", () => {
         ...createDefaultAppSettings(),
         memoryGenerationEnabled: false,
         autoCollapseActionDockOnSend: false,
+        userMicrocopyCatalog: {
+          ...createDefaultAppSettings().userMicrocopyCatalog,
+          "dock.status.preparing": ["準備中"],
+        },
         codingProviderSettings: {
           codex: {
             enabled: false,

--- a/scripts/tests/home-components.test.tsx
+++ b/scripts/tests/home-components.test.tsx
@@ -193,6 +193,7 @@ describe("HomeSettingsContent", () => {
     onRemoveMateMemoryGenerationPriority: noOp,
     onChangeMateMemoryGenerationTriggerIntervalMinutes: noOp,
     onChangeAutoCollapseActionDockOnSend: noOp,
+    onChangeUserMicrocopySlot: noOp,
     onChangeProviderEnabled: noOp,
     onChangeProviderInstructionEnabled: noOp,
     onChangeProviderInstructionWriteMode: noOp,
@@ -860,6 +861,7 @@ describe("HomeSettingsContent", () => {
         onRemoveMateMemoryGenerationPriority={noOp}
         onChangeMateMemoryGenerationTriggerIntervalMinutes={noOp}
         onChangeAutoCollapseActionDockOnSend={noOp}
+        onChangeUserMicrocopySlot={noOp}
         onChangeProviderEnabled={noOp}
         onChangeProviderInstructionEnabled={noOp}
         onChangeProviderInstructionWriteMode={noOp}
@@ -973,6 +975,7 @@ describe("HomeSettingsContent", () => {
         onRemoveMateMemoryGenerationPriority={noOp}
         onChangeMateMemoryGenerationTriggerIntervalMinutes={noOp}
         onChangeAutoCollapseActionDockOnSend={noOp}
+        onChangeUserMicrocopySlot={noOp}
         onChangeProviderEnabled={noOp}
         onChangeProviderInstructionEnabled={noOp}
         onChangeProviderInstructionWriteMode={noOp}
@@ -1085,6 +1088,7 @@ describe("HomeSettingsContent", () => {
         onRemoveMateMemoryGenerationPriority={noOp}
         onChangeMateMemoryGenerationTriggerIntervalMinutes={noOp}
         onChangeAutoCollapseActionDockOnSend={noOp}
+        onChangeUserMicrocopySlot={noOp}
         onChangeProviderEnabled={noOp}
         onChangeProviderInstructionEnabled={noOp}
         onChangeProviderInstructionWriteMode={noOp}

--- a/scripts/tests/home-settings-draft.test.ts
+++ b/scripts/tests/home-settings-draft.test.ts
@@ -31,6 +31,7 @@ import {
   updateMateMemoryGenerationPriorityModelDraft,
   updateMateMemoryGenerationPriorityReasoningEffortDraft,
   updateMateMemoryGenerationPriorityTimeoutSecondsDraft,
+  updateUserMicrocopySlotDraft,
   addMateMemoryGenerationPriorityDraft,
   removeMateMemoryGenerationPriorityDraft,
 } from "../../src/settings/settings-draft.js";
@@ -49,6 +50,7 @@ import {
   handleChangeProviderEnabled as handleChangeProviderEnabledAction,
   handleChangeProviderSkillRelativePath as handleChangeProviderSkillRelativePathAction,
   handleChangeProviderSkillRootPath as handleChangeProviderSkillRootPathAction,
+  handleChangeUserMicrocopySlot as handleChangeUserMicrocopySlotAction,
   handleAddMateMemoryGenerationPriority as handleAddMateMemoryGenerationPriorityAction,
   handleRemoveMateMemoryGenerationPriority as handleRemoveMateMemoryGenerationPriorityAction,
 } from "../../src/settings/settings-draft-actions.js";
@@ -254,6 +256,14 @@ describe("home-settings-draft", () => {
     assert.equal(next.autoCollapseActionDockOnSend, false);
   });
 
+  it("microcopy slot draft は編集中の末尾改行を保持する", () => {
+    const draft = createDefaultAppSettings();
+
+    const next = updateUserMicrocopySlotDraft(draft, "chat.pending.response_waiting", "応答待機中\n");
+
+    assert.equal(next.userMicrocopyCatalog["chat.pending.response_waiting"], "応答待機中\n");
+  });
+
   it("mate memory generation の priority 1 を provider / model / reasoning / timeout / interval で更新できる", () => {
     const draft = createDefaultAppSettings();
 
@@ -335,9 +345,15 @@ describe("home-settings-draft", () => {
       enabled: false,
       setSettingsDraft: state.setSettingsDraft,
     });
+    handleChangeUserMicrocopySlotAction({
+      slot: "dock.status.responding",
+      value: "応答生成中\n",
+      setSettingsDraft: state.setSettingsDraft,
+    });
 
     assert.equal(state.draft.memoryGenerationEnabled, false);
     assert.equal(state.draft.autoCollapseActionDockOnSend, false);
+    assert.equal(state.draft.userMicrocopyCatalog["dock.status.responding"], "応答生成中\n");
   });
 
   it("action: catalog 不在時は memory extraction model 更新を反映しない", () => {

--- a/scripts/tests/microcopy-state.test.ts
+++ b/scripts/tests/microcopy-state.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  BUILT_IN_MICROCOPY_CATALOG,
+  createDefaultUserMicrocopyCatalog,
+  normalizeUserMicrocopyCatalog,
+  resolveMicrocopy,
+} from "../../src/microcopy-state.js";
+
+describe("microcopy-state", () => {
+  it("user default catalog は built-in default を clone する", () => {
+    const catalog = createDefaultUserMicrocopyCatalog();
+
+    assert.deepEqual(catalog, BUILT_IN_MICROCOPY_CATALOG);
+    assert.notEqual(catalog["dock.status.preparing"], BUILT_IN_MICROCOPY_CATALOG["dock.status.preparing"]);
+  });
+
+  it("normalizeUserMicrocopyCatalog は slot ごとの複数 copy と fallback を扱う", () => {
+    const catalog = normalizeUserMicrocopyCatalog({
+      "chat.pending.response_waiting": ["  応答待機中  ", "", "出力待機中"],
+      "dock.status.working": [],
+      unknown: ["ignored"],
+    });
+
+    assert.deepEqual(catalog["chat.pending.response_waiting"], ["応答待機中", "出力待機中"]);
+    assert.deepEqual(catalog["dock.status.working"], BUILT_IN_MICROCOPY_CATALOG["dock.status.working"]);
+    assert.equal("unknown" in catalog, false);
+  });
+
+  it("resolveMicrocopy は同じ seed で安定して variant を選ぶ", () => {
+    const userCatalog = normalizeUserMicrocopyCatalog({
+      "chat.pending.response_waiting": ["A", "B", "C"],
+    });
+
+    const first = resolveMicrocopy({
+      slot: "chat.pending.response_waiting",
+      userCatalog,
+      seedParts: ["session-1", "run-1"],
+    });
+    const second = resolveMicrocopy({
+      slot: "chat.pending.response_waiting",
+      userCatalog,
+      seedParts: ["session-1", "run-1"],
+    });
+
+    assert.equal(first, second);
+    assert.ok(["A", "B", "C"].includes(first));
+  });
+});

--- a/scripts/tests/provider-settings-state.test.ts
+++ b/scripts/tests/provider-settings-state.test.ts
@@ -92,4 +92,16 @@ describe("provider-settings-state", () => {
     assert.equal(normalizeAppSettings({ autoCollapseActionDockOnSend: false }).autoCollapseActionDockOnSend, false);
     assert.equal(normalizeAppSettings({}).autoCollapseActionDockOnSend, true);
   });
+
+  it("user microcopy catalog は複数 copy を保持し、空 slot は default に戻す", () => {
+    const settings = normalizeAppSettings({
+      userMicrocopyCatalog: {
+        "chat.pending.response_waiting": ["応答待機中", "出力待機中"],
+        "dock.status.preparing": [],
+      },
+    });
+
+    assert.deepEqual(settings.userMicrocopyCatalog["chat.pending.response_waiting"], ["応答待機中", "出力待機中"]);
+    assert.deepEqual(settings.userMicrocopyCatalog["dock.status.preparing"], ["応答を準備中"]);
+  });
 });

--- a/scripts/tests/session-message-column.test.ts
+++ b/scripts/tests/session-message-column.test.ts
@@ -5,9 +5,11 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import {
   SessionActionDockCompactRow,
+  SessionContextPane,
   SessionComposerExpanded,
   SessionMessageColumn,
 } from "../../src/session-components.js";
+import { buildContextPaneProjection } from "../../src/session-ui-projection.js";
 import type { CharacterProfile, LiveApprovalRequest, LiveElicitationRequest, Message } from "../../src/app-state.js";
 
 function createCharacterProfile(): CharacterProfile {
@@ -112,6 +114,7 @@ function renderSessionMessageColumn(options: {
   liveApprovalRequest?: LiveApprovalRequest | null;
   liveElicitationRequest?: LiveElicitationRequest | null;
   liveRunAssistantText?: string;
+  pendingMessageText?: string;
 }): string {
   return renderToStaticMarkup(
     React.createElement(SessionMessageColumn, {
@@ -128,6 +131,7 @@ function renderSessionMessageColumn(options: {
       liveRunAssistantText: options.liveRunAssistantText ?? "",
       hasLiveRunAssistantText: !!options.liveRunAssistantText,
       liveRunErrorMessage: "",
+      pendingMessageText: options.pendingMessageText,
       isMessageListFollowing: options.isMessageListFollowing ?? false,
       onMessageListScroll() {},
       onToggleArtifact() {},
@@ -229,6 +233,21 @@ test("SessionMessageColumn は inline content のない pending bubble を描画
 
   assert.doesNotMatch(html, /pending-row/);
   assert.match(html, /message-list-bottom-anchor/);
+});
+
+test("SessionMessageColumn は pending message text があれば実行開始直後の assistant row を描画する", () => {
+  const html = renderSessionMessageColumn({
+    messages: createMessages(1),
+    isRunning: true,
+    pendingMessageText: "応答を準備しています",
+  });
+
+  assert.match(html, /pending-row/);
+  assert.match(html, /応答を準備しています/);
+  assert.ok(
+    html.indexOf("message 1") < html.indexOf("pending-row"),
+    "pending row は既存メッセージの後に描画する",
+  );
 });
 
 test("SessionComposerExpanded は jump button を Hide の左に描画する", () => {
@@ -431,6 +450,8 @@ test("SessionActionDockCompactRow は実行中の compact 表示を progress と
     }),
   );
 
+  assert.match(html, /aria-label="ActionDock を展開"/);
+  assert.match(html, /session-action-dock-compact-progress-button/);
   assert.match(html, /session-action-dock-compact-progress/);
   assert.match(html, /処理を実行中/);
   assert.match(html, /session-action-dock-compact-actions/);
@@ -438,4 +459,48 @@ test("SessionActionDockCompactRow は実行中の compact 表示を progress と
   assert.doesNotMatch(html, /Draft/);
   assert.doesNotMatch(html, /添付 2/);
   assert.doesNotMatch(html, /末尾へ移動/);
+});
+
+test("SessionContextPane は latest command がないとき empty text を表示する", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(SessionContextPane, {
+      taskTitle: "task",
+      isHeaderExpanded: false,
+      activeContextPaneTab: "latest-command",
+      availableContextPaneTabs: ["latest-command"],
+      contextPaneProjection: buildContextPaneProjection({
+        activeContextPaneTab: "latest-command",
+        latestCommandView: null,
+        backgroundTasks: [],
+      }),
+      latestCommandView: null,
+      latestCommandEmptyText: "直近 run の command 記録はありません",
+      runningDetailsEntries: [],
+      liveRunReasoningText: "",
+      backgroundTasks: [],
+      companionGroupMonitorEntries: [],
+      selectedSessionLiveRunErrorMessage: "",
+      isSelectedSessionRunning: false,
+      isCopilotSession: false,
+      selectedCopilotRemainingPercentLabel: "",
+      selectedCopilotRemainingRequestsLabel: "",
+      selectedCopilotQuotaResetLabel: "",
+      selectedSessionContextTelemetry: null,
+      selectedSessionContextTelemetryProjection: {
+        summaryLabel: "",
+        currentTokensLabel: "",
+        tokenLimitLabel: "",
+        messagesLengthLabel: "",
+        systemTokensLabel: "",
+        conversationTokensLabel: "",
+      },
+      contextEmptyText: "context usage はまだありません",
+      onToggleHeaderExpanded() {},
+      onCycleContextPaneTab() {},
+      onOpenCompanionReview() {},
+    }),
+  );
+
+  assert.match(html, /直近 run の command 記録はありません/);
+  assert.match(html, /command-monitor-empty-shell/);
 });

--- a/src-electron/app-settings-storage.ts
+++ b/src-electron/app-settings-storage.ts
@@ -10,6 +10,7 @@ const AUTO_COLLAPSE_ACTION_DOCK_ON_SEND_KEY = "auto_collapse_action_dock_on_send
 const CODING_PROVIDER_SETTINGS_KEY = "coding_provider_settings_json";
 const MEMORY_EXTRACTION_PROVIDER_SETTINGS_KEY = "memory_extraction_provider_settings_json";
 const MATE_MEMORY_GENERATION_SETTINGS_KEY = "mate_memory_generation_settings_json";
+const USER_MICROCOPY_CATALOG_KEY = "user_microcopy_catalog_json";
 
 type AppSettingRow = {
   setting_key: string;
@@ -74,6 +75,17 @@ export class AppSettingsStorage {
         JSON.stringify(DEFAULT_APP_SETTINGS.mateMemoryGenerationSettings),
         updatedAt,
       );
+    this.db
+      .prepare(`
+        INSERT INTO app_settings (setting_key, setting_value, updated_at)
+        VALUES (?, ?, ?)
+        ON CONFLICT(setting_key) DO NOTHING
+      `)
+      .run(
+        USER_MICROCOPY_CATALOG_KEY,
+        JSON.stringify(DEFAULT_APP_SETTINGS.userMicrocopyCatalog),
+        updatedAt,
+      );
   }
 
   getSettings(): AppSettings {
@@ -133,6 +145,18 @@ export class AppSettingsStorage {
         }).mateMemoryGenerationSettings;
       } catch {
         settings.mateMemoryGenerationSettings = createDefaultAppSettings().mateMemoryGenerationSettings;
+      }
+    }
+
+    const userMicrocopyCatalogJson = rows.find((row) => row.setting_key === USER_MICROCOPY_CATALOG_KEY)?.setting_value;
+    if (userMicrocopyCatalogJson) {
+      try {
+        settings.userMicrocopyCatalog = normalizeAppSettings({
+          ...settings,
+          userMicrocopyCatalog: JSON.parse(userMicrocopyCatalogJson),
+        }).userMicrocopyCatalog;
+      } catch {
+        settings.userMicrocopyCatalog = createDefaultAppSettings().userMicrocopyCatalog;
       }
     }
 
@@ -200,6 +224,19 @@ export class AppSettingsStorage {
         .run(
           MATE_MEMORY_GENERATION_SETTINGS_KEY,
           JSON.stringify(normalized.mateMemoryGenerationSettings),
+          updatedAt,
+        );
+      this.db
+        .prepare(`
+          INSERT INTO app_settings (setting_key, setting_value, updated_at)
+          VALUES (?, ?, ?)
+          ON CONFLICT(setting_key) DO UPDATE SET
+            setting_value = excluded.setting_value,
+            updated_at = excluded.updated_at
+        `)
+        .run(
+          USER_MICROCOPY_CATALOG_KEY,
+          JSON.stringify(normalized.userMicrocopyCatalog),
           updatedAt,
         );
       this.db.exec("COMMIT");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import {
   getProviderAppSettings,
   type AppSettings,
 } from "./provider-settings-state.js";
+import { resolveMicrocopy, type MicrocopySlot } from "./microcopy-state.js";
 import {
   type DiffPreviewPayload,
   type Message,
@@ -362,31 +363,6 @@ function createPendingLiveSessionRunState(
   };
 }
 
-function hashStringToPositiveInt(value: string): number {
-  let hash = 0;
-  for (let index = 0; index < value.length; index += 1) {
-    hash = ((hash << 5) - hash + value.charCodeAt(index)) | 0;
-  }
-
-  return Math.abs(hash);
-}
-
-function renderCharacterSessionCopy(
-  templates: string[],
-  characterName?: string | null,
-  seed = "",
-): string {
-  const normalizedTemplates = templates
-    .map((template) => template.trim())
-    .filter((template) => template.length > 0);
-  if (normalizedTemplates.length === 0) {
-    return "";
-  }
-
-  const selectedTemplate = normalizedTemplates[hashStringToPositiveInt(seed || normalizedTemplates.join("\u001f")) % normalizedTemplates.length];
-  return selectedTemplate.replaceAll("{name}", characterName?.trim() || DEFAULT_SESSION_RUNTIME_NAME);
-}
-
 export default function AgentSessionWindowApp() {
   const desktopRuntime = isDesktopRuntime();
   const withmateApi = getWithMateApi();
@@ -641,7 +617,15 @@ export default function AgentSessionWindowApp() {
     () => (selectedDiff ? buildCharacterThemeStyle(selectedDiff.themeColors) : {}),
     [selectedDiff],
   );
-  const selectedSessionCopy = DEFAULT_CHARACTER_SESSION_COPY;
+  const resolveSessionMicrocopy = (
+    slot: MicrocopySlot,
+    seedParts: Array<string | number | null | undefined>,
+  ) => resolveMicrocopy({
+    slot,
+    userCatalog: appSettings.userMicrocopyCatalog,
+    seedParts,
+    replacements: { name: selectedSessionCharacter?.name || DEFAULT_SESSION_RUNTIME_NAME },
+  });
   const isSelectedProviderEnabled = useMemo(
     () => !!selectedSession && getProviderAppSettings(appSettings, selectedSession.provider).enabled,
     [appSettings, selectedSession],
@@ -1275,25 +1259,36 @@ export default function AgentSessionWindowApp() {
   const isApprovalRequestPending = !!liveApprovalRequest;
   const isElicitationRequestPending = !!liveElicitationRequest;
   const hasLiveRunAssistantText = liveRunAssistantText.length > 0;
-  const pendingIndicatorCharacterName = useMemo(() => {
-    const candidateNames = [selectedSessionCharacter?.name]
-      .map((name) => name?.trim() ?? "")
-      .filter(Boolean);
-
-    return candidateNames[0] ?? "";
-  }, [selectedSessionCharacter?.name]);
   const selectedContextEmptyText = useMemo(
     () =>
-      renderCharacterSessionCopy(
-        selectedSessionCopy.contextEmpty,
-        pendingIndicatorCharacterName,
-        `context-empty:${selectedSession?.id ?? ""}:${selectedSession?.updatedAt ?? ""}`,
-      ),
+      resolveSessionMicrocopy("empty.context", [
+        "context-empty",
+        selectedSession?.id,
+        selectedSession?.updatedAt,
+      ]),
     [
-      pendingIndicatorCharacterName,
+      appSettings.userMicrocopyCatalog,
       selectedSession?.id,
       selectedSession?.updatedAt,
-      selectedSessionCopy.contextEmpty,
+      selectedSessionCharacter?.name,
+    ],
+  );
+  const latestCommandEmptyText = useMemo(
+    () => resolveSessionMicrocopy(
+      selectedSessionRunState === "running" ? "empty.latest_command.waiting" : "empty.latest_command",
+      [
+        "latest-command-empty",
+        selectedSession?.id,
+        selectedSessionRunState,
+        latestTerminalAuditLog?.id,
+      ],
+    ),
+    [
+      appSettings.userMicrocopyCatalog,
+      latestTerminalAuditLog?.id,
+      selectedSession?.id,
+      selectedSessionCharacter?.name,
+      selectedSessionRunState,
     ],
   );
   const retryBanner = useMemo<RetryBannerState | null>(() => {
@@ -1320,11 +1315,12 @@ export default function AgentSessionWindowApp() {
         return {
           kind,
           badge: "中断",
-          title: renderCharacterSessionCopy(
-            selectedSessionCopy.retryInterruptedTitle,
-            pendingIndicatorCharacterName,
-            `retry:interrupted:${selectedSession.id}:${lastUserMessage.text}`,
-          ),
+          title: resolveSessionMicrocopy("retry.interrupted.title", [
+            "retry",
+            "interrupted",
+            selectedSession.id,
+            lastUserMessage.text,
+          ]),
           stopSummary,
           lastRequestText: lastUserMessage.text,
         };
@@ -1332,11 +1328,12 @@ export default function AgentSessionWindowApp() {
         return {
           kind,
           badge: "失敗",
-          title: renderCharacterSessionCopy(
-            selectedSessionCopy.retryFailedTitle,
-            pendingIndicatorCharacterName,
-            `retry:failed:${selectedSession.id}:${lastUserMessage.text}`,
-          ),
+          title: resolveSessionMicrocopy("retry.failed.title", [
+            "retry",
+            "failed",
+            selectedSession.id,
+            lastUserMessage.text,
+          ]),
           stopSummary,
           lastRequestText: lastUserMessage.text,
         };
@@ -1344,11 +1341,13 @@ export default function AgentSessionWindowApp() {
         return {
           kind,
           badge: "キャンセル",
-          title: renderCharacterSessionCopy(
-            selectedSessionCopy.retryCanceledTitle,
-            pendingIndicatorCharacterName,
-            `retry:canceled:${selectedSession.id}:${lastUserMessage.text}:${latestTerminalAuditLog?.id ?? ""}`,
-          ),
+          title: resolveSessionMicrocopy("retry.canceled.title", [
+            "retry",
+            "canceled",
+            selectedSession.id,
+            lastUserMessage.text,
+            latestTerminalAuditLog?.id,
+          ]),
           stopSummary,
           lastRequestText: lastUserMessage.text,
         };
@@ -1359,11 +1358,9 @@ export default function AgentSessionWindowApp() {
     lastAssistantMessage,
     lastUserMessage,
     latestTerminalAuditLog,
-    pendingIndicatorCharacterName,
+    appSettings.userMicrocopyCatalog,
     selectedSession,
-    selectedSessionCopy.retryCanceledTitle,
-    selectedSessionCopy.retryFailedTitle,
-    selectedSessionCopy.retryInterruptedTitle,
+    selectedSessionCharacter?.name,
     isSelectedSessionReadOnly,
     selectedSessionLiveRun,
   ]);
@@ -2446,32 +2443,41 @@ export default function AgentSessionWindowApp() {
   };
 
   const pendingRunIndicatorText = isApprovalRequestPending || isElicitationRequestPending
-    ? renderCharacterSessionCopy(
-      selectedSessionCopy.pendingApproval,
-      pendingIndicatorCharacterName,
-      [
-        `pending:approval:${selectedSession?.id ?? ""}:${liveApprovalRequest?.requestId ?? ""}`,
-        `pending:elicitation:${selectedSession?.id ?? ""}:${liveElicitationRequest?.requestId ?? ""}`,
-      ].join("|"),
-    )
+    ? resolveSessionMicrocopy("dock.status.approval", [
+      "pending",
+      "approval",
+      selectedSession?.id,
+      liveApprovalRequest?.requestId,
+      liveElicitationRequest?.requestId,
+    ])
     : hasInProgressLiveRunStep
-      ? renderCharacterSessionCopy(
-        selectedSessionCopy.pendingWorking,
-        pendingIndicatorCharacterName,
-        `pending:working:${selectedSession?.id ?? ""}:${selectedSessionLiveRun?.threadId ?? ""}:${orderedLiveRunSteps.map((step) => `${step.id}:${step.status}`).join("|")}`,
-      )
+      ? resolveSessionMicrocopy("dock.status.working", [
+        "pending",
+        "working",
+        selectedSession?.id,
+        selectedSessionLiveRun?.threadId,
+        orderedLiveRunSteps.map((step) => `${step.id}:${step.status}`).join("|"),
+      ])
       : hasLiveRunAssistantText
-        ? renderCharacterSessionCopy(
-          selectedSessionCopy.pendingResponding,
-          pendingIndicatorCharacterName,
-          `pending:responding:${selectedSession?.id ?? ""}:${selectedSessionLiveRun?.threadId ?? ""}:${liveRunAssistantText.length}`,
-        )
-        : renderCharacterSessionCopy(
-          selectedSessionCopy.pendingPreparing,
-          pendingIndicatorCharacterName,
-          `pending:preparing:${selectedSession?.id ?? ""}:${selectedSessionLiveRun?.threadId ?? ""}`,
-        );
+        ? resolveSessionMicrocopy("dock.status.responding", [
+          "pending",
+          "responding",
+          selectedSession?.id,
+          selectedSessionLiveRun?.threadId,
+        ])
+        : resolveSessionMicrocopy("dock.status.preparing", [
+          "pending",
+          "preparing",
+          selectedSession?.id,
+          selectedSessionLiveRun?.threadId,
+        ]);
   const pendingRunIndicatorAnnouncement = pendingRunIndicatorText;
+  const pendingMessageText = resolveSessionMicrocopy("chat.pending.response_waiting", [
+    "chat",
+    "pending",
+    selectedSession?.id,
+    selectedSessionLiveRun?.threadId,
+  ]);
   const isSelectedSessionRunning = selectedSessionRunState === "running";
   const contextPaneProjection = useMemo(
     () => buildContextPaneProjection({
@@ -2528,6 +2534,7 @@ export default function AgentSessionWindowApp() {
         messageListRef,
         pendingRunIndicatorAnnouncement,
         pendingRunIndicatorText,
+        pendingMessageText,
         liveApprovalRequest,
         approvalActionRequestId,
         liveElicitationRequest,
@@ -2586,6 +2593,7 @@ export default function AgentSessionWindowApp() {
         selectedSessionContextTelemetry,
         selectedSessionContextTelemetryProjection,
         selectedContextEmptyText,
+        latestCommandEmptyText,
         selectedDiff,
         selectedDiffThemeStyle,
         auditLogsOpen,
@@ -2626,11 +2634,7 @@ export default function AgentSessionWindowApp() {
         getChangedFilesEmptyText: (artifactKey, artifactHasSnapshotRisk) =>
           artifactHasSnapshotRisk
             ? "差分は見つからなかったけど、snapshot の上限や省略で取りこぼしがあるかもしれないよ。"
-            : renderCharacterSessionCopy(
-              selectedSessionCopy.changedFilesEmpty,
-              pendingIndicatorCharacterName,
-              `changed-files-empty:${artifactKey}`,
-            ),
+            : resolveSessionMicrocopy("empty.changed_files", ["changed-files-empty", artifactKey]),
         onToggleRetryDetails: () => setIsRetryDetailsOpen((current) => !current),
         onResendLastMessage: () => void handleResendLastMessage(),
         onEditLastMessage: handleEditLastMessage,
@@ -2679,7 +2683,7 @@ export default function AgentSessionWindowApp() {
           setComposerCaret(composerTextareaRef.current?.selectionStart ?? draft.length);
         },
         onSendOrCancel: () => void (selectedSession.runState === "running" ? handleCancelRun() : handleSend()),
-        onExpandActionDock: () => handleExpandActionDock({ focusComposer: true }),
+        onExpandActionDock: () => handleExpandActionDock({ focusComposer: selectedSession.runState !== "running" }),
         onSelectWorkspacePathMatch: handleSelectWorkspacePathMatch,
         onActivateWorkspacePathMatch: setActiveWorkspacePathMatchIndex,
         onChangeApprovalMode: (value) => void handleChangeApproval(value),

--- a/src/CompanionReviewApp.tsx
+++ b/src/CompanionReviewApp.tsx
@@ -2287,7 +2287,7 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
           setComposerCaret(composerTextareaRef.current?.selectionStart ?? composerText.length);
         },
         onSendOrCancel: () => void (isSelectedSessionRunning ? cancelCompanionTurn() : sendCompanionTurn()),
-        onExpandActionDock: () => handleExpandActionDock({ focusComposer: true }),
+        onExpandActionDock: () => handleExpandActionDock({ focusComposer: !isSelectedSessionRunning }),
         onSelectWorkspacePathMatch: handleSelectWorkspacePathMatch,
         onActivateWorkspacePathMatch: setActiveWorkspacePathMatchIndex,
         onChangeApprovalMode: (value) => void handleChangeApproval(value),

--- a/src/character-state.ts
+++ b/src/character-state.ts
@@ -51,17 +51,17 @@ export const DEFAULT_CHARACTER_THEME_COLORS: CharacterThemeColors = {
 };
 
 export const DEFAULT_CHARACTER_SESSION_COPY: CharacterSessionCopy = {
-  pendingApproval: ["承認を待機中"],
-  pendingWorking: ["処理を実行中"],
-  pendingResponding: ["応答を生成中"],
-  pendingPreparing: ["応答を準備中"],
-  retryInterruptedTitle: ["前回の依頼は中断されたままです"],
-  retryFailedTitle: ["前回の依頼は完了できませんでした"],
-  retryCanceledTitle: ["この依頼は途中で停止しました"],
-  latestCommandWaiting: ["最初の command を待機中"],
-  latestCommandEmpty: ["直近 run の command 記録はありません"],
-  changedFilesEmpty: ["ファイル変更はありません"],
-  contextEmpty: ["context usage はまだありません"],
+  pendingApproval: [...BUILT_IN_MICROCOPY_CATALOG["dock.status.approval"]],
+  pendingWorking: [...BUILT_IN_MICROCOPY_CATALOG["dock.status.working"]],
+  pendingResponding: [...BUILT_IN_MICROCOPY_CATALOG["dock.status.responding"]],
+  pendingPreparing: [...BUILT_IN_MICROCOPY_CATALOG["dock.status.preparing"]],
+  retryInterruptedTitle: [...BUILT_IN_MICROCOPY_CATALOG["retry.interrupted.title"]],
+  retryFailedTitle: [...BUILT_IN_MICROCOPY_CATALOG["retry.failed.title"]],
+  retryCanceledTitle: [...BUILT_IN_MICROCOPY_CATALOG["retry.canceled.title"]],
+  latestCommandWaiting: [...BUILT_IN_MICROCOPY_CATALOG["empty.latest_command.waiting"]],
+  latestCommandEmpty: [...BUILT_IN_MICROCOPY_CATALOG["empty.latest_command"]],
+  changedFilesEmpty: [...BUILT_IN_MICROCOPY_CATALOG["empty.changed_files"]],
+  contextEmpty: [...BUILT_IN_MICROCOPY_CATALOG["empty.context"]],
 };
 
 export function cloneCharacterSessionCopy(copy: CharacterSessionCopy): CharacterSessionCopy {
@@ -157,3 +157,4 @@ export function cloneCharacterProfiles(characters: CharacterProfile[]): Characte
 export function getCharacterById(characters: CharacterProfile[], characterId: string): CharacterProfile | null {
   return cloneCharacterProfiles(characters).find((character) => character.id === characterId) ?? null;
 }
+import { BUILT_IN_MICROCOPY_CATALOG } from "./microcopy-state.js";

--- a/src/chat/chat-window-adapter.ts
+++ b/src/chat/chat-window-adapter.ts
@@ -168,6 +168,7 @@ type LiveSessionMessageColumnProps = {
   liveRunAssistantText: string;
   hasLiveRunAssistantText: boolean;
   liveRunErrorMessage: string;
+  pendingMessageText?: string;
   isMessageListFollowing: boolean;
   onMessageListScroll: UIEventHandler<HTMLDivElement>;
   onToggleArtifact: (artifactKey: string) => void;
@@ -214,6 +215,7 @@ export function buildLiveSessionMessageColumnProps(input: LiveSessionMessageColu
     liveRunAssistantText: input.liveRunAssistantText,
     hasLiveRunAssistantText: input.hasLiveRunAssistantText,
     liveRunErrorMessage: input.liveRunErrorMessage,
+    pendingMessageText: input.pendingMessageText,
     isMessageListFollowing: input.isMessageListFollowing,
     onMessageListScroll: input.onMessageListScroll,
     onToggleArtifact: input.onToggleArtifact,

--- a/src/chat/session-chat-projection.tsx
+++ b/src/chat/session-chat-projection.tsx
@@ -42,6 +42,7 @@ export type AgentSessionChatProjectionInput = {
   messageListRef: RefObject<HTMLDivElement | null>;
   pendingRunIndicatorAnnouncement: string;
   pendingRunIndicatorText: string;
+  pendingMessageText: string;
   liveApprovalRequest: SessionMessageColumnProps["liveApprovalRequest"];
   approvalActionRequestId: string | null;
   liveElicitationRequest: SessionMessageColumnProps["liveElicitationRequest"];
@@ -100,6 +101,7 @@ export type AgentSessionChatProjectionInput = {
   selectedSessionContextTelemetry: SessionContextPaneProps["selectedSessionContextTelemetry"];
   selectedSessionContextTelemetryProjection: SessionContextPaneProps["selectedSessionContextTelemetryProjection"];
   selectedContextEmptyText: string;
+  latestCommandEmptyText: string;
   selectedDiff: DiffPreviewPayload | null;
   selectedDiffThemeStyle: CSSProperties;
   auditLogsOpen: boolean;
@@ -234,6 +236,7 @@ export function buildAgentSessionChatWindowProps(input: AgentSessionChatProjecti
     liveRunAssistantText: input.liveRunAssistantText,
     hasLiveRunAssistantText: input.hasLiveRunAssistantText,
     liveRunErrorMessage: input.liveRunErrorMessage,
+    pendingMessageText: input.pendingMessageText,
     isMessageListFollowing: input.isMessageListFollowing,
     onMessageListScroll: input.onMessageListScroll,
     onToggleArtifact: input.onToggleArtifact,
@@ -385,6 +388,7 @@ export function buildAgentSessionChatWindowProps(input: AgentSessionChatProjecti
           selectedSessionContextTelemetry={input.selectedSessionContextTelemetry}
           selectedSessionContextTelemetryProjection={input.selectedSessionContextTelemetryProjection}
           contextEmptyText={input.selectedContextEmptyText}
+          latestCommandEmptyText={input.latestCommandEmptyText}
           onToggleHeaderExpanded={input.onToggleHeaderExpanded}
           onCycleContextPaneTab={input.onCycleContextPaneTab}
           onOpenCompanionReview={input.onOpenCompanionReview}

--- a/src/microcopy-state.ts
+++ b/src/microcopy-state.ts
@@ -1,0 +1,120 @@
+export const MICROCOPY_SLOTS = [
+  "chat.pending.response_waiting",
+  "dock.status.approval",
+  "dock.status.working",
+  "dock.status.responding",
+  "dock.status.preparing",
+  "retry.interrupted.title",
+  "retry.failed.title",
+  "retry.canceled.title",
+  "empty.latest_command.waiting",
+  "empty.latest_command",
+  "empty.changed_files",
+  "empty.context",
+] as const;
+
+export type MicrocopySlot = typeof MICROCOPY_SLOTS[number];
+
+export type MicrocopyCatalog = Partial<Record<MicrocopySlot, string[] | string>>;
+
+export type MicrocopyResolveInput = {
+  slot: MicrocopySlot;
+  userCatalog?: MicrocopyCatalog | null;
+  seedParts?: Array<string | number | null | undefined>;
+  replacements?: Record<string, string | null | undefined>;
+};
+
+export const BUILT_IN_MICROCOPY_CATALOG: Record<MicrocopySlot, string[]> = {
+  "chat.pending.response_waiting": [
+    "応答を準備しています",
+    "出力を待機しています",
+  ],
+  "dock.status.approval": ["承認を待機中"],
+  "dock.status.working": ["処理を実行中"],
+  "dock.status.responding": ["応答を生成中"],
+  "dock.status.preparing": ["応答を準備中"],
+  "retry.interrupted.title": ["前回の依頼は中断されたままです"],
+  "retry.failed.title": ["前回の依頼は完了できませんでした"],
+  "retry.canceled.title": ["この依頼は途中で停止しました"],
+  "empty.latest_command.waiting": ["最初の command を待機中"],
+  "empty.latest_command": ["直近 run の command 記録はありません"],
+  "empty.changed_files": ["ファイル変更はありません"],
+  "empty.context": ["context usage はまだありません"],
+};
+
+const MICROCOPY_SLOT_SET = new Set<string>(MICROCOPY_SLOTS);
+
+function cloneCatalog(catalog: Record<MicrocopySlot, string[]>): Record<MicrocopySlot, string[]> {
+  return Object.fromEntries(
+    MICROCOPY_SLOTS.map((slot) => [slot, [...catalog[slot]]]),
+  ) as Record<MicrocopySlot, string[]>;
+}
+
+export function createDefaultUserMicrocopyCatalog(): Record<MicrocopySlot, string[]> {
+  return cloneCatalog(BUILT_IN_MICROCOPY_CATALOG);
+}
+
+function normalizeMicrocopyVariants(value: unknown, fallback: string[]): string[] {
+  if (Array.isArray(value)) {
+    const normalized = value
+      .filter((entry): entry is string => typeof entry === "string")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+    return normalized.length > 0 ? normalized : [...fallback];
+  }
+
+  if (typeof value === "string") {
+    const normalized = value
+      .split(/\r?\n/)
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+    return normalized.length > 0 ? normalized : [...fallback];
+  }
+
+  return [...fallback];
+}
+
+export function normalizeUserMicrocopyCatalog(value: unknown): Record<MicrocopySlot, string[]> {
+  const normalized = createDefaultUserMicrocopyCatalog();
+  if (!value || typeof value !== "object") {
+    return normalized;
+  }
+
+  for (const [slot, variants] of Object.entries(value as Record<string, unknown>)) {
+    if (!MICROCOPY_SLOT_SET.has(slot)) {
+      continue;
+    }
+
+    normalized[slot as MicrocopySlot] = normalizeMicrocopyVariants(
+      variants,
+      BUILT_IN_MICROCOPY_CATALOG[slot as MicrocopySlot],
+    );
+  }
+
+  return normalized;
+}
+
+function stableHash(value: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+export function resolveMicrocopy({
+  slot,
+  userCatalog,
+  seedParts = [],
+  replacements = {},
+}: MicrocopyResolveInput): string {
+  const normalizedUserCatalog = normalizeUserMicrocopyCatalog(userCatalog);
+  const variants = normalizedUserCatalog[slot] ?? BUILT_IN_MICROCOPY_CATALOG[slot];
+  const seed = [slot, ...seedParts.map((part) => part ?? "")].join("\u001f");
+  const selected = variants[stableHash(seed) % variants.length] ?? BUILT_IN_MICROCOPY_CATALOG[slot][0];
+
+  return Object.entries(replacements).reduce((current, [key, value]) => {
+    return current.replaceAll(`{${key}}`, value?.trim() ?? "");
+  }, selected);
+}

--- a/src/provider-settings-state.ts
+++ b/src/provider-settings-state.ts
@@ -5,6 +5,11 @@ import {
   normalizeProviderId,
   type ModelReasoningEffort,
 } from "./model-catalog.js";
+import {
+  createDefaultUserMicrocopyCatalog,
+  normalizeUserMicrocopyCatalog,
+  type MicrocopyCatalog,
+} from "./microcopy-state.js";
 import type {
   ProviderInstructionFailPolicy,
   ProviderInstructionLastSyncState,
@@ -16,6 +21,7 @@ import type {
 export type AppSettings = {
   memoryGenerationEnabled: boolean;
   autoCollapseActionDockOnSend: boolean;
+  userMicrocopyCatalog: MicrocopyCatalog;
   mateMemoryGenerationSettings: MateMemoryGenerationSettings;
   codingProviderSettings: Record<string, ProviderAppSettings>;
   memoryExtractionProviderSettings: Record<string, MemoryExtractionProviderSettings>;
@@ -107,6 +113,7 @@ export function createDefaultAppSettings(): AppSettings {
   return {
     memoryGenerationEnabled: true,
     autoCollapseActionDockOnSend: true,
+    userMicrocopyCatalog: createDefaultUserMicrocopyCatalog(),
     mateMemoryGenerationSettings: {
       ...DEFAULT_MATE_MEMORY_GENERATION_SETTINGS,
       priorityList: [{ ...DEFAULT_MATE_MEMORY_GENERATION_PROVIDER_SETTINGS }],
@@ -312,6 +319,7 @@ export function normalizeAppSettings(value: unknown): AppSettings {
       typeof candidate.memoryGenerationEnabled === "boolean" ? candidate.memoryGenerationEnabled : true,
     autoCollapseActionDockOnSend:
       typeof candidate.autoCollapseActionDockOnSend === "boolean" ? candidate.autoCollapseActionDockOnSend : true,
+    userMicrocopyCatalog: normalizeUserMicrocopyCatalog(candidate.userMicrocopyCatalog),
     mateMemoryGenerationSettings: normalizeMateMemoryGenerationSettings(candidate.mateMemoryGenerationSettings),
     codingProviderSettings,
     memoryExtractionProviderSettings,

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -1347,6 +1347,7 @@ export type SessionContextPaneProps = {
   selectedSessionContextTelemetry: SessionContextTelemetry | null;
   selectedSessionContextTelemetryProjection: SessionContextTelemetryProjection;
   contextEmptyText: string;
+  latestCommandEmptyText?: string;
   onToggleHeaderExpanded: () => void;
   onCycleContextPaneTab: (direction: -1 | 1) => void;
   onOpenCompanionReview: (sessionId: string) => void;
@@ -1459,6 +1460,7 @@ export function SessionContextPane({
   selectedSessionContextTelemetry,
   selectedSessionContextTelemetryProjection,
   contextEmptyText,
+  latestCommandEmptyText = "",
   onToggleHeaderExpanded,
   onCycleContextPaneTab,
   onOpenCompanionReview,
@@ -1659,6 +1661,9 @@ export function SessionContextPane({
                 </div>
               ) : (
                 <div className="command-monitor-empty-shell">
+                  {latestCommandEmptyText.trim() ? (
+                    <p className="provider-context-empty">{latestCommandEmptyText}</p>
+                  ) : null}
                   {selectedSessionLiveRunErrorMessage ? (
                     <div className="live-run-error-block" role="alert">
                       <strong>実行エラー</strong>
@@ -1918,6 +1923,7 @@ export type SessionMessageColumnProps = {
   liveRunAssistantText: string;
   hasLiveRunAssistantText: boolean;
   liveRunErrorMessage: string;
+  pendingMessageText?: string;
   isMessageListFollowing: boolean;
   onMessageListScroll: UIEventHandler<HTMLDivElement>;
   onToggleArtifact: (artifactKey: string) => void;
@@ -1943,6 +1949,7 @@ export function SessionMessageColumn({
   liveRunAssistantText,
   hasLiveRunAssistantText,
   liveRunErrorMessage,
+  pendingMessageText = "",
   isMessageListFollowing,
   onMessageListScroll,
   onToggleArtifact,
@@ -1973,7 +1980,8 @@ export function SessionMessageColumn({
     liveApprovalRequest !== null ||
     liveElicitationRequest !== null ||
     hasLiveRunAssistantText ||
-    liveRunErrorMessage.trim().length > 0;
+    liveRunErrorMessage.trim().length > 0 ||
+    pendingMessageText.trim().length > 0;
 
   const loadOlderMessages = useCallback((listElement: HTMLDivElement | null = messageListRef.current) => {
     if (!listElement || latestMessageWindowStartIndex <= 0) {
@@ -2331,6 +2339,9 @@ export function SessionMessageColumn({
                       />
                     ) : null}
                     {hasLiveRunAssistantText ? <MessageRichText text={liveRunAssistantText} onOpenPath={onOpenPath} /> : null}
+                    {!liveApprovalRequest && !liveElicitationRequest && !hasLiveRunAssistantText && !liveRunErrorMessage.trim() && pendingMessageText.trim() ? (
+                      <MessageRichText text={pendingMessageText} onOpenPath={onOpenPath} />
+                    ) : null}
                     {liveRunErrorMessage ? (
                       <p className="pending-run-error-note" role="alert">{liveRunErrorMessage}</p>
                     ) : null}
@@ -2378,12 +2389,18 @@ export function SessionActionDockCompactRow({
   if (isRunning) {
     return (
       <div className="session-action-dock-compact-row running">
-        <div className="session-action-dock-compact-progress">
+        <button
+          className="session-action-dock-compact-progress session-action-dock-compact-progress-button"
+          type="button"
+          onClick={onExpand}
+          aria-label="ActionDock を展開"
+          title="ActionDock を展開"
+        >
           <PendingRunIndicator
             announcement={pendingRunIndicatorAnnouncement}
             text={pendingRunIndicatorText}
           />
-        </div>
+        </button>
         <div className="session-action-dock-compact-actions">
           <button
             className="danger session-send-button"

--- a/src/settings/SettingsContent.tsx
+++ b/src/settings/SettingsContent.tsx
@@ -4,6 +4,7 @@ import {
   type AppSettings,
   type MemoryExtractionProviderSettings,
 } from "../app-state.js";
+import { MICROCOPY_SLOTS, type MicrocopySlot } from "../microcopy-state.js";
 import type { MateEmbeddingSettings } from "../mate/mate-embedding-settings.js";
 import {
   DEFAULT_MATE_GROWTH_APPLY_INTERVAL_MINUTES,
@@ -119,6 +120,7 @@ export type HomeSettingsContentProps = {
   onRemoveMateMemoryGenerationPriority: (index: number) => void;
   onChangeMateMemoryGenerationTriggerIntervalMinutes: (value: string) => void;
   onChangeAutoCollapseActionDockOnSend: (enabled: boolean) => void;
+  onChangeUserMicrocopySlot: (slot: MicrocopySlot, value: string) => void;
   onChangeProviderEnabled: (providerId: string, enabled: boolean) => void;
   onChangeProviderInstructionEnabled: (providerId: string, enabled: boolean) => void;
   onChangeProviderInstructionWriteMode: (providerId: string, value: string) => void;
@@ -186,6 +188,29 @@ const GROWTH_EVENT_STATE_LABEL: Record<MateGrowthEventListItem["state"], string>
   failed: "失敗",
 };
 
+const MICROCOPY_SLOT_LABEL: Record<MicrocopySlot, string> = {
+  "chat.pending.response_waiting": "Chat / 応答待機",
+  "dock.status.approval": "ActionDock / 承認待機",
+  "dock.status.working": "ActionDock / 処理中",
+  "dock.status.responding": "ActionDock / 応答生成中",
+  "dock.status.preparing": "ActionDock / 応答準備中",
+  "retry.interrupted.title": "Retry / 中断",
+  "retry.failed.title": "Retry / 失敗",
+  "retry.canceled.title": "Retry / キャンセル",
+  "empty.latest_command.waiting": "Empty / command 待機",
+  "empty.latest_command": "Empty / command なし",
+  "empty.changed_files": "Empty / 変更なし",
+  "empty.context": "Empty / context なし",
+};
+
+const microcopyTextareaValue = (value: AppSettings["userMicrocopyCatalog"][MicrocopySlot]): string => {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  return (value ?? []).join("\n");
+};
+
 const normalizeProviderInstructionErrorPreview = (errorPreview: string): string => {
   const trimmed = errorPreview.trim();
   if (trimmed.length <= MAX_PROVIDER_INSTRUCTION_ERROR_PREVIEW_LENGTH) {
@@ -250,6 +275,7 @@ export function HomeSettingsContent({
   onRemoveMateMemoryGenerationPriority,
   onChangeMateMemoryGenerationTriggerIntervalMinutes,
   onChangeAutoCollapseActionDockOnSend,
+  onChangeUserMicrocopySlot,
   onChangeProviderEnabled,
   onChangeProviderInstructionEnabled,
   onChangeProviderInstructionWriteMode,
@@ -428,6 +454,27 @@ export function HomeSettingsContent({
                   onChange={(event) => onChangeAutoCollapseActionDockOnSend(event.target.checked)}
                 />
               </label>
+            </div>
+          </section>
+
+          <section className="settings-section-card">
+            <div className="settings-field">
+              <strong>Default Microcopy</strong>
+              <p className="settings-note">1 行を 1 候補として保存する。空の slot は system default に戻る。</p>
+              <div className="settings-provider-list">
+                {MICROCOPY_SLOTS.map((slot) => (
+                  <label key={slot} className="settings-provider-input">
+                    <span>{MICROCOPY_SLOT_LABEL[slot]}</span>
+                    <textarea
+                      className="settings-microcopy-textarea"
+                      value={microcopyTextareaValue(settingsDraft.userMicrocopyCatalog[slot])}
+                      onChange={(event) => onChangeUserMicrocopySlot(slot, event.target.value)}
+                      rows={3}
+                      spellCheck={false}
+                    />
+                  </label>
+                ))}
+              </div>
             </div>
           </section>
 

--- a/src/settings/settings-draft-actions.ts
+++ b/src/settings/settings-draft-actions.ts
@@ -1,4 +1,5 @@
 import type { ModelCatalogSnapshot } from "../model-catalog.js";
+import type { MicrocopySlot } from "../microcopy-state.js";
 import type { AppSettings } from "../provider-settings-state.js";
 import {
   addMateMemoryGenerationPriorityDraft,
@@ -17,6 +18,7 @@ import {
   updateMemoryExtractionThresholdDraft,
   updateMemoryExtractionTimeoutSecondsDraft,
   updateMemoryGenerationEnabled,
+  updateUserMicrocopySlotDraft,
 } from "./settings-draft.js";
 
 type SetSettingsDraft = (updater: (current: AppSettings) => AppSettings) => void;
@@ -65,6 +67,13 @@ export function handleChangeAutoCollapseActionDockOnSend(input: SettingsDraftAct
   enabled: boolean;
 }): void {
   input.setSettingsDraft((current) => updateAutoCollapseActionDockOnSend(current, input.enabled));
+}
+
+export function handleChangeUserMicrocopySlot(input: SettingsDraftActionInput & {
+  slot: MicrocopySlot;
+  value: string;
+}): void {
+  input.setSettingsDraft((current) => updateUserMicrocopySlotDraft(current, input.slot, input.value));
 }
 
 export function handleChangeMemoryExtractionModel(input: ModelCatalogActionInput & {

--- a/src/settings/settings-draft-handlers.ts
+++ b/src/settings/settings-draft-handlers.ts
@@ -1,4 +1,5 @@
 import type { ModelCatalogSnapshot } from "../model-catalog.js";
+import type { MicrocopySlot } from "../microcopy-state.js";
 import type { AppSettings } from "../provider-settings-state.js";
 import type { HomeSettingsContentBaseProps } from "./home-settings-content-props.js";
 import {
@@ -17,6 +18,7 @@ import {
   handleChangeProviderEnabled,
   handleChangeProviderSkillRelativePath,
   handleChangeProviderSkillRootPath,
+  handleChangeUserMicrocopySlot,
   handleRemoveMateMemoryGenerationPriority,
 } from "./settings-draft-actions.js";
 
@@ -36,6 +38,7 @@ export type SettingsDraftHandlers = Pick<
   | "onRemoveMateMemoryGenerationPriority"
   | "onChangeMateMemoryGenerationTriggerIntervalMinutes"
   | "onChangeAutoCollapseActionDockOnSend"
+  | "onChangeUserMicrocopySlot"
   | "onChangeProviderEnabled"
   | "onChangeProviderSkillRelativePath"
   | "onChangeProviderSkillRootPath"
@@ -76,6 +79,9 @@ export function buildSettingsDraftHandlers({
     },
     onChangeAutoCollapseActionDockOnSend: (enabled) => {
       handleChangeAutoCollapseActionDockOnSend({ enabled, setSettingsDraft });
+    },
+    onChangeUserMicrocopySlot: (slot: MicrocopySlot, value: string) => {
+      handleChangeUserMicrocopySlot({ slot, value, setSettingsDraft });
     },
     onChangeProviderEnabled: (providerId, enabled) => {
       handleChangeProviderEnabled({ providerId, enabled, setSettingsDraft });

--- a/src/settings/settings-draft.ts
+++ b/src/settings/settings-draft.ts
@@ -8,6 +8,7 @@ import {
   type ProviderAppSettings,
 } from "../provider-settings-state.js";
 import { coerceModelSelection, type ModelCatalogProvider } from "../model-catalog.js";
+import type { MicrocopySlot } from "../microcopy-state.js";
 
 export function updateMemoryGenerationEnabled(
   draft: AppSettings,
@@ -26,6 +27,20 @@ export function updateAutoCollapseActionDockOnSend(
   return {
     ...draft,
     autoCollapseActionDockOnSend: enabled,
+  };
+}
+
+export function updateUserMicrocopySlotDraft(
+  draft: AppSettings,
+  slot: MicrocopySlot,
+  rawValue: string,
+): AppSettings {
+  return {
+    ...draft,
+    userMicrocopyCatalog: {
+      ...draft.userMicrocopyCatalog,
+      [slot]: rawValue,
+    },
   };
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1927,6 +1927,10 @@ button:disabled {
   line-height: 1.55;
 }
 
+.settings-field textarea.settings-microcopy-textarea {
+  min-height: 86px;
+}
+
 .settings-field input {
   width: 100%;
   border: 1px solid rgba(32, 36, 55, 0.12);
@@ -2883,6 +2887,20 @@ button:disabled {
 
 .session-action-dock-compact-progress {
   min-width: 0;
+}
+
+.session-action-dock-compact-progress-button {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.session-action-dock-compact-progress-button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--character-main) 72%, #ffffff 28%);
+  outline-offset: 3px;
 }
 
 .session-action-dock-compact-progress .pending-run-indicator {


### PR DESCRIPTION
## 変更内容
- Default Microcopy を Settings で編集できる user catalog として追加
- Session / ActionDock / latest-command empty 表示の文言を runtime resolver 経由に接続
- streaming 中に文言が揺れない seed に修正し、将来のキャラ別 override 方針を設計書へ記載

## 検証
- npx tsx --test scripts/tests/microcopy-state.test.ts scripts/tests/provider-settings-state.test.ts scripts/tests/app-settings-storage.test.ts scripts/tests/session-message-column.test.ts scripts/tests/chat-window-adapter.test.ts scripts/tests/chat-window-mate-talk-mode.test.ts scripts/tests/home-components.test.tsx scripts/tests/home-settings-draft.test.ts
- npm run typecheck
- git diff --check