### PR TITLE
fix(codex): suppress taskkill parse noise after activity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "4.2.12",
+  "version": "4.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "4.2.12",
+      "version": "4.2.13",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "4.2.12",
+  "version": "4.2.13",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/scripts/tests/codex-adapter.test.ts
+++ b/scripts/tests/codex-adapter.test.ts
@@ -290,6 +290,113 @@ describe("CodexAdapter thread settings", () => {
     }
   });
 
+  it("assistant item 後の Windows taskkill parse noise は turn.completed 前でも成功結果として返す", async () => {
+    const workspacePath = await mkdtemp(path.join(os.tmpdir(), "withmate-codex-taskkill-item-completed-"));
+    const adapter = new CodexAdapter() as unknown as {
+      getClient: () => {
+        client: {
+          startThread: () => {
+            id: string;
+            runStreamed: () => Promise<{ events: AsyncGenerator<never> }>;
+          };
+          resumeThread: never;
+        };
+        clientKey: string;
+      };
+      runSessionTurn: CodexAdapter["runSessionTurn"];
+    };
+
+    try {
+      adapter.getClient = () => ({
+        client: {
+          startThread: () => ({
+            id: "thread-1",
+            runStreamed: async () => ({
+              events: createCodexStreamThatThrowsAfter([
+                {
+                  type: "item.completed",
+                  item: {
+                    id: "message-1",
+                    type: "agent_message",
+                    text: "done",
+                  },
+                },
+              ], windowsTaskkillParseNoiseMessage),
+            }),
+          }),
+          resumeThread: undefined as never,
+        },
+        clientKey: "client-key",
+      });
+
+      const result = await adapter.runSessionTurn(createCodexRunSessionTurnInput(workspacePath));
+
+      assert.equal(result.threadId, "thread-1");
+      assert.equal(result.assistantText, "done");
+    } finally {
+      await rm(workspacePath, { recursive: true, force: true });
+    }
+  });
+
+  it("assistant item 後の Windows taskkill parse noise event は進捗 error に出さず成功結果として返す", async () => {
+    const workspacePath = await mkdtemp(path.join(os.tmpdir(), "withmate-codex-taskkill-event-item-completed-"));
+    const adapter = new CodexAdapter() as unknown as {
+      getClient: () => {
+        client: {
+          startThread: () => {
+            id: string;
+            runStreamed: () => Promise<{ events: AsyncGenerator<never> }>;
+          };
+          resumeThread: never;
+        };
+        clientKey: string;
+      };
+      runSessionTurn: CodexAdapter["runSessionTurn"];
+    };
+    const progressErrors: string[] = [];
+
+    try {
+      adapter.getClient = () => ({
+        client: {
+          startThread: () => ({
+            id: "thread-1",
+            runStreamed: async () => ({
+              events: createCodexStreamFromEvents([
+                {
+                  type: "item.completed",
+                  item: {
+                    id: "message-1",
+                    type: "agent_message",
+                    text: "done",
+                  },
+                },
+                {
+                  type: "error",
+                  message: windowsTaskkillParseNoiseMessage,
+                },
+              ]),
+            }),
+          }),
+          resumeThread: undefined as never,
+        },
+        clientKey: "client-key",
+      });
+
+      const result = await adapter.runSessionTurn(
+        createCodexRunSessionTurnInput(workspacePath),
+        (state) => {
+          progressErrors.push(state.errorMessage);
+        },
+      );
+
+      assert.equal(result.threadId, "thread-1");
+      assert.equal(result.assistantText, "done");
+      assert.deepEqual(progressErrors.filter(Boolean), []);
+    } finally {
+      await rm(workspacePath, { recursive: true, force: true });
+    }
+  });
+
   it("turn.completed 前の Windows taskkill parse noise は通常の失敗として返す", async () => {
     const workspacePath = await mkdtemp(path.join(os.tmpdir(), "withmate-codex-taskkill-before-completed-"));
     const adapter = new CodexAdapter() as unknown as {

--- a/src-electron/codex-adapter.ts
+++ b/src-electron/codex-adapter.ts
@@ -134,6 +134,25 @@ export function isCodexWindowsTaskkillSuccessParseNoiseMessage(message: string):
   return CODEX_WINDOWS_TASKKILL_SUCCESS_PARSE_NOISE_PATTERN.test(message.trim());
 }
 
+function hasCodexTurnResultActivity(state: CodexTurnStreamState): boolean {
+  return (
+    state.turnCompleted
+    || state.items.size > 0
+    || state.streamedAssistantText.trim().length > 0
+    || state.finalAssistantText.trim().length > 0
+  );
+}
+
+function shouldIgnoreCodexWindowsTaskkillParseNoise(
+  state: CodexTurnStreamState,
+  message: string,
+): boolean {
+  return (
+    isCodexWindowsTaskkillSuccessParseNoiseMessage(message)
+    && hasCodexTurnResultActivity(state)
+  );
+}
+
 export type CodexThreadOptions = {
   workingDirectory: string;
   skipGitRepoCheck: true;
@@ -955,10 +974,7 @@ function getLiveAssistantText(state: CodexTurnStreamState): string {
 }
 
 function getLiveStreamErrorMessage(state: CodexTurnStreamState): string {
-  if (
-    state.turnCompleted
-    && isCodexWindowsTaskkillSuccessParseNoiseMessage(state.streamErrorMessage)
-  ) {
+  if (shouldIgnoreCodexWindowsTaskkillParseNoise(state, state.streamErrorMessage)) {
     return "";
   }
 
@@ -1502,7 +1518,8 @@ export class CodexAdapter implements ProviderTurnAdapter {
       }
 
       if (streamState.streamErrorMessage) {
-        const isWindowsTaskkillParseNoise = isCodexWindowsTaskkillSuccessParseNoiseMessage(
+        const shouldIgnoreWindowsTaskkillParseNoise = shouldIgnoreCodexWindowsTaskkillParseNoise(
+          streamState,
           streamState.streamErrorMessage,
         );
         const partialResult = await this.buildTurnResult(
@@ -1516,7 +1533,7 @@ export class CodexAdapter implements ProviderTurnAdapter {
           beforeSnapshot,
           beforeSnapshotStats,
         );
-        if (isWindowsTaskkillParseNoise && streamState.turnCompleted) {
+        if (shouldIgnoreWindowsTaskkillParseNoise) {
           return partialResult;
         }
 
@@ -1544,7 +1561,10 @@ export class CodexAdapter implements ProviderTurnAdapter {
       }
 
       const message = error instanceof Error ? error.message : String(error);
-      const isWindowsTaskkillParseNoise = isCodexWindowsTaskkillSuccessParseNoiseMessage(message);
+      const shouldIgnoreWindowsTaskkillParseNoise = shouldIgnoreCodexWindowsTaskkillParseNoise(
+        streamState,
+        message,
+      );
       const partialResult = await this.buildTurnResult(
         input,
         prompt,
@@ -1556,7 +1576,7 @@ export class CodexAdapter implements ProviderTurnAdapter {
         beforeSnapshot,
         beforeSnapshotStats,
       );
-      if (isWindowsTaskkillParseNoise && streamState.turnCompleted) {
+      if (shouldIgnoreWindowsTaskkillParseNoise) {
         return partialResult;
       }
 


### PR DESCRIPTION
## Summary
- Codex stream で assistant/item が届いた後の Windows taskkill parse noise を成功結果として扱う
- turn.completed 前に SDK が parse 例外化する再発ケースを追加
- app version を 4.2.13 に更新

## Validation
- npx tsx --test scripts/tests/codex-adapter.test.ts
- npm run typecheck