### PR TITLE
fix(codex): Windows taskkill parse noise を抑止

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "4.2.8",
+  "version": "4.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "4.2.8",
+      "version": "4.2.9",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "4.2.8",
+  "version": "4.2.9",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/scripts/tests/codex-adapter.test.ts
+++ b/scripts/tests/codex-adapter.test.ts
@@ -16,6 +16,7 @@ import {
   collectCodexAssistantTextSnapshotsFromEventsForTesting,
   collectCodexAssistantTextFromEventsForTesting,
   collectCodexReasoningTextFromEventsForTesting,
+  isCodexWindowsTaskkillSuccessParseNoiseMessage,
   resolveCodexThreadForSettings,
   type CodexThreadOptions,
 } from "../../src-electron/codex-adapter.js";
@@ -113,6 +114,22 @@ function createCodexBackgroundPromptInput(
 }
 
 describe("CodexAdapter thread settings", () => {
+  it("Windows taskkill の SUCCESS 行だけ Codex JSON parse noise として扱う", () => {
+    assert.equal(
+      isCodexWindowsTaskkillSuccessParseNoiseMessage(
+        "Failed to parse item: SUCCESS: The process with PID 13760 (child process of PID 32340) has been terminated.",
+      ),
+      true,
+    );
+    assert.equal(
+      isCodexWindowsTaskkillSuccessParseNoiseMessage(
+        "Failed to parse item: ERROR: The process with PID 13760 could not be terminated.",
+      ),
+      false,
+    );
+    assert.equal(isCodexWindowsTaskkillSuccessParseNoiseMessage("SUCCESS: ordinary command output"), false);
+  });
+
   it("delta 系 event から assistant text を逐次復元し、final item で確定形に置き換える", () => {
     const streamedText = collectCodexAssistantTextFromEventsForTesting([
       {

--- a/src-electron/codex-adapter.ts
+++ b/src-electron/codex-adapter.ts
@@ -111,9 +111,17 @@ type CodexTurnStreamState = {
   usage: Usage | null;
   liveUsage: AuditLogUsage | null;
   streamErrorMessage: string;
+  turnCompleted: boolean;
 };
 
 type CodexEventRecord = Record<string, unknown>;
+
+const CODEX_WINDOWS_TASKKILL_SUCCESS_PARSE_NOISE_PATTERN =
+  /^Failed to parse item:\s*SUCCESS:\s+The process with PID \d+ \(child process of PID \d+\) has been terminated\.\s*$/;
+
+export function isCodexWindowsTaskkillSuccessParseNoiseMessage(message: string): boolean {
+  return CODEX_WINDOWS_TASKKILL_SUCCESS_PARSE_NOISE_PATTERN.test(message.trim());
+}
 
 export type CodexThreadOptions = {
   workingDirectory: string;
@@ -797,6 +805,7 @@ function createCodexTurnStreamState(threadId: string | null): CodexTurnStreamSta
     usage: null,
     liveUsage: null,
     streamErrorMessage: "",
+    turnCompleted: false,
   };
 }
 
@@ -902,6 +911,7 @@ function applyCodexTurnEvent(state: CodexTurnStreamState, event: ThreadEvent): v
     case "turn.completed":
       state.usage = event.usage;
       state.liveUsage = normalizeCodexTokenUsage(event.usage);
+      state.turnCompleted = true;
       break;
     case "turn.failed":
       state.streamErrorMessage = event.error.message;
@@ -1452,6 +1462,7 @@ export class CodexAdapter implements ProviderTurnAdapter {
       }
 
       const message = error instanceof Error ? error.message : String(error);
+      const isWindowsTaskkillParseNoise = isCodexWindowsTaskkillSuccessParseNoiseMessage(message);
       const partialResult = await this.buildTurnResult(
         input,
         prompt,
@@ -1463,10 +1474,14 @@ export class CodexAdapter implements ProviderTurnAdapter {
         beforeSnapshot,
         beforeSnapshotStats,
       );
+      if (isWindowsTaskkillParseNoise && streamState.turnCompleted) {
+        return partialResult;
+      }
+
       throw new ProviderTurnError(
         message,
         partialResult,
-        Boolean(input.signal?.aborted) || isCanceledProviderMessage(message),
+        Boolean(input.signal?.aborted) || isCanceledProviderMessage(message) || isWindowsTaskkillParseNoise,
       );
     }
   }


### PR DESCRIPTION
## 概要
- Codex SDK の JSON stream に混入する Windows taskkill の SUCCESS 行を終了ノイズとして扱う
- turn.completed 後の同ノイズでは partial result を成功として返す
- アプリバージョンを 4.2.9 に更新

## 検証
- npx tsx --test scripts/tests/codex-adapter.test.ts
- npm run typecheck
- git diff --check