### PR TITLE
fix: verify provider binaries before packaging

### DIFF
--- a/scripts/stage-provider-binaries.ts
+++ b/scripts/stage-provider-binaries.ts
@@ -1,7 +1,12 @@
+import { existsSync } from "node:fs";
 import { cp, mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 
-import { listSupportedProviderBinaryPackageSpecifiers } from "../src-electron/provider-binary-paths.js";
+import {
+  listSupportedProviderBinaryPackageSpecifiers,
+  resolveProviderBinarySpec,
+  type SupportedProviderBinary,
+} from "../src-electron/provider-binary-paths.js";
 
 const repoRoot = process.cwd();
 const stageRoot = path.join(repoRoot, "build", "provider-binaries");
@@ -20,6 +25,30 @@ async function stagePackage(packageSpecifier: string): Promise<void> {
   }
 }
 
+function verifyCurrentPlatformBinary(provider: SupportedProviderBinary): void {
+  const spec = resolveProviderBinarySpec(provider);
+  if (!spec) {
+    throw new Error(
+      `${provider} の provider binary はこの platform/arch をサポートしていません: ${process.platform}/${process.arch}`,
+    );
+  }
+
+  const stagedBinaryPath = path.join(stageRoot, ...spec.packageSpecifier.split("/"), ...spec.binaryRelativePath);
+  if (existsSync(stagedBinaryPath)) {
+    return;
+  }
+
+  const sourceBinaryPath = path.join(repoRoot, "node_modules", ...spec.packageSpecifier.split("/"), ...spec.binaryRelativePath);
+  throw new Error(
+    [
+      `${provider} の provider binary が見つかりません。`,
+      `expected: ${path.relative(repoRoot, stagedBinaryPath)}`,
+      `source: ${path.relative(repoRoot, sourceBinaryPath)}`,
+      "optional dependencies を含めて npm install し直してから installer を作成してください。",
+    ].join("\n"),
+  );
+}
+
 async function main(): Promise<void> {
   await rm(stageRoot, { recursive: true, force: true });
   await mkdir(stageRoot, { recursive: true });
@@ -27,6 +56,9 @@ async function main(): Promise<void> {
   for (const packageSpecifier of listSupportedProviderBinaryPackageSpecifiers()) {
     await stagePackage(packageSpecifier);
   }
+
+  verifyCurrentPlatformBinary("codex");
+  verifyCurrentPlatformBinary("copilot");
 
   console.log("provider binary stage 完了:", path.relative(repoRoot, stageRoot));
 }


### PR DESCRIPTION
## 概要
- `stage-provider-binaries` 後に、現在の platform/arch 用 Codex/Copilot provider binary が staged されていることを検証
- optional dependency が欠けている状態で installer 作成まで進み、実行時に `Unable to locate Codex CLI binaries...` で落ちるケースを packaging 前に止める
- 欠落時は expected/source path と `npm install --include=optional` の案内を出す

## 検証
- `npm run stage:provider-binaries`
- `npm run typecheck`