### PR TITLE
ActionDock の進捗表示折り返しを抑制

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "4.2.4",
+      "version": "4.2.5",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/src/styles.css
+++ b/src/styles.css
@@ -2908,6 +2908,25 @@ button:disabled {
   padding: 8px 10px;
 }
 
+.session-action-dock-compact-progress .pending-run-indicator,
+.composer-toolbar-progress .pending-run-indicator {
+  flex-wrap: nowrap;
+}
+
+.session-action-dock-compact-progress .pending-run-indicator .live-run-shell-status-badge,
+.composer-toolbar-progress .pending-run-indicator .live-run-shell-status-badge {
+  flex-shrink: 0;
+}
+
+.session-action-dock-compact-progress .pending-run-indicator .live-run-shell-status-text,
+.composer-toolbar-progress .pending-run-indicator .live-run-shell-status-text {
+  flex-basis: auto;
+  overflow: hidden;
+  overflow-wrap: normal;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .session-action-dock-compact-preview {
   display: grid;
   gap: 4px;


### PR DESCRIPTION
## 概要
- ActionDock 内の running progress 表示を 1 行固定にし、狭い場合は本文だけ省略表示に変更
- 末尾へ移動ボタンが表示される状態でも badge / text / dots が縦に崩れないよう調整
- アプリバージョンを 4.2.5 に更新

## 検証
- git diff --check

## 未実行
- npm run build:renderer: この worktree に node_modules がなく vite が見つからないため未実行
- npx tsx --test scripts/tests/session-message-column.test.ts: node_modules がなく react が見つからないため未実行