### PR TITLE
chore(codex): gate stream diagnostics behind debug flag

### DIFF
--- a/docs/design/app-log-base.md
+++ b/docs/design/app-log-base.md
@@ -93,6 +93,29 @@ flowchart LR
 
 通常の `ipc.request` / `ipc.response`、画面ロード成功、API request / response は初期実装では記録しない。量と機密情報漏えいリスクが高く、クラッシュ調査の初期価値に対してノイズが多いため。
 
+## Provider Diagnostic Log Policy
+
+provider 実行ログは、通常運用では turn 単位の summary を残し、stream event 単位の詳細ログは出さない。
+
+Codex の通常ログに残す summary:
+
+- `codex.run.started`
+- `codex.run.completed`
+- `codex.run.failed`
+- `codex.run.provider-error`
+- `codex.run.stream-error`
+- `codex.run.parse-noise.ignored`
+
+`codex.run.completed` / `codex.run.failed` / `codex.run.provider-error` / `codex.run.stream-error` には、原因分析に必要な `providerErrorReason`、`turnCompleted`、`hasUsage`、`itemCount`、`liveStepCount`、`streamErrorMessage` などの構造化 summary を残す。
+
+Codex stream の event-level 診断ログは通常運用では出さない。
+
+- `codex.run.stream.opened`
+- `codex.run.stream.event`
+- `codex.run.stream.finished`
+
+上記 3 種は、provider stream の lifecycle や SDK event payload を調べる必要がある場合だけ、`WITHMATE_CODEX_STREAM_DEBUG=1` で再有効化する。
+
 ## Privacy And Redaction
 
 - IPC payload、API request / response body、API key、添付ファイル内容は記録しない。

--- a/docs/plans/20260612-codex-diagnostic-log-cleanup.md
+++ b/docs/plans/20260612-codex-diagnostic-log-cleanup.md
@@ -1,0 +1,105 @@
+# Codex Diagnostic Log Cleanup
+
+## Goal
+
+Codex 実行時の一時的な stream 診断ログを通常運用ログから外し、必要時だけ debug flag で再有効化できる状態にする。
+
+## Background
+
+#156 では、Codex SDK stream の `collab_tool_call` lifecycle、Windows `taskkill` parse noise、`turn.completed` 前後の failure 判定を確認するため、stream event level の診断ログを一時的に増やしていた。
+
+添付 JSONL の分析では、全 3,200 行のうち 2,704 行が Codex stream 診断ログだった。
+
+| kind | count |
+| --- | ---: |
+| `codex.run.stream.event` | 2,360 |
+| `codex.run.stream.opened` | 174 |
+| `codex.run.stream.finished` | 170 |
+| total | 2,704 |
+
+これは全体の 84.5% であり、通常運用ログとしては多すぎる。
+
+## Findings
+
+### collab_tool_call lifecycle
+
+添付ログでは `spawn_agent` / `wait` / `close_agent` の started / completed が揃っていた。
+
+| tool | started | completed |
+| --- | ---: | ---: |
+| `spawn_agent` | 35 | 35 |
+| `wait` | 30 | 30 |
+| `close_agent` | 15 | 15 |
+
+#156 の「collab_tool_call lifecycle を実ログで確認する」目的は達成済みと判断する。
+
+### Windows taskkill parse noise
+
+添付ログでは `taskkill` / `parse-noise` / `codex.run.parse-noise.ignored` は 0 件だった。
+
+そのため、#156 を閉じる理由として「taskkill parse noise の本番実例を確認した」とは書かない。parse-noise 境界は既存 test と summary log で維持し、event-level stream log を通常運用に常設する理由にはしない。
+
+### failure / error summary
+
+通常運用に残す必要があるのは、event 全件ではなく turn summary である。
+
+- usage limit は `streamErrorMessage` と `providerErrorReason=usage_limit` で追える。
+- user cancel / abort は `aborted`、`canceledMessage`、`providerErrorReason=canceled` で追える。
+- provider error / stream error は `codex.run.provider-error` と `codex.run.stream-error` に summary を残す。
+- `turnCompleted`、`hasUsage`、`itemCount`、`liveStepCount` は completed / failed / provider-error の summary に残す。
+
+## Decision
+
+通常運用では summary log だけを出す。
+
+通常ログに残す:
+
+- `codex.run.started`
+- `codex.run.completed`
+- `codex.run.failed`
+- `codex.run.provider-error`
+- `codex.run.stream-error`
+- `codex.run.parse-noise.ignored`
+
+通常ログから外す:
+
+- `codex.run.stream.opened`
+- `codex.run.stream.event`
+- `codex.run.stream.finished`
+
+必要時だけ、次の debug flag で stream 診断ログを再有効化する。
+
+```text
+WITHMATE_CODEX_STREAM_DEBUG=1
+```
+
+debug flag 有効時は、`stream.opened` / `stream.event` / `stream.finished` を従来どおり出す。
+
+## Implementation Scope
+
+- `src-electron/codex-adapter.ts`
+  - `WITHMATE_CODEX_STREAM_DEBUG` を読み、stream 詳細ログ 3 種だけを gate する。
+  - completed / failed / provider-error / stream-error の summary は維持する。
+- `scripts/tests/codex-adapter.test.ts`
+  - 通常時に stream 診断ログが出ないことを検証する。
+  - debug flag 有効時に `collab_tool_call` lifecycle の詳細ログが出ることを検証する。
+
+## Done Criteria
+
+- 通常運用で `codex.run.stream.event` が大量に出ない。
+- `codex.run.completed` / `codex.run.failed` の summary は残る。
+- usage limit / cancel / provider error / stream error の原因分析に必要な summary は残る。
+- 必要時は `WITHMATE_CODEX_STREAM_DEBUG=1` で stream event を再有効化できる。
+- CodexAdapter 関連 test が通る。
+
+## Validation
+
+```bash
+node --import tsx --test scripts/tests/codex-adapter.test.ts
+npm run typecheck
+npm test
+```
+
+## Follow-up
+
+添付ログでは `ipc.error` が 83 件あり、すべて `withmate:list-session-skills` の `対象セッションが見つからないよ。` だった。これは #156 の対象外だが、stream 診断ログ整理後に次のログ騒音として目立つ可能性がある。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "4.2.17-preview.1",
+  "version": "4.2.17-preview.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "4.2.17-preview.1",
+      "version": "4.2.17-preview.2",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.0-beta.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "4.2.17-preview.1",
+  "version": "4.2.17-preview.2",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/scripts/tests/codex-adapter.test.ts
+++ b/scripts/tests/codex-adapter.test.ts
@@ -736,8 +736,9 @@ describe("CodexAdapter thread settings", () => {
     ]);
   });
 
-  it("collab_tool_call の stream lifecycle を app log に流す", async () => {
+  it("stream 診断ログは通常運用の app log に流さず summary だけ残す", async () => {
     const workspacePath = await mkdtemp(path.join(os.tmpdir(), "withmate-codex-collab-log-"));
+    const previousDebugValue = process.env.WITHMATE_CODEX_STREAM_DEBUG;
     const logs: Array<{ kind: string; level: string; data?: Record<string, unknown> }> = [];
     const adapter = new CodexAdapter((entry) => {
       logs.push(entry as { kind: string; level: string; data?: Record<string, unknown> });
@@ -756,6 +757,95 @@ describe("CodexAdapter thread settings", () => {
     };
 
     try {
+      delete process.env.WITHMATE_CODEX_STREAM_DEBUG;
+      adapter.getClient = () => ({
+        client: {
+          startThread: () => ({
+            id: "thread-1",
+            runStreamed: async () => ({
+              events: createCodexStreamFromEvents([
+                {
+                  type: "item.completed",
+                  item: {
+                    id: "item_33",
+                    type: "collab_tool_call",
+                    tool: "wait",
+                    status: "completed",
+                    agents_states: {
+                      "agent-1": {
+                        status: "completed",
+                        message: "Pass",
+                      },
+                    },
+                  },
+                },
+                {
+                  type: "item.completed",
+                  item: {
+                    id: "message-1",
+                    type: "agent_message",
+                    text: "done",
+                  },
+                },
+                {
+                  type: "turn.completed",
+                  usage: null,
+                },
+              ]),
+            }),
+          }),
+          resumeThread: undefined as never,
+        },
+        clientKey: "client-key",
+      });
+
+      const result = await adapter.runSessionTurn(createCodexRunSessionTurnInput(workspacePath));
+      const openedLog = logs.find((entry) => entry.kind === "codex.run.stream.opened");
+      const finishedLog = logs.find((entry) => entry.kind === "codex.run.stream.finished");
+      const collabLog = logs.find(
+        (entry) => entry.kind === "codex.run.stream.event" && entry.data?.itemType === "collab_tool_call",
+      );
+      const completedLog = logs.find((entry) => entry.kind === "codex.run.completed");
+
+      assert.equal(result.assistantText, "done");
+      assert.equal(openedLog, undefined);
+      assert.equal(finishedLog, undefined);
+      assert.equal(collabLog, undefined);
+      assert.equal(completedLog?.data?.turnCompleted, true);
+      assert.equal(completedLog?.data?.operationCount, 2);
+      assert.equal(completedLog?.data?.hasUsage, false);
+    } finally {
+      if (previousDebugValue === undefined) {
+        delete process.env.WITHMATE_CODEX_STREAM_DEBUG;
+      } else {
+        process.env.WITHMATE_CODEX_STREAM_DEBUG = previousDebugValue;
+      }
+      await rm(workspacePath, { recursive: true, force: true });
+    }
+  });
+
+  it("debug flag 有効時は collab_tool_call の stream lifecycle を app log に流す", async () => {
+    const workspacePath = await mkdtemp(path.join(os.tmpdir(), "withmate-codex-collab-debug-log-"));
+    const previousDebugValue = process.env.WITHMATE_CODEX_STREAM_DEBUG;
+    const logs: Array<{ kind: string; level: string; data?: Record<string, unknown> }> = [];
+    const adapter = new CodexAdapter((entry) => {
+      logs.push(entry as { kind: string; level: string; data?: Record<string, unknown> });
+    }) as unknown as {
+      getClient: () => {
+        client: {
+          startThread: () => {
+            id: string;
+            runStreamed: () => Promise<{ events: AsyncGenerator<never> }>;
+          };
+          resumeThread: never;
+        };
+        clientKey: string;
+      };
+      runSessionTurn: CodexAdapter["runSessionTurn"];
+    };
+
+    try {
+      process.env.WITHMATE_CODEX_STREAM_DEBUG = "1";
       adapter.getClient = () => ({
         client: {
           startThread: () => ({
@@ -819,6 +909,11 @@ describe("CodexAdapter thread settings", () => {
       assert.equal(completedLog?.data?.turnCompleted, true);
       assert.equal(completedLog?.data?.operationCount, 2);
     } finally {
+      if (previousDebugValue === undefined) {
+        delete process.env.WITHMATE_CODEX_STREAM_DEBUG;
+      } else {
+        process.env.WITHMATE_CODEX_STREAM_DEBUG = previousDebugValue;
+      }
       await rm(workspacePath, { recursive: true, force: true });
     }
   });

--- a/src-electron/codex-adapter.ts
+++ b/src-electron/codex-adapter.ts
@@ -143,6 +143,7 @@ const CODEX_WINDOWS_TASKKILL_SUCCESS_PARSE_NOISE_PATTERN =
 const CODEX_USAGE_LIMIT_MESSAGE_PATTERN = /you['’]ve hit your usage limit\./i;
 const CODEX_USAGE_LIMIT_PURCHASE_PATTERN = /purchase more credits/i;
 const CODEX_USAGE_LIMIT_RETRY_PATTERN = /try again at/i;
+const CODEX_STREAM_DEBUG_ENV = "WITHMATE_CODEX_STREAM_DEBUG";
 
 export function isCodexWindowsTaskkillSuccessParseNoiseMessage(message: string): boolean {
   return CODEX_WINDOWS_TASKKILL_SUCCESS_PARSE_NOISE_PATTERN.test(message.trim());
@@ -164,6 +165,11 @@ function resolveCodexProviderErrorReason(message: string, canceled: boolean): Pr
   }
 
   return "unknown";
+}
+
+function isCodexStreamDebugLogEnabled(): boolean {
+  const value = process.env[CODEX_STREAM_DEBUG_ENV]?.trim().toLowerCase();
+  return value === "1" || value === "true" || value === "yes" || value === "on";
 }
 
 function shouldIgnoreCodexWindowsTaskkillParseNoise(
@@ -1659,20 +1665,23 @@ export class CodexAdapter implements ProviderTurnAdapter {
       const { events } = await thread.runStreamed(turnInput, {
         signal: input.signal,
       });
-      this.writeLog({
-        level: "debug",
-        kind: "codex.run.stream.opened",
-        message: "Codex session turn stream opened",
-        data: {
-          sessionId: input.session.id,
-          threadId: streamState.threadId,
-        },
-      });
+      const streamDebugLogEnabled = isCodexStreamDebugLogEnabled();
+      if (streamDebugLogEnabled) {
+        this.writeLog({
+          level: "debug",
+          kind: "codex.run.stream.opened",
+          message: "Codex session turn stream opened",
+          data: {
+            sessionId: input.session.id,
+            threadId: streamState.threadId,
+          },
+        });
+      }
 
       for await (const event of events) {
         applyCodexTurnEvent(streamState, event);
-        const eventLogData = buildCodexTurnEventLogData(event);
-        if (eventLogData) {
+        const eventLogData = streamDebugLogEnabled ? buildCodexTurnEventLogData(event) : null;
+        if (streamDebugLogEnabled && eventLogData) {
           this.writeLog({
             level: event.type === "turn.failed" || event.type === "error" ? "warn" : "debug",
             kind: "codex.run.stream.event",
@@ -1695,15 +1704,17 @@ export class CodexAdapter implements ProviderTurnAdapter {
           getLiveStreamErrorMessage(streamState),
         );
       }
-      this.writeLog({
-        level: "info",
-        kind: "codex.run.stream.finished",
-        message: "Codex session turn stream finished",
-        data: {
-          sessionId: input.session.id,
-          ...summarizeCodexTurnStreamState(streamState),
-        },
-      });
+      if (streamDebugLogEnabled) {
+        this.writeLog({
+          level: "info",
+          kind: "codex.run.stream.finished",
+          message: "Codex session turn stream finished",
+          data: {
+            sessionId: input.session.id,
+            ...summarizeCodexTurnStreamState(streamState),
+          },
+        });
+      }
 
       if (streamState.streamErrorMessage) {
         const shouldIgnoreWindowsTaskkillParseNoise = shouldIgnoreCodexWindowsTaskkillParseNoise(


### PR DESCRIPTION
## Summary
- Codex stream の event-level 診断ログを通常運用では出さず、`WITHMATE_CODEX_STREAM_DEBUG=1` のときだけ出すように変更
- `codex.run.completed` / `failed` / `provider-error` / `stream-error` の summary ログは維持
- #156 のログ分析と運用方針を docs に移植し、アプリバージョンを `4.2.17-preview.2` へ更新

## Validation
- `$env:WITHMATE_CODEX_STREAM_DEBUG='1'; node --import tsx --test scripts/tests/codex-adapter.test.ts`
- `npm run typecheck`
- `npm test`
- `git diff --check`