### PR TITLE
fix(codex): collab tool call の diff 欠落を防ぐ

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "4.2.10",
+  "version": "4.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "4.2.10",
+      "version": "4.2.11",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "4.2.10",
+  "version": "4.2.11",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/scripts/tests/codex-adapter.test.ts
+++ b/scripts/tests/codex-adapter.test.ts
@@ -145,6 +145,16 @@ async function* createCodexStreamThatThrowsAfter(
   throw new Error(errorMessage);
 }
 
+async function* createCodexStreamFromEvents(
+  events: unknown[],
+  beforeYield?: () => Promise<void>,
+): AsyncGenerator<never> {
+  await beforeYield?.();
+  for (const event of events) {
+    yield event as never;
+  }
+}
+
 describe("CodexAdapter thread settings", () => {
   const windowsTaskkillParseNoiseMessage =
     "Failed to parse item: SUCCESS: The process with PID 13760 (child process of PID 32340) has been terminated.";
@@ -432,6 +442,41 @@ describe("CodexAdapter thread settings", () => {
     assert.equal(collectCodexReasoningTextFromEventsForTesting(events), "既存経路を確認してから UI に流す");
   });
 
+  it("collab_tool_call は監査 rawItems に残す", () => {
+    const items = buildCodexStableRawItems([
+      {
+        id: "item_33",
+        type: "collab_tool_call",
+        tool: "close_agent",
+        status: "completed",
+        agents_states: {
+          "agent-1": {
+            status: "completed",
+            message: "Pass",
+          },
+        },
+      } as never,
+    ]);
+
+    assert.deepEqual(items, [
+      {
+        type: "collab_tool_call",
+        data: {
+          id: "item_33",
+          status: "completed",
+          tool: "close_agent",
+          agentsStates: {
+            "agent-1": {
+              status: "completed",
+              message: "Pass",
+            },
+          },
+          errorMessage: null,
+        },
+      },
+    ]);
+  });
+
   it("model / reasoning 変更後の thread settings は新 options と settingsKey を反映する", () => {
     const previousSession = createSession({
       threadId: "thread-1",
@@ -637,6 +682,99 @@ describe("workspace snapshot targeted capture", () => {
       assert.equal(refreshed.usedFullRebuild, false);
       assert.equal(refreshed.reason, "file-refresh");
       assert.equal(refreshed.snapshot.get("src/changed.ts"), "after\n");
+    } finally {
+      await rm(workspacePath, { recursive: true, force: true });
+    }
+  });
+
+  it("collab_tool_call がある場合は file_change 候補だけを信用せず snapshot fallback で差分を拾う", async () => {
+    const workspacePath = await mkdtemp(path.join(os.tmpdir(), "withmate-codex-collab-diff-"));
+    const adapter = new CodexAdapter() as unknown as {
+      getClient: () => {
+        client: {
+          startThread: () => {
+            id: string;
+            runStreamed: () => Promise<{ events: AsyncGenerator<never> }>;
+          };
+          resumeThread: never;
+        };
+        clientKey: string;
+      };
+      runSessionTurn: CodexAdapter["runSessionTurn"];
+    };
+
+    try {
+      await mkdir(path.join(workspacePath, "src"), { recursive: true });
+      const explicitFilePath = path.join(workspacePath, "src", "explicit.ts");
+      const collabSideEffectFilePath = path.join(workspacePath, "src", "collab-side-effect.ts");
+      await writeFile(explicitFilePath, "before explicit\n", "utf8");
+      await writeFile(collabSideEffectFilePath, "before collab\n", "utf8");
+
+      adapter.getClient = () => ({
+        client: {
+          startThread: () => ({
+            id: "thread-1",
+            runStreamed: async () => ({
+              events: createCodexStreamFromEvents([
+                {
+                  type: "item.completed",
+                  item: {
+                    id: "file-change-1",
+                    type: "file_change",
+                    status: "completed",
+                    changes: [
+                      {
+                        kind: "update",
+                        path: explicitFilePath,
+                      },
+                    ],
+                  },
+                },
+                {
+                  type: "item.completed",
+                  item: {
+                    id: "item_33",
+                    type: "collab_tool_call",
+                    tool: "close_agent",
+                    status: "completed",
+                    agents_states: {
+                      "agent-1": {
+                        status: "completed",
+                        message: "Pass",
+                      },
+                    },
+                  },
+                },
+                {
+                  type: "item.completed",
+                  item: {
+                    id: "message-1",
+                    type: "agent_message",
+                    text: "done",
+                  },
+                },
+                {
+                  type: "turn.completed",
+                  usage: null,
+                },
+              ], async () => {
+                await writeFile(explicitFilePath, "after explicit\n", "utf8");
+                await writeFile(collabSideEffectFilePath, "after collab\n", "utf8");
+              }),
+            }),
+          }),
+          resumeThread: undefined as never,
+        },
+        clientKey: "client-key",
+      });
+
+      const result = await adapter.runSessionTurn(createCodexRunSessionTurnInput(workspacePath));
+      const changedPaths = result.artifact?.changedFiles.map((file) => file.path).sort();
+
+      assert.deepEqual(changedPaths, [
+        "src/collab-side-effect.ts",
+        "src/explicit.ts",
+      ]);
     } finally {
       await rm(workspacePath, { recursive: true, force: true });
     }

--- a/src-electron/codex-adapter.ts
+++ b/src-electron/codex-adapter.ts
@@ -102,7 +102,7 @@ type RawDiffOp =
   | { kind: "add"; rightNumber: number; rightText: string };
 
 type CodexTurnStreamState = {
-  items: Map<string, ThreadItem>;
+  items: Map<string, CodexTurnItem>;
   liveSteps: Map<string, LiveRunStep>;
   threadId: string | null;
   streamedAssistantText: string;
@@ -115,6 +115,17 @@ type CodexTurnStreamState = {
 };
 
 type CodexEventRecord = Record<string, unknown>;
+
+type CodexCollabToolCallItem = {
+  id: string;
+  type: "collab_tool_call";
+  tool?: string;
+  status?: string;
+  agents_states?: unknown;
+  error?: { message?: string };
+};
+
+type CodexTurnItem = ThreadItem | CodexCollabToolCallItem;
 
 const CODEX_WINDOWS_TASKKILL_SUCCESS_PARSE_NOISE_PATTERN =
   /^Failed to parse item:\s*SUCCESS:\s+The process with PID \d+ \(child process of PID \d+\) has been terminated\.\s*$/;
@@ -369,14 +380,23 @@ function compareSnapshotChanges(beforeSnapshot: WorkspaceSnapshot, afterSnapshot
   return changes.sort((left, right) => left.path.localeCompare(right.path));
 }
 
-function collectCompletedFileChangeItems(items: ThreadItem[]): Array<Extract<ThreadItem, { type: "file_change" }>> {
+function isCodexCollabToolCallItem(item: unknown): item is CodexCollabToolCallItem {
+  return (
+    typeof item === "object"
+    && item !== null
+    && (item as { type?: unknown }).type === "collab_tool_call"
+    && typeof (item as { id?: unknown }).id === "string"
+  );
+}
+
+function collectCompletedFileChangeItems(items: CodexTurnItem[]): Array<Extract<ThreadItem, { type: "file_change" }>> {
   return items.filter(
     (item): item is Extract<ThreadItem, { type: "file_change" }> =>
       item.type === "file_change" && item.status === "completed",
   );
 }
 
-function collectCompletedFileChangePaths(workspacePath: string, items: ThreadItem[]): string[] {
+function collectCompletedFileChangePaths(workspacePath: string, items: CodexTurnItem[]): string[] {
   const paths = new Set<string>();
 
   for (const item of collectCompletedFileChangeItems(items)) {
@@ -388,19 +408,19 @@ function collectCompletedFileChangePaths(workspacePath: string, items: ThreadIte
   return Array.from(paths).sort((left, right) => left.localeCompare(right));
 }
 
-function hasBroadFilesystemChangeSource(items: ThreadItem[]): boolean {
+function hasBroadFilesystemChangeSource(items: CodexTurnItem[]): boolean {
   return items.some((item) => {
     if ("status" in item && item.status !== "completed") {
       return false;
     }
 
-    return item.type === "command_execution" || item.type === "mcp_tool_call";
+    return item.type === "command_execution" || item.type === "mcp_tool_call" || isCodexCollabToolCallItem(item);
   });
 }
 
 function buildChangedFilesFromSources(
   workspacePath: string,
-  items: ThreadItem[],
+  items: CodexTurnItem[],
   beforeSnapshot: WorkspaceSnapshot,
   afterSnapshot: WorkspaceSnapshot,
   useSnapshotFallback: boolean,
@@ -445,10 +465,17 @@ function buildChangedFilesFromSources(
     });
 }
 
-function toActivitySummary(items: ThreadItem[]): string[] {
+function toActivitySummary(items: CodexTurnItem[]): string[] {
   const summary: string[] = [];
 
   for (const item of items) {
+    if (isCodexCollabToolCallItem(item)) {
+      if (item.status === "completed") {
+        summary.push(`collab: ${item.tool ?? "tool"}`);
+      }
+      continue;
+    }
+
     switch (item.type) {
       case "command_execution":
         if (item.status === "completed") {
@@ -476,7 +503,7 @@ function toActivitySummary(items: ThreadItem[]): string[] {
   return summary.slice(0, 6);
 }
 
-function collectAssistantText(items: Iterable<ThreadItem>): string {
+function collectAssistantText(items: Iterable<CodexTurnItem>): string {
   const parts: string[] = [];
 
   for (const item of items) {
@@ -526,10 +553,21 @@ function parseStructuredPromptJson(rawText: string): unknown | null {
   }
 }
 
-function toAuditOperations(items: ThreadItem[]): AuditLogOperation[] {
+function toAuditOperations(items: CodexTurnItem[]): AuditLogOperation[] {
   const operations: AuditLogOperation[] = [];
 
   for (const item of items) {
+    if (isCodexCollabToolCallItem(item)) {
+      operations.push({
+        type: item.type,
+        summary: item.tool ?? "collab tool",
+        details: item.error?.message
+          ? toAuditTextPreview(item.error.message)
+          : stringifyBoundedAuditValue(item.agents_states),
+      });
+      continue;
+    }
+
     switch (item.type) {
       case "command_execution":
         operations.push({
@@ -598,10 +636,24 @@ function pushCodexRawItem(items: BoundedAuditRawItem[], item: BoundedAuditRawIte
   items.push(boundAuditRawItem(item));
 }
 
-export function buildCodexStableRawItems(items: ThreadItem[]): BoundedAuditRawItem[] {
+export function buildCodexStableRawItems(items: CodexTurnItem[]): BoundedAuditRawItem[] {
   const rawItems: BoundedAuditRawItem[] = [];
 
   for (const item of items) {
+    if (isCodexCollabToolCallItem(item)) {
+      pushCodexRawItem(rawItems, {
+        type: item.type,
+        data: {
+          id: item.id,
+          status: item.status ?? null,
+          tool: item.tool ?? null,
+          agentsStates: item.agents_states ?? null,
+          errorMessage: item.error?.message ?? null,
+        },
+      });
+      continue;
+    }
+
     switch (item.type) {
       case "command_execution":
         pushCodexRawItem(rawItems, {
@@ -708,7 +760,19 @@ function toLiveStepStatus(value: string | undefined): LiveRunStep["status"] {
   return "in_progress";
 }
 
-function buildLiveStep(item: ThreadItem): LiveRunStep | null {
+function buildLiveStep(item: CodexTurnItem): LiveRunStep | null {
+  if (isCodexCollabToolCallItem(item)) {
+    return {
+      id: item.id,
+      type: item.type,
+      summary: item.tool ?? "collab tool",
+      details: item.error?.message
+        ? toAuditTextPreview(item.error.message)
+        : stringifyBoundedAuditValue(item.agents_states),
+      status: toLiveStepStatus(item.status),
+    };
+  }
+
   switch (item.type) {
     case "command_execution":
       return {
@@ -890,7 +954,7 @@ function getLiveAssistantText(state: CodexTurnStreamState): string {
   return state.finalAssistantText || state.streamedAssistantText;
 }
 
-function collectReasoningText(items: Iterable<ThreadItem>): string {
+function collectReasoningText(items: Iterable<CodexTurnItem>): string {
   return Array.from(items)
     .filter((item): item is Extract<ThreadItem, { type: "reasoning" }> => item.type === "reasoning")
     .map((item) => item.text.trim())
@@ -1056,7 +1120,7 @@ function summarizeSnapshotWarning(stats: SnapshotCaptureStats): string {
 async function buildArtifact(
   session: Session,
   workspacePath: string,
-  items: ThreadItem[],
+  items: CodexTurnItem[],
   usage: Usage | null,
   threadId: string | null,
   beforeSnapshot: WorkspaceSnapshot,
@@ -1314,7 +1378,7 @@ export class CodexAdapter implements ProviderTurnAdapter {
 
   private async captureAfterWorkspaceSnapshot(
     input: RunSessionTurnInput,
-    finalItems: ThreadItem[],
+    finalItems: CodexTurnItem[],
   ): Promise<{
     afterSnapshot: WorkspaceSnapshot;
     afterSnapshotStats: SnapshotCaptureStats;
@@ -1342,7 +1406,7 @@ export class CodexAdapter implements ProviderTurnAdapter {
   private async buildTurnResult(
     input: RunSessionTurnInput,
     prompt: ProviderPromptComposition,
-    items: Map<string, ThreadItem>,
+    items: Map<string, CodexTurnItem>,
     usage: Usage | null,
     threadId: string | null,
     streamedAssistantText: string,


### PR DESCRIPTION
## 概要
- Codex の collab_tool_call item を監査 rawItems / operation / live step に保持
- collab_tool_call が含まれる run では file_change 候補だけを信用せず snapshot fallback を使う
- app version を 4.2.11 に更新

## 原因
close_agent などの collab_tool_call は root session から見ると副作用範囲が不明な tool call だが、既存実装では broad filesystem change source として扱っていなかった。そのため同じ turn に ile_change があると targeted snapshot が使われ、subagent 側の副作用差分を Companion diff で拾い漏らす可能性があった。

## 検証
- 
pm run typecheck
- 
pm test -- scripts/tests/codex-adapter.test.ts
