### PR TITLE
[codex] Classify Codex usage limit errors

### DIFF
--- a/docs/design/provider-adapter.md
+++ b/docs/design/provider-adapter.md
@@ -79,6 +79,26 @@ type ProviderTurnResult = {
 };
 ```
 
+Provider 実行が失敗した場合、adapter は `ProviderTurnError` を投げる。`canceled` は既存の session phase / retry / invalidation 判定のため boolean として維持し、失敗分類は `reason` で渡す。
+
+```ts
+type ProviderErrorReason =
+  | "usage_limit"
+  | "auth"
+  | "network"
+  | "provider_unavailable"
+  | "canceled"
+  | "unknown";
+
+type ProviderTurnError = Error & {
+  partialResult: ProviderTurnResult;
+  canceled: boolean;
+  reason: ProviderErrorReason;
+};
+```
+
+Provider 固有の error message 判定は adapter 側に閉じる。`SessionRuntimeService` は `reason` を見て audit log と assistant fallback message を分け、provider 固有の英語 message を再 parse しない。
+
 ```ts
 type ProviderTurnAdapter = ProviderCodingAdapter & ProviderBackgroundAdapter;
 ```

--- a/docs/plans/20260612-codex-usage-limit-error.md
+++ b/docs/plans/20260612-codex-usage-limit-error.md
@@ -1,0 +1,80 @@
+# Codex Usage Limit Error Classification
+
+## Goal
+
+Codex の使用上限到達を通常の provider failure と分け、runtime / audit / UI で内部クラッシュのように見えない状態にする。
+
+## Background
+
+Codex 使用上限到達時、現在は通常の `codex.run.failed` として扱われる。確認済みログでは、SDK が投げる最終 error message は汎用的でも、stream event 側の `streamErrorMessage` には使用上限到達が明確に含まれていた。
+
+```text
+kind: codex.run.failed
+level: error
+streamErrorMessage: You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Jun 12th, 2026 2:07 AM.
+error.message: Codex Exec exited with code 1: Reading prompt from stdin...
+```
+
+該当ログでは次の順で記録されていた。
+
+- `codex.run.stream.event` / `eventType=error`
+- `codex.run.stream.event` / `eventType=turn.failed`
+- `codex.run.failed`
+
+## Design
+
+Provider failure の分類は `ProviderTurnError` の契約に `reason` として持たせる。分類判定そのものは provider 固有 helper に閉じ、`SessionRuntimeService` が Codex 固有の英語 message を再 parse しないようにする。
+
+```ts
+type ProviderErrorReason =
+  | "usage_limit"
+  | "auth"
+  | "network"
+  | "provider_unavailable"
+  | "canceled"
+  | "unknown";
+```
+
+`canceled` は既存の session phase / retry / invalidation 判定に使われているため、boolean として維持する。`reason` は追加情報として扱い、既存 constructor 呼び出しには `unknown` / `canceled` の default を与える。
+
+Codex usage-limit 判定は保守的な文字列判定にする。
+
+- `You've hit your usage limit.`
+- `purchase more credits`
+- `try again at`
+
+SDK が wrapper error を投げる場合でも、stream event の `streamErrorMessage` に usage-limit message が残っていれば `usage_limit` として扱う。
+
+## User Facing Message
+
+使用上限到達時は通常の `実行に失敗したよ。` ではなく、次の形式で表示・保存する。
+
+```text
+Codexの使用上限に達しました。
+再実行可能時刻: Jun 12th, 2026 2:07 AM
+```
+
+再実行可能時刻を抽出できない場合は、元 message の短い preview を詳細として残す。
+
+## Scope
+
+- `src-electron/provider-runtime.ts`
+- `src-electron/codex-adapter.ts`
+- `src-electron/session-runtime-service.ts`
+- `scripts/tests/codex-adapter.test.ts`
+- `scripts/tests/session-runtime-service.test.ts`
+
+## Done
+
+- 使用上限到達が `ProviderTurnError.reason === "usage_limit"` として分類される。
+- 通常 provider failure、user cancel、既存の Windows taskkill parse-noise 境界と区別される。
+- audit log / assistant fallback message が内部クラッシュのような汎用失敗文言だけにならない。
+- Codex adapter と session runtime の targeted tests が通る。
+
+## Validation
+
+```bash
+node --import tsx --test scripts/tests/codex-adapter.test.ts
+node --import tsx --test scripts/tests/session-runtime-service.test.ts
+npm run typecheck
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "4.2.17-preview.0",
+  "version": "4.2.17-preview.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "4.2.17-preview.0",
+      "version": "4.2.17-preview.1",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.0-beta.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "4.2.17-preview.0",
+  "version": "4.2.17-preview.1",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/scripts/tests/codex-adapter.test.ts
+++ b/scripts/tests/codex-adapter.test.ts
@@ -17,6 +17,7 @@ import {
   collectCodexAssistantTextFromEventsForTesting,
   collectCodexReasoningTextFromEventsForTesting,
   isCodexWindowsTaskkillSuccessParseNoiseMessage,
+  isCodexUsageLimitMessage,
   resolveCodexThreadForSettings,
   type CodexThreadOptions,
 } from "../../src-electron/codex-adapter.js";
@@ -158,6 +159,8 @@ async function* createCodexStreamFromEvents(
 describe("CodexAdapter thread settings", () => {
   const windowsTaskkillParseNoiseMessage =
     "Failed to parse item: SUCCESS: The process with PID 13760 (child process of PID 32340) has been terminated.";
+  const usageLimitMessage =
+    "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Jun 12th, 2026 2:07 AM.";
 
   it("Windows taskkill の SUCCESS 行だけ Codex JSON parse noise として扱う", () => {
     assert.equal(
@@ -173,6 +176,13 @@ describe("CodexAdapter thread settings", () => {
       false,
     );
     assert.equal(isCodexWindowsTaskkillSuccessParseNoiseMessage("SUCCESS: ordinary command output"), false);
+  });
+
+  it("Codex usage limit message は保守的な marker が揃う場合だけ扱う", () => {
+    assert.equal(isCodexUsageLimitMessage(usageLimitMessage), true);
+    assert.equal(isCodexUsageLimitMessage("You've hit your usage limit."), false);
+    assert.equal(isCodexUsageLimitMessage("purchase more credits and try again at 2 AM"), false);
+    assert.equal(isCodexUsageLimitMessage("ordinary provider failure"), false);
   });
 
   it("turn.completed 後の Windows taskkill parse noise は成功結果として返す", async () => {
@@ -451,6 +461,70 @@ describe("CodexAdapter thread settings", () => {
           return true;
         },
       );
+    } finally {
+      await rm(workspacePath, { recursive: true, force: true });
+    }
+  });
+
+  it("stream error の usage limit は SDK wrapper error より優先して reason を付ける", async () => {
+    const workspacePath = await mkdtemp(path.join(os.tmpdir(), "withmate-codex-usage-limit-"));
+    const logs: Array<{ kind: string; data?: Record<string, unknown> }> = [];
+    const adapter = new CodexAdapter((entry) => {
+      logs.push(entry as { kind: string; data?: Record<string, unknown> });
+    }) as unknown as {
+      getClient: () => {
+        client: {
+          startThread: () => {
+            id: string;
+            runStreamed: () => Promise<{ events: AsyncGenerator<never> }>;
+          };
+          resumeThread: never;
+        };
+        clientKey: string;
+      };
+      runSessionTurn: CodexAdapter["runSessionTurn"];
+    };
+
+    try {
+      adapter.getClient = () => ({
+        client: {
+          startThread: () => ({
+            id: "thread-usage-limit",
+            runStreamed: async () => ({
+              events: createCodexStreamThatThrowsAfter([
+                {
+                  type: "error",
+                  message: usageLimitMessage,
+                },
+                {
+                  type: "turn.failed",
+                  error: {
+                    message: usageLimitMessage,
+                  },
+                },
+              ], "Codex Exec exited with code 1: Reading prompt from stdin..."),
+            }),
+          }),
+          resumeThread: undefined as never,
+        },
+        clientKey: "client-key",
+      });
+
+      await assert.rejects(
+        () => adapter.runSessionTurn(createCodexRunSessionTurnInput(workspacePath)),
+        (error) => {
+          assert.equal(error instanceof ProviderTurnError, true);
+          assert.equal((error as ProviderTurnError).canceled, false);
+          assert.equal((error as ProviderTurnError).reason, "usage_limit");
+          assert.equal((error as Error).message, usageLimitMessage);
+          assert.equal((error as ProviderTurnError).partialResult.threadId, "thread-usage-limit");
+          return true;
+        },
+      );
+
+      const failedLog = logs.find((entry) => entry.kind === "codex.run.failed");
+      assert.equal(failedLog?.data?.providerErrorReason, "usage_limit");
+      assert.equal(failedLog?.data?.streamErrorMessage, usageLimitMessage);
     } finally {
       await rm(workspacePath, { recursive: true, force: true });
     }

--- a/scripts/tests/session-runtime-service.test.ts
+++ b/scripts/tests/session-runtime-service.test.ts
@@ -2451,6 +2451,106 @@ describe("SessionRuntimeService", () => {
     assert.deepEqual(auditUpdates.at(-1)?.usage, { inputTokens: 9, cachedInputTokens: 1, outputTokens: 3 });
   });
 
+  it("usage_limit reason は audit log と assistant fallback で通常失敗文言にしない", async () => {
+    const session = createSession({ provider: "codex", threadId: "thread-before-limit" });
+    const storedSessions: Session[] = [];
+    const auditUpdates: UpdateAuditLogInput[] = [];
+    const usageLimitMessage =
+      "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Jun 12th, 2026 2:07 AM.";
+
+    const adapter: ProviderCodingAdapter = {
+      composePrompt() {
+        return {
+          systemBodyText: "system",
+          inputBodyText: "input",
+          logicalPrompt: { systemText: "system", inputText: "input", composedText: "system\ninput" },
+          imagePaths: [],
+          additionalDirectories: [],
+        };
+      },
+      async getProviderQuotaTelemetry() {
+        return null;
+      },
+      invalidateSessionThread() {},
+      invalidateAllSessionThreads() {},
+      async runSessionTurn() {
+        throw new ProviderTurnError(
+          usageLimitMessage,
+          createPartialResult({ threadId: "thread-before-limit" }),
+          false,
+          "usage_limit",
+        );
+      },
+    };
+
+    const service = new SessionRuntimeService({
+      getSession(sessionId) {
+        return sessionId === session.id ? session : null;
+      },
+      upsertSession(next) {
+        storedSessions.push(next);
+        return next;
+      },
+      async resolveComposerPreview() {
+        return { attachments: [], errors: [] };
+      },
+      async resolveSessionCharacter() {
+        return createCharacter();
+      },
+      getAppSettings() {
+        return normalizeAppSettings({});
+      },
+      resolveProviderCatalog() {
+        return { snapshot: { revision: 1, providers: [createProviderCatalog()] }, provider: createProviderCatalog() };
+      },
+      getProviderCodingAdapter() {
+        return adapter;
+      },
+      getSessionMemory(currentSession) {
+        return createSessionMemory(currentSession.id);
+      },
+      resolveProjectMemoryEntriesForPrompt() {
+        return [];
+      },
+      createAuditLog(input) {
+        return createAuditLogBase(input);
+      },
+      updateAuditLog(_id, entry) {
+        auditUpdates.push(entry);
+      },
+      setLiveSessionRun() {},
+      getLiveSessionRun() {
+        return null;
+      },
+      async waitForApprovalDecision() {
+        return "approve";
+      },
+      async waitForElicitationResponse() {
+        return { action: "cancel" } as const;
+      },
+      setProviderQuotaTelemetry() {},
+      setSessionContextTelemetry() {},
+      invalidateProviderSessionThread() {},
+      scheduleProviderQuotaTelemetryRefresh() {},
+      runSessionMemoryExtraction() {},
+      runCharacterReflection() {},
+      clearWorkspaceFileIndex() {},
+      broadcastLiveSessionRun() {},
+      resolvePendingApprovalRequest() {},
+      resolvePendingElicitationRequest() {},
+      currentTimestampLabel,
+    });
+
+    const result = await service.runSessionTurn(session.id, { userMessage: "お願いします" });
+    const expectedMessage = "Codexの使用上限に達しました。\n再実行可能時刻: Jun 12th, 2026 2:07 AM";
+
+    assert.equal(result.runState, "error");
+    assert.equal(auditUpdates.at(-1)?.phase, "failed");
+    assert.equal(auditUpdates.at(-1)?.errorMessage, expectedMessage);
+    assert.equal(storedSessions.at(-1)?.messages.at(-1)?.text, expectedMessage);
+    assert.doesNotMatch(storedSessions.at(-1)?.messages.at(-1)?.text ?? "", /実行に失敗したよ。/);
+  });
+
   it("meaningful partial が出た stale error は internal retry しない", async () => {
     const session = createSession({ provider: "codex", threadId: "thread-stale" });
     const storedSessions: Session[] = [];

--- a/src-electron/codex-adapter.ts
+++ b/src-electron/codex-adapter.ts
@@ -47,6 +47,7 @@ import {
   MATE_TALK_BACKGROUND_STRUCTURED_PROMPT_POLICY,
   type ExtractSessionMemoryResult,
   type ExtractSessionMemoryInput,
+  type ProviderErrorReason,
   type ProviderPromptComposition,
   type RunBackgroundStructuredPromptInput,
   type RunBackgroundStructuredPromptResult,
@@ -139,9 +140,30 @@ type CodexAdapterLogger = (input: CodexAdapterLogInput) => void;
 
 const CODEX_WINDOWS_TASKKILL_SUCCESS_PARSE_NOISE_PATTERN =
   /^Failed to parse item:\s*SUCCESS:\s+The process with PID \d+ \(child process of PID \d+\) has been terminated\.\s*$/;
+const CODEX_USAGE_LIMIT_MESSAGE_PATTERN = /you['’]ve hit your usage limit\./i;
+const CODEX_USAGE_LIMIT_PURCHASE_PATTERN = /purchase more credits/i;
+const CODEX_USAGE_LIMIT_RETRY_PATTERN = /try again at/i;
 
 export function isCodexWindowsTaskkillSuccessParseNoiseMessage(message: string): boolean {
   return CODEX_WINDOWS_TASKKILL_SUCCESS_PARSE_NOISE_PATTERN.test(message.trim());
+}
+
+export function isCodexUsageLimitMessage(message: string): boolean {
+  return CODEX_USAGE_LIMIT_MESSAGE_PATTERN.test(message)
+    && CODEX_USAGE_LIMIT_PURCHASE_PATTERN.test(message)
+    && CODEX_USAGE_LIMIT_RETRY_PATTERN.test(message);
+}
+
+function resolveCodexProviderErrorReason(message: string, canceled: boolean): ProviderErrorReason {
+  if (canceled) {
+    return "canceled";
+  }
+
+  if (isCodexUsageLimitMessage(message)) {
+    return "usage_limit";
+  }
+
+  return "unknown";
 }
 
 function shouldIgnoreCodexWindowsTaskkillParseNoise(
@@ -1711,6 +1733,8 @@ export class CodexAdapter implements ProviderTurnAdapter {
           });
           return partialResult;
         }
+        const canceled = Boolean(input.signal?.aborted) || isCanceledProviderMessage(streamState.streamErrorMessage);
+        const reason = resolveCodexProviderErrorReason(streamState.streamErrorMessage, canceled);
 
         this.writeLog({
           level: "error",
@@ -1718,13 +1742,15 @@ export class CodexAdapter implements ProviderTurnAdapter {
           message: "Codex session turn stream ended with an error message",
           data: {
             sessionId: input.session.id,
+            providerErrorReason: reason,
             ...summarizeCodexTurnStreamState(streamState),
           },
         });
         throw new ProviderTurnError(
           streamState.streamErrorMessage,
           partialResult,
-          Boolean(input.signal?.aborted) || isCanceledProviderMessage(streamState.streamErrorMessage),
+          canceled,
+          reason,
         );
       }
 
@@ -1760,6 +1786,7 @@ export class CodexAdapter implements ProviderTurnAdapter {
           data: {
             sessionId: input.session.id,
             canceled: error.canceled,
+            providerErrorReason: error.reason,
             ...summarizeCodexTurnStreamState(streamState),
           },
           error: errorToCodexAdapterLogError(error),
@@ -1768,6 +1795,10 @@ export class CodexAdapter implements ProviderTurnAdapter {
       }
 
       const message = error instanceof Error ? error.message : String(error);
+      const candidateProviderMessage = streamState.streamErrorMessage || message;
+      const canceled = Boolean(input.signal?.aborted) || isCanceledProviderMessage(candidateProviderMessage);
+      const reason = resolveCodexProviderErrorReason(candidateProviderMessage, canceled);
+      const providerMessage = reason === "usage_limit" ? candidateProviderMessage : message;
       const shouldIgnoreWindowsTaskkillParseNoise = shouldIgnoreCodexWindowsTaskkillParseNoise(
         streamState,
         message,
@@ -1798,21 +1829,23 @@ export class CodexAdapter implements ProviderTurnAdapter {
       }
 
       this.writeLog({
-        level: Boolean(input.signal?.aborted) || isCanceledProviderMessage(message) ? "warn" : "error",
+        level: canceled ? "warn" : "error",
         kind: "codex.run.failed",
         message: "Codex session turn failed",
         data: {
           sessionId: input.session.id,
           aborted: Boolean(input.signal?.aborted),
-          canceledMessage: isCanceledProviderMessage(message),
+          canceledMessage: isCanceledProviderMessage(candidateProviderMessage),
+          providerErrorReason: reason,
           ...summarizeCodexTurnStreamState(streamState),
         },
         error: errorToCodexAdapterLogError(error),
       });
       throw new ProviderTurnError(
-        message,
+        providerMessage,
         partialResult,
-        Boolean(input.signal?.aborted) || isCanceledProviderMessage(message),
+        canceled,
+        reason,
       );
     }
   }

--- a/src-electron/provider-runtime.ts
+++ b/src-electron/provider-runtime.ts
@@ -137,15 +137,30 @@ export type RunSessionTurnResult = {
   providerQuotaTelemetry?: ProviderQuotaTelemetry | null;
 };
 
+export type ProviderErrorReason =
+  | "usage_limit"
+  | "auth"
+  | "network"
+  | "provider_unavailable"
+  | "canceled"
+  | "unknown";
+
 export class ProviderTurnError extends Error {
   readonly partialResult: RunSessionTurnResult;
   readonly canceled: boolean;
+  readonly reason: ProviderErrorReason;
 
-  constructor(message: string, partialResult: RunSessionTurnResult, canceled: boolean) {
+  constructor(
+    message: string,
+    partialResult: RunSessionTurnResult,
+    canceled: boolean,
+    reason: ProviderErrorReason = canceled ? "canceled" : "unknown",
+  ) {
     super(message);
     this.name = "ProviderTurnError";
     this.partialResult = partialResult;
     this.canceled = canceled;
+    this.reason = reason;
   }
 }
 

--- a/src-electron/session-runtime-service.ts
+++ b/src-electron/session-runtime-service.ts
@@ -205,6 +205,56 @@ function shouldResetFailedSessionThread(
   return candidateThreadId.length > 0;
 }
 
+function extractProviderUsageLimitRetryAt(message: string): string | null {
+  const match = /\btry again at\s+(.+?)(?:\.|$)/i.exec(message);
+  return match?.[1]?.trim() || null;
+}
+
+function formatProviderUsageLimitMessage(providerId: Session["provider"], message: string): string {
+  const providerLabel = providerId === "codex" ? "Codex" : "Provider";
+  const retryAt = extractProviderUsageLimitRetryAt(message);
+  if (retryAt) {
+    return `${providerLabel}の使用上限に達しました。\n再実行可能時刻: ${retryAt}`;
+  }
+
+  const preview = toAuditTextPreview(message) ?? message;
+  return `${providerLabel}の使用上限に達しました。\n詳細: ${preview}`;
+}
+
+function formatProviderFailureMessage(params: {
+  providerId: Session["provider"];
+  reason: ProviderTurnError["reason"] | null;
+  message: string;
+  canceled: boolean;
+}): string {
+  if (params.canceled) {
+    return "ユーザーがキャンセルしたよ。";
+  }
+
+  if (params.reason === "usage_limit") {
+    return formatProviderUsageLimitMessage(params.providerId, params.message);
+  }
+
+  return params.message;
+}
+
+function formatProviderFailureNotice(params: {
+  providerId: Session["provider"];
+  reason: ProviderTurnError["reason"] | null;
+  message: string;
+  canceled: boolean;
+}): string {
+  if (params.canceled) {
+    return "実行をキャンセルしたよ。";
+  }
+
+  if (params.reason === "usage_limit") {
+    return formatProviderUsageLimitMessage(params.providerId, params.message);
+  }
+
+  return `実行に失敗したよ。\n${params.message}`;
+}
+
 function pickPreferredThreadId(...candidates: Array<string | null | undefined>): string {
   for (const candidate of candidates) {
     const normalized = candidate?.trim() ?? "";
@@ -748,6 +798,13 @@ export class SessionRuntimeService {
       const providerTurnError = error instanceof ProviderTurnError ? error : null;
       const canceled = providerTurnError ? providerTurnError.canceled : isCanceledRunError(error);
       const message = error instanceof Error ? error.message : String(error);
+      const providerErrorReason = providerTurnError?.reason ?? null;
+      const failureMessage = formatProviderFailureMessage({
+        providerId: activeRunningSession.provider,
+        reason: providerErrorReason,
+        message,
+        canceled,
+      });
       const partialResult = providerTurnError?.partialResult;
       const failedAuditThreadId = pickPreferredThreadId(
         partialResult?.threadId,
@@ -799,12 +856,17 @@ export class SessionRuntimeService {
         operations: partialResult?.operations ?? [],
         rawItemsJson: partialResult?.rawItemsJson ?? "[]",
         usage: partialResult?.usage ?? null,
-        errorMessage: canceled ? "ユーザーがキャンセルしたよ。" : message,
+        errorMessage: failureMessage,
       });
       await this.deps.updateAuditLog(runningAuditLog.id, failedAuditEntry);
       runningAuditEntry = failedAuditEntry;
 
-      const fallbackNotice = canceled ? "実行をキャンセルしたよ。" : `実行に失敗したよ。\n${message}`;
+      const fallbackNotice = formatProviderFailureNotice({
+        providerId: activeRunningSession.provider,
+        reason: providerErrorReason,
+        message,
+        canceled,
+      });
       const assistantText = partialResult?.assistantText.trim()
         ? `${partialResult.assistantText}\n\n${fallbackNotice}`
         : fallbackNotice;


### PR DESCRIPTION
## Summary
- Classify confirmed Codex usage-limit failures as `ProviderTurnError.reason === "usage_limit"`.
- Prefer Codex stream `streamErrorMessage` over SDK wrapper errors for usage-limit classification.
- Show/save a dedicated usage-limit message instead of the generic run failure text.
- Add the issue plan note and sync the provider adapter contract docs.
- Bump app version to `4.2.17-preview.1`.

## Root Cause
Codex usage-limit details can arrive in stream events while the final thrown SDK error is a generic `Codex Exec exited...` wrapper. The runtime only had a canceled boolean, so usage-limit failures were indistinguishable from ordinary provider failures.

## Validation
- `node --import tsx --test scripts/tests/codex-adapter.test.ts`
- `node --import tsx --test scripts/tests/session-runtime-service.test.ts`
- `npm run typecheck`
- `npm test`

## Notes
The usage-limit marker is intentionally conservative and follows the confirmed Codex message shape. If Codex changes the wording, it will fall back to `unknown` rather than risk false positives.