### PR TITLE
Assistant response actions を floating toolbar 化

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "4.2.17-preview.3",
+  "version": "4.2.17-preview.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "4.2.17-preview.3",
+      "version": "4.2.17-preview.4",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.0-beta.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "4.2.17-preview.3",
+  "version": "4.2.17-preview.4",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -1946,27 +1946,121 @@ export type SessionMessageColumnProps = {
   onQuoteMessageText?: (text: string) => void;
 };
 
-function getSelectedTextWithin(element: Element | null): string {
+function getSelectionDetailsWithinMessageList(element: Element | null): { anchorRect: DOMRect; text: string } | null {
   if (!element || typeof window === "undefined") {
-    return "";
+    return null;
   }
 
   const selection = window.getSelection();
   if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
-    return "";
+    return null;
   }
 
   const range = selection.getRangeAt(0);
   const commonAncestor = range.commonAncestorContainer;
   const commonElement =
     commonAncestor.nodeType === Node.ELEMENT_NODE
-      ? commonAncestor
+      ? commonAncestor as Element
       : commonAncestor.parentElement;
-  if (!commonElement || !element.contains(commonElement)) {
-    return "";
+  const messageBody = commonElement?.closest("[data-message-body='true']") ?? null;
+  if (
+    !messageBody ||
+    !element.contains(messageBody) ||
+    !messageBody.closest(".message-card.has-response-actions")
+  ) {
+    return null;
   }
 
-  return selection.toString().trim();
+  const text = selection.toString().trim();
+  if (!text) {
+    return null;
+  }
+
+  const rangeRect = range.getBoundingClientRect();
+  if (rangeRect.width > 0 || rangeRect.height > 0) {
+    return { anchorRect: rangeRect, text };
+  }
+
+  const fallbackRect = range.getClientRects()[0] ?? null;
+  return fallbackRect ? { anchorRect: fallbackRect, text } : null;
+}
+
+function clampToolbarPosition(input: {
+  anchorRect: DOMRect;
+  boundaryRect: DOMRect;
+  toolbarRect: Pick<DOMRect, "width" | "height">;
+  padding?: number;
+}): CSSProperties {
+  const padding = input.padding ?? 8;
+  const toolbarWidth = input.toolbarRect.width || 112;
+  const toolbarHeight = input.toolbarRect.height || 32;
+  const preferredLeft = input.anchorRect.left + (input.anchorRect.width - toolbarWidth) / 2;
+  const preferredTop =
+    input.anchorRect.top - toolbarHeight - padding >= input.boundaryRect.top + padding
+      ? input.anchorRect.top - toolbarHeight - padding
+      : input.anchorRect.bottom + padding;
+  const left = Math.min(
+    input.boundaryRect.right - toolbarWidth - padding,
+    Math.max(input.boundaryRect.left + padding, preferredLeft),
+  );
+  const top = Math.min(
+    input.boundaryRect.bottom - toolbarHeight - padding,
+    Math.max(input.boundaryRect.top + padding, preferredTop),
+  );
+
+  return { left, top };
+}
+
+function rectsIntersect(a: DOMRect, b: DOMRect): boolean {
+  return a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top;
+}
+
+type MessageResponseActionsProps = {
+  actionText: string;
+  className?: string;
+  onCopyMessageText?: (text: string) => void;
+  onQuoteMessageText?: (text: string) => void;
+  style?: CSSProperties;
+  toolbarRef?: RefObject<HTMLDivElement | null>;
+};
+
+function MessageResponseActions({
+  actionText,
+  className = "",
+  onCopyMessageText,
+  onQuoteMessageText,
+  style,
+  toolbarRef,
+}: MessageResponseActionsProps) {
+  return (
+    <div
+      ref={toolbarRef}
+      className={`message-response-actions${className ? ` ${className}` : ""}`}
+      aria-label="Response actions"
+      style={style}
+    >
+      {onCopyMessageText ? (
+        <button
+          className="message-response-action"
+          type="button"
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => onCopyMessageText(actionText)}
+        >
+          Copy
+        </button>
+      ) : null}
+      {onQuoteMessageText ? (
+        <button
+          className="message-response-action"
+          type="button"
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => onQuoteMessageText(actionText)}
+        >
+          Quote
+        </button>
+      ) : null}
+    </div>
+  );
 }
 
 export function SessionMessageColumn({
@@ -2002,6 +2096,8 @@ export function SessionMessageColumn({
   const [openArtifactFolds, setOpenArtifactFolds] = useState<Record<string, boolean>>({});
   const [loadedArtifactDetails, setLoadedArtifactDetails] = useState<Record<string, MessageArtifact>>({});
   const [loadingArtifactDetails, setLoadingArtifactDetails] = useState<Record<string, boolean>>({});
+  const [selectionToolbar, setSelectionToolbar] = useState<{ style: CSSProperties; text: string } | null>(null);
+  const selectionToolbarRef = useRef<HTMLDivElement | null>(null);
   const [messageWindowStartIndex, setMessageWindowStartIndex] = useState(() =>
     Math.max(0, messages.length - SESSION_MESSAGE_INITIAL_RENDER_COUNT),
   );
@@ -2058,6 +2154,49 @@ export function SessionMessageColumn({
     }
     onMessageListScroll(event);
   };
+
+  const updateSelectionToolbar = useCallback(() => {
+    const messageListElement = messageListRef.current;
+    const selectionDetails = getSelectionDetailsWithinMessageList(messageListElement);
+    const boundaryRect = messageListElement?.getBoundingClientRect() ?? null;
+    const toolbarRect =
+      selectionToolbarRef.current?.getBoundingClientRect() ??
+      { width: 112, height: 32 };
+    if (
+      !selectionDetails ||
+      !boundaryRect ||
+      !rectsIntersect(selectionDetails.anchorRect, boundaryRect)
+    ) {
+      setSelectionToolbar(null);
+      return;
+    }
+
+    setSelectionToolbar({
+      style: clampToolbarPosition({
+        anchorRect: selectionDetails.anchorRect,
+        boundaryRect,
+        toolbarRect,
+      }),
+      text: selectionDetails.text,
+    });
+  }, [messageListRef]);
+
+  useEffect(() => {
+    if (typeof document === "undefined" || typeof window === "undefined") {
+      return;
+    }
+
+    document.addEventListener("selectionchange", updateSelectionToolbar);
+    window.addEventListener("resize", updateSelectionToolbar);
+    const messageListElement = messageListRef.current;
+    messageListElement?.addEventListener("scroll", updateSelectionToolbar, { passive: true });
+
+    return () => {
+      document.removeEventListener("selectionchange", updateSelectionToolbar);
+      window.removeEventListener("resize", updateSelectionToolbar);
+      messageListElement?.removeEventListener("scroll", updateSelectionToolbar);
+    };
+  }, [messageListRef, updateSelectionToolbar]);
 
   useLayoutEffect(() => {
     setMessageWindowStartIndex((current) => {
@@ -2237,12 +2376,6 @@ export function SessionMessageColumn({
               })) ??
               [];
             const hasMessageTextActions = isAssistant && (onCopyMessageText || onQuoteMessageText);
-            const pickMessageActionText = (button: HTMLButtonElement) => {
-              const messageBody = button
-                .closest(".message-card")
-                ?.querySelector("[data-message-body='true']") ?? null;
-              return getSelectedTextWithin(messageBody) || message.text;
-            };
 
             return (
               <Fragment key={`${message.role}-${messageKey}`}>
@@ -2285,7 +2418,7 @@ export function SessionMessageColumn({
                     ) : null}
                   </div>
                 ) : null}
-                <div className={`message-card ${message.role}${message.accent ? " accent" : ""}${artifact ? " has-artifact" : ""}`}>
+                <div className={`message-card ${message.role}${message.accent ? " accent" : ""}${artifact ? " has-artifact" : ""}${hasMessageTextActions ? " has-response-actions" : ""}`}>
                   {artifact && !isAssistant ? (
                     <button
                       className="artifact-toggle artifact-toggle-icon"
@@ -2308,26 +2441,11 @@ export function SessionMessageColumn({
                     <MessageRichText text={message.text} onOpenPath={onOpenPath} />
                   </div>
                   {hasMessageTextActions ? (
-                    <div className="message-response-actions" aria-label="Response actions">
-                      {onCopyMessageText ? (
-                        <button
-                          className="message-response-action"
-                          type="button"
-                          onClick={(event) => onCopyMessageText(pickMessageActionText(event.currentTarget))}
-                        >
-                          Copy
-                        </button>
-                      ) : null}
-                      {onQuoteMessageText ? (
-                        <button
-                          className="message-response-action"
-                          type="button"
-                          onClick={(event) => onQuoteMessageText(pickMessageActionText(event.currentTarget))}
-                        >
-                          Quote
-                        </button>
-                      ) : null}
-                    </div>
+                    <MessageResponseActions
+                      actionText={message.text}
+                      onCopyMessageText={onCopyMessageText}
+                      onQuoteMessageText={onQuoteMessageText}
+                    />
                   ) : null}
 
                   {artifact ? (
@@ -2468,6 +2586,16 @@ export function SessionMessageColumn({
               <div className="message-list-bottom-anchor" aria-hidden="true" />
             </div>
           </div>
+        ) : null}
+        {selectionToolbar ? (
+          <MessageResponseActions
+            actionText={selectionToolbar.text}
+            className="is-selection-anchor"
+            onCopyMessageText={onCopyMessageText}
+            onQuoteMessageText={onQuoteMessageText}
+            style={selectionToolbar.style}
+            toolbarRef={selectionToolbarRef}
+          />
         ) : null}
       </div>
     </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -3689,18 +3689,52 @@ button:disabled {
   padding-top: 14px;
 }
 
+.message-card.has-response-actions {
+  min-height: 0;
+}
+
+.message-card.has-response-actions > [data-message-body="true"] {
+  min-height: 34px;
+  padding-inline-end: 124px;
+}
+
 .message-response-actions {
-  display: flex;
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 3;
+  display: inline-flex;
   justify-content: flex-end;
   gap: 6px;
-  min-height: 24px;
+  padding: 4px;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--character-sub-soft) 38%, rgba(15, 23, 42, 0.92));
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.28);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 120ms ease, transform 120ms ease;
+  transform: translateY(-2px);
+}
+
+.message-card.has-response-actions:hover .message-response-actions,
+.message-card.has-response-actions:focus-within .message-response-actions,
+.message-response-actions.is-selection-anchor {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.message-response-actions.is-selection-anchor {
+  position: fixed;
+  right: auto;
 }
 
 .message-response-action {
   border: 1px solid rgba(148, 163, 184, 0.28);
   border-radius: var(--radius-sm);
-  background: rgba(15, 23, 42, 0.24);
-  color: var(--muted);
+  background: rgba(15, 23, 42, 0.54);
+  color: var(--ink);
   font: inherit;
   font-size: 0.78rem;
   line-height: 1;
@@ -3713,6 +3747,14 @@ button:disabled {
   border-color: color-mix(in srgb, var(--character-sub) 48%, rgba(148, 163, 184, 0.36));
   color: var(--ink);
   background: rgba(30, 41, 59, 0.42);
+}
+
+@media (hover: none) {
+  .message-card.has-response-actions .message-response-actions {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
 }
 
 .session-page.auxiliary-session-mode .session-work-surface {


### PR DESCRIPTION
## 概要
- assistant response の Copy / Quote action を本文下の通常フローから floating toolbar に変更
- selection toolbar を message list 単位の単一管理にして、選択テキストを cached text として Copy / Quote に使用
- hover / focus / touch fallback が本文右上を塞がないように余白を確保
- アプリバージョンを 4.2.17-preview.4 に更新

## 検証
- node --import tsx --test scripts/tests/session-message-column.test.ts scripts/tests/chat-window-mate-talk-mode.test.ts scripts/tests/message-text-actions.test.ts
- npm run typecheck
- git diff --check
- npm run test