### PR TITLE
Codex taskkill parse noise の未完了ターンを失敗扱いにする

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "4.2.13",
+  "version": "4.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "4.2.13",
+      "version": "4.2.14",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "4.2.13",
+  "version": "4.2.14",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/scripts/tests/codex-adapter.test.ts
+++ b/scripts/tests/codex-adapter.test.ts
@@ -647,6 +647,147 @@ describe("CodexAdapter thread settings", () => {
     ]);
   });
 
+  it("collab_tool_call の stream lifecycle を app log に流す", async () => {
+    const workspacePath = await mkdtemp(path.join(os.tmpdir(), "withmate-codex-collab-log-"));
+    const logs: Array<{ kind: string; level: string; data?: Record<string, unknown> }> = [];
+    const adapter = new CodexAdapter((entry) => {
+      logs.push(entry as { kind: string; level: string; data?: Record<string, unknown> });
+    }) as unknown as {
+      getClient: () => {
+        client: {
+          startThread: () => {
+            id: string;
+            runStreamed: () => Promise<{ events: AsyncGenerator<never> }>;
+          };
+          resumeThread: never;
+        };
+        clientKey: string;
+      };
+      runSessionTurn: CodexAdapter["runSessionTurn"];
+    };
+
+    try {
+      adapter.getClient = () => ({
+        client: {
+          startThread: () => ({
+            id: "thread-1",
+            runStreamed: async () => ({
+              events: createCodexStreamFromEvents([
+                {
+                  type: "item.completed",
+                  item: {
+                    id: "item_33",
+                    type: "collab_tool_call",
+                    tool: "wait",
+                    status: "completed",
+                    agents_states: {
+                      "agent-1": {
+                        status: "completed",
+                        message: "Pass",
+                      },
+                    },
+                  },
+                },
+                {
+                  type: "item.completed",
+                  item: {
+                    id: "message-1",
+                    type: "agent_message",
+                    text: "done",
+                  },
+                },
+                {
+                  type: "turn.completed",
+                  usage: null,
+                },
+              ]),
+            }),
+          }),
+          resumeThread: undefined as never,
+        },
+        clientKey: "client-key",
+      });
+
+      const result = await adapter.runSessionTurn(createCodexRunSessionTurnInput(workspacePath));
+      const openedLog = logs.find((entry) => entry.kind === "codex.run.stream.opened");
+      const finishedLog = logs.find((entry) => entry.kind === "codex.run.stream.finished");
+      const collabLog = logs.find(
+        (entry) => entry.kind === "codex.run.stream.event" && entry.data?.itemType === "collab_tool_call",
+      );
+      const completedLog = logs.find((entry) => entry.kind === "codex.run.completed");
+
+      assert.equal(result.assistantText, "done");
+      assert.equal(openedLog?.data?.threadId, "thread-1");
+      assert.equal(finishedLog?.data?.turnCompleted, true);
+      assert.equal(collabLog?.data?.tool, "wait");
+      assert.equal(collabLog?.data?.status, "completed");
+      assert.deepEqual(collabLog?.data?.agents, {
+        total: 1,
+        statuses: {
+          completed: 1,
+        },
+      });
+      assert.equal(completedLog?.data?.turnCompleted, true);
+      assert.equal(completedLog?.data?.operationCount, 2);
+    } finally {
+      await rm(workspacePath, { recursive: true, force: true });
+    }
+  });
+
+  it("app log callback が失敗しても provider 実行は継続する", async () => {
+    const workspacePath = await mkdtemp(path.join(os.tmpdir(), "withmate-codex-log-throw-"));
+    const adapter = new CodexAdapter(() => {
+      throw new Error("log write failed");
+    }) as unknown as {
+      getClient: () => {
+        client: {
+          startThread: () => {
+            id: string;
+            runStreamed: () => Promise<{ events: AsyncGenerator<never> }>;
+          };
+          resumeThread: never;
+        };
+        clientKey: string;
+      };
+      runSessionTurn: CodexAdapter["runSessionTurn"];
+    };
+
+    try {
+      adapter.getClient = () => ({
+        client: {
+          startThread: () => ({
+            id: "thread-1",
+            runStreamed: async () => ({
+              events: createCodexStreamFromEvents([
+                {
+                  type: "item.completed",
+                  item: {
+                    id: "message-1",
+                    type: "agent_message",
+                    text: "done",
+                  },
+                },
+                {
+                  type: "turn.completed",
+                  usage: null,
+                },
+              ]),
+            }),
+          }),
+          resumeThread: undefined as never,
+        },
+        clientKey: "client-key",
+      });
+
+      const result = await adapter.runSessionTurn(createCodexRunSessionTurnInput(workspacePath));
+
+      assert.equal(result.threadId, "thread-1");
+      assert.equal(result.assistantText, "done");
+    } finally {
+      await rm(workspacePath, { recursive: true, force: true });
+    }
+  });
+
   it("model / reasoning 変更後の thread settings は新 options と settingsKey を反映する", () => {
     const previousSession = createSession({
       threadId: "thread-1",

--- a/scripts/tests/codex-adapter.test.ts
+++ b/scripts/tests/codex-adapter.test.ts
@@ -290,7 +290,7 @@ describe("CodexAdapter thread settings", () => {
     }
   });
 
-  it("assistant item 後の Windows taskkill parse noise は turn.completed 前でも成功結果として返す", async () => {
+  it("assistant item 後でも turn.completed 前の Windows taskkill parse noise は失敗として返す", async () => {
     const workspacePath = await mkdtemp(path.join(os.tmpdir(), "withmate-codex-taskkill-item-completed-"));
     const adapter = new CodexAdapter() as unknown as {
       getClient: () => {
@@ -329,16 +329,23 @@ describe("CodexAdapter thread settings", () => {
         clientKey: "client-key",
       });
 
-      const result = await adapter.runSessionTurn(createCodexRunSessionTurnInput(workspacePath));
-
-      assert.equal(result.threadId, "thread-1");
-      assert.equal(result.assistantText, "done");
+      await assert.rejects(
+        () => adapter.runSessionTurn(createCodexRunSessionTurnInput(workspacePath)),
+        (error) => {
+          assert.equal(error instanceof ProviderTurnError, true);
+          assert.equal((error as ProviderTurnError).canceled, false);
+          assert.equal((error as Error).message, windowsTaskkillParseNoiseMessage);
+          assert.equal((error as ProviderTurnError).partialResult.threadId, "thread-1");
+          assert.equal((error as ProviderTurnError).partialResult.assistantText, "done");
+          return true;
+        },
+      );
     } finally {
       await rm(workspacePath, { recursive: true, force: true });
     }
   });
 
-  it("assistant item 後の Windows taskkill parse noise event は進捗 error に出さず成功結果として返す", async () => {
+  it("assistant item 後でも turn.completed 前の Windows taskkill parse noise event は進捗 error に出して失敗にする", async () => {
     const workspacePath = await mkdtemp(path.join(os.tmpdir(), "withmate-codex-taskkill-event-item-completed-"));
     const adapter = new CodexAdapter() as unknown as {
       getClient: () => {
@@ -382,16 +389,24 @@ describe("CodexAdapter thread settings", () => {
         clientKey: "client-key",
       });
 
-      const result = await adapter.runSessionTurn(
-        createCodexRunSessionTurnInput(workspacePath),
-        (state) => {
-          progressErrors.push(state.errorMessage);
+      await assert.rejects(
+        () => adapter.runSessionTurn(
+          createCodexRunSessionTurnInput(workspacePath),
+          (state) => {
+            progressErrors.push(state.errorMessage);
+          },
+        ),
+        (error) => {
+          assert.equal(error instanceof ProviderTurnError, true);
+          assert.equal((error as ProviderTurnError).canceled, false);
+          assert.equal((error as Error).message, windowsTaskkillParseNoiseMessage);
+          assert.equal((error as ProviderTurnError).partialResult.threadId, "thread-1");
+          assert.equal((error as ProviderTurnError).partialResult.assistantText, "done");
+          return true;
         },
       );
 
-      assert.equal(result.threadId, "thread-1");
-      assert.equal(result.assistantText, "done");
-      assert.deepEqual(progressErrors.filter(Boolean), []);
+      assert.deepEqual(progressErrors.filter(Boolean), [windowsTaskkillParseNoiseMessage]);
     } finally {
       await rm(workspacePath, { recursive: true, force: true });
     }

--- a/src-electron/codex-adapter.ts
+++ b/src-electron/codex-adapter.ts
@@ -144,22 +144,13 @@ export function isCodexWindowsTaskkillSuccessParseNoiseMessage(message: string):
   return CODEX_WINDOWS_TASKKILL_SUCCESS_PARSE_NOISE_PATTERN.test(message.trim());
 }
 
-function hasCodexTurnResultActivity(state: CodexTurnStreamState): boolean {
-  return (
-    state.turnCompleted
-    || state.items.size > 0
-    || state.streamedAssistantText.trim().length > 0
-    || state.finalAssistantText.trim().length > 0
-  );
-}
-
 function shouldIgnoreCodexWindowsTaskkillParseNoise(
   state: CodexTurnStreamState,
   message: string,
 ): boolean {
   return (
     isCodexWindowsTaskkillSuccessParseNoiseMessage(message)
-    && hasCodexTurnResultActivity(state)
+    && state.turnCompleted
   );
 }
 

--- a/src-electron/codex-adapter.ts
+++ b/src-electron/codex-adapter.ts
@@ -127,6 +127,16 @@ type CodexCollabToolCallItem = {
 
 type CodexTurnItem = ThreadItem | CodexCollabToolCallItem;
 
+type CodexAdapterLogInput = {
+  level: "debug" | "info" | "warn" | "error";
+  kind: string;
+  message: string;
+  data?: unknown;
+  error?: { name?: string; message: string; stack?: string };
+};
+
+type CodexAdapterLogger = (input: CodexAdapterLogInput) => void;
+
 const CODEX_WINDOWS_TASKKILL_SUCCESS_PARSE_NOISE_PATTERN =
   /^Failed to parse item:\s*SUCCESS:\s+The process with PID \d+ \(child process of PID \d+\) has been terminated\.\s*$/;
 
@@ -151,6 +161,20 @@ function shouldIgnoreCodexWindowsTaskkillParseNoise(
     isCodexWindowsTaskkillSuccessParseNoiseMessage(message)
     && hasCodexTurnResultActivity(state)
   );
+}
+
+function errorToCodexAdapterLogError(error: unknown): CodexAdapterLogInput["error"] {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+  }
+
+  return {
+    message: typeof error === "string" ? error : String(error),
+  };
 }
 
 export type CodexThreadOptions = {
@@ -969,6 +993,104 @@ function readCodexAssistantDelta(event: ThreadEvent): string | null {
   return readStringFromUnknown(record);
 }
 
+function summarizeCodexAgentsStates(value: unknown): {
+  total: number;
+  statuses: Record<string, number>;
+} | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  const statuses: Record<string, number> = {};
+  let total = 0;
+  for (const agentState of Object.values(value as Record<string, unknown>)) {
+    if (!agentState || typeof agentState !== "object") {
+      total += 1;
+      statuses.unknown = (statuses.unknown ?? 0) + 1;
+      continue;
+    }
+
+    const status = (agentState as { status?: unknown }).status;
+    const normalizedStatus = typeof status === "string" && status.trim().length > 0 ? status : "unknown";
+    total += 1;
+    statuses[normalizedStatus] = (statuses[normalizedStatus] ?? 0) + 1;
+  }
+
+  return { total, statuses };
+}
+
+function buildCodexTurnEventLogData(event: ThreadEvent): Record<string, unknown> | null {
+  const record = event as unknown as CodexEventRecord;
+  const eventType = typeof record.type === "string" ? record.type : "";
+
+  switch (event.type) {
+    case "thread.started":
+      return {
+        eventType,
+        threadId: event.thread_id,
+      };
+    case "turn.completed":
+      return {
+        eventType,
+        hasUsage: event.usage !== null,
+      };
+    case "turn.failed":
+      return {
+        eventType,
+        errorMessage: event.error.message,
+      };
+    case "error":
+      return {
+        eventType,
+        errorMessage: event.message,
+      };
+    case "item.started":
+    case "item.updated":
+    case "item.completed": {
+      const item = event.item as unknown;
+      if (isCodexCollabToolCallItem(item)) {
+        return {
+          eventType,
+          itemId: item.id,
+          itemType: item.type,
+          tool: item.tool ?? null,
+          status: item.status ?? null,
+          agents: summarizeCodexAgentsStates(item.agents_states),
+          errorMessage: item.error?.message ?? null,
+        };
+      }
+
+      const threadItem = event.item;
+      if (threadItem.type === "agent_message" || threadItem.type === "error") {
+        return {
+          eventType,
+          itemId: threadItem.id,
+          itemType: threadItem.type,
+          status: "status" in threadItem ? threadItem.status ?? null : null,
+        };
+      }
+
+      return null;
+    }
+    default:
+      return null;
+  }
+}
+
+function summarizeCodexTurnStreamState(state: CodexTurnStreamState): Record<string, unknown> {
+  return {
+    threadId: state.threadId,
+    itemCount: state.items.size,
+    liveStepCount: state.liveSteps.size,
+    turnCompleted: state.turnCompleted,
+    streamedAssistantTextLength: state.streamedAssistantText.length,
+    finalAssistantTextLength: state.finalAssistantText.length,
+    reasoningTextLength: state.reasoningText.length,
+    hasUsage: state.usage !== null,
+    streamErrorMessage: state.streamErrorMessage || null,
+  };
+}
+
 function getLiveAssistantText(state: CodexTurnStreamState): string {
   return state.finalAssistantText || state.streamedAssistantText;
 }
@@ -1194,6 +1316,16 @@ export class CodexAdapter implements ProviderTurnAdapter {
   private readonly clients = new Map<string, Codex>();
   private readonly threads = new Map<string, CachedCodexThread>();
   private readonly workspaceSnapshotIndexes = new Map<string, WorkspaceSnapshotIndex>();
+
+  constructor(private readonly logger?: CodexAdapterLogger) {}
+
+  private writeLog(input: CodexAdapterLogInput): void {
+    try {
+      this.logger?.(input);
+    } catch {
+      // Logging must not affect provider execution.
+    }
+  }
 
   composePrompt(input: RunSessionTurnInput): ProviderPromptComposition {
     return composeProviderPrompt(input);
@@ -1487,6 +1619,19 @@ export class CodexAdapter implements ProviderTurnAdapter {
         : prompt.logicalPrompt.composedText;
     const streamState = createCodexTurnStreamState(thread.id);
 
+    this.writeLog({
+      level: "info",
+      kind: "codex.run.started",
+      message: "Codex session turn started",
+      data: {
+        sessionId: input.session.id,
+        threadId: streamState.threadId,
+        model: selection.resolvedModel,
+        reasoningEffort: selection.resolvedReasoningEffort,
+        existingThreadId: input.session.threadId || null,
+      },
+    });
+
     await emitLiveState(
       onProgress,
       input.session.id,
@@ -1502,9 +1647,31 @@ export class CodexAdapter implements ProviderTurnAdapter {
       const { events } = await thread.runStreamed(turnInput, {
         signal: input.signal,
       });
+      this.writeLog({
+        level: "debug",
+        kind: "codex.run.stream.opened",
+        message: "Codex session turn stream opened",
+        data: {
+          sessionId: input.session.id,
+          threadId: streamState.threadId,
+        },
+      });
 
       for await (const event of events) {
         applyCodexTurnEvent(streamState, event);
+        const eventLogData = buildCodexTurnEventLogData(event);
+        if (eventLogData) {
+          this.writeLog({
+            level: event.type === "turn.failed" || event.type === "error" ? "warn" : "debug",
+            kind: "codex.run.stream.event",
+            message: "Codex session turn stream event",
+            data: {
+              sessionId: input.session.id,
+              threadId: streamState.threadId,
+              ...eventLogData,
+            },
+          });
+        }
         await emitLiveState(
           onProgress,
           input.session.id,
@@ -1516,6 +1683,15 @@ export class CodexAdapter implements ProviderTurnAdapter {
           getLiveStreamErrorMessage(streamState),
         );
       }
+      this.writeLog({
+        level: "info",
+        kind: "codex.run.stream.finished",
+        message: "Codex session turn stream finished",
+        data: {
+          sessionId: input.session.id,
+          ...summarizeCodexTurnStreamState(streamState),
+        },
+      });
 
       if (streamState.streamErrorMessage) {
         const shouldIgnoreWindowsTaskkillParseNoise = shouldIgnoreCodexWindowsTaskkillParseNoise(
@@ -1534,9 +1710,27 @@ export class CodexAdapter implements ProviderTurnAdapter {
           beforeSnapshotStats,
         );
         if (shouldIgnoreWindowsTaskkillParseNoise) {
+          this.writeLog({
+            level: "warn",
+            kind: "codex.run.parse-noise.ignored",
+            message: "Codex session turn ignored Windows taskkill parse noise after activity",
+            data: {
+              sessionId: input.session.id,
+              ...summarizeCodexTurnStreamState(streamState),
+            },
+          });
           return partialResult;
         }
 
+        this.writeLog({
+          level: "error",
+          kind: "codex.run.stream-error",
+          message: "Codex session turn stream ended with an error message",
+          data: {
+            sessionId: input.session.id,
+            ...summarizeCodexTurnStreamState(streamState),
+          },
+        });
         throw new ProviderTurnError(
           streamState.streamErrorMessage,
           partialResult,
@@ -1544,7 +1738,7 @@ export class CodexAdapter implements ProviderTurnAdapter {
         );
       }
 
-      return this.buildTurnResult(
+      const result = await this.buildTurnResult(
         input,
         prompt,
         streamState.items,
@@ -1555,8 +1749,31 @@ export class CodexAdapter implements ProviderTurnAdapter {
         beforeSnapshot,
         beforeSnapshotStats,
       );
+      this.writeLog({
+        level: "info",
+        kind: "codex.run.completed",
+        message: "Codex session turn completed",
+        data: {
+          sessionId: input.session.id,
+          ...summarizeCodexTurnStreamState(streamState),
+          operationCount: result.operations.length,
+          assistantTextLength: result.assistantText.length,
+        },
+      });
+      return result;
     } catch (error) {
       if (error instanceof ProviderTurnError) {
+        this.writeLog({
+          level: error.canceled ? "warn" : "error",
+          kind: "codex.run.provider-error",
+          message: "Codex session turn provider error",
+          data: {
+            sessionId: input.session.id,
+            canceled: error.canceled,
+            ...summarizeCodexTurnStreamState(streamState),
+          },
+          error: errorToCodexAdapterLogError(error),
+        });
         throw error;
       }
 
@@ -1577,9 +1794,31 @@ export class CodexAdapter implements ProviderTurnAdapter {
         beforeSnapshotStats,
       );
       if (shouldIgnoreWindowsTaskkillParseNoise) {
+        this.writeLog({
+          level: "warn",
+          kind: "codex.run.parse-noise.ignored",
+          message: "Codex session turn ignored Windows taskkill parse noise after thrown error",
+          data: {
+            sessionId: input.session.id,
+            ...summarizeCodexTurnStreamState(streamState),
+          },
+          error: errorToCodexAdapterLogError(error),
+        });
         return partialResult;
       }
 
+      this.writeLog({
+        level: Boolean(input.signal?.aborted) || isCanceledProviderMessage(message) ? "warn" : "error",
+        kind: "codex.run.failed",
+        message: "Codex session turn failed",
+        data: {
+          sessionId: input.session.id,
+          aborted: Boolean(input.signal?.aborted),
+          canceledMessage: isCanceledProviderMessage(message),
+          ...summarizeCodexTurnStreamState(streamState),
+        },
+        error: errorToCodexAdapterLogError(error),
+      });
       throw new ProviderTurnError(
         message,
         partialResult,

--- a/src-electron/main.ts
+++ b/src-electron/main.ts
@@ -248,7 +248,10 @@ const devServerUrl = process.env.VITE_DEV_SERVER_URL;
 const bundledModelCatalogPath = devServerUrl
   ? path.resolve(currentDir, "../../public/model-catalog.json")
   : path.resolve(rendererDistPath, "model-catalog.json");
-const codexAdapter = new CodexAdapter();
+const codexAdapter = new CodexAdapter((input) => writeAppLog({
+  ...input,
+  process: "main",
+}));
 const copilotAdapter = new CopilotAdapter();
 const WAL_MAINTENANCE_INTERVAL_MS = 5 * 60 * 1000;
 


### PR DESCRIPTION
## 概要
- Windows taskkill の SUCCESS parse noise を成功扱いで無視する条件を turn.completed 後に限定
- turn.completed 前に assistant item がある場合でも ProviderTurnError として partial result を失敗側へ渡すように変更
- アプリバージョンを 4.2.14 に更新

Closes #154

## 検証
- npx tsx --test scripts/tests/codex-adapter.test.ts
- npx tsx --test scripts/tests/session-runtime-service.test.ts
- npm run typecheck
- git diff --check
- npm test