### PR TITLE
[codex] Keep live assistant render continuous

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "4.2.17-preview.4",
+  "version": "4.2.17-preview.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "4.2.17-preview.4",
+      "version": "4.2.17-preview.5",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.0-beta.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "4.2.17-preview.4",
+  "version": "4.2.17-preview.5",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/scripts/tests/auxiliary-session-message-projection.test.ts
+++ b/scripts/tests/auxiliary-session-message-projection.test.ts
@@ -3,8 +3,11 @@ import test from "node:test";
 
 import {
   buildMessageListProjection,
+  hasPersistedLiveAssistantMessage,
   loadProjectedMessageArtifact,
+  resolveLiveAssistantMessageIndex,
   resolvePendingAuxiliaryMessageGroupId,
+  shouldProjectLiveAssistantBridge,
 } from "../../src/auxiliary-session-message-projection.js";
 import type { AuxiliarySession } from "../../src/auxiliary-session-state.js";
 import type { Message, MessageArtifact } from "../../src/session-state.js";
@@ -174,6 +177,247 @@ test("buildMessageListProjection は Auxiliary を parent message の保存位�
       "main response 2",
       "aux prompt 2",
     ],
+  );
+});
+
+test("buildMessageListProjection は live assistant を transient message として末尾に追加する", () => {
+  const projection = buildMessageListProjection(
+    [{ role: "user", text: "main prompt" }],
+    [],
+    "session-1",
+    {
+      liveAssistant: {
+        sessionId: "session-1",
+        threadId: "thread-1",
+        messageIndex: 1,
+        text: "streaming response",
+      },
+    },
+  );
+
+  assert.deepEqual(
+    projection.messages.map((message) => `${message.role}:${message.text}`),
+    ["user:main prompt", "assistant:streaming response"],
+  );
+  assert.deepEqual(projection.sources[1], {
+    kind: "live-assistant",
+    sessionId: "session-1",
+    threadId: "thread-1",
+  });
+  assert.equal(projection.keys[1], "live-assistant-session-1-1-thread-1");
+});
+
+test("buildMessageListProjection は persisted assistant と live assistant を index で照合して key を引き継ぐ", () => {
+  const projection = buildMessageListProjection(
+    [
+      { role: "user", text: "main prompt" },
+      { role: "assistant", text: "final response" },
+    ],
+    [],
+    "session-1",
+    {
+      liveAssistant: {
+        sessionId: "session-1",
+        threadId: "thread-1",
+        messageIndex: 1,
+        text: "streaming response",
+      },
+    },
+  );
+
+  assert.deepEqual(
+    projection.messages.map((message) => `${message.role}:${message.text}`),
+    ["user:main prompt", "assistant:final response"],
+  );
+  assert.deepEqual(projection.sources, [
+    { kind: "session", messageIndex: 0 },
+    { kind: "session", messageIndex: 1 },
+  ]);
+  assert.equal(projection.keys[1], "live-assistant-session-1-1-thread-1");
+});
+
+test("buildMessageListProjection は live text が既存末尾 assistant と同じでも新規 live row を追加する", () => {
+  const projection = buildMessageListProjection(
+    [
+      { role: "assistant", text: "same response" },
+      { role: "user", text: "next prompt" },
+    ],
+    [],
+    "session-1",
+    {
+      liveAssistant: {
+        sessionId: "session-1",
+        threadId: "thread-2",
+        messageIndex: 2,
+        text: "same response",
+      },
+    },
+  );
+
+  assert.deepEqual(
+    projection.messages.map((message) => `${message.role}:${message.text}`),
+    ["assistant:same response", "user:next prompt", "assistant:same response"],
+  );
+  assert.deepEqual(projection.sources[2], {
+    kind: "live-assistant",
+    sessionId: "session-1",
+    threadId: "thread-2",
+  });
+  assert.equal(projection.keys[2], "live-assistant-session-1-2-thread-2");
+});
+
+test("hasPersistedLiveAssistantMessage は final text が live text と違っても target index の assistant で完了扱いにする", () => {
+  assert.equal(
+    hasPersistedLiveAssistantMessage(
+      [
+        { role: "user", text: "main prompt" },
+        { role: "assistant", text: "完了したよ。" },
+      ],
+      [],
+      {
+        sessionId: "session-1",
+        threadId: "thread-1",
+        messageIndex: 1,
+        text: "処理中... テスト完了",
+      },
+      "session-1",
+    ),
+    true,
+  );
+});
+
+test("hasPersistedLiveAssistantMessage は partial fallback notice 付き final も target index で完了扱いにする", () => {
+  assert.equal(
+    hasPersistedLiveAssistantMessage(
+      [
+        { role: "user", text: "main prompt" },
+        { role: "assistant", text: "partial response\n\n実行に失敗しました。" },
+      ],
+      [],
+      {
+        sessionId: "session-1",
+        threadId: "thread-1",
+        messageIndex: 1,
+        text: "partial response",
+      },
+      "session-1",
+    ),
+    true,
+  );
+});
+
+test("buildMessageListProjection は Auxiliary live assistant を対象 group 内に追加する", () => {
+  const projection = buildMessageListProjection(
+    [
+      { role: "assistant", text: "main response" },
+      { role: "assistant", text: "later main response" },
+    ],
+    [
+      createAuxiliarySession([{ role: "user", text: "aux prompt" }], {
+        id: "aux-1",
+        displayAfterMessageIndex: 0,
+      }),
+    ],
+    "session-1",
+    {
+      liveAssistant: {
+        sessionId: "aux-1",
+        threadId: "aux-thread-1",
+        messageIndex: 1,
+        text: "aux streaming response",
+      },
+    },
+  );
+
+  assert.deepEqual(
+    projection.messages.map((message) => message.text),
+    ["main response", "aux prompt", "aux streaming response", "later main response"],
+  );
+  assert.deepEqual(projection.groups, [
+    null,
+    { id: "aux-1", label: "Auxiliary" },
+    { id: "aux-1", label: "Auxiliary" },
+    null,
+  ]);
+  assert.equal(projection.keys[2], "live-assistant-aux-1-1-aux-thread-1");
+});
+
+test("resolveLiveAssistantMessageIndex は target session の次 assistant index を返す", () => {
+  const auxiliarySession = createAuxiliarySession([{ role: "user", text: "aux prompt" }], {
+    id: "aux-1",
+  });
+
+  assert.equal(
+    resolveLiveAssistantMessageIndex(
+      [{ role: "user", text: "main prompt" }],
+      [auxiliarySession],
+      "session-1",
+      "session-1",
+    ),
+    1,
+  );
+  assert.equal(
+    resolveLiveAssistantMessageIndex(
+      [{ role: "user", text: "main prompt" }],
+      [auxiliarySession],
+      "aux-1",
+      "session-1",
+    ),
+    1,
+  );
+});
+
+test("shouldProjectLiveAssistantBridge は live run が消えて persisted assistant もなければ bridge を投影しない", () => {
+  assert.equal(
+    shouldProjectLiveAssistantBridge({
+      bridge: {
+        sessionId: "session-1",
+        threadId: "thread-1",
+        messageIndex: 1,
+        text: "stale streaming response",
+      },
+      activeSessionId: "session-1",
+      hasLiveRun: false,
+      hasPersistedAssistant: false,
+    }),
+    false,
+  );
+});
+
+test("shouldProjectLiveAssistantBridge は live run 中または persisted assistant 検知後だけ bridge を投影する", () => {
+  const bridge = {
+    sessionId: "session-1",
+    threadId: "thread-1",
+    messageIndex: 1,
+    text: "streaming response",
+  };
+
+  assert.equal(
+    shouldProjectLiveAssistantBridge({
+      bridge,
+      activeSessionId: "session-1",
+      hasLiveRun: true,
+      hasPersistedAssistant: false,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldProjectLiveAssistantBridge({
+      bridge,
+      activeSessionId: "session-1",
+      hasLiveRun: false,
+      hasPersistedAssistant: true,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldProjectLiveAssistantBridge({
+      bridge,
+      activeSessionId: "session-2",
+      hasLiveRun: true,
+      hasPersistedAssistant: true,
+    }),
+    false,
   );
 });
 

--- a/scripts/tests/session-message-column.test.ts
+++ b/scripts/tests/session-message-column.test.ts
@@ -250,22 +250,25 @@ test("SessionMessageColumn は pending と live approval\/elicitation を messag
   );
 });
 
-test("SessionMessageColumn は実行中の assistant text を pending bubble 内に表示する", () => {
+test("SessionMessageColumn は projection 済みの実行中 assistant text を通常 message row として表示する", () => {
   const html = renderSessionMessageColumn({
-    messages: createMessages(100),
+    messages: [
+      ...createMessages(100),
+      { role: "assistant", text: "ストリーミング中の返答" },
+    ],
     isRunning: true,
     liveRunAssistantText: "ストリーミング中の返答",
   });
 
-  assert.match(html, /pending-row/);
+  assert.doesNotMatch(html, /pending-row/);
   assert.match(html, /ストリーミング中の返答/);
   assert.ok(
-    html.indexOf("message 100") < html.indexOf("pending-row"),
-    "pending row は既存メッセージの後に描画する",
+    html.indexOf("message 100") < html.indexOf("ストリーミング中の返答"),
+    "projection 済みの live assistant text は既存メッセージの後に描画する",
   );
   assert.ok(
-    html.indexOf("pending-row") < html.indexOf("ストリーミング中の返答"),
-    "streaming assistant text は pending row 内に描画する",
+    html.indexOf("ストリーミング中の返答") < html.indexOf("message-list-bottom-anchor"),
+    "projection 済みの live assistant text は bottom anchor より前に描画する",
   );
   assert.doesNotMatch(html, /処理を実行中/);
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -206,8 +206,12 @@ import {
 } from "./chat/retry-state.js";
 import {
   buildMessageListProjection,
+  hasPersistedLiveAssistantMessage,
   loadProjectedMessageArtifact,
+  resolveLiveAssistantMessageIndex,
   resolvePendingAuxiliaryMessageGroupId,
+  shouldProjectLiveAssistantBridge,
+  type LiveAssistantProjection,
 } from "./auxiliary-session-message-projection.js";
 import {
   runAuxiliaryDraftChangeAndSaveOperation,
@@ -426,6 +430,7 @@ export default function AgentSessionWindowApp() {
   const [expandedArtifacts, setExpandedArtifacts] = useState<Record<string, boolean>>({});
   const [selectedDiff, setSelectedDiff] = useState<DiffPreviewPayload | null>(null);
   const [liveRunState, setLiveRunState] = useState<OwnedLiveSessionRunState>({ ownerSessionId: null, state: null });
+  const [liveAssistantBridge, setLiveAssistantBridge] = useState<LiveAssistantProjection | null>(null);
   const [providerQuotaTelemetryState, setProviderQuotaTelemetryState] = useState<ProviderOwnedQuotaTelemetry>({
     ownerProviderId: null,
     telemetry: null,
@@ -656,6 +661,12 @@ export default function AgentSessionWindowApp() {
     runState: selectedSession?.runState,
     hasLiveRun: !!selectedSessionLiveRun,
   });
+  const liveRunAssistantText = selectedSessionLiveRun?.assistantText ?? "";
+  const liveApprovalRequest = selectedSessionLiveRun?.approvalRequest ?? null;
+  const liveElicitationRequest = selectedSessionLiveRun?.elicitationRequest ?? null;
+  const isApprovalRequestPending = !!liveApprovalRequest;
+  const isElicitationRequestPending = !!liveElicitationRequest;
+  const hasLiveRunAssistantText = liveRunAssistantText.length > 0;
 
   const selectedSessionCharacter = useMemo(
     () =>
@@ -816,18 +827,148 @@ export default function AgentSessionWindowApp() {
   }, [withmateApi]);
 
   const displayedMessages: Message[] = selectedSession ? selectedSession.messages : [];
+  const projectedAuxiliarySessions = useMemo(
+    () => [
+      ...closedAuxiliarySessions,
+      ...(activeAuxiliarySession ? [activeAuxiliarySession] : []),
+    ],
+    [activeAuxiliarySession, closedAuxiliarySessions],
+  );
+  const liveAssistantMessageIndex = useMemo(
+    () =>
+      activeRunSessionId
+        ? resolveLiveAssistantMessageIndex(
+          displayedMessages,
+          projectedAuxiliarySessions,
+          activeRunSessionId,
+          selectedSession?.id,
+        )
+        : 0,
+    [activeRunSessionId, displayedMessages, projectedAuxiliarySessions, selectedSession?.id],
+  );
+  const hasPersistedLiveAssistantBridge = useMemo(
+    () =>
+      liveAssistantBridge
+        ? hasPersistedLiveAssistantMessage(
+          displayedMessages,
+          projectedAuxiliarySessions,
+          liveAssistantBridge,
+          selectedSession?.id,
+        )
+        : false,
+    [displayedMessages, liveAssistantBridge, projectedAuxiliarySessions, selectedSession?.id],
+  );
+  const projectedLiveAssistant = useMemo<LiveAssistantProjection | null>(() => {
+    if (!activeRunSessionId) {
+      return null;
+    }
+
+    const liveThreadId = selectedSessionLiveRun?.threadId ?? null;
+    const bridgeMessageIndex =
+      liveAssistantBridge?.sessionId === activeRunSessionId &&
+      liveAssistantBridge.threadId === liveThreadId
+        ? liveAssistantBridge.messageIndex
+        : liveAssistantMessageIndex;
+    if (liveRunAssistantText) {
+      return {
+        sessionId: activeRunSessionId,
+        threadId: liveThreadId,
+        messageIndex: bridgeMessageIndex,
+        text: liveRunAssistantText,
+      };
+    }
+
+    return shouldProjectLiveAssistantBridge({
+      bridge: liveAssistantBridge,
+      activeSessionId: activeRunSessionId,
+      hasLiveRun: selectedSessionLiveRun !== null,
+      hasPersistedAssistant: hasPersistedLiveAssistantBridge,
+    })
+      ? liveAssistantBridge
+      : null;
+  }, [
+    activeRunSessionId,
+    hasPersistedLiveAssistantBridge,
+    liveAssistantBridge,
+    liveAssistantMessageIndex,
+    liveRunAssistantText,
+    selectedSessionLiveRun,
+    selectedSessionLiveRun?.threadId,
+  ]);
   const messageListProjection = useMemo(
     () =>
-      buildMessageListProjection(displayedMessages, [
-        ...closedAuxiliarySessions,
-        ...(activeAuxiliarySession ? [activeAuxiliarySession] : []),
-      ], selectedSession?.id),
-    [activeAuxiliarySession, closedAuxiliarySessions, displayedMessages, selectedSession?.id],
+      buildMessageListProjection(displayedMessages, projectedAuxiliarySessions, selectedSession?.id, {
+        liveAssistant: projectedLiveAssistant,
+      }),
+    [displayedMessages, projectedAuxiliarySessions, projectedLiveAssistant, selectedSession?.id],
   );
   const messageListMessages = messageListProjection.messages;
   const messageListSources = messageListProjection.sources;
   const messageListKeys = messageListProjection.keys;
   const messageListGroups = messageListProjection.groups;
+  useEffect(() => {
+    if (!activeRunSessionId || !liveRunAssistantText) {
+      return;
+    }
+
+    const liveThreadId = selectedSessionLiveRun?.threadId ?? null;
+    setLiveAssistantBridge((current) => {
+      if (current?.sessionId === activeRunSessionId && current.threadId === liveThreadId) {
+        return {
+          ...current,
+          text: liveRunAssistantText,
+        };
+      }
+
+      return {
+        sessionId: activeRunSessionId,
+        threadId: liveThreadId,
+        messageIndex: liveAssistantMessageIndex,
+        text: liveRunAssistantText,
+      };
+    });
+  }, [activeRunSessionId, liveAssistantMessageIndex, liveRunAssistantText, selectedSessionLiveRun?.threadId]);
+  useEffect(() => {
+    if (!liveAssistantBridge) {
+      return;
+    }
+
+    if (
+      liveAssistantBridge.sessionId !== activeRunSessionId ||
+      (selectedSessionLiveRun === null && !hasPersistedLiveAssistantBridge)
+    ) {
+      setLiveAssistantBridge(null);
+    }
+  }, [activeRunSessionId, hasPersistedLiveAssistantBridge, liveAssistantBridge, selectedSessionLiveRun]);
+  useEffect(() => {
+    if (!liveAssistantBridge) {
+      return;
+    }
+
+    if (!hasPersistedLiveAssistantBridge) {
+      return;
+    }
+
+    let secondFrameId: number | null = null;
+    const firstFrameId = requestAnimationFrame(() => {
+      secondFrameId = requestAnimationFrame(() => {
+        setLiveAssistantBridge((current) =>
+          current?.sessionId === liveAssistantBridge.sessionId &&
+          current.threadId === liveAssistantBridge.threadId &&
+          current.text === liveAssistantBridge.text
+            ? null
+            : current,
+        );
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(firstFrameId);
+      if (secondFrameId !== null) {
+        cancelAnimationFrame(secondFrameId);
+      }
+    };
+  }, [hasPersistedLiveAssistantBridge, liveAssistantBridge]);
   const displayedMessagesScrollSignature = useMemo(
     () => buildDisplayedMessagesScrollSignature(messageListMessages),
     [messageListMessages],
@@ -836,7 +977,6 @@ export default function AgentSessionWindowApp() {
     () =>
       [
         selectedSessionRunState ?? "",
-        selectedSessionLiveRun?.assistantText ?? "",
         selectedSessionLiveRun?.errorMessage ?? "",
         selectedSessionLiveRun?.approvalRequest
           ? [
@@ -857,7 +997,6 @@ export default function AgentSessionWindowApp() {
       selectedSessionRunState,
       selectedSessionLiveRun?.approvalRequest,
       selectedSessionLiveRun?.elicitationRequest,
-      selectedSessionLiveRun?.assistantText,
       selectedSessionLiveRun?.errorMessage,
     ],
   );
@@ -1189,12 +1328,6 @@ export default function AgentSessionWindowApp() {
     [orderedLiveRunSteps],
   );
 
-  const liveRunAssistantText = selectedSessionLiveRun?.assistantText ?? "";
-  const liveApprovalRequest = selectedSessionLiveRun?.approvalRequest ?? null;
-  const liveElicitationRequest = selectedSessionLiveRun?.elicitationRequest ?? null;
-  const isApprovalRequestPending = !!liveApprovalRequest;
-  const isElicitationRequestPending = !!liveElicitationRequest;
-  const hasLiveRunAssistantText = liveRunAssistantText.length > 0;
   const selectedContextEmptyText = useMemo(
     () =>
       resolveSessionMicrocopy("empty.context", [

--- a/src/CompanionReviewApp.tsx
+++ b/src/CompanionReviewApp.tsx
@@ -194,8 +194,12 @@ import {
 import { startLiveSessionRunSubscription } from "./session-live-run-subscription.js";
 import {
   buildMessageListProjection,
+  hasPersistedLiveAssistantMessage,
   loadProjectedMessageArtifact,
+  resolveLiveAssistantMessageIndex,
   resolvePendingAuxiliaryMessageGroupId,
+  shouldProjectLiveAssistantBridge,
+  type LiveAssistantProjection,
 } from "./auxiliary-session-message-projection.js";
 import { useSessionAuditLogs } from "./session-audit-log-state.js";
 import {
@@ -489,6 +493,7 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
     ownerSessionId: null,
     state: null,
   });
+  const [liveAssistantBridge, setLiveAssistantBridge] = useState<LiveAssistantProjection | null>(null);
   const [providerQuotaTelemetryState, setProviderQuotaTelemetryState] =
     useState<ProviderOwnedQuotaTelemetry>({ ownerProviderId: null, telemetry: null });
   const [sessionContextTelemetryState, setSessionContextTelemetryState] =
@@ -649,17 +654,150 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
   );
   const isAuxiliaryMode = activeAuxiliarySession?.status === "active";
   const activeComposerText = activeAuxiliarySession?.composerDraft ?? composerText;
-  const messageListProjection = useMemo(
-    () => buildMessageListProjection(snapshot?.session.messages ?? [], [
+  const selectedSessionLiveRun =
+    activeRunSessionId !== null && liveRunState.ownerSessionId === activeRunSessionId ? liveRunState.state : null;
+  const projectedAuxiliarySessions = useMemo(
+    () => [
       ...closedAuxiliarySessions,
       ...(activeAuxiliarySession ? [activeAuxiliarySession] : []),
-    ], snapshot?.session.id),
-    [activeAuxiliarySession, closedAuxiliarySessions, snapshot?.session.id, snapshot?.session.messages],
+    ],
+    [activeAuxiliarySession, closedAuxiliarySessions],
+  );
+  const liveAssistantMessageIndex = useMemo(
+    () =>
+      activeRunSessionId
+        ? resolveLiveAssistantMessageIndex(
+          snapshot?.session.messages ?? [],
+          projectedAuxiliarySessions,
+          activeRunSessionId,
+          snapshot?.session.id,
+        )
+        : 0,
+    [activeRunSessionId, projectedAuxiliarySessions, snapshot?.session.id, snapshot?.session.messages],
+  );
+  const hasPersistedLiveAssistantBridge = useMemo(
+    () =>
+      liveAssistantBridge
+        ? hasPersistedLiveAssistantMessage(
+          snapshot?.session.messages ?? [],
+          projectedAuxiliarySessions,
+          liveAssistantBridge,
+          snapshot?.session.id,
+        )
+        : false,
+    [liveAssistantBridge, projectedAuxiliarySessions, snapshot?.session.id, snapshot?.session.messages],
+  );
+  const projectedLiveAssistant = useMemo<LiveAssistantProjection | null>(() => {
+    if (!activeRunSessionId) {
+      return null;
+    }
+
+    const liveRunAssistantText = selectedSessionLiveRun?.assistantText ?? "";
+    const liveThreadId = selectedSessionLiveRun?.threadId ?? null;
+    const bridgeMessageIndex =
+      liveAssistantBridge?.sessionId === activeRunSessionId &&
+      liveAssistantBridge.threadId === liveThreadId
+        ? liveAssistantBridge.messageIndex
+        : liveAssistantMessageIndex;
+    if (liveRunAssistantText) {
+      return {
+        sessionId: activeRunSessionId,
+        threadId: liveThreadId,
+        messageIndex: bridgeMessageIndex,
+        text: liveRunAssistantText,
+      };
+    }
+
+    return shouldProjectLiveAssistantBridge({
+      bridge: liveAssistantBridge,
+      activeSessionId: activeRunSessionId,
+      hasLiveRun: selectedSessionLiveRun !== null,
+      hasPersistedAssistant: hasPersistedLiveAssistantBridge,
+    })
+      ? liveAssistantBridge
+      : null;
+  }, [
+    activeRunSessionId,
+    hasPersistedLiveAssistantBridge,
+    liveAssistantBridge,
+    liveAssistantMessageIndex,
+    selectedSessionLiveRun,
+    selectedSessionLiveRun?.assistantText,
+    selectedSessionLiveRun?.threadId,
+  ]);
+  const messageListProjection = useMemo(
+    () => buildMessageListProjection(snapshot?.session.messages ?? [], projectedAuxiliarySessions, snapshot?.session.id, {
+      liveAssistant: projectedLiveAssistant,
+    }),
+    [projectedAuxiliarySessions, projectedLiveAssistant, snapshot?.session.id, snapshot?.session.messages],
   );
   const messageListMessages = messageListProjection.messages;
   const messageListSources = messageListProjection.sources;
   const messageListKeys = messageListProjection.keys;
   const messageListGroups = messageListProjection.groups;
+  useEffect(() => {
+    if (!activeRunSessionId || !selectedSessionLiveRun?.assistantText) {
+      return;
+    }
+
+    const liveThreadId = selectedSessionLiveRun.threadId ?? null;
+    setLiveAssistantBridge((current) => {
+      if (current?.sessionId === activeRunSessionId && current.threadId === liveThreadId) {
+        return {
+          ...current,
+          text: selectedSessionLiveRun.assistantText,
+        };
+      }
+
+      return {
+        sessionId: activeRunSessionId,
+        threadId: liveThreadId,
+        messageIndex: liveAssistantMessageIndex,
+        text: selectedSessionLiveRun.assistantText,
+      };
+    });
+  }, [activeRunSessionId, liveAssistantMessageIndex, selectedSessionLiveRun?.assistantText, selectedSessionLiveRun?.threadId]);
+  useEffect(() => {
+    if (!liveAssistantBridge) {
+      return;
+    }
+
+    if (
+      liveAssistantBridge.sessionId !== activeRunSessionId ||
+      (selectedSessionLiveRun === null && !hasPersistedLiveAssistantBridge)
+    ) {
+      setLiveAssistantBridge(null);
+    }
+  }, [activeRunSessionId, hasPersistedLiveAssistantBridge, liveAssistantBridge, selectedSessionLiveRun]);
+  useEffect(() => {
+    if (!liveAssistantBridge) {
+      return;
+    }
+
+    if (!hasPersistedLiveAssistantBridge) {
+      return;
+    }
+
+    let secondFrameId: number | null = null;
+    const firstFrameId = requestAnimationFrame(() => {
+      secondFrameId = requestAnimationFrame(() => {
+        setLiveAssistantBridge((current) =>
+          current?.sessionId === liveAssistantBridge.sessionId &&
+          current.threadId === liveAssistantBridge.threadId &&
+          current.text === liveAssistantBridge.text
+            ? null
+            : current,
+        );
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(firstFrameId);
+      if (secondFrameId !== null) {
+        cancelAnimationFrame(secondFrameId);
+      }
+    };
+  }, [hasPersistedLiveAssistantBridge, liveAssistantBridge]);
 
   useEffect(() => {
     let active = true;
@@ -881,8 +1019,6 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
   );
   const unstagedFileTree = useMemo(() => buildChangedFileTree(unstagedChangedFiles), [unstagedChangedFiles]);
   const stagedFileTree = useMemo(() => buildChangedFileTree(stagedChangedFiles), [stagedChangedFiles]);
-  const selectedSessionLiveRun =
-    activeRunSessionId !== null && liveRunState.ownerSessionId === activeRunSessionId ? liveRunState.state : null;
   useEffect(() => {
     setApprovalActionRequestId(null);
   }, [selectedSessionLiveRun?.approvalRequest?.requestId]);
@@ -1000,12 +1136,10 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
         displayedSession?.id ?? "",
         displayedSession?.runState ?? "",
         messageListMessages.map((message) => `${message.role}:${message.text.length}:${message.text}`).join("\u001d"),
-        selectedSessionLiveRun?.assistantText ?? "",
         selectedSessionLiveRun?.reasoningText ?? "",
         selectedSessionLiveRun?.errorMessage ?? "",
       ].join("\u001a"),
     [
-      selectedSessionLiveRun?.assistantText,
       selectedSessionLiveRun?.reasoningText,
       selectedSessionLiveRun?.errorMessage,
       displayedSession?.id,

--- a/src/auxiliary-session-message-projection.ts
+++ b/src/auxiliary-session-message-projection.ts
@@ -11,6 +11,11 @@ export type MessageListSource =
       sessionId: string;
       messageIndex: number;
       artifact: Message["artifact"];
+    }
+  | {
+      kind: "live-assistant";
+      sessionId: string;
+      threadId: string | null;
     };
 
 export type MessageListProjection = {
@@ -28,6 +33,24 @@ export type MessageListGroup = {
 type ProjectedMessageArtifact = NonNullable<Message["artifact"]>;
 
 type PendingAuxiliaryMessageGroupSession = Pick<AuxiliarySession, "id" | "runState">;
+
+export type LiveAssistantProjection = {
+  sessionId: string;
+  threadId: string | null;
+  messageIndex: number;
+  text: string;
+};
+
+export type MessageListProjectionOptions = {
+  liveAssistant?: LiveAssistantProjection | null;
+};
+
+export type LiveAssistantBridgeProjectionInput = {
+  bridge: LiveAssistantProjection | null | undefined;
+  activeSessionId: string | null | undefined;
+  hasLiveRun: boolean;
+  hasPersistedAssistant: boolean;
+};
 
 export type LoadProjectedMessageArtifactOptions = {
   source: MessageListSource | undefined;
@@ -48,6 +71,10 @@ export function loadProjectedMessageArtifact({
     return Promise.resolve(source.artifact ?? null);
   }
 
+  if (source.kind === "live-assistant") {
+    return Promise.resolve(null);
+  }
+
   return Promise.resolve(loadSessionArtifact(source.messageIndex)).then((artifact) => artifact ?? null);
 }
 
@@ -61,6 +88,7 @@ export function buildMessageListProjection(
   sessionMessages: Message[],
   auxiliarySessions: AuxiliarySession[],
   sessionId = "session",
+  options: MessageListProjectionOptions = {},
 ): MessageListProjection {
   const messages: Message[] = [];
   const sources: MessageListSource[] = [];
@@ -68,11 +96,23 @@ export function buildMessageListProjection(
   const groups: Array<MessageListGroup | null> = [];
   const auxiliaryBuckets = new Map<number, AuxiliarySession[]>();
   const fallbackAuxiliarySessions: AuxiliarySession[] = [];
+  const liveAssistant = normalizeLiveAssistantProjection(options.liveAssistant);
+  const liveAssistantKey = liveAssistant
+    ? buildLiveAssistantProjectionKey(liveAssistant.sessionId, liveAssistant.threadId, liveAssistant.messageIndex)
+    : null;
 
   const addSessionMessage = (message: Message, messageIndex: number) => {
     messages.push(message);
     sources.push({ kind: "session", messageIndex });
-    keys.push(`session-${sessionId}-${messageIndex}`);
+    keys.push(isMatchingPersistedLiveAssistantMessage({
+      message,
+      messageIndex,
+      messageCount: sessionMessages.length,
+      targetSessionId: sessionId,
+      liveAssistant,
+    }) && liveAssistantKey
+      ? liveAssistantKey
+      : `session-${sessionId}-${messageIndex}`);
     groups.push(null);
   };
 
@@ -92,9 +132,44 @@ export function buildMessageListProjection(
         messageIndex,
         artifact: message.artifact,
       });
-      keys.push(`auxiliary-${auxiliarySession.id}-${messageIndex}`);
+      keys.push(isMatchingPersistedLiveAssistantMessage({
+        message,
+        messageIndex,
+        messageCount: auxiliarySession.messages.length,
+        targetSessionId: auxiliarySession.id,
+        liveAssistant,
+      }) && liveAssistantKey
+        ? liveAssistantKey
+        : `auxiliary-${auxiliarySession.id}-${messageIndex}`);
       groups.push(group);
     });
+
+    if (
+      liveAssistant &&
+      liveAssistant.sessionId === auxiliarySession.id &&
+      !hasPersistedLiveAssistantMessage(sessionMessages, [auxiliarySession], liveAssistant, sessionId)
+    ) {
+      addLiveAssistantMessage(group);
+    }
+  };
+
+  const addLiveAssistantMessage = (group: MessageListGroup | null) => {
+    if (!liveAssistant || !liveAssistantKey) {
+      return;
+    }
+
+    messages.push({
+      role: "assistant",
+      text: liveAssistant.text,
+      ...(group ? { accent: true } : {}),
+    });
+    sources.push({
+      kind: "live-assistant",
+      sessionId: liveAssistant.sessionId,
+      threadId: liveAssistant.threadId,
+    });
+    keys.push(liveAssistantKey);
+    groups.push(group);
   };
 
   const sortedAuxiliarySessions = [...auxiliarySessions].sort(compareAuxiliarySessions);
@@ -128,7 +203,109 @@ export function buildMessageListProjection(
     addAuxiliarySession(auxiliarySession);
   }
 
+  if (
+    liveAssistant &&
+    liveAssistantKey &&
+    liveAssistant.sessionId === sessionId &&
+    !hasPersistedLiveAssistantMessage(sessionMessages, auxiliarySessions, liveAssistant, sessionId)
+  ) {
+    addLiveAssistantMessage(null);
+  }
+
   return { messages, sources, keys, groups };
+}
+
+export function buildLiveAssistantProjectionKey(
+  sessionId: string,
+  threadId: string | null,
+  messageIndex: number,
+): string {
+  return `live-assistant-${sessionId}-${messageIndex}-${threadId || "pending"}`;
+}
+
+export function hasPersistedLiveAssistantMessage(
+  sessionMessages: Message[],
+  auxiliarySessions: AuxiliarySession[],
+  liveAssistant: LiveAssistantProjection | null | undefined,
+  sessionId = "session",
+): boolean {
+  const normalizedLiveAssistant = normalizeLiveAssistantProjection(liveAssistant);
+  if (!normalizedLiveAssistant) {
+    return false;
+  }
+
+  if (
+    normalizedLiveAssistant.sessionId === sessionId &&
+    hasAssistantMessageAtIndex(sessionMessages, normalizedLiveAssistant.messageIndex)
+  ) {
+    return true;
+  }
+
+  return auxiliarySessions.some((auxiliarySession) =>
+    auxiliarySession.id === normalizedLiveAssistant.sessionId &&
+    hasAssistantMessageAtIndex(auxiliarySession.messages, normalizedLiveAssistant.messageIndex)
+  );
+}
+
+export function resolveLiveAssistantMessageIndex(
+  sessionMessages: Message[],
+  auxiliarySessions: AuxiliarySession[],
+  targetSessionId: string,
+  sessionId = "session",
+): number {
+  if (targetSessionId === sessionId) {
+    return sessionMessages.length;
+  }
+
+  const targetAuxiliarySession = auxiliarySessions.find((auxiliarySession) => auxiliarySession.id === targetSessionId);
+  return targetAuxiliarySession?.messages.length ?? 0;
+}
+
+export function shouldProjectLiveAssistantBridge({
+  bridge,
+  activeSessionId,
+  hasLiveRun,
+  hasPersistedAssistant,
+}: LiveAssistantBridgeProjectionInput): boolean {
+  return !!bridge && bridge.sessionId === activeSessionId && (hasLiveRun || hasPersistedAssistant);
+}
+
+function normalizeLiveAssistantProjection(
+  liveAssistant: LiveAssistantProjection | null | undefined,
+): LiveAssistantProjection | null {
+  if (!liveAssistant || !liveAssistant.text || !Number.isInteger(liveAssistant.messageIndex)) {
+    return null;
+  }
+
+  return {
+    ...liveAssistant,
+    messageIndex: Math.max(0, liveAssistant.messageIndex),
+  };
+}
+
+function isMatchingPersistedLiveAssistantMessage({
+  message,
+  messageIndex,
+  messageCount,
+  targetSessionId,
+  liveAssistant,
+}: {
+  message: Message;
+  messageIndex: number;
+  messageCount: number;
+  targetSessionId: string;
+  liveAssistant: LiveAssistantProjection | null;
+}): boolean {
+  return (
+    liveAssistant?.sessionId === targetSessionId &&
+    messageIndex === liveAssistant.messageIndex &&
+    messageIndex < messageCount &&
+    message.role === "assistant"
+  );
+}
+
+function hasAssistantMessageAtIndex(messages: Message[], messageIndex: number): boolean {
+  return messages[messageIndex]?.role === "assistant";
 }
 
 function compareAuxiliarySessions(left: AuxiliarySession, right: AuxiliarySession): number {

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -2076,7 +2076,6 @@ export function SessionMessageColumn({
   approvalActionRequestId,
   liveElicitationRequest,
   elicitationActionRequestId,
-  liveRunAssistantText,
   hasLiveRunAssistantText,
   liveRunErrorMessage,
   pendingMessageText = "",
@@ -2111,12 +2110,17 @@ export function SessionMessageColumn({
     [latestMessageWindowStartIndex, messages],
   );
   const hasOlderMessages = latestMessageWindowStartIndex > 0;
+  const hasPendingMessageText =
+    !hasLiveRunAssistantText &&
+    liveApprovalRequest === null &&
+    liveElicitationRequest === null &&
+    !liveRunErrorMessage.trim() &&
+    pendingMessageText.trim().length > 0;
   const hasPendingInlineContent =
     liveApprovalRequest !== null ||
     liveElicitationRequest !== null ||
-    hasLiveRunAssistantText ||
     liveRunErrorMessage.trim().length > 0 ||
-    pendingMessageText.trim().length > 0;
+    hasPendingMessageText;
   const canRenderGroupedPendingInlineContent = useMemo(
     () =>
       hasPendingInlineContent &&
@@ -2320,8 +2324,7 @@ export function SessionMessageColumn({
             onOpenPath={onOpenPath}
           />
         ) : null}
-        {hasLiveRunAssistantText ? <MessageRichText text={liveRunAssistantText} onOpenPath={onOpenPath} /> : null}
-        {!liveApprovalRequest && !liveElicitationRequest && !hasLiveRunAssistantText && !liveRunErrorMessage.trim() && pendingMessageText.trim() ? (
+        {hasPendingMessageText ? (
           <MessageRichText text={pendingMessageText} onOpenPath={onOpenPath} />
         ) : null}
         {liveRunErrorMessage ? (


### PR DESCRIPTION
## Summary

- Project live assistant responses into the normal message list so the visible response does not disappear at turn completion.
- Keep a short bridge from live text to the persisted assistant row using session/message-index boundaries instead of text equality.
- Preserve Auxiliary and Companion rendering paths, including no-persisted-assistant endings such as cancel/interruption.
- Bump the app version to `4.2.17-preview.5`.

## Root Cause

The renderer displayed streaming assistant text as a separate pending row, then replaced it with a persisted assistant message when the run completed. The first fix used text equality to reconcile live and persisted rows, but final assistant text can differ from the last live progress text, and no assistant message may be saved on cancel/interruption. The bridge now uses the target message index and live/persisted lifecycle state instead.

## Validation

- `node --import tsx --test scripts/tests/auxiliary-session-message-projection.test.ts scripts/tests/session-message-column.test.ts scripts/tests/session-chat-projection.test.ts scripts/tests/companion-chat-projection.test.ts scripts/tests/chat-window-adapter.test.ts`
- `npm run typecheck`
- `npm test`
- `git diff --check`

## Not Run

- Electron manual UI verification. This is left for local manual confirmation.
