### PR TITLE
fix: Codex CLI binary path resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "4.2.15",
+  "version": "4.2.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "4.2.15",
+      "version": "4.2.16",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.0-beta.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "4.2.15",
+  "version": "4.2.16",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/scripts/tests/provider-binary-paths.test.ts
+++ b/scripts/tests/provider-binary-paths.test.ts
@@ -13,7 +13,7 @@ describe("provider-binary-paths", () => {
   it("provider ごとの native package spec を返す", () => {
     assert.deepEqual(resolveProviderBinarySpec("codex", "win32", "x64"), {
       packageSpecifier: "@openai/codex-win32-x64",
-      binaryRelativePath: ["vendor", "x86_64-pc-windows-msvc", "codex", "codex.exe"],
+      binaryRelativePath: ["vendor", "x86_64-pc-windows-msvc", "bin", "codex.exe"],
     });
     assert.deepEqual(resolveProviderBinarySpec("copilot", "darwin", "arm64"), {
       packageSpecifier: "@github/copilot-darwin-arm64",
@@ -31,7 +31,7 @@ describe("provider-binary-paths", () => {
       "codex-win32-x64",
       "vendor",
       "x86_64-pc-windows-msvc",
-      "codex",
+      "bin",
       "codex.exe",
     );
 

--- a/src-electron/provider-binary-paths.ts
+++ b/src-electron/provider-binary-paths.ts
@@ -17,13 +17,13 @@ function resolveCodexSpec(
       if (arch === "x64") {
         return {
           packageSpecifier: "@openai/codex-win32-x64",
-          binaryRelativePath: ["vendor", "x86_64-pc-windows-msvc", "codex", "codex.exe"],
+          binaryRelativePath: ["vendor", "x86_64-pc-windows-msvc", "bin", "codex.exe"],
         };
       }
       if (arch === "arm64") {
         return {
           packageSpecifier: "@openai/codex-win32-arm64",
-          binaryRelativePath: ["vendor", "aarch64-pc-windows-msvc", "codex", "codex.exe"],
+          binaryRelativePath: ["vendor", "aarch64-pc-windows-msvc", "bin", "codex.exe"],
         };
       }
       return null;
@@ -31,13 +31,13 @@ function resolveCodexSpec(
       if (arch === "x64") {
         return {
           packageSpecifier: "@openai/codex-darwin-x64",
-          binaryRelativePath: ["vendor", "x86_64-apple-darwin", "codex", "codex"],
+          binaryRelativePath: ["vendor", "x86_64-apple-darwin", "bin", "codex"],
         };
       }
       if (arch === "arm64") {
         return {
           packageSpecifier: "@openai/codex-darwin-arm64",
-          binaryRelativePath: ["vendor", "aarch64-apple-darwin", "codex", "codex"],
+          binaryRelativePath: ["vendor", "aarch64-apple-darwin", "bin", "codex"],
         };
       }
       return null;
@@ -45,13 +45,13 @@ function resolveCodexSpec(
       if (arch === "x64") {
         return {
           packageSpecifier: "@openai/codex-linux-x64",
-          binaryRelativePath: ["vendor", "x86_64-unknown-linux-musl", "codex", "codex"],
+          binaryRelativePath: ["vendor", "x86_64-unknown-linux-musl", "bin", "codex"],
         };
       }
       if (arch === "arm64") {
         return {
           packageSpecifier: "@openai/codex-linux-arm64",
-          binaryRelativePath: ["vendor", "aarch64-unknown-linux-musl", "codex", "codex"],
+          binaryRelativePath: ["vendor", "aarch64-unknown-linux-musl", "bin", "codex"],
         };
       }
       return null;


### PR DESCRIPTION
## 概要
- packaged app の Codex CLI 検出先を、@openai/codex 0.135.0 の native package 構造に合わせて `vendor/.../bin/codex(.exe)` へ修正
- provider binary path のテスト期待値を更新
- app version を 4.2.16 へ更新

## 原因
`@openai/codex-win32-x64` の実体は `vendor/x86_64-pc-windows-msvc/bin/codex.exe` にあるが、WithMate 側は旧構造の `vendor/x86_64-pc-windows-msvc/codex/codex.exe` を見ていた。packaged app では native package を `node_modules` から除外しているため、override が解決できないと SDK が optional dependency を探しに行き、`Unable to locate Codex CLI binaries...` で失敗していた。

## 検証
- `node --import tsx --test scripts/tests/provider-binary-paths.test.ts`
- `npm run stage:provider-binaries`
- staged Codex CLI の path 解決確認
- `build/provider-binaries/@openai/codex-win32-x64/vendor/x86_64-pc-windows-msvc/bin/codex.exe --version`
- `npm run typecheck`
- `npm run build`