### PR TITLE
fix(codex): taskkill parse noise event を成功扱いにする

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "4.2.11",
+  "version": "4.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "4.2.11",
+      "version": "4.2.12",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "4.2.11",
+  "version": "4.2.12",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/scripts/tests/codex-adapter.test.ts
+++ b/scripts/tests/codex-adapter.test.ts
@@ -227,6 +227,69 @@ describe("CodexAdapter thread settings", () => {
     }
   });
 
+  it("turn.completed 後の Windows taskkill parse noise event は進捗 error に出さず成功結果として返す", async () => {
+    const workspacePath = await mkdtemp(path.join(os.tmpdir(), "withmate-codex-taskkill-event-completed-"));
+    const adapter = new CodexAdapter() as unknown as {
+      getClient: () => {
+        client: {
+          startThread: () => {
+            id: string;
+            runStreamed: () => Promise<{ events: AsyncGenerator<never> }>;
+          };
+          resumeThread: never;
+        };
+        clientKey: string;
+      };
+      runSessionTurn: CodexAdapter["runSessionTurn"];
+    };
+    const progressErrors: string[] = [];
+
+    try {
+      adapter.getClient = () => ({
+        client: {
+          startThread: () => ({
+            id: "thread-1",
+            runStreamed: async () => ({
+              events: createCodexStreamFromEvents([
+                {
+                  type: "item.completed",
+                  item: {
+                    id: "message-1",
+                    type: "agent_message",
+                    text: "done",
+                  },
+                },
+                {
+                  type: "turn.completed",
+                  usage: null,
+                },
+                {
+                  type: "error",
+                  message: windowsTaskkillParseNoiseMessage,
+                },
+              ]),
+            }),
+          }),
+          resumeThread: undefined as never,
+        },
+        clientKey: "client-key",
+      });
+
+      const result = await adapter.runSessionTurn(
+        createCodexRunSessionTurnInput(workspacePath),
+        (state) => {
+          progressErrors.push(state.errorMessage);
+        },
+      );
+
+      assert.equal(result.threadId, "thread-1");
+      assert.equal(result.assistantText, "done");
+      assert.deepEqual(progressErrors.filter(Boolean), []);
+    } finally {
+      await rm(workspacePath, { recursive: true, force: true });
+    }
+  });
+
   it("turn.completed 前の Windows taskkill parse noise は通常の失敗として返す", async () => {
     const workspacePath = await mkdtemp(path.join(os.tmpdir(), "withmate-codex-taskkill-before-completed-"));
     const adapter = new CodexAdapter() as unknown as {

--- a/src-electron/codex-adapter.ts
+++ b/src-electron/codex-adapter.ts
@@ -954,6 +954,17 @@ function getLiveAssistantText(state: CodexTurnStreamState): string {
   return state.finalAssistantText || state.streamedAssistantText;
 }
 
+function getLiveStreamErrorMessage(state: CodexTurnStreamState): string {
+  if (
+    state.turnCompleted
+    && isCodexWindowsTaskkillSuccessParseNoiseMessage(state.streamErrorMessage)
+  ) {
+    return "";
+  }
+
+  return state.streamErrorMessage;
+}
+
 function collectReasoningText(items: Iterable<CodexTurnItem>): string {
   return Array.from(items)
     .filter((item): item is Extract<ThreadItem, { type: "reasoning" }> => item.type === "reasoning")
@@ -1468,7 +1479,7 @@ export class CodexAdapter implements ProviderTurnAdapter {
       getLiveAssistantText(streamState),
       streamState.reasoningText,
       streamState.liveUsage,
-      streamState.streamErrorMessage,
+      getLiveStreamErrorMessage(streamState),
     );
 
     try {
@@ -1486,11 +1497,14 @@ export class CodexAdapter implements ProviderTurnAdapter {
           getLiveAssistantText(streamState),
           streamState.reasoningText,
           streamState.liveUsage,
-          streamState.streamErrorMessage,
+          getLiveStreamErrorMessage(streamState),
         );
       }
 
       if (streamState.streamErrorMessage) {
+        const isWindowsTaskkillParseNoise = isCodexWindowsTaskkillSuccessParseNoiseMessage(
+          streamState.streamErrorMessage,
+        );
         const partialResult = await this.buildTurnResult(
           input,
           prompt,
@@ -1502,6 +1516,10 @@ export class CodexAdapter implements ProviderTurnAdapter {
           beforeSnapshot,
           beforeSnapshotStats,
         );
+        if (isWindowsTaskkillParseNoise && streamState.turnCompleted) {
+          return partialResult;
+        }
+
         throw new ProviderTurnError(
           streamState.streamErrorMessage,
           partialResult,


### PR DESCRIPTION
## 概要
- Codex SDK が turn.completed 後に Windows taskkill SUCCESS の parse noise を error event として返す場合も成功扱いにする
- live progress の errorMessage に同 noise を出さない
- アプリ version を 4.2.12 に更新

## 検証
- npx tsx --test scripts/tests/codex-adapter.test.ts
- npm run typecheck

## 補足
- 新規 worktree branch: fix/codex-taskkill-parse-noise-event
- npm install 時に既存依存の npm audit 警告が出たが、この修正範囲では未対応