### PR TITLE
fix(session): limit response actions to selection

### DIFF
--- a/docs/design/auxiliary-session.md
+++ b/docs/design/auxiliary-session.md
@@ -82,10 +82,11 @@ Session Header に `Auxiliary` action を置く。
 - Active Auxiliary 中は同じ位置に `Return to main` を表示し、メイン送信はできない。
 - Auxiliary 実行中は `Return to main` を無効にし、必要ならまず `Cancel` で実行を止める。
 - `Return to main` は Session Header の通常操作群ではなく、Auxiliary 枠 header または Auxiliary ActionDock に置く。
-- response の `Copy` / `Quote` は ActionDock ではなく、assistant response の message card 内 action として置く。
+- response の `Copy` / `Quote` は ActionDock ではなく、assistant response 内の選択範囲に対する selection action として扱う。
 
-response action は assistant response ごとの固定機能とする。
-desktop では hover / focus 時に表示してもよいが、機能の存在が分からなくならないよう、message card 内の一貫した位置に出す。
+response action は assistant response ごとの固定機能ではなく、ユーザーが assistant response text を選択したときだけ表示する。
+未選択時に message card 内へ常設しない。
+`Copy` / `Quote` の対象は選択範囲のみとし、response 全体を暗黙の fallback 対象にはしない。
 右クリックメニューは初期実装の主導線にしない。
 
 ### Active Auxiliary

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "4.2.17-preview.6",
+  "version": "4.2.17-preview.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "4.2.17-preview.6",
+      "version": "4.2.17-preview.7",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.0-beta.9",
@@ -22,12 +22,14 @@
         "remark-math": "^6.0.0"
       },
       "devDependencies": {
+        "@types/jsdom": "^28.0.3",
         "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
         "electron": "^41.3.0",
         "electron-builder": "^26.8.1",
+        "jsdom": "^29.1.1",
         "png-to-ico": "^3.0.1",
         "sharp": "^0.34.5",
         "tsx": "^4.21.0",
@@ -48,17 +50,221 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@braintree/sanitize-url": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
       "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
       "license": "MIT"
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@chevrotain/types": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
       "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.3.tgz",
+      "integrity": "sha512-DOgvIPkikIOixQRlD4YF31VN6fLLUTdrzhfRbis8vm0kMTgIbEPX0Ip/YX9fOeV9iywAS4sUUbTclpan7yYP8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
     },
     "node_modules/@develar/schema-utils": {
       "version": "2.6.5",
@@ -981,6 +1187,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@github/copilot": {
@@ -2613,6 +2837,45 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsdom": {
+      "version": "28.0.3",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-28.0.3.tgz",
+      "integrity": "sha512-/HQ2uFoetFTXuye8vzIcHw2z6Fwi7Hi/qcgC+RoS9NCyewiqxhVGqlG+ViGB6lkax481R6dmhf1I7lIGlzJStQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^8.0.0",
+        "undici-types": "^7.21.0"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/@types/katex": {
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
@@ -2699,6 +2962,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -3300,6 +3570,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -3804,6 +4084,20 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/csstype": {
@@ -4320,6 +4614,20 @@
         "lodash-es": "^4.17.21"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.20",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
@@ -4342,6 +4650,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -5805,6 +6120,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -6044,6 +6372,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isbinaryfile": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
@@ -6106,6 +6441,93 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/undici": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/json-buffer": {
@@ -6865,6 +7287,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mermaid": {
       "version": "11.15.0",
@@ -8515,6 +8944,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resedit": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
@@ -8716,6 +9155,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -9135,6 +9587,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tar": {
       "version": "7.5.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
@@ -9316,6 +9775,26 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.2"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -9334,6 +9813,32 @@
       "license": "MIT",
       "dependencies": {
         "tmp": "^0.2.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -9765,6 +10270,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -9773,6 +10291,41 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -9815,6 +10368,16 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
@@ -9824,6 +10387,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "4.2.17-preview.6",
+  "version": "4.2.17-preview.7",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",
@@ -42,12 +42,14 @@
     "remark-math": "^6.0.0"
   },
   "devDependencies": {
+    "@types/jsdom": "^28.0.3",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
     "electron": "^41.3.0",
     "electron-builder": "^26.8.1",
+    "jsdom": "^29.1.1",
     "png-to-ico": "^3.0.1",
     "sharp": "^0.34.5",
     "tsx": "^4.21.0",

--- a/scripts/tests/chat-window-mate-talk-mode.test.ts
+++ b/scripts/tests/chat-window-mate-talk-mode.test.ts
@@ -237,7 +237,7 @@ test("MateTalk は ChatWindow で user/mate メッセージを共通 message row
   assert.doesNotMatch(html, /session-plain-message-speaker/);
 });
 
-test("MateTalk は mate response に共通 Copy / Quote action を表示する", () => {
+test("MateTalk は未選択時に Copy / Quote action を描画しない", () => {
   const html = renderPanel({
     withResponseActions: true,
     messages: [
@@ -247,9 +247,11 @@ test("MateTalk は mate response に共通 Copy / Quote action を表示する",
     input: "test",
   });
 
-  assert.match(html, /<div class="message-response-actions" aria-label="Response actions">/);
-  assert.match(html, />Copy<\/button>/);
-  assert.match(html, />Quote<\/button>/);
+  assert.doesNotMatch(html, /<div class="message-response-actions" aria-label="Response actions">/);
+  assert.doesNotMatch(html, />Copy<\/button>/);
+  assert.doesNotMatch(html, />Quote<\/button>/);
+  assert.match(html, /data-message-text-actions="true"/);
+  assert.equal((html.match(/data-message-text-actions="true"/g) ?? []).length, 1);
 });
 
 test("MateTalk は Mate avatar path を返信メッセージの avatar に渡す", () => {

--- a/scripts/tests/session-message-column.test.ts
+++ b/scripts/tests/session-message-column.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { JSDOM } from "jsdom";
 import React, { createRef } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import {
@@ -12,6 +15,8 @@ import {
 } from "../../src/session-components.js";
 import { buildContextPaneProjection } from "../../src/session-ui-projection.js";
 import type { CharacterProfile, LiveApprovalRequest, LiveElicitationRequest, Message } from "../../src/app-state.js";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 function createCharacterProfile(): CharacterProfile {
   return {
@@ -154,6 +159,113 @@ function renderSessionMessageColumn(options: {
   );
 }
 
+function createRect(input: {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}): DOMRect {
+  return {
+    left: input.left,
+    top: input.top,
+    width: input.width,
+    height: input.height,
+    right: input.left + input.width,
+    bottom: input.top + input.height,
+    x: input.left,
+    y: input.top,
+    toJSON() {
+      return this;
+    },
+  } as DOMRect;
+}
+
+type MountedSessionMessageColumn = {
+  container: HTMLElement;
+  dom: JSDOM;
+  messageListRef: React.RefObject<HTMLDivElement | null>;
+  root: Root;
+  cleanup: () => Promise<void>;
+};
+
+async function mountSessionMessageColumn(options: {
+  messages: Message[];
+  onCopyMessageText?: (text: string) => void;
+  onQuoteMessageText?: (text: string) => void;
+}): Promise<MountedSessionMessageColumn> {
+  const previousWindow = globalThis.window;
+  const previousDocument = globalThis.document;
+  const previousNode = globalThis.Node;
+  const previousDOMRect = globalThis.DOMRect;
+  const previousEvent = globalThis.Event;
+  const previousMouseEvent = globalThis.MouseEvent;
+  const previousNavigator = globalThis.navigator;
+  const dom = new JSDOM("<!doctype html><div id=\"root\"></div>", { pretendToBeVisual: true });
+  const container = dom.window.document.getElementById("root") as HTMLElement;
+  const messageListRef = createRef<HTMLDivElement>();
+  const root = createRoot(container);
+
+  Object.defineProperty(globalThis, "window", { configurable: true, value: dom.window });
+  Object.defineProperty(globalThis, "document", { configurable: true, value: dom.window.document });
+  Object.defineProperty(globalThis, "Node", { configurable: true, value: dom.window.Node });
+  Object.defineProperty(globalThis, "DOMRect", { configurable: true, value: dom.window.DOMRect });
+  Object.defineProperty(globalThis, "Event", { configurable: true, value: dom.window.Event });
+  Object.defineProperty(globalThis, "MouseEvent", { configurable: true, value: dom.window.MouseEvent });
+  Object.defineProperty(globalThis, "navigator", { configurable: true, value: dom.window.navigator });
+
+  await act(async () => {
+    root.render(
+      React.createElement(SessionMessageColumn, {
+        sessionId: "session-1",
+        character: createCharacterProfile(),
+        messages: options.messages,
+        expandedArtifacts: {},
+        messageListRef,
+        isRunning: false,
+        liveApprovalRequest: null,
+        approvalActionRequestId: null,
+        liveElicitationRequest: null,
+        elicitationActionRequestId: null,
+        liveRunAssistantText: "",
+        hasLiveRunAssistantText: false,
+        liveRunErrorMessage: "",
+        isMessageListFollowing: false,
+        onMessageListScroll() {},
+        onToggleArtifact() {},
+        onOpenDiff() {},
+        onResolveLiveApproval() {},
+        onResolveLiveElicitation() {},
+        onOpenPath: undefined,
+        getChangedFilesEmptyText() {
+          return "変更ファイルはありません";
+        },
+        onCopyMessageText: options.onCopyMessageText,
+        onQuoteMessageText: options.onQuoteMessageText,
+      }),
+    );
+  });
+
+  return {
+    container,
+    dom,
+    messageListRef,
+    root,
+    async cleanup() {
+      await act(async () => {
+        root.unmount();
+      });
+      dom.window.close();
+      Object.defineProperty(globalThis, "window", { configurable: true, value: previousWindow });
+      Object.defineProperty(globalThis, "document", { configurable: true, value: previousDocument });
+      Object.defineProperty(globalThis, "Node", { configurable: true, value: previousNode });
+      Object.defineProperty(globalThis, "DOMRect", { configurable: true, value: previousDOMRect });
+      Object.defineProperty(globalThis, "Event", { configurable: true, value: previousEvent });
+      Object.defineProperty(globalThis, "MouseEvent", { configurable: true, value: previousMouseEvent });
+      Object.defineProperty(globalThis, "navigator", { configurable: true, value: previousNavigator });
+    },
+  };
+}
+
 test("SessionMessageColumn は大量メッセージを最新 chunk に絞って描画する", () => {
   const html = renderSessionMessageColumn({
     messages: createMessages(100),
@@ -190,7 +302,7 @@ test("SessionMessageColumn は artifact 展開と diff 起動に必要な表示�
   assert.match(html, /snapshot files/);
 });
 
-test("SessionMessageColumn は assistant response action を assistant message にだけ描画する", () => {
+test("SessionMessageColumn は未選択時に response action を描画しない", () => {
   const html = renderSessionMessageColumn({
     messages: [
       { role: "assistant", text: "assistant result" },
@@ -199,10 +311,137 @@ test("SessionMessageColumn は assistant response action を assistant message �
     withResponseActions: true,
   });
 
-  assert.match(html, /message-response-actions/);
-  assert.match(html, />Copy</);
-  assert.match(html, />Quote</);
-  assert.equal((html.match(/message-response-actions/g) ?? []).length, 1);
+  assert.doesNotMatch(html, /message-response-actions/);
+  assert.doesNotMatch(html, />Copy</);
+  assert.doesNotMatch(html, />Quote</);
+  assert.match(html, /data-message-text-actions="true"/);
+  assert.equal((html.match(/data-message-text-actions="true"/g) ?? []).length, 1);
+});
+
+test("SessionMessageColumn は選択範囲にだけ response action toolbar を表示する", async () => {
+  const copiedTexts: string[] = [];
+  const quotedTexts: string[] = [];
+  const mounted = await mountSessionMessageColumn({
+    messages: [
+      { role: "assistant", text: "assistant result text" },
+      { role: "user", text: "user prompt text" },
+    ],
+    onCopyMessageText: (text) => copiedTexts.push(text),
+    onQuoteMessageText: (text) => quotedTexts.push(text),
+  });
+
+  try {
+    const { container, dom, messageListRef } = mounted;
+    const messageList = messageListRef.current;
+    assert.ok(messageList);
+    Object.defineProperty(messageList, "getBoundingClientRect", {
+      configurable: true,
+      value: () => createRect({ left: 0, top: 0, width: 500, height: 500 }),
+    });
+
+    let selectedText = "";
+    let isCollapsed = true;
+    let anchorRect = createRect({ left: 100, top: 100, width: 60, height: 20 });
+    let selectionNode: Node = container;
+    const selection = {
+      get isCollapsed() {
+        return isCollapsed;
+      },
+      get rangeCount() {
+        return isCollapsed ? 0 : 1;
+      },
+      getRangeAt() {
+        return {
+          commonAncestorContainer: selectionNode,
+          getBoundingClientRect: () => anchorRect,
+          getClientRects: () => [anchorRect],
+        };
+      },
+      toString() {
+        return selectedText;
+      },
+    } as unknown as Selection;
+    Object.defineProperty(dom.window, "getSelection", {
+      configurable: true,
+      value: () => selection,
+    });
+
+    const selectText = async (body: Element, text: string, rect: DOMRect) => {
+      const paragraph = body.querySelector(".message-paragraph");
+      assert.ok(paragraph?.firstChild);
+      selectionNode = paragraph.firstChild;
+      selectedText = text;
+      isCollapsed = false;
+      anchorRect = rect;
+      await act(async () => {
+        dom.window.document.dispatchEvent(new dom.window.Event("selectionchange"));
+      });
+    };
+    const clearSelection = async () => {
+      isCollapsed = true;
+      selectedText = "";
+      await act(async () => {
+        dom.window.document.dispatchEvent(new dom.window.Event("selectionchange"));
+      });
+    };
+
+    const assistantBody = container.querySelector("[data-message-text-actions=\"true\"]");
+    assert.ok(assistantBody);
+    await selectText(assistantBody, "assistant result", anchorRect);
+
+    let toolbar = container.querySelector(".message-response-actions") as HTMLElement | null;
+    assert.ok(toolbar);
+    assert.equal(toolbar.style.left, "74px");
+    assert.equal(toolbar.style.top, "60px");
+
+    const copyButton = Array.from(toolbar.querySelectorAll("button"))
+      .find((button) => button.textContent === "Copy") as HTMLButtonElement | undefined;
+    const quoteButton = Array.from(toolbar.querySelectorAll("button"))
+      .find((button) => button.textContent === "Quote") as HTMLButtonElement | undefined;
+    assert.ok(copyButton);
+    assert.ok(quoteButton);
+
+    await act(async () => {
+      copyButton.click();
+      quoteButton.click();
+    });
+    assert.deepEqual(copiedTexts, ["assistant result"]);
+    assert.deepEqual(quotedTexts, ["assistant result"]);
+
+    const userBody = Array.from(container.querySelectorAll("[data-message-body=\"true\"]"))
+      .find((body) => body.getAttribute("data-message-text-actions") !== "true");
+    assert.ok(userBody);
+    await selectText(userBody, "user prompt", createRect({ left: 120, top: 140, width: 60, height: 20 }));
+    assert.equal(container.querySelector(".message-response-actions"), null);
+
+    await selectText(assistantBody, "result text", createRect({ left: 200, top: 220, width: 80, height: 20 }));
+    toolbar = container.querySelector(".message-response-actions") as HTMLElement | null;
+    assert.ok(toolbar);
+    assert.equal(toolbar.style.left, "184px");
+    assert.equal(toolbar.style.top, "180px");
+
+    anchorRect = createRect({ left: 240, top: 260, width: 80, height: 20 });
+    await act(async () => {
+      dom.window.dispatchEvent(new dom.window.Event("resize"));
+    });
+    toolbar = container.querySelector(".message-response-actions") as HTMLElement | null;
+    assert.ok(toolbar);
+    assert.equal(toolbar.style.left, "224px");
+    assert.equal(toolbar.style.top, "220px");
+
+    anchorRect = createRect({ left: 520, top: 520, width: 40, height: 20 });
+    await act(async () => {
+      messageList.dispatchEvent(new dom.window.Event("scroll"));
+    });
+    assert.equal(container.querySelector(".message-response-actions"), null);
+
+    await selectText(assistantBody, "assistant result", createRect({ left: 100, top: 100, width: 60, height: 20 }));
+    assert.ok(container.querySelector(".message-response-actions"));
+    await clearSelection();
+    assert.equal(container.querySelector(".message-response-actions"), null);
+  } finally {
+    mounted.cleanup();
+  }
 });
 
 test("SessionMessageColumn は Auxiliary transcript group を message list 内に描画する", () => {

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -1966,7 +1966,7 @@ function getSelectionDetailsWithinMessageList(element: Element | null): { anchor
   if (
     !messageBody ||
     !element.contains(messageBody) ||
-    !messageBody.closest(".message-card.has-response-actions")
+    messageBody.getAttribute("data-message-text-actions") !== "true"
   ) {
     return null;
   }
@@ -2017,7 +2017,6 @@ function rectsIntersect(a: DOMRect, b: DOMRect): boolean {
 
 type MessageResponseActionsProps = {
   actionText: string;
-  className?: string;
   onCopyMessageText?: (text: string) => void;
   onQuoteMessageText?: (text: string) => void;
   style?: CSSProperties;
@@ -2026,7 +2025,6 @@ type MessageResponseActionsProps = {
 
 function MessageResponseActions({
   actionText,
-  className = "",
   onCopyMessageText,
   onQuoteMessageText,
   style,
@@ -2035,7 +2033,7 @@ function MessageResponseActions({
   return (
     <div
       ref={toolbarRef}
-      className={`message-response-actions${className ? ` ${className}` : ""}`}
+      className="message-response-actions"
       aria-label="Response actions"
       style={style}
     >
@@ -2378,7 +2376,7 @@ export function SessionMessageColumn({
                 details: undefined,
               })) ??
               [];
-            const hasMessageTextActions = isAssistant && (onCopyMessageText || onQuoteMessageText);
+            const canUseMessageTextActions = isAssistant && (onCopyMessageText || onQuoteMessageText);
 
             return (
               <Fragment key={`${message.role}-${messageKey}`}>
@@ -2421,7 +2419,7 @@ export function SessionMessageColumn({
                     ) : null}
                   </div>
                 ) : null}
-                <div className={`message-card ${message.role}${message.accent ? " accent" : ""}${artifact ? " has-artifact" : ""}${hasMessageTextActions ? " has-response-actions" : ""}`}>
+                <div className={`message-card ${message.role}${message.accent ? " accent" : ""}${artifact ? " has-artifact" : ""}`}>
                   {artifact && !isAssistant ? (
                     <button
                       className="artifact-toggle artifact-toggle-icon"
@@ -2440,16 +2438,12 @@ export function SessionMessageColumn({
                       {artifactExpanded ? "−" : "i"}
                     </button>
                   ) : null}
-                  <div data-message-body="true">
+                  <div
+                    data-message-body="true"
+                    data-message-text-actions={canUseMessageTextActions ? "true" : undefined}
+                  >
                     <MessageRichText text={message.text} onOpenPath={onOpenPath} />
                   </div>
-                  {hasMessageTextActions ? (
-                    <MessageResponseActions
-                      actionText={message.text}
-                      onCopyMessageText={onCopyMessageText}
-                      onQuoteMessageText={onQuoteMessageText}
-                    />
-                  ) : null}
 
                   {artifact ? (
                     <section className="artifact-shell">
@@ -2593,7 +2587,6 @@ export function SessionMessageColumn({
         {selectionToolbar ? (
           <MessageResponseActions
             actionText={selectionToolbar.text}
-            className="is-selection-anchor"
             onCopyMessageText={onCopyMessageText}
             onQuoteMessageText={onQuoteMessageText}
             style={selectionToolbar.style}

--- a/src/styles.css
+++ b/src/styles.css
@@ -3689,18 +3689,8 @@ button:disabled {
   padding-top: 14px;
 }
 
-.message-card.has-response-actions {
-  min-height: 0;
-}
-
-.message-card.has-response-actions > [data-message-body="true"] {
-  min-height: 34px;
-}
-
 .message-response-actions {
-  position: absolute;
-  top: 8px;
-  right: 8px;
+  position: fixed;
   z-index: 3;
   display: inline-flex;
   justify-content: flex-end;
@@ -3710,23 +3700,7 @@ button:disabled {
   border-radius: var(--radius-sm);
   background: color-mix(in srgb, var(--character-sub-soft) 38%, rgba(15, 23, 42, 0.92));
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.28);
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 120ms ease, transform 120ms ease;
-  transform: translateY(-2px);
-}
-
-.message-card.has-response-actions:hover .message-response-actions,
-.message-card.has-response-actions:focus-within .message-response-actions,
-.message-response-actions.is-selection-anchor {
-  opacity: 1;
   pointer-events: auto;
-  transform: translateY(0);
-}
-
-.message-response-actions.is-selection-anchor {
-  position: fixed;
-  right: auto;
 }
 
 .message-response-action {
@@ -3746,18 +3720,6 @@ button:disabled {
   border-color: color-mix(in srgb, var(--character-sub) 48%, rgba(148, 163, 184, 0.36));
   color: var(--ink);
   background: rgba(30, 41, 59, 0.42);
-}
-
-@media (hover: none) {
-  .message-card.has-response-actions > [data-message-body="true"] {
-    padding-inline-end: 124px;
-  }
-
-  .message-card.has-response-actions .message-response-actions {
-    opacity: 1;
-    pointer-events: auto;
-    transform: translateY(0);
-  }
 }
 
 .session-page.auxiliary-session-mode .session-work-surface {


### PR DESCRIPTION
## Summary
- Copy / Quote の未選択時固定 toolbar を削除し、assistant response の選択範囲だけを action 対象に変更
- selectionchange / resize / scroll 経由の toolbar 表示、再配置、消失を DOM test で固定
- user message 選択では toolbar が出ないこと、Copy / Quote が選択範囲だけを渡すことを検証
- selection action 仕様に合わせて docs/design/auxiliary-session.md を更新
- DOM test 用に jsdom / @types/jsdom を devDependency に追加
- アプリバージョンを 4.2.17-preview.7 に更新

## Validation
- node --import tsx --test scripts/tests/session-message-column.test.ts scripts/tests/chat-window-mate-talk-mode.test.ts scripts/tests/message-text-actions.test.ts
- npm run typecheck
- git diff --check