### PR TITLE
Auxiliary 起動時に Provider を選択できるようにする

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "4.2.6",
+  "version": "4.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "4.2.6",
+      "version": "4.2.7",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "4.2.6",
+  "version": "4.2.7",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/scripts/tests/auxiliary-session-storage.test.ts
+++ b/scripts/tests/auxiliary-session-storage.test.ts
@@ -26,6 +26,15 @@ function buildTestModelCatalogSnapshot(revision: number): ModelCatalogSnapshot {
           { id: "gpt-5.4-mini", label: "GPT-5.4 Mini", reasoningEfforts: ["medium"] },
         ],
       },
+      {
+        id: "copilot",
+        label: "Copilot",
+        defaultModelId: "claude-sonnet-4.5",
+        defaultReasoningEffort: "medium",
+        models: [
+          { id: "claude-sonnet-4.5", label: "Claude Sonnet 4.5", reasoningEfforts: ["medium"] },
+        ],
+      },
     ],
   };
 }
@@ -83,7 +92,7 @@ test("AuxiliarySessionService は親 session から実行 context を継承し�
       getModelCatalogSnapshot: () => activeModelCatalog,
     });
 
-    const auxiliary = service.createAuxiliarySession(parent.id);
+    const auxiliary = service.createAuxiliarySession({ parentSessionId: parent.id, provider: parent.provider });
     assert.equal(auxiliary.parentSessionId, parent.id);
     assert.equal(auxiliary.status, "active");
     assert.equal(auxiliary.runState, "idle");
@@ -93,7 +102,7 @@ test("AuxiliarySessionService は親 session から実行 context を継承し�
     assert.deepEqual(auxiliary.allowedAdditionalDirectories, ["C:/shared"]);
     assert.equal(auxiliary.displayAfterMessageIndex, parent.messages.length - 1);
 
-    const sameActive = service.createAuxiliarySession(parent.id);
+    const sameActive = service.createAuxiliarySession({ parentSessionId: parent.id, provider: "copilot" });
     assert.equal(sameActive.id, auxiliary.id);
 
     const updated = service.updateAuxiliarySession({
@@ -253,7 +262,10 @@ test("AuxiliarySessionService は親 session から実行 context を継承し�
 
     const orphanedParent = { ...parent, id: "session-orphaned", taskTitle: "orphaned main task" };
     sessionStorage.upsertSession(orphanedParent);
-    const orphanedAuxiliary = service.createAuxiliarySession(orphanedParent.id);
+    const orphanedAuxiliary = service.createAuxiliarySession({
+      parentSessionId: orphanedParent.id,
+      provider: orphanedParent.provider,
+    });
     assert.equal(service.listAuxiliarySessions(orphanedParent.id)[0]?.id, orphanedAuxiliary.id);
 
     sessionStorage.replaceSessions([{ ...parent, taskTitle: "retained main task" }]);
@@ -262,6 +274,60 @@ test("AuxiliarySessionService は親 session から実行 context を継承し�
 
     sessionStorage.deleteSession(parent.id);
     assert.deepEqual(service.listAuxiliarySessions(parent.id), []);
+  } finally {
+    auxiliaryStorage?.close();
+    sessionStorage?.close();
+    await removeDirectoryWithRetry(tempDirectory);
+  }
+});
+
+test("AuxiliarySessionService は指定 Provider の既定 model で active session を作成する", async () => {
+  const tempDirectory = await mkdtemp(path.join(os.tmpdir(), "withmate-auxiliary-provider-"));
+  const dbPath = path.join(tempDirectory, "withmate.db");
+  let sessionStorage: SessionStorage | null = null;
+  let auxiliaryStorage: AuxiliarySessionStorage | null = null;
+
+  try {
+    sessionStorage = new SessionStorage(dbPath);
+    auxiliaryStorage = new AuxiliarySessionStorage(dbPath);
+    const parent = {
+      ...buildNewSession({
+        taskTitle: "main task",
+        workspaceLabel: "workspace",
+        workspacePath: "C:/workspace",
+        branch: "main",
+        characterId: "mate",
+        character: "Mate",
+        characterIconPath: "",
+        characterThemeColors: { main: "#6f8cff", sub: "#6fb8c7" },
+        approvalMode: DEFAULT_APPROVAL_MODE,
+      }),
+      id: "session-main",
+      provider: "codex",
+      model: "gpt-5.4",
+      reasoningEffort: "high" as const,
+    };
+    sessionStorage.upsertSession(parent);
+    const activeModelCatalog = buildTestModelCatalogSnapshot(parent.catalogRevision);
+
+    const service = new AuxiliarySessionService({
+      getSession: (sessionId) => sessionStorage?.getSession(sessionId) ?? null,
+      getStorage: () => auxiliaryStorage!,
+      getModelCatalogSnapshot: () => activeModelCatalog,
+    });
+
+    const auxiliary = service.createAuxiliarySession({
+      parentSessionId: parent.id,
+      provider: "copilot",
+    });
+
+    assert.equal(auxiliary.parentSessionId, parent.id);
+    assert.equal(auxiliary.provider, "copilot");
+    assert.equal(auxiliary.catalogRevision, activeModelCatalog.revision);
+    assert.equal(auxiliary.model, "claude-sonnet-4.5");
+    assert.equal(auxiliary.reasoningEffort, "medium");
+    assert.equal(auxiliary.approvalMode, parent.approvalMode);
+    assert.equal(auxiliary.displayAfterMessageIndex, parent.messages.length - 1);
   } finally {
     auxiliaryStorage?.close();
     sessionStorage?.close();
@@ -297,8 +363,9 @@ test("AuxiliarySessionService は起動時に running active session を復旧�
     const service = new AuxiliarySessionService({
       getSession: (sessionId) => sessionStorage?.getSession(sessionId) ?? null,
       getStorage: () => auxiliaryStorage!,
+      getModelCatalogSnapshot: () => buildTestModelCatalogSnapshot(parent.catalogRevision),
     });
-    const auxiliary = service.createAuxiliarySession(parent.id);
+    const auxiliary = service.createAuxiliarySession({ parentSessionId: parent.id, provider: parent.provider });
     auxiliaryStorage.upsertAuxiliarySession({
       ...auxiliary,
       runState: "running",

--- a/scripts/tests/chat-session-modals.test.tsx
+++ b/scripts/tests/chat-session-modals.test.tsx
@@ -3,6 +3,7 @@ import test from "node:test";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
+import { AuxiliaryLaunchProviderDialog } from "../../src/chat/AuxiliaryLaunchProviderDialog.js";
 import { ChatSessionModals } from "../../src/chat/chat-session-modals.js";
 import type { AuditLogSummary } from "../../src/runtime-state.js";
 
@@ -53,4 +54,29 @@ test("ChatSessionModals は共有 modal と呼び出し側の追加表示を同�
   assert.match(html, /audit-log-card completed/);
   assert.match(html, /companion-session-toast success/);
   assert.doesNotMatch(html, /diff-editor panel/);
+});
+
+test("AuxiliaryLaunchProviderDialog は Provider だけを選択対象として描画する", () => {
+  const html = renderToStaticMarkup(
+    <AuxiliaryLaunchProviderDialog
+      open={true}
+      providers={[
+        { id: "codex", label: "Codex" },
+        { id: "copilot", label: "Copilot" },
+      ]}
+      selectedProviderId="copilot"
+      feedback=""
+      starting={false}
+      onClose={() => {}}
+      onSelectProvider={() => {}}
+      onStart={() => {}}
+    />,
+  );
+
+  assert.match(html, /Coding Provider/);
+  assert.match(html, /Codex/);
+  assert.match(html, /Copilot/);
+  assert.match(html, /Start Auxiliary/);
+  assert.doesNotMatch(html, /Reasoning/);
+  assert.doesNotMatch(html, /Sandbox/);
 });

--- a/scripts/tests/preload-api.test.ts
+++ b/scripts/tests/preload-api.test.ts
@@ -175,9 +175,9 @@ test("createWithMateWindowApi は invoke 系 API を domain ごとに束ねる",
     channel: "withmate:open-session-files-terminal",
     args: ["session-1"],
   });
-  assert.deepEqual(await api.createAuxiliarySession("session-1"), {
+  assert.deepEqual(await api.createAuxiliarySession({ parentSessionId: "session-1", provider: "copilot" }), {
     channel: "withmate:create-auxiliary-session",
-    args: ["session-1"],
+    args: [{ parentSessionId: "session-1", provider: "copilot" }],
   });
   assert.deepEqual(await api.runAuxiliarySessionTurn("aux-1", { userMessage: "review" }), {
     channel: "withmate:run-auxiliary-session-turn",

--- a/src-electron/auxiliary-session-service.ts
+++ b/src-electron/auxiliary-session-service.ts
@@ -4,8 +4,10 @@ import { currentTimestampLabel } from "../src/time-state.js";
 import type {
   AuxiliarySession,
   AuxiliarySessionSummary,
+  CreateAuxiliarySessionInput,
 } from "../src/auxiliary-session-state.js";
 import {
+  coerceModelSelection,
   getModelCatalogItem,
   getProviderCatalog,
   type ModelCatalogSnapshot,
@@ -84,16 +86,27 @@ export class AuxiliarySessionService {
     return this.deps.getStorage().listRunningActiveAuxiliarySessions();
   }
 
-  createAuxiliarySession(parentSessionId: string): AuxiliarySession {
-    const parent = this.deps.getSession(parentSessionId);
+  createAuxiliarySession(input: CreateAuxiliarySessionInput): AuxiliarySession {
+    const parent = this.deps.getSession(input.parentSessionId);
     if (!parent) {
       throw new Error("親セッションが見つからないよ。");
     }
 
-    const currentActive = this.getActiveAuxiliarySession(parentSessionId);
+    const currentActive = this.getActiveAuxiliarySession(input.parentSessionId);
     if (currentActive) {
       return currentActive;
     }
+
+    const snapshot = this.deps.getModelCatalogSnapshot?.();
+    const providerCatalog = getProviderCatalog(snapshot?.providers ?? [], input.provider);
+    if (!snapshot || !providerCatalog || providerCatalog.id !== input.provider.trim()) {
+      throw new Error("Auxiliary Session の Provider が model catalog に存在しないよ。");
+    }
+    const modelSelection = coerceModelSelection(
+      providerCatalog,
+      providerCatalog.defaultModelId,
+      providerCatalog.defaultReasoningEffort,
+    );
 
     const now = currentTimestampLabel();
     return this.deps.getStorage().upsertAuxiliarySession({
@@ -102,10 +115,10 @@ export class AuxiliarySessionService {
       status: "active",
       runState: "idle",
       title: buildAuxiliaryTitle(parent),
-      provider: parent.provider,
-      catalogRevision: parent.catalogRevision,
-      model: parent.model,
-      reasoningEffort: parent.reasoningEffort,
+      provider: providerCatalog.id,
+      catalogRevision: snapshot.revision,
+      model: modelSelection.resolvedModel,
+      reasoningEffort: modelSelection.resolvedReasoningEffort,
       approvalMode: parent.approvalMode,
       codexSandboxMode: parent.codexSandboxMode,
       customAgentName: parent.customAgentName,

--- a/src-electron/main-ipc-deps.ts
+++ b/src-electron/main-ipc-deps.ts
@@ -20,7 +20,11 @@ import type {
   SessionSummary,
 } from "../src/app-state.js";
 import type { AppDatabaseDiagnostics } from "../src/app-database-diagnostics-state.js";
-import type { AuxiliarySession, AuxiliarySessionSummary } from "../src/auxiliary-session-state.js";
+import type {
+  AuxiliarySession,
+  AuxiliarySessionSummary,
+  CreateAuxiliarySessionInput,
+} from "../src/auxiliary-session-state.js";
 import type { CompanionSession, CompanionSessionSummary, CreateCompanionSessionInput } from "../src/companion-state.js";
 import type {
   CompanionMergeSelectedFilesRequest,
@@ -202,7 +206,7 @@ export type MainIpcAuxiliaryDepsArgs = {
   listAuxiliarySessions(parentSessionId: string): Awaitable<AuxiliarySessionSummary[]>;
   getActiveAuxiliarySession(parentSessionId: string): Awaitable<AuxiliarySession | null>;
   getAuxiliarySession(auxiliarySessionId: string): Awaitable<AuxiliarySession | null>;
-  createAuxiliarySession(parentSessionId: string): Awaitable<AuxiliarySession>;
+  createAuxiliarySession(input: CreateAuxiliarySessionInput): Awaitable<AuxiliarySession>;
   updateAuxiliarySession(session: AuxiliarySession): Awaitable<AuxiliarySession>;
   closeAuxiliarySession(auxiliarySessionId: string): Awaitable<AuxiliarySession>;
   runAuxiliarySessionTurn(auxiliarySessionId: string, request: RunSessionTurnRequest): Awaitable<AuxiliarySession>;

--- a/src-electron/main-ipc-registration.ts
+++ b/src-electron/main-ipc-registration.ts
@@ -21,7 +21,11 @@ import type {
   SessionContextTelemetry,
   SessionSummary,
 } from "../src/app-state.js";
-import type { AuxiliarySession, AuxiliarySessionSummary } from "../src/auxiliary-session-state.js";
+import type {
+  AuxiliarySession,
+  AuxiliarySessionSummary,
+  CreateAuxiliarySessionInput,
+} from "../src/auxiliary-session-state.js";
 import type {
   CreateMateInput,
   MateProfile,
@@ -301,7 +305,7 @@ export type MainIpcRegistrationDeps = {
   listAuxiliarySessions?(parentSessionId: string): Awaitable<AuxiliarySessionSummary[]>;
   getActiveAuxiliarySession?(parentSessionId: string): Awaitable<AuxiliarySession | null>;
   getAuxiliarySession?(auxiliarySessionId: string): Awaitable<AuxiliarySession | null>;
-  createAuxiliarySession?(parentSessionId: string): Awaitable<AuxiliarySession>;
+  createAuxiliarySession?(input: CreateAuxiliarySessionInput): Awaitable<AuxiliarySession>;
   updateAuxiliarySession?(session: AuxiliarySession): Awaitable<AuxiliarySession>;
   closeAuxiliarySession?(auxiliarySessionId: string): Awaitable<AuxiliarySession>;
   runAuxiliarySessionTurn?(auxiliarySessionId: string, request: RunSessionTurnRequest): Awaitable<AuxiliarySession>;
@@ -465,7 +469,7 @@ type MainIpcAuxiliaryDepsRequired = {
   listAuxiliarySessions: (parentSessionId: string) => Awaitable<AuxiliarySessionSummary[]>;
   getActiveAuxiliarySession: (parentSessionId: string) => Awaitable<AuxiliarySession | null>;
   getAuxiliarySession: (auxiliarySessionId: string) => Awaitable<AuxiliarySession | null>;
-  createAuxiliarySession: (parentSessionId: string) => Awaitable<AuxiliarySession>;
+  createAuxiliarySession: (input: CreateAuxiliarySessionInput) => Awaitable<AuxiliarySession>;
   updateAuxiliarySession: (session: AuxiliarySession) => Awaitable<AuxiliarySession>;
   closeAuxiliarySession: (auxiliarySessionId: string) => Awaitable<AuxiliarySession>;
   runAuxiliarySessionTurn: (
@@ -689,8 +693,8 @@ function registerAuxiliaryHandlers(ipcMain: IpcHandleRegistrar, deps: MainIpcAux
     }
     return auxiliaryDeps.getAuxiliarySession(auxiliarySessionId);
   });
-  ipcMain.handle(WITHMATE_CREATE_AUXILIARY_SESSION_CHANNEL, (_event, parentSessionId: string) =>
-    getAuxiliaryDeps(deps).createAuxiliarySession(parentSessionId),
+  ipcMain.handle(WITHMATE_CREATE_AUXILIARY_SESSION_CHANNEL, (_event, input: CreateAuxiliarySessionInput) =>
+    getAuxiliaryDeps(deps).createAuxiliarySession(input),
   );
   ipcMain.handle(WITHMATE_UPDATE_AUXILIARY_SESSION_CHANNEL, (_event, session: AuxiliarySession) =>
     getAuxiliaryDeps(deps).updateAuxiliarySession(session),

--- a/src-electron/main.ts
+++ b/src-electron/main.ts
@@ -1121,8 +1121,8 @@ function requireMainInfrastructureRegistry(): MainInfrastructureRegistry<
                   requireAuxiliarySessionService().getActiveAuxiliarySession(parentSessionId),
                 getAuxiliarySession: (auxiliarySessionId) =>
                   requireAuxiliarySessionService().getAuxiliarySession(auxiliarySessionId),
-                createAuxiliarySession: (parentSessionId) =>
-                  requireAuxiliarySessionService().createAuxiliarySession(parentSessionId),
+                createAuxiliarySession: (input) =>
+                  requireAuxiliarySessionService().createAuxiliarySession(input),
                 updateAuxiliarySession: (session) =>
                   requireAuxiliarySessionService().updateAuxiliarySession(session),
                 closeAuxiliarySession: (auxiliarySessionId) =>

--- a/src-electron/preload-api.ts
+++ b/src-electron/preload-api.ts
@@ -359,8 +359,8 @@ function createAuxiliaryApi(ipcRenderer: IpcRendererLike): WithMateWindowAuxilia
     getAuxiliarySession(auxiliarySessionId) {
       return ipcRenderer.invoke(WITHMATE_GET_AUXILIARY_SESSION_CHANNEL, auxiliarySessionId);
     },
-    createAuxiliarySession(parentSessionId) {
-      return ipcRenderer.invoke(WITHMATE_CREATE_AUXILIARY_SESSION_CHANNEL, parentSessionId);
+    createAuxiliarySession(input) {
+      return ipcRenderer.invoke(WITHMATE_CREATE_AUXILIARY_SESSION_CHANNEL, input);
     },
     updateAuxiliarySession(session) {
       return ipcRenderer.invoke(WITHMATE_UPDATE_AUXILIARY_SESSION_CHANNEL, session);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,6 +60,7 @@ import {
   resolveAvailableContextPaneTabs,
 } from "./session-ui-projection.js";
 import { ChatWindow, ChatWindowStatusScreen } from "./chat/chat-window.js";
+import { AuxiliaryLaunchProviderDialog } from "./chat/AuxiliaryLaunchProviderDialog.js";
 import {
   buildComposerSendabilityState,
   getComposerSendButtonTitle,
@@ -456,6 +457,9 @@ export default function AgentSessionWindowApp() {
   const [activeAuxiliarySession, setActiveAuxiliarySession] = useState<AuxiliarySession | null>(null);
   const [closedAuxiliarySessions, setClosedAuxiliarySessions] = useState<AuxiliarySession[]>([]);
   const [isAuxiliaryActionPending, setIsAuxiliaryActionPending] = useState(false);
+  const [auxiliaryLaunchDialogOpen, setAuxiliaryLaunchDialogOpen] = useState(false);
+  const [auxiliaryLaunchProviderId, setAuxiliaryLaunchProviderId] = useState<string | null>(null);
+  const [auxiliaryLaunchFeedback, setAuxiliaryLaunchFeedback] = useState("");
   const activityMonitorRef = useRef<HTMLDivElement | null>(null);
   const composerTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const activityMonitorSignatureRef = useRef("");
@@ -667,12 +671,12 @@ export default function AgentSessionWindowApp() {
   });
   const selectedProviderQuotaTelemetry = useMemo(
     () => (
-      selectedSession?.provider
-      && providerQuotaTelemetryState.ownerProviderId === selectedSession.provider
+      displayedSession?.provider
+      && providerQuotaTelemetryState.ownerProviderId === displayedSession.provider
         ? providerQuotaTelemetryState.telemetry
         : null
     ),
-    [providerQuotaTelemetryState.ownerProviderId, providerQuotaTelemetryState.telemetry, selectedSession?.provider],
+    [displayedSession?.provider, providerQuotaTelemetryState.ownerProviderId, providerQuotaTelemetryState.telemetry],
   );
   const selectedSessionContextTelemetry = useMemo(
     () => (
@@ -745,8 +749,18 @@ export default function AgentSessionWindowApp() {
     replacements: { name: selectedSessionCharacter?.name || DEFAULT_SESSION_RUNTIME_NAME },
   });
   const isSelectedProviderEnabled = useMemo(
-    () => !!selectedSession && getProviderAppSettings(appSettings, selectedSession.provider).enabled,
-    [appSettings, selectedSession],
+    () => !!displayedSession && getProviderAppSettings(appSettings, displayedSession.provider).enabled,
+    [appSettings, displayedSession],
+  );
+  const auxiliaryLaunchProviders = useMemo(
+    () => (modelCatalog?.providers ?? []).filter(
+      (provider) => getProviderAppSettings(appSettings, provider.id).enabled,
+    ),
+    [appSettings, modelCatalog],
+  );
+  const auxiliaryLaunchProviderItems = useMemo(
+    () => auxiliaryLaunchProviders.map((provider) => ({ id: provider.id, label: provider.label })),
+    [auxiliaryLaunchProviders],
   );
   const sessionExecutionBlockedReason = useMemo(() => {
     if (!selectedSession) {
@@ -776,7 +790,7 @@ export default function AgentSessionWindowApp() {
   useEffect(() => {
     let active = true;
 
-    if (!withmateApi || !selectedSession || selectedSession.provider !== "copilot") {
+    if (!withmateApi || !activeRunSessionId || displayedSession?.provider !== "copilot") {
       setAvailableCustomAgents([]);
       setIsCustomAgentListLoading(false);
       return () => {
@@ -785,7 +799,7 @@ export default function AgentSessionWindowApp() {
     }
 
     setIsCustomAgentListLoading(true);
-    void withmateApi.listSessionCustomAgents(selectedSession.id).then((agents) => {
+    void withmateApi.listSessionCustomAgents(activeRunSessionId).then((agents) => {
       if (active) {
         setAvailableCustomAgents(agents);
         setIsCustomAgentListLoading(false);
@@ -800,12 +814,12 @@ export default function AgentSessionWindowApp() {
     return () => {
       active = false;
     };
-  }, [selectedSession]);
+  }, [activeRunSessionId, displayedSession?.provider, withmateApi]);
 
   useEffect(() => {
     let active = true;
 
-    if (!withmateApi || !selectedSession) {
+    if (!withmateApi || !activeRunSessionId) {
       setAvailableSkills([]);
       setIsSkillListLoading(false);
       return () => {
@@ -814,7 +828,7 @@ export default function AgentSessionWindowApp() {
     }
 
     setIsSkillListLoading(true);
-    void withmateApi.listSessionSkills(selectedSession.id).then((skills) => {
+    void withmateApi.listSessionSkills(activeRunSessionId).then((skills) => {
       if (active) {
         setAvailableSkills(skills);
         setIsSkillListLoading(false);
@@ -829,7 +843,7 @@ export default function AgentSessionWindowApp() {
     return () => {
       active = false;
     };
-  }, [appSettings, selectedSession]);
+  }, [activeRunSessionId, appSettings, withmateApi]);
 
   useEffect(() => {
     setIsAgentPickerOpen(false);
@@ -1126,7 +1140,7 @@ export default function AgentSessionWindowApp() {
 
   useEffect(() => {
     let active = true;
-    const providerId = selectedSession?.provider ?? null;
+    const providerId = displayedSession?.provider ?? null;
 
     if (!withmateApi || providerId !== "copilot") {
       setProviderQuotaTelemetryState({ ownerProviderId: providerId, telemetry: null });
@@ -1163,7 +1177,7 @@ export default function AgentSessionWindowApp() {
       active = false;
       unsubscribe();
     };
-  }, [selectedSession?.provider]);
+  }, [displayedSession?.provider, withmateApi]);
 
   useEffect(() => {
     let active = true;
@@ -1297,7 +1311,7 @@ export default function AgentSessionWindowApp() {
     () => (modelCatalog && displayedSession ? getProviderCatalog(modelCatalog.providers, displayedSession.provider) : null),
     [displayedSession, modelCatalog],
   );
-  const isCopilotSession = selectedSession?.provider === "copilot";
+  const isCopilotSession = displayedSession?.provider === "copilot";
   const selectedCopilotQuotaProjection = useMemo(
     () => (isCopilotSession ? buildCopilotQuotaProjection(selectedProviderQuotaTelemetry) : null),
     [isCopilotSession, selectedProviderQuotaTelemetry],
@@ -1580,20 +1594,20 @@ export default function AgentSessionWindowApp() {
   );
   const approvalChoiceOptions = useMemo(
     () => {
-      const options = getApprovalOptionsForProvider(selectedSession?.provider);
-      if (!selectedSession || options.some((option) => option.value === selectedSession.approvalMode)) {
+      const options = getApprovalOptionsForProvider(displayedSession?.provider);
+      if (!displayedSession || options.some((option) => option.value === displayedSession.approvalMode)) {
         return options;
       }
 
-      return [{ value: selectedSession.approvalMode, label: selectedSession.approvalMode }, ...options];
+      return [{ value: displayedSession.approvalMode, label: displayedSession.approvalMode }, ...options];
     },
-    [selectedSession?.approvalMode, selectedSession?.provider],
+    [displayedSession?.approvalMode, displayedSession?.provider],
   );
   const sandboxChoiceOptions = useMemo(
-    () => selectedSession
-      ? getSandboxOptionsForProviderSelection(selectedSession.provider, selectedSession.codexSandboxMode)
+    () => displayedSession
+      ? getSandboxOptionsForProviderSelection(displayedSession.provider, displayedSession.codexSandboxMode)
       : getSandboxOptionsForProvider(undefined),
-    [selectedSession?.codexSandboxMode, selectedSession?.provider],
+    [displayedSession?.codexSandboxMode, displayedSession?.provider],
   );
   const modelSelectOptions = useMemo(
     () => modelOptions.map((model) => ({ value: model.id, label: modelOptionLabel(model) })),
@@ -2474,8 +2488,40 @@ export default function AgentSessionWindowApp() {
     }
   };
 
+  const handleOpenAuxiliaryLaunchDialog = () => {
+    if (!selectedSession || isAuxiliaryActionPending) {
+      return;
+    }
+
+    const providerId =
+      auxiliaryLaunchProviders.find((provider) => provider.id === selectedSession.provider)?.id ??
+      auxiliaryLaunchProviders[0]?.id ??
+      null;
+    setAuxiliaryLaunchProviderId(providerId);
+    setAuxiliaryLaunchFeedback(providerId ? "" : "有効な Coding Provider がないよ。");
+    setAuxiliaryLaunchDialogOpen(true);
+  };
+
+  const handleCloseAuxiliaryLaunchDialog = () => {
+    if (isAuxiliaryActionPending) {
+      return;
+    }
+
+    setAuxiliaryLaunchDialogOpen(false);
+    setAuxiliaryLaunchFeedback("");
+  };
+
+  const handleSelectAuxiliaryLaunchProvider = (providerId: string) => {
+    setAuxiliaryLaunchProviderId(providerId);
+    setAuxiliaryLaunchFeedback("");
+  };
+
   const handleStartAuxiliarySession = async () => {
     if (!withmateApi || !selectedSession || isAuxiliaryActionPending) {
+      return;
+    }
+    if (!auxiliaryLaunchProviderId) {
+      setAuxiliaryLaunchFeedback("有効な Coding Provider を選んでね。");
       return;
     }
 
@@ -2486,12 +2532,17 @@ export default function AgentSessionWindowApp() {
 
     setIsAuxiliaryActionPending(true);
     try {
-      const session = await withmateApi.createAuxiliarySession(parentSessionId);
+      const session = await withmateApi.createAuxiliarySession({
+        parentSessionId,
+        provider: auxiliaryLaunchProviderId,
+      });
       setActiveAuxiliarySession(session);
       setIsActionDockPinnedExpanded(true);
       setForceComposerBlockedFeedback(false);
+      setAuxiliaryLaunchDialogOpen(false);
+      setAuxiliaryLaunchFeedback("");
     } catch (error) {
-      window.alert(error instanceof Error ? error.message : "Auxiliary Session の開始に失敗したよ。");
+      setAuxiliaryLaunchFeedback(error instanceof Error ? error.message : "Auxiliary Session の開始に失敗したよ。");
     } finally {
       void loadClosedAuxiliarySessions(parentSessionId, canApplyLoadResult);
       setIsAuxiliaryActionPending(false);
@@ -3172,7 +3223,7 @@ export default function AgentSessionWindowApp() {
       <button
         className="drawer-toggle compact secondary"
         type="button"
-        onClick={() => void handleStartAuxiliarySession()}
+        onClick={handleOpenAuxiliaryLaunchDialog}
         disabled={isAuxiliaryActionPending || isSelectedSessionRunning || isSelectedSessionReadOnly}
       >
         Auxiliary
@@ -3427,6 +3478,16 @@ export default function AgentSessionWindowApp() {
         onLoadAuditLogOperationDetail: handleLoadAuditLogOperationDetail,
         onCloseAuditLog: () => setAuditLogsOpen(false),
       })}
+      />
+      <AuxiliaryLaunchProviderDialog
+        open={auxiliaryLaunchDialogOpen}
+        providers={auxiliaryLaunchProviderItems}
+        selectedProviderId={auxiliaryLaunchProviderId}
+        feedback={auxiliaryLaunchFeedback}
+        starting={isAuxiliaryActionPending}
+        onClose={handleCloseAuxiliaryLaunchDialog}
+        onSelectProvider={handleSelectAuxiliaryLaunchProvider}
+        onStart={() => void handleStartAuxiliarySession()}
       />
     </>
   );

--- a/src/auxiliary-session-state.ts
+++ b/src/auxiliary-session-state.ts
@@ -5,6 +5,11 @@ import { normalizeMessage, type Message } from "./session-state.js";
 
 export type AuxiliarySessionStatus = "active" | "closed";
 
+export type CreateAuxiliarySessionInput = {
+  parentSessionId: string;
+  provider: string;
+};
+
 export type AuxiliarySession = {
   id: string;
   parentSessionId: string;

--- a/src/chat/AuxiliaryLaunchProviderDialog.tsx
+++ b/src/chat/AuxiliaryLaunchProviderDialog.tsx
@@ -1,0 +1,106 @@
+import { useRef } from "react";
+
+import { focusRovingItemByKey, useDialogA11y } from "../a11y.js";
+
+type AuxiliaryLaunchProviderDialogProps = {
+  open: boolean;
+  providers: Array<{ id: string; label: string }>;
+  selectedProviderId: string | null;
+  feedback: string;
+  starting: boolean;
+  onClose: () => void;
+  onSelectProvider: (providerId: string) => void;
+  onStart: () => void;
+};
+
+export function AuxiliaryLaunchProviderDialog({
+  open,
+  providers,
+  selectedProviderId,
+  feedback,
+  starting,
+  onClose,
+  onSelectProvider,
+  onStart,
+}: AuxiliaryLaunchProviderDialogProps) {
+  const startButtonRef = useRef<HTMLButtonElement | null>(null);
+  const { dialogRef, handleDialogKeyDown } = useDialogA11y<HTMLElement>({
+    open,
+    onClose,
+    initialFocusRef: startButtonRef,
+  });
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="launch-modal" role="dialog" aria-modal="true" onClick={onClose}>
+      <section
+        ref={dialogRef}
+        className="launch-dialog panel auxiliary-provider-dialog"
+        onClick={(event) => event.stopPropagation()}
+        onKeyDown={handleDialogKeyDown}
+      >
+        <div className="launch-dialog-head minimal">
+          <button className="diff-close" type="button" onClick={onClose}>
+            Close
+          </button>
+        </div>
+
+        <div className="launch-panel minimal">
+          <section className="launch-section minimal">
+            <div className="launch-field">
+              <label className="launch-field-label" htmlFor="auxiliary-provider-picker">
+                Coding Provider
+              </label>
+              {providers.length > 0 ? (
+                <div
+                  id="auxiliary-provider-picker"
+                  className="choice-list launch-provider-list"
+                  role="listbox"
+                  aria-label="Coding Provider"
+                  aria-orientation="horizontal"
+                  onKeyDown={(event) => {
+                    focusRovingItemByKey(event, { orientation: "horizontal", activateOnFocus: true });
+                  }}
+                >
+                  {providers.map((provider) => (
+                    <button
+                      key={provider.id}
+                      className={`choice-chip${provider.id === selectedProviderId ? " active" : ""}`}
+                      type="button"
+                      role="option"
+                      aria-selected={provider.id === selectedProviderId}
+                      tabIndex={provider.id === selectedProviderId ? 0 : -1}
+                      onClick={() => onSelectProvider(provider.id)}
+                    >
+                      {provider.label}
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <article className="empty-list-card compact">
+                  <p>有効な Coding Provider がないよ。</p>
+                </article>
+              )}
+            </div>
+          </section>
+        </div>
+
+        <div className="launch-dialog-foot minimal">
+          {feedback ? <p className="launch-feedback">{feedback}</p> : null}
+          <button
+            ref={startButtonRef}
+            className="start-session-button"
+            type="button"
+            disabled={!selectedProviderId || starting}
+            onClick={onStart}
+          >
+            {starting ? "Starting..." : "Start Auxiliary"}
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1781,6 +1781,10 @@ button:disabled {
   background: rgba(251, 248, 244, 0.97);
 }
 
+.auxiliary-provider-dialog {
+  width: min(560px, 100%);
+}
+
 .settings-dialog {
   width: min(720px, 100%);
   max-height: min(760px, calc(100vh - 52px));

--- a/src/withmate-window-api.ts
+++ b/src/withmate-window-api.ts
@@ -51,7 +51,11 @@ import type {
 import type { RendererLogInput } from "./app-log-types.js";
 import type { AppBootStatus } from "./app-boot-state.js";
 import type { AppDatabaseDiagnostics } from "./app-database-diagnostics-state.js";
-import type { AuxiliarySession, AuxiliarySessionSummary } from "./auxiliary-session-state.js";
+import type {
+  AuxiliarySession,
+  AuxiliarySessionSummary,
+  CreateAuxiliarySessionInput,
+} from "./auxiliary-session-state.js";
 import type { WorkspacePathCandidate } from "./workspace-path-candidate.js";
 import type {
   OpenPathOptions,
@@ -144,7 +148,7 @@ export type WithMateWindowAuxiliaryApi = {
   listAuxiliarySessions(parentSessionId: string): Promise<AuxiliarySessionSummary[]>;
   getActiveAuxiliarySession(parentSessionId: string): Promise<AuxiliarySession | null>;
   getAuxiliarySession(auxiliarySessionId: string): Promise<AuxiliarySession | null>;
-  createAuxiliarySession(parentSessionId: string): Promise<AuxiliarySession>;
+  createAuxiliarySession(input: CreateAuxiliarySessionInput): Promise<AuxiliarySession>;
   updateAuxiliarySession(session: AuxiliarySession): Promise<AuxiliarySession>;
   closeAuxiliarySession(auxiliarySessionId: string): Promise<AuxiliarySession>;
   runAuxiliarySessionTurn(auxiliarySessionId: string, request: RunSessionTurnRequest): Promise<AuxiliarySession>;


### PR DESCRIPTION
## Summary
- Auxiliary 起動前に Provider だけを選べる dialog を追加
- createAuxiliarySession の入力を parentSessionId + provider に変更し、選択 Provider の catalog default model / reasoning で初期化
- Auxiliary 中の ActionDock / quota / custom agent / skill 表示を displayed session の Provider 基準に補正
- アプリバージョンを 4.2.7 に更新

## Validation
- npm exec -- tsx --test scripts/tests/main-ipc-registration.test.ts scripts/tests/auxiliary-session-storage.test.ts scripts/tests/preload-api.test.ts scripts/tests/chat-session-modals.test.tsx
- npm run typecheck
- npm run build
- git diff --check