### PR TITLE
fix(session): avoid reserving response action width

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "4.2.17-preview.5",
+  "version": "4.2.17-preview.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "4.2.17-preview.5",
+      "version": "4.2.17-preview.6",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.0-beta.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "4.2.17-preview.5",
+  "version": "4.2.17-preview.6",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/src/styles.css
+++ b/src/styles.css
@@ -3695,7 +3695,6 @@ button:disabled {
 
 .message-card.has-response-actions > [data-message-body="true"] {
   min-height: 34px;
-  padding-inline-end: 124px;
 }
 
 .message-response-actions {
@@ -3750,6 +3749,10 @@ button:disabled {
 }
 
 @media (hover: none) {
+  .message-card.has-response-actions > [data-message-body="true"] {
+    padding-inline-end: 124px;
+  }
+
   .message-card.has-response-actions .message-response-actions {
     opacity: 1;
     pointer-events: auto;


### PR DESCRIPTION
## Summary
- Copy / Quote の floating toolbar 用に desktop で本文右幅を常時予約しないよう修正
- hover 可能な環境ではメッセージ本文が横幅いっぱいを使い、ボタンは右上に overlay 表示
- hover できない端末では常時表示ボタンと本文が重ならないよう右余白を維持
- アプリバージョンを 4.2.17-preview.6 に更新

## Validation
- node --import tsx --test scripts/tests/session-message-column.test.ts scripts/tests/chat-window-mate-talk-mode.test.ts scripts/tests/message-text-actions.test.ts
- npm run typecheck
- git diff --check