### PR TITLE
[codex] ActionDock compact row の末尾移動ボタンを復旧

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "4.2.17-preview.2",
+  "version": "4.2.17-preview.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "4.2.17-preview.2",
+      "version": "4.2.17-preview.3",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.0-beta.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "4.2.17-preview.2",
+  "version": "4.2.17-preview.3",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/scripts/tests/session-message-column.test.ts
+++ b/scripts/tests/session-message-column.test.ts
@@ -527,7 +527,7 @@ test("SessionActionDockCompactRow は jump button を Send の左に描画する
   assert.ok(html.indexOf("末尾へ移動") < html.indexOf("Send"));
 });
 
-test("SessionActionDockCompactRow は実行中の compact 表示を progress と Cancel だけにする", () => {
+test("SessionActionDockCompactRow は実行中の compact 表示に jump button と Cancel を描画する", () => {
   const html = renderToStaticMarkup(
     React.createElement(SessionActionDockCompactRow, {
       draft: "draft",
@@ -550,10 +550,10 @@ test("SessionActionDockCompactRow は実行中の compact 表示を progress と
   assert.match(html, /session-action-dock-compact-progress/);
   assert.match(html, /処理を実行中/);
   assert.match(html, /session-action-dock-compact-actions/);
+  assert.ok(html.indexOf("末尾へ移動") < html.indexOf("Cancel"));
   assert.match(html, />Cancel<\/button>/);
   assert.doesNotMatch(html, /Draft/);
   assert.doesNotMatch(html, /添付 2/);
-  assert.doesNotMatch(html, /末尾へ移動/);
 });
 
 test("SessionContextPane は latest command がないとき empty text を表示する", () => {

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -2522,6 +2522,15 @@ export function SessionActionDockCompactRow({
           />
         </button>
         <div className="session-action-dock-compact-actions">
+          {showJumpToBottom ? (
+            <button
+              className="drawer-toggle compact secondary message-jump-bottom-button"
+              type="button"
+              onClick={onJumpToBottom}
+            >
+              末尾へ移動
+            </button>
+          ) : null}
           <button
             className="danger session-send-button"
             type="button"


### PR DESCRIPTION
## 概要

- ActionDock を Hide している実行中 compact row でも、未追従時に「末尾へ移動」ボタンを表示するようにしました。
- compact row の実行中表示テストを更新し、progress/microcopy、末尾移動、Cancel の描画を確認するようにしました。
- アプリバージョンを `4.2.17-preview.3` に上げました。

## 背景 / 原因

`showJumpToBottom` は compact ActionDock まで渡されていましたが、`isRunning` の compact 分岐が早期 return しており、実行中は progress と Cancel だけを描画していました。そのため ActionDock を Hide している状態では、未追従でも「末尾へ移動」が DOM に出ませんでした。

## 検証

- `node --import tsx --test scripts/tests/session-message-column.test.ts`
- `npm run typecheck`

## 補足

検証のため `npm install` を実行しました。依存導入は成功しましたが、既存依存に対する `npm audit` 警告が 6 件出ています。今回の変更では扱っていません。