### PR TITLE
chore: update provider SDKs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "withmate",
-  "version": "4.2.14",
+  "version": "4.2.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "4.2.14",
+      "version": "4.2.15",
       "license": "ISC",
       "dependencies": {
-        "@github/copilot-sdk": "^0.3.0",
-        "@openai/codex-sdk": "^0.128.0",
+        "@github/copilot-sdk": "^1.0.0-beta.9",
+        "@openai/codex-sdk": "^0.135.0",
         "@xenova/transformers": "^2.17.2",
         "ignore": "^7.0.5",
         "mermaid": "^11.15.0",
@@ -984,26 +984,31 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.45",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.45.tgz",
-      "integrity": "sha512-2QADgQcw/d0GFqTq2+nHwX152ZRvZxW0CHONG5d1RCs6YJtdr/GdbnMYYeRH2BiBIhnfkcvF50ImCRvsS5Tnwg==",
+      "version": "1.0.56",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.56.tgz",
+      "integrity": "sha512-epJ9yRqK1QjU73FDAlxPqZKh+CxkA1TIYbhTvXblturw5wWUhCSRhI2XoamNERohPznY10Wg3tbZC3jUAmQdJw==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "detect-libc": "^2.1.2"
+      },
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.45",
-        "@github/copilot-darwin-x64": "1.0.45",
-        "@github/copilot-linux-arm64": "1.0.45",
-        "@github/copilot-linux-x64": "1.0.45",
-        "@github/copilot-win32-arm64": "1.0.45",
-        "@github/copilot-win32-x64": "1.0.45"
+        "@github/copilot-darwin-arm64": "1.0.56",
+        "@github/copilot-darwin-x64": "1.0.56",
+        "@github/copilot-linux-arm64": "1.0.56",
+        "@github/copilot-linux-x64": "1.0.56",
+        "@github/copilot-linuxmusl-arm64": "1.0.56",
+        "@github/copilot-linuxmusl-x64": "1.0.56",
+        "@github/copilot-win32-arm64": "1.0.56",
+        "@github/copilot-win32-x64": "1.0.56"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.45",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.45.tgz",
-      "integrity": "sha512-gCJy1nOIWL5lpLFJTRk2Kz7bS30emkA4p4gM+PJ5/dOwNRBOyUO0/2f03/m5vYL4DNd/T47cFIN6s82gISAIYQ==",
+      "version": "1.0.56",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.56.tgz",
+      "integrity": "sha512-vCittEfa/Qys86TxhI5rgxy8L8WTQoooIjEj8kZe7mq62TOOrFGnWJjqaR6mgljmPTxKRFmT6achUxKRVZil9g==",
       "cpu": [
         "arm64"
       ],
@@ -1017,9 +1022,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.45",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.45.tgz",
-      "integrity": "sha512-nLzC7C0i/WAY+4FukHuONBDNeKUAqBBab3n36aEdpqxVDP5h2Tbzg2yShqav2blR7KDJL7YMcYTVFxmwfQj+yQ==",
+      "version": "1.0.56",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.56.tgz",
+      "integrity": "sha512-yO7OvFysG/98s9T8k5cEXzBz++mki7ufkH2S8/jqC7YIKhlj64rh+/vIBU5DQ9RLXbPKm6OjGjJn8iDWXzzuJQ==",
       "cpu": [
         "x64"
       ],
@@ -1033,9 +1038,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.45",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.45.tgz",
-      "integrity": "sha512-MdRNZUNMrI0dpQ+DiDoZQ7AbitQp9eN7ir176Za2Kf7dkUxPwmio32yhRbBS81McU6vBw8cCzEZviwv/jc8buQ==",
+      "version": "1.0.56",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.56.tgz",
+      "integrity": "sha512-ukOwSwFOqgpQQs5Nw3GAFRGIn6LqA8KfI6hD+tUeqoWkB0OlXxwQER7sKEfSQZu1vcNnW1+YIM/qT5W5RWdmhA==",
       "cpu": [
         "arm64"
       ],
@@ -1049,9 +1054,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.45",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.45.tgz",
-      "integrity": "sha512-xSRUjWA+wrSSjktJSjNtiS/47Cy0PviPejj7RUmtChsPfDJB8wW2iZ6NfpdiAomtxAz5xx4AjbjT1I4b1FqnwA==",
+      "version": "1.0.56",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.56.tgz",
+      "integrity": "sha512-C84nduDAeHCTEfjs+mYfIjbBjGRx2huy8XZBu0ETAD08uUBuQpUHn2PYhaaHb1yKoG6LMceKt10PTrqNdOE9IQ==",
       "cpu": [
         "x64"
       ],
@@ -1064,13 +1069,45 @@
         "copilot-linux-x64": "copilot"
       }
     },
+    "node_modules/@github/copilot-linuxmusl-arm64": {
+      "version": "1.0.56",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.56.tgz",
+      "integrity": "sha512-EuDmGVl4fEk7Q+AVhkQkpiRlXpjGGQ5GzfBzMEOWgrvfdCLcT62p1uEaz+AT2UdkJiViruLyVf3pZFUyQwyvjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linuxmusl-x64": {
+      "version": "1.0.56",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.56.tgz",
+      "integrity": "sha512-qRXub9+1J7mNIzweAaw0tGgztS6XK+ZlwhUjOcFTusbqnED33zw4HzExUNUTTDue/BOUwkYzvXqMqn5N6juIJg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-x64": "copilot"
+      }
+    },
     "node_modules/@github/copilot-sdk": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.3.0.tgz",
-      "integrity": "sha512-SUo35k56pzzgYgwmDPHcu7kZxPrzXbH66IWXaEf6pmb94DlA709F82HrrDeja087TL4djJ9OuvRFWWOKCosAsg==",
+      "version": "1.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-1.0.0-beta.9.tgz",
+      "integrity": "sha512-D4yiGL4/faFCjL7bozhX7bgxt/x1wp2LZ2p9Tw+xrA5hbcLh5Be5kPen+bFA8NbVfgt1G2djDYFZlrZjXXmcBw==",
       "license": "MIT",
       "dependencies": {
-        "@github/copilot": "^1.0.36-0",
+        "@github/copilot": "^1.0.55-5",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
       },
@@ -1079,9 +1116,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.45",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.45.tgz",
-      "integrity": "sha512-lhcTlKs7MWMzIXv21hUSpL4aFW49jqVhNrQKaB8sYk2nzvGRJvNwTcBS1Tn5ndXlPzQ9P/p9B6B5uwwmZ1vHHw==",
+      "version": "1.0.56",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.56.tgz",
+      "integrity": "sha512-/lj/zEezNoewCxvVORLN0JFvvi9WmQTYvtIyyg8kVlA9HZeg0vpRTBM5hdoni2D8mKb7g/8w8VF2Ecy9D3+NpA==",
       "cpu": [
         "arm64"
       ],
@@ -1095,9 +1132,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.45",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.45.tgz",
-      "integrity": "sha512-XYZ983NQmooVr/n+pCnHIorBmf1hd3o1rMlSAodwG/VFlQaydGoOs1F1NntxWBoFAND+eM6N4PZfw8M8sRayfA==",
+      "version": "1.0.56",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.56.tgz",
+      "integrity": "sha512-062C3lp4nvVl+vkkteYOrYpgnqZ/SAi54NuTQ4k45V2TNmLIpmMybmM0tCluxOfiTY+8EuS72H9RS8NUj1CzhQ==",
       "cpu": [
         "x64"
       ],
@@ -1746,9 +1783,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.128.0.tgz",
-      "integrity": "sha512-+xp6ODmFfBNnexIWRHApEaPXot2j6gyM8A5we/5IS/uY4eYHj4arETct4hQ5M4eO+MK7JY3ZU4xhuobhlysr0A==",
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0.tgz",
+      "integrity": "sha512-ID75QEYmAT1WsUQmpxPlNsL5W1a+2eeD7fP6ywdwGseiXUG8D5i16L+dzbr8MT+2oTkaVqzOdvAqVOCeV/H/Bw==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -1757,19 +1794,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.128.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.128.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.128.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.128.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.128.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.128.0-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.135.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.135.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.135.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.135.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.135.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.135.0-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.128.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.128.0-darwin-arm64.tgz",
-      "integrity": "sha512-w+6zohfHx/kHBdles/CyFKaY57u9I3nK8QI9+NrdwMliKA0b7xn13yblRNkMpe09j6vL1oAWoxYsMOQ/vjBGug==",
+      "version": "0.135.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-darwin-arm64.tgz",
+      "integrity": "sha512-wpNzssusKfrldVlq39+HyQh1wCyc9SQNpHdAFGKtPenrgRte4Ct8/oVsDtKWuFZsqLBFwbL4MrzrevnB63+9HA==",
       "cpu": [
         "arm64"
       ],
@@ -1784,9 +1821,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.128.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.128.0-darwin-x64.tgz",
-      "integrity": "sha512-SDbn6fO22Puy8xmMIbZi4f2znMrUEPwABApke4mo+4ihaauwuVjeqzXvW5SPJz5ty/bG11/mSupQgReT7T8BBw==",
+      "version": "0.135.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-darwin-x64.tgz",
+      "integrity": "sha512-ZrjAqce23lbv9KfkYOhElf1lTI+SysXmyGM0FV5u4+PBCKPkkEs4eaS3H8Uig0i4bUSu1QylrOOCskzYhZ6VyQ==",
       "cpu": [
         "x64"
       ],
@@ -1801,9 +1838,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.128.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.128.0-linux-arm64.tgz",
-      "integrity": "sha512-+SvH73H60qvCXFuQGP/EsmR//s1hHMBR22PvJkXvM/hdnTIGucx+JqRUjAWdmmQ1IU6j3kgwVvdLW/6ICB+M6w==",
+      "version": "0.135.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-linux-arm64.tgz",
+      "integrity": "sha512-dM+cv5ZL+BgIQzEIvMg9AxZ98n5lkKLgtp5zJLXWSrbCllbnUSqxYMUiWI5c1a1uBDUtkbY9fcGKXFLf+d+gyg==",
       "cpu": [
         "arm64"
       ],
@@ -1818,9 +1855,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.128.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.128.0-linux-x64.tgz",
-      "integrity": "sha512-2lnSPA05CRRuKAzFW8BCmmNCSieDcToLwfC2ALLbBYilGLgzhRibjlDglK9F1BkEzfohSSWJu4PBbRu/aG60lQ==",
+      "version": "0.135.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-linux-x64.tgz",
+      "integrity": "sha512-5EosY67yU28UJSnl/obdN2F1CDaimYbzm9SLR8dwwzkeBBnY6dHgAKJ2GTu9Nc8CmgmtVFBGzgPqehsIcueVvA==",
       "cpu": [
         "x64"
       ],
@@ -1834,12 +1871,12 @@
       }
     },
     "node_modules/@openai/codex-sdk": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.128.0.tgz",
-      "integrity": "sha512-Eao0LLA5x90qwU6SXYd21h4KxdCef1WpCvHFgKdbqzWMJ79lUvguGDGvx1RheP+zTdKGxJfJ6dulI5wSXoUBhQ==",
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.135.0.tgz",
+      "integrity": "sha512-4FziwR9RmYexAkAUqnWBQRUcFGWpBeBwDJpJKlabnuUXxaKQtBtKMTEYBA27ymn8W6mxxDMmwZC+inw7foFFaA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openai/codex": "0.128.0"
+        "@openai/codex": "0.135.0"
       },
       "engines": {
         "node": ">=18"
@@ -1847,9 +1884,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.128.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.128.0-win32-arm64.tgz",
-      "integrity": "sha512-ECJvsqmYFdA9pn42xxK3Odp/G16AjmBW0BglX8L0PwPjqbstbmlew9bfHf7xvL+SNfNl4NmyotW0+RNo1phgaA==",
+      "version": "0.135.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-win32-arm64.tgz",
+      "integrity": "sha512-SAeR+CUv7KWwE6eTc2UFaFjo6FpHywYfDFKrK6FqLms1rq1NPju2SoX7rhM6UEew/lUx2mdZv/LDs11s/N/Qgg==",
       "cpu": [
         "arm64"
       ],
@@ -1864,9 +1901,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.128.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.128.0-win32-x64.tgz",
-      "integrity": "sha512-k3jmUAFrzkUtvjGTXvSKjQqJLLlzjxp/VoHJDYedgmXUn6j70HxK38IwapzmnYfiBiTuzETvGwjXHzZgzKjhoQ==",
+      "version": "0.135.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-win32-x64.tgz",
+      "integrity": "sha512-uYwUBMbOfmVlCESJZmZsOG+cYwNFYvkMbQ+FB6C1u9RYz0m3mZeYNN0j+l1hRSyUgPMFJHzNpgNx1Usal5QZFQ==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "4.2.14",
+  "version": "4.2.15",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",
@@ -29,8 +29,8 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
-    "@github/copilot-sdk": "^0.3.0",
-    "@openai/codex-sdk": "^0.128.0",
+    "@github/copilot-sdk": "^1.0.0-beta.9",
+    "@openai/codex-sdk": "^0.135.0",
     "@xenova/transformers": "^2.17.2",
     "ignore": "^7.0.5",
     "mermaid": "^11.15.0",

--- a/scripts/tests/session-ui-projection.test.ts
+++ b/scripts/tests/session-ui-projection.test.ts
@@ -72,8 +72,39 @@ describe("session-ui-projection", () => {
 
     assert.equal(projection.snapshot?.quotaKey, "chat");
     assert.equal(projection.remainingPercentLabel, "40% left");
-    assert.equal(projection.remainingRequestsLabel, "80 / 200 left");
+    assert.equal(projection.remainingRequestsLabel, "80 / 200 requests left");
     assert.match(projection.resetLabel, /\d{2}\/\d{2} \d{2}:\d{2}/);
+  });
+
+  it("Copilot quota projection は AI credits snapshot を優先して credits 表示にする", () => {
+    const telemetry: ProviderQuotaTelemetry = {
+      provider: "copilot",
+      updatedAt: "2026-06-01T00:00:00.000Z",
+      snapshots: [
+        {
+          quotaKey: "premium_interactions",
+          entitlementRequests: 200,
+          usedRequests: 120,
+          remainingPercentage: 40,
+          overage: 0,
+          overageAllowedWithExhaustedQuota: false,
+        },
+        {
+          quotaKey: "ai_credits",
+          entitlementRequests: 1500,
+          usedRequests: 250,
+          remainingPercentage: 83.3,
+          overage: 0,
+          overageAllowedWithExhaustedQuota: false,
+        },
+      ],
+    };
+
+    const projection = buildCopilotQuotaProjection(telemetry);
+
+    assert.equal(projection.snapshot?.quotaKey, "ai_credits");
+    assert.equal(projection.remainingPercentLabel, "83% left");
+    assert.equal(projection.remainingRequestsLabel, "1250 / 1500 credits left");
   });
 
   it("ContextPaneProjection は LatestCommand tab の表示情報を作る", () => {

--- a/src-electron/copilot-adapter.ts
+++ b/src-electron/copilot-adapter.ts
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import {
   CopilotClient,
+  RuntimeConnection,
   type CopilotSession,
   type PermissionHandler,
   type MessageOptions,
@@ -315,9 +316,10 @@ function applyCopilotTurnEvent(args: {
     case "assistant.usage":
       state.usage = normalizeCopilotTokenUsage(event.data);
       if (args.onProviderQuotaTelemetry) {
+        const quotaSnapshots = readCopilotQuotaSnapshots(event.data);
         const telemetry = buildCopilotProviderQuotaTelemetry(
           providerId,
-          event.data.quotaSnapshots,
+          quotaSnapshots,
           event.timestamp,
         );
         if (telemetry) {
@@ -494,6 +496,37 @@ type CopilotQuotaSnapshotLike = {
   resetDate?: string;
 };
 
+function isCopilotQuotaSnapshotLike(value: unknown): value is CopilotQuotaSnapshotLike {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<CopilotQuotaSnapshotLike>;
+  return typeof candidate.entitlementRequests === "number"
+    && typeof candidate.usedRequests === "number"
+    && typeof candidate.remainingPercentage === "number";
+}
+
+function readCopilotQuotaSnapshots(value: unknown): Record<string, CopilotQuotaSnapshotLike> | null {
+  if (!value || typeof value !== "object" || !("quotaSnapshots" in value)) {
+    return null;
+  }
+
+  const quotaSnapshots = (value as { quotaSnapshots?: unknown }).quotaSnapshots;
+  if (!quotaSnapshots || typeof quotaSnapshots !== "object") {
+    return null;
+  }
+
+  const normalized: Record<string, CopilotQuotaSnapshotLike> = {};
+  for (const [quotaKey, snapshot] of Object.entries(quotaSnapshots)) {
+    if (isCopilotQuotaSnapshotLike(snapshot)) {
+      normalized[quotaKey] = snapshot;
+    }
+  }
+
+  return normalized;
+}
+
 function normalizeQuotaRemainingPercentage(value: number): number {
   if (Number.isNaN(value) || !Number.isFinite(value)) {
     return 0;
@@ -507,13 +540,14 @@ function normalizeQuotaRemainingPercentage(value: number): number {
 }
 
 export function toProviderQuotaSnapshots(
-  snapshots: Record<string, CopilotQuotaSnapshotLike> | null | undefined,
+  snapshots: Record<string, CopilotQuotaSnapshotLike | undefined> | null | undefined,
 ): ProviderQuotaSnapshot[] {
   if (!snapshots) {
     return [];
   }
 
   return Object.entries(snapshots)
+    .filter((entry): entry is [string, CopilotQuotaSnapshotLike] => isCopilotQuotaSnapshotLike(entry[1]))
     .map(([quotaKey, snapshot]) => ({
       quotaKey,
       entitlementRequests: snapshot.entitlementRequests,
@@ -528,7 +562,7 @@ export function toProviderQuotaSnapshots(
 
 export function buildCopilotProviderQuotaTelemetry(
   providerId: string,
-  snapshots: Record<string, CopilotQuotaSnapshotLike> | null | undefined,
+  snapshots: Record<string, CopilotQuotaSnapshotLike | undefined> | null | undefined,
   updatedAt: string,
 ): ProviderQuotaTelemetry | null {
   const normalizedSnapshots = toProviderQuotaSnapshots(snapshots);
@@ -1975,9 +2009,9 @@ export class CopilotAdapter implements ProviderTurnAdapter {
 
     const cliPath = resolveCopilotCliPath();
     const client = new CopilotClient({
-      cliPath,
+      connection: RuntimeConnection.forStdio({ path: cliPath }),
       env: buildCopilotClientEnv(process.env),
-      ...(codingApiKey ? { githubToken: codingApiKey, useLoggedInUser: false } : {}),
+      ...(codingApiKey ? { gitHubToken: codingApiKey, useLoggedInUser: false } : {}),
     });
     this.clients.set(clientKey, client);
     return { client, clientKey };
@@ -1992,9 +2026,9 @@ export class CopilotAdapter implements ProviderTurnAdapter {
 
     const apiKey = getProviderAppSettings(appSettings, providerId).apiKey.trim();
     const client = new CopilotClient({
-      cliPath: resolveCopilotCliPath(),
+      connection: RuntimeConnection.forStdio({ path: resolveCopilotCliPath() }),
       env: buildCopilotClientEnv(process.env),
-      ...(apiKey ? { githubToken: apiKey, useLoggedInUser: false } : {}),
+      ...(apiKey ? { gitHubToken: apiKey, useLoggedInUser: false } : {}),
     });
     this.clients.set(clientKey, client);
     return client;
@@ -2465,7 +2499,7 @@ export class CopilotAdapter implements ProviderTurnAdapter {
   ): Promise<ProviderQuotaTelemetry | null> {
     const client = this.getOrCreateClientByAppSettings(providerId, appSettings);
     await client.start();
-    const quota = await client.rpc.account.getQuota();
+    const quota = await client.rpc.account.getQuota({});
     return buildCopilotProviderQuotaTelemetry(providerId, quota.quotaSnapshots, new Date().toISOString());
   }
 }

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -1765,7 +1765,7 @@ export function SessionContextPane({
         <section className="provider-usage-shell" aria-label="Copilot usage">
           <div className="provider-usage-strip">
             <div className="provider-usage-strip-copy">
-              <span className="provider-usage-label">Premium Requests</span>
+              <span className="provider-usage-label">Copilot Usage</span>
               <strong>{selectedCopilotRemainingPercentLabel}</strong>
             </div>
             <span className="provider-usage-pill">

--- a/src/session-ui-projection.ts
+++ b/src/session-ui-projection.ts
@@ -178,7 +178,7 @@ export function selectPrimaryQuotaSnapshot(telemetry: ProviderQuotaTelemetry | n
     return null;
   }
 
-  const preferredKeys = ["premium_interactions", "premium_requests", "premium", "chat"];
+  const preferredKeys = ["ai_credits", "ai_credit", "aiu", "premium_interactions", "premium_requests", "premium", "chat"];
   for (const preferredKey of preferredKeys) {
     const matched = telemetry.snapshots.find((snapshot) => snapshot.quotaKey === preferredKey);
     if (matched) {
@@ -187,6 +187,14 @@ export function selectPrimaryQuotaSnapshot(telemetry: ProviderQuotaTelemetry | n
   }
 
   return telemetry.snapshots[0] ?? null;
+}
+
+function formatCopilotQuotaUnitLabel(quotaKey: string): string {
+  const normalized = quotaKey.toLowerCase();
+  if (normalized.includes("credit") || normalized.includes("aiu")) {
+    return "credits";
+  }
+  return "requests";
 }
 
 export function formatQuotaResetLabel(resetDate: string | undefined): string {
@@ -219,10 +227,11 @@ export function buildCopilotQuotaProjection(telemetry: ProviderQuotaTelemetry | 
   }
 
   const remainingRequests = Math.max(0, snapshot.entitlementRequests - snapshot.usedRequests);
+  const unitLabel = formatCopilotQuotaUnitLabel(snapshot.quotaKey);
   return {
     snapshot,
     remainingPercentLabel: `${Math.max(0, Math.round(snapshot.remainingPercentage))}% left`,
-    remainingRequestsLabel: `${remainingRequests} / ${snapshot.entitlementRequests} left`,
+    remainingRequestsLabel: `${remainingRequests} / ${snapshot.entitlementRequests} ${unitLabel} left`,
     resetLabel: formatQuotaResetLabel(snapshot.resetDate),
   };
 }


### PR DESCRIPTION
## Summary
- Codex SDK を 0.135.0、Copilot SDK を 1.0.0-beta.9 へ更新
- Copilot SDK 1.0 beta の RuntimeConnection / gitHubToken / account.getQuota API 変更に追従
- Copilot usage UI を Premium Requests 固定表示から Copilot Usage に変更し、AI credits snapshot が来た場合は credits 単位で優先表示
- アプリバージョンを 4.2.15 に更新

## Notes
- 最新 Copilot SDK の account.getQuota は引き続き request-based quota snapshot 形式
- SDK 型には AI Credits 系の model billing price / totalNanoAiu が入っているため、将来の ai_credits / aiu snapshot を優先表示する分岐を追加

## Validation
- npm run typecheck
- node --import tsx --test scripts/tests/session-ui-projection.test.ts
- node --import tsx --test scripts/tests/copilot-adapter.test.ts