### PR TITLE
feat(character): SettingsにCharacter editorを追加

### DIFF
--- a/docs/design/settings-ui.md
+++ b/docs/design/settings-ui.md
@@ -14,7 +14,7 @@
 - 設定は `Home Window` から開く独立 `Settings Window` とする
 - app 共通 system prompt を編集する旧設定項目は廃止する
 - Mate 定義は `Provider Instruction Sync` の managed block へ投影し、turn prompt へ共通 system 指示として合成しない
-- current 実装では `Session Window`、`Coding Agent Providers`、`Provider Instruction Sync`、`Skill Roots`、`Memory Extraction`、`Character Reflection`、`Diagnostics`、`Model Catalog` を置く
+- current 実装では `Session Window`、`Characters`、`Coding Agent Providers`、`Provider Instruction Sync`、`Skill Roots`、`Memory Extraction`、`Character Reflection`、`Diagnostics`、`Model Catalog` を置く
 - `Settings Window` は縦方向の余白を少し増やしつつ、内容が増えた場合は window 内スクロールで末尾まで操作できるようにする
 - file picker / save dialog は Main Process 側で開く
 - current 実装では Main Process 側の settings / catalog 更新は `src-electron/settings-catalog-service.ts` に寄せ、renderer 側の provider row 組み立ては `src/home-settings-view-model.ts` に寄せる
@@ -35,6 +35,13 @@
 - Settings Window
   - `Session Window`
     - `送信後に Action Dock を自動で閉じる`
+  - `Characters`
+    - Character 一覧
+    - name / description / icon path / theme
+    - raw `character.md` editor
+    - optional `character-notes.md` editor
+    - import / replace
+    - save / cancel / set default / archive
   - `Coding Agent Providers`
     - provider 名を左、enable checkbox を右に置いた 1 行 row
   - `Provider Instruction Sync`
@@ -56,6 +63,14 @@
 ## Current Scope
 
 - `Session Window` の `送信後に Action Dock を自動で閉じる` の保存
+- V5 Core Character の最低限 editor
+  - Character 一覧
+  - 新規作成
+  - metadata 編集
+  - raw `character.md` import / replace / 保存
+  - optional `character-notes.md` 保存
+  - default 切替
+  - archive
 - coding provider ごとの enable / disable
 - provider instruction sync の root / path / write mode 保存
 - coding provider ごとの `Skill Root` 入力保存
@@ -75,6 +90,8 @@
 - Settings Window の `loading` 派生状態は `HomeApp.tsx` が組み立てる
 - Settings Window の `import / export / save` の文言組み立てと戻り値解釈は `home-settings-actions` が担当する
 - Settings 保存成功時は renderer 側で戻り値の `appSettings` を draft に同期し、dirty 状態を解消する
+- Character editor は app settings draft とは分離し、`CharacterStorage` IPC を直接呼び出して保存する。
+- `character.md` の validation error は raw editor の操作結果として Settings Window 内に表示する。
 
 ## Future Scope
 

--- a/scripts/tests/home-components.test.tsx
+++ b/scripts/tests/home-components.test.tsx
@@ -55,6 +55,7 @@ describe("HomeSettingsContent", () => {
     canResetMate?: boolean;
     mateResetBusy?: boolean;
     onResetMate?: () => void;
+    characterEditorBusy?: boolean;
   };
 
   const collectElementsById = (node: ReactNode, predicate: (element: React.ReactElement) => boolean): React.ReactElement[] => {
@@ -91,6 +92,7 @@ describe("HomeSettingsContent", () => {
     modelCatalogRevisionLabel: String(modelCatalog.revision),
     settingsDirty: false,
     settingsFeedback: "",
+    characterEditorBusy: params?.characterEditorBusy ?? false,
     onChangeAutoCollapseActionDockOnSend: noOp,
     onChangeUserMicrocopySlot: noOp,
     onChangeProviderEnabled: noOp,
@@ -148,6 +150,15 @@ describe("HomeSettingsContent", () => {
     assert.ok(!html.includes("Mate Growth を手動適用"));
     assert.ok(!html.includes("Mate Growth Settings"));
     assert.ok(!html.includes("最近の Growth Event"));
+  });
+
+  it("Character editor は busy 中に編集 field を disabled にする", () => {
+    const html = renderSettings({ characterEditorBusy: true });
+
+    assert.match(html, /<input type="text" disabled="" value="New Character"\/>/);
+    assert.match(html, /<input type="color" disabled="" value="#6f8cff"\/>/);
+    assert.match(html, /<textarea class="settings-character-markdown-textarea" rows="14" spellCheck="false" disabled="">/);
+    assert.match(html, /<textarea class="settings-character-notes-textarea" rows="5" spellCheck="false" disabled="">/);
   });
 });
 

--- a/scripts/tests/settings-ui.test.ts
+++ b/scripts/tests/settings-ui.test.ts
@@ -15,7 +15,15 @@ import {
   buildResetDatabaseConfirmMessage,
   buildResetDatabaseSuccessMessage,
 } from "../../src/settings/settings-ui.js";
+import {
+  buildDefaultCharacterDefinition,
+  createCharacterEditorDraftFromDetail,
+  createNewCharacterEditorDraft,
+  isSettingsCharacterDraftDirty,
+  resolveSettingsCharacterSelection,
+} from "../../src/settings/settings-character-editor-state.js";
 import { HOME_WINDOW_DEFAULT_BOUNDS } from "../../src-electron/window-defaults.js";
+import { DEFAULT_CHARACTER_THEME, type CharacterDetail } from "../../src/character/character-catalog.js";
 import { ALL_RESET_APP_DATABASE_TARGETS } from "../../src/withmate-window-types.js";
 
 describe("Settings UI constants", () => {
@@ -50,5 +58,39 @@ describe("Settings UI constants", () => {
       minWidth: 900,
       minHeight: 680,
     });
+  });
+
+  it("Character editor draft は V5 character.md の初期本文を作る", () => {
+    const draft = createNewCharacterEditorDraft("Mia");
+
+    assert.equal(draft.mode, "create");
+    assert.equal(draft.name, "Mia");
+    assert.match(draft.definitionMarkdown, /schema: withmate-character-v5/);
+    assert.match(draft.definitionMarkdown, /name: Mia/);
+    assert.match(buildDefaultCharacterDefinition("   "), /name: New Character/);
+  });
+
+  it("Character editor は selection fallback と dirty 判定を持つ", () => {
+    const detail: CharacterDetail = {
+      id: "mia",
+      name: "Mia",
+      description: "first",
+      iconFilePath: "",
+      theme: { ...DEFAULT_CHARACTER_THEME },
+      state: "active",
+      isDefault: true,
+      createdAt: "2026-06-14T00:00:00.000Z",
+      updatedAt: "2026-06-14T00:00:00.000Z",
+      archivedAt: null,
+      definitionMarkdown: buildDefaultCharacterDefinition("Mia"),
+      notesMarkdown: "# Character Notes\n",
+    };
+    const draft = createCharacterEditorDraftFromDetail(detail);
+
+    assert.equal(resolveSettingsCharacterSelection([detail], "mia"), "mia");
+    assert.equal(resolveSettingsCharacterSelection([detail], "missing"), "mia");
+    assert.equal(isSettingsCharacterDraftDirty(draft, detail), false);
+    assert.equal(isSettingsCharacterDraftDirty({ ...draft, description: "changed" }, detail), true);
+    assert.equal(isSettingsCharacterDraftDirty(createNewCharacterEditorDraft(), null), true);
   });
 });

--- a/scripts/tests/settings-ui.test.ts
+++ b/scripts/tests/settings-ui.test.ts
@@ -21,6 +21,7 @@ import {
   createNewCharacterEditorDraft,
   isSettingsCharacterDraftDirty,
   resolveSettingsCharacterSelection,
+  updateSettingsCharacterEditorDraft,
 } from "../../src/settings/settings-character-editor-state.js";
 import { HOME_WINDOW_DEFAULT_BOUNDS } from "../../src-electron/window-defaults.js";
 import { DEFAULT_CHARACTER_THEME, type CharacterDetail } from "../../src/character/character-catalog.js";
@@ -68,6 +69,23 @@ describe("Settings UI constants", () => {
     assert.match(draft.definitionMarkdown, /schema: withmate-character-v5/);
     assert.match(draft.definitionMarkdown, /name: Mia/);
     assert.match(buildDefaultCharacterDefinition("   "), /name: New Character/);
+  });
+
+  it("Character editor draft は未編集の新規 character.md だけ name 変更に追従する", () => {
+    const draft = createNewCharacterEditorDraft();
+    const renamed = updateSettingsCharacterEditorDraft(draft, { name: "Mia" });
+
+    assert.equal(renamed.name, "Mia");
+    assert.match(renamed.definitionMarkdown, /name: Mia/);
+    assert.match(renamed.definitionMarkdown, /- Mia/);
+
+    const edited = updateSettingsCharacterEditorDraft(
+      { ...draft, definitionMarkdown: `${draft.definitionMarkdown}\n## Custom\n` },
+      { name: "Noa" },
+    );
+    assert.equal(edited.name, "Noa");
+    assert.match(edited.definitionMarkdown, /name: New Character/);
+    assert.match(edited.definitionMarkdown, /## Custom/);
   });
 
   it("Character editor は selection fallback と dirty 判定を持つ", () => {

--- a/src/HomeApp.tsx
+++ b/src/HomeApp.tsx
@@ -30,6 +30,16 @@ import {
   buildPersistedAppSettingsFromRows,
   type HomeProviderSettingRow,
 } from "./settings/settings-view-model.js";
+import type { CharacterCatalogEntry, CharacterDetail } from "./character/character-catalog.js";
+import {
+  createCharacterEditorDraftFromDetail,
+  createNewCharacterEditorDraft,
+  formatCharacterEditorError,
+  isSettingsCharacterDraftDirty,
+  normalizeThemeColorDraft,
+  resolveSettingsCharacterSelection,
+  type SettingsCharacterEditorDraft,
+} from "./settings/settings-character-editor-state.js";
 import { HomeAppRouter } from "./home/HomeAppRouter.js";
 import { buildHomeDashboardSlots } from "./home/HomeDashboardSlots.js";
 import { buildHomeRecentSessionsPanelProps } from "./home/home-recent-sessions-panel-props.js";
@@ -77,6 +87,12 @@ export default function HomeApp() {
   const [appSettings, setAppSettings] = useState<AppSettings>(createDefaultAppSettings());
   const [settingsDraft, setSettingsDraft] = useState<AppSettings>(createDefaultAppSettings());
   const [modelCatalog, setModelCatalog] = useState<ModelCatalogSnapshot | null>(null);
+  const [characterEntries, setCharacterEntries] = useState<CharacterCatalogEntry[]>([]);
+  const [selectedCharacterId, setSelectedCharacterId] = useState<string | null>(null);
+  const [selectedCharacterDetail, setSelectedCharacterDetail] = useState<CharacterDetail | null>(null);
+  const [characterDraft, setCharacterDraft] = useState<SettingsCharacterEditorDraft>(() => createNewCharacterEditorDraft());
+  const [characterEditorBusy, setCharacterEditorBusy] = useState(false);
+  const [characterEditorFeedback, setCharacterEditorFeedback] = useState("");
   const [settingsDraftLoaded, setSettingsDraftLoaded] = useState(!isSettingsWindowMode);
   const [modelCatalogLoaded, setModelCatalogLoaded] = useState(!isSettingsWindowMode);
   const [launchDraft, setLaunchDraft] = useState<HomeLaunchDraft>(() => createClosedLaunchDraft());
@@ -112,6 +128,36 @@ export default function HomeApp() {
     setMateDisplayName,
     setMateAvatarUpdating,
   });
+
+  const applyLoadedCharacterEntries = async (
+    api: NonNullable<ReturnType<typeof getWithMateApi>>,
+    entries: CharacterCatalogEntry[],
+    preferredCharacterId?: string | null,
+  ) => {
+    setCharacterEntries(entries);
+    const nextSelectedCharacterId = resolveSettingsCharacterSelection(entries, preferredCharacterId ?? selectedCharacterId);
+    setSelectedCharacterId(nextSelectedCharacterId);
+
+    if (!nextSelectedCharacterId) {
+      setSelectedCharacterDetail(null);
+      setCharacterDraft(createNewCharacterEditorDraft());
+      return;
+    }
+
+    const detail = await api.getCharacter(nextSelectedCharacterId);
+    setSelectedCharacterDetail(detail);
+    if (detail) {
+      setCharacterDraft(createCharacterEditorDraftFromDetail(detail));
+    }
+  };
+
+  const refreshCharacterEntries = async (
+    api: NonNullable<ReturnType<typeof getWithMateApi>>,
+    preferredCharacterId?: string | null,
+  ) => {
+    const entries = await api.listCharacters();
+    await applyLoadedCharacterEntries(api, entries, preferredCharacterId);
+  };
 
   useEffect(() => {
     let active = true;
@@ -161,6 +207,16 @@ export default function HomeApp() {
       setMateState("not_created");
       setMateProfile(null);
       setMateCreationFeedback(error instanceof Error ? error.message : "Mate 状態の取得に失敗したよ。");
+    });
+
+    void refreshCharacterEntries(withmateApi).catch((error) => {
+      if (!active) {
+        return;
+      }
+
+      setCharacterEditorFeedback(
+        formatCharacterEditorError(error, "Character 一覧の読み込みに失敗したよ。"),
+      );
     });
 
     const unsubscribeModelCatalog = startModelCatalogSubscription({
@@ -339,17 +395,176 @@ export default function HomeApp() {
     refreshMateStatus,
   });
 
+  const characterEditorDirty = useMemo(
+    () => isSettingsCharacterDraftDirty(characterDraft, selectedCharacterDetail),
+    [characterDraft, selectedCharacterDetail],
+  );
+
+  const runCharacterEditorCommand = async (command: (api: NonNullable<ReturnType<typeof getWithMateApi>>) => Promise<void>) => {
+    const api = getWithMateApi();
+    if (!api || characterEditorBusy) {
+      return;
+    }
+
+    setCharacterEditorBusy(true);
+    try {
+      await command(api);
+    } finally {
+      setCharacterEditorBusy(false);
+    }
+  };
+
+  const characterEditorHandlers = {
+    onSelectCharacter: (characterId: string) => {
+      void runCharacterEditorCommand(async (api) => {
+        const detail = await api.getCharacter(characterId);
+        setSelectedCharacterId(characterId);
+        setSelectedCharacterDetail(detail);
+        if (detail) {
+          setCharacterDraft(createCharacterEditorDraftFromDetail(detail));
+          setCharacterEditorFeedback("");
+        } else {
+          setCharacterEditorFeedback("Character が見つからなかったよ。");
+        }
+      });
+    },
+    onNewCharacter: () => {
+      setSelectedCharacterId(null);
+      setSelectedCharacterDetail(null);
+      setCharacterDraft(createNewCharacterEditorDraft());
+      setCharacterEditorFeedback("");
+    },
+    onChangeCharacterDraft: (patch: Partial<SettingsCharacterEditorDraft>) => {
+      setCharacterDraft((current) => ({
+        ...current,
+        ...patch,
+        theme: patch.theme
+          ? {
+              main: normalizeThemeColorDraft(patch.theme.main, current.theme.main),
+              sub: normalizeThemeColorDraft(patch.theme.sub, current.theme.sub),
+            }
+          : current.theme,
+      }));
+    },
+    onImportCharacterDefinitionFile: (file: File) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        if (typeof reader.result === "string") {
+          setCharacterDraft((current) => ({
+            ...current,
+            definitionMarkdown: reader.result as string,
+          }));
+          setCharacterEditorFeedback(`${file.name} を読み込んだよ。`);
+        }
+      };
+      reader.onerror = () => {
+        setCharacterEditorFeedback("character.md の読み込みに失敗したよ。");
+      };
+      reader.readAsText(file);
+    },
+    onPickCharacterIcon: () => {
+      void runCharacterEditorCommand(async (api) => {
+        const pickedPath = await api.pickImageFile(characterDraft.iconFilePath || undefined);
+        if (pickedPath) {
+          setCharacterDraft((current) => ({
+            ...current,
+            iconFilePath: pickedPath,
+          }));
+        }
+      });
+    },
+    onSaveCharacter: () => {
+      void runCharacterEditorCommand(async (api) => {
+        try {
+          const saved = characterDraft.mode === "create"
+            ? await api.createCharacter({
+                name: characterDraft.name,
+                description: characterDraft.description,
+                iconFilePath: characterDraft.iconFilePath,
+                theme: characterDraft.theme,
+                definitionMarkdown: characterDraft.definitionMarkdown,
+                notesMarkdown: characterDraft.notesMarkdown,
+              })
+            : await (async () => {
+                if (!characterDraft.characterId) {
+                  throw new Error("保存対象の Character が選択されていないよ。");
+                }
+                if (characterDraft.name.trim().length === 0) {
+                  throw new Error("Character name を入力してね。");
+                }
+                await api.updateCharacterDefinition({
+                  characterId: characterDraft.characterId,
+                  definitionMarkdown: characterDraft.definitionMarkdown,
+                  notesMarkdown: characterDraft.notesMarkdown,
+                });
+                return api.updateCharacterMetadata({
+                  characterId: characterDraft.characterId,
+                  name: characterDraft.name,
+                  description: characterDraft.description,
+                  iconFilePath: characterDraft.iconFilePath,
+                  theme: characterDraft.theme,
+                });
+              })();
+
+          setSelectedCharacterId(saved.id);
+          setSelectedCharacterDetail(saved);
+          setCharacterDraft(createCharacterEditorDraftFromDetail(saved));
+          await refreshCharacterEntries(api, saved.id);
+          setCharacterEditorFeedback("Character を保存したよ。");
+        } catch (error) {
+          setCharacterEditorFeedback(formatCharacterEditorError(error, "Character の保存に失敗したよ。"));
+        }
+      });
+    },
+    onCancelCharacterEdit: () => {
+      if (selectedCharacterDetail) {
+        setCharacterDraft(createCharacterEditorDraftFromDetail(selectedCharacterDetail));
+        setCharacterEditorFeedback("編集を保存前の状態へ戻したよ。");
+      } else {
+        setCharacterDraft(createNewCharacterEditorDraft());
+        setCharacterEditorFeedback("");
+      }
+    },
+    onSetDefaultCharacter: () => {
+      void runCharacterEditorCommand(async (api) => {
+        if (!characterDraft.characterId) {
+          return;
+        }
+        await api.setDefaultCharacter(characterDraft.characterId);
+        await refreshCharacterEntries(api, characterDraft.characterId);
+        setCharacterEditorFeedback("Default Character を更新したよ。");
+      });
+    },
+    onArchiveCharacter: () => {
+      void runCharacterEditorCommand(async (api) => {
+        if (!characterDraft.characterId) {
+          return;
+        }
+        await api.archiveCharacter(characterDraft.characterId);
+        await refreshCharacterEntries(api);
+        setCharacterEditorFeedback("Character を archive したよ。");
+      });
+    },
+  };
+
   const isMateStateLoading = mateState === null;
   const canUsePrimaryFeatures = mateState !== null;
 
   const baseSettingsContentProps: HomeSettingsContentBaseProps = {
     settingsDraft,
     providerSettingRows,
+    characterEntries,
+    selectedCharacterId,
+    characterDraft,
+    characterEditorDirty,
+    characterEditorBusy,
+    characterEditorFeedback,
     modelCatalogRevisionLabel: String(modelCatalog?.revision ?? "-"),
     settingsDirty,
     settingsFeedback,
     ...settingsDraftHandlers,
     ...settingsCommandHandlers,
+    ...characterEditorHandlers,
   };
 
   const { settingsContent, mateSetupContent, monitorContent } = buildHomeWindowContentSlots({

--- a/src/HomeApp.tsx
+++ b/src/HomeApp.tsx
@@ -36,9 +36,9 @@ import {
   createNewCharacterEditorDraft,
   formatCharacterEditorError,
   isSettingsCharacterDraftDirty,
-  normalizeThemeColorDraft,
   resolveSettingsCharacterSelection,
   type SettingsCharacterEditorDraft,
+  updateSettingsCharacterEditorDraft,
 } from "./settings/settings-character-editor-state.js";
 import { HomeAppRouter } from "./home/HomeAppRouter.js";
 import { buildHomeDashboardSlots } from "./home/HomeDashboardSlots.js";
@@ -400,15 +400,24 @@ export default function HomeApp() {
     [characterDraft, selectedCharacterDetail],
   );
 
-  const runCharacterEditorCommand = async (command: (api: NonNullable<ReturnType<typeof getWithMateApi>>) => Promise<void>) => {
+  const runCharacterEditorCommand = async (
+    command: (api: NonNullable<ReturnType<typeof getWithMateApi>>) => Promise<void>,
+    fallbackMessage = "Character 操作に失敗したよ。",
+  ) => {
     const api = getWithMateApi();
-    if (!api || characterEditorBusy) {
+    if (characterEditorBusy) {
+      return;
+    }
+    if (!api) {
+      setCharacterEditorFeedback("Character 操作には desktop runtime が必要だよ。");
       return;
     }
 
     setCharacterEditorBusy(true);
     try {
       await command(api);
+    } catch (error) {
+      setCharacterEditorFeedback(formatCharacterEditorError(error, fallbackMessage));
     } finally {
       setCharacterEditorBusy(false);
     }
@@ -416,6 +425,13 @@ export default function HomeApp() {
 
   const characterEditorHandlers = {
     onSelectCharacter: (characterId: string) => {
+      if (characterId === selectedCharacterId) {
+        return;
+      }
+      if (characterEditorDirty) {
+        setCharacterEditorFeedback("未保存の編集があります。保存またはCancelしてから切り替えてね。");
+        return;
+      }
       void runCharacterEditorCommand(async (api) => {
         const detail = await api.getCharacter(characterId);
         setSelectedCharacterId(characterId);
@@ -426,25 +442,20 @@ export default function HomeApp() {
         } else {
           setCharacterEditorFeedback("Character が見つからなかったよ。");
         }
-      });
+      }, "Character の読み込みに失敗したよ。");
     },
     onNewCharacter: () => {
+      if (characterEditorDirty) {
+        setCharacterEditorFeedback("未保存の編集があります。保存またはCancelしてから切り替えてね。");
+        return;
+      }
       setSelectedCharacterId(null);
       setSelectedCharacterDetail(null);
       setCharacterDraft(createNewCharacterEditorDraft());
       setCharacterEditorFeedback("");
     },
     onChangeCharacterDraft: (patch: Partial<SettingsCharacterEditorDraft>) => {
-      setCharacterDraft((current) => ({
-        ...current,
-        ...patch,
-        theme: patch.theme
-          ? {
-              main: normalizeThemeColorDraft(patch.theme.main, current.theme.main),
-              sub: normalizeThemeColorDraft(patch.theme.sub, current.theme.sub),
-            }
-          : current.theme,
-      }));
+      setCharacterDraft((current) => updateSettingsCharacterEditorDraft(current, patch));
     },
     onImportCharacterDefinitionFile: (file: File) => {
       const reader = new FileReader();
@@ -471,50 +482,46 @@ export default function HomeApp() {
             iconFilePath: pickedPath,
           }));
         }
-      });
+      }, "Character icon の選択に失敗したよ。");
     },
     onSaveCharacter: () => {
       void runCharacterEditorCommand(async (api) => {
-        try {
-          const saved = characterDraft.mode === "create"
-            ? await api.createCharacter({
+        const saved = characterDraft.mode === "create"
+          ? await api.createCharacter({
+              name: characterDraft.name,
+              description: characterDraft.description,
+              iconFilePath: characterDraft.iconFilePath,
+              theme: characterDraft.theme,
+              definitionMarkdown: characterDraft.definitionMarkdown,
+              notesMarkdown: characterDraft.notesMarkdown,
+            })
+          : await (async () => {
+              if (!characterDraft.characterId) {
+                throw new Error("保存対象の Character が選択されていないよ。");
+              }
+              if (characterDraft.name.trim().length === 0) {
+                throw new Error("Character name を入力してね。");
+              }
+              await api.updateCharacterDefinition({
+                characterId: characterDraft.characterId,
+                definitionMarkdown: characterDraft.definitionMarkdown,
+                notesMarkdown: characterDraft.notesMarkdown,
+              });
+              return api.updateCharacterMetadata({
+                characterId: characterDraft.characterId,
                 name: characterDraft.name,
                 description: characterDraft.description,
                 iconFilePath: characterDraft.iconFilePath,
                 theme: characterDraft.theme,
-                definitionMarkdown: characterDraft.definitionMarkdown,
-                notesMarkdown: characterDraft.notesMarkdown,
-              })
-            : await (async () => {
-                if (!characterDraft.characterId) {
-                  throw new Error("保存対象の Character が選択されていないよ。");
-                }
-                if (characterDraft.name.trim().length === 0) {
-                  throw new Error("Character name を入力してね。");
-                }
-                await api.updateCharacterDefinition({
-                  characterId: characterDraft.characterId,
-                  definitionMarkdown: characterDraft.definitionMarkdown,
-                  notesMarkdown: characterDraft.notesMarkdown,
-                });
-                return api.updateCharacterMetadata({
-                  characterId: characterDraft.characterId,
-                  name: characterDraft.name,
-                  description: characterDraft.description,
-                  iconFilePath: characterDraft.iconFilePath,
-                  theme: characterDraft.theme,
-                });
-              })();
+              });
+            })();
 
-          setSelectedCharacterId(saved.id);
-          setSelectedCharacterDetail(saved);
-          setCharacterDraft(createCharacterEditorDraftFromDetail(saved));
-          await refreshCharacterEntries(api, saved.id);
-          setCharacterEditorFeedback("Character を保存したよ。");
-        } catch (error) {
-          setCharacterEditorFeedback(formatCharacterEditorError(error, "Character の保存に失敗したよ。"));
-        }
-      });
+        setSelectedCharacterId(saved.id);
+        setSelectedCharacterDetail(saved);
+        setCharacterDraft(createCharacterEditorDraftFromDetail(saved));
+        await refreshCharacterEntries(api, saved.id);
+        setCharacterEditorFeedback("Character を保存したよ。");
+      }, "Character の保存に失敗したよ。");
     },
     onCancelCharacterEdit: () => {
       if (selectedCharacterDetail) {
@@ -533,7 +540,7 @@ export default function HomeApp() {
         await api.setDefaultCharacter(characterDraft.characterId);
         await refreshCharacterEntries(api, characterDraft.characterId);
         setCharacterEditorFeedback("Default Character を更新したよ。");
-      });
+      }, "Default Character の更新に失敗したよ。");
     },
     onArchiveCharacter: () => {
       void runCharacterEditorCommand(async (api) => {
@@ -543,7 +550,7 @@ export default function HomeApp() {
         await api.archiveCharacter(characterDraft.characterId);
         await refreshCharacterEntries(api);
         setCharacterEditorFeedback("Character を archive したよ。");
-      });
+      }, "Character のarchiveに失敗したよ。");
     },
   };
 

--- a/src/settings/SettingsContent.tsx
+++ b/src/settings/SettingsContent.tsx
@@ -1,5 +1,9 @@
+import { useRef, type CSSProperties } from "react";
+
 import type { AppSettings } from "../app-state.js";
+import type { CharacterCatalogEntry } from "../character/character-catalog.js";
 import { MICROCOPY_SLOTS, type MicrocopySlot } from "../microcopy-state.js";
+import type { SettingsCharacterEditorDraft } from "./settings-character-editor-state.js";
 import type { HomeProviderSettingRow } from "./settings-view-model.js";
 import {
   SETTINGS_ACTION_DOCK_AUTO_CLOSE_LABEL,
@@ -13,12 +17,27 @@ import {
 export type HomeSettingsContentProps = {
   settingsDraft: AppSettings;
   providerSettingRows: HomeProviderSettingRow[];
+  characterEntries: CharacterCatalogEntry[];
+  selectedCharacterId: string | null;
+  characterDraft: SettingsCharacterEditorDraft;
+  characterEditorDirty: boolean;
+  characterEditorBusy: boolean;
+  characterEditorFeedback: string;
   modelCatalogRevisionLabel: string;
   settingsDirty: boolean;
   settingsFeedback: string;
   onChangeAutoCollapseActionDockOnSend: (enabled: boolean) => void;
   onChangeUserMicrocopySlot: (slot: MicrocopySlot, value: string) => void;
   onChangeProviderEnabled: (providerId: string, enabled: boolean) => void;
+  onSelectCharacter: (characterId: string) => void;
+  onNewCharacter: () => void;
+  onChangeCharacterDraft: (patch: Partial<SettingsCharacterEditorDraft>) => void;
+  onImportCharacterDefinitionFile: (file: File) => void;
+  onPickCharacterIcon: () => void;
+  onSaveCharacter: () => void;
+  onCancelCharacterEdit: () => void;
+  onSetDefaultCharacter: () => void;
+  onArchiveCharacter: () => void;
   onImportModelCatalog: () => void;
   onExportModelCatalog: () => void;
   onOpenAppLogFolder: () => void;
@@ -55,12 +74,27 @@ const microcopyTextareaValue = (value: AppSettings["userMicrocopyCatalog"][Micro
 export function HomeSettingsContent({
   settingsDraft,
   providerSettingRows,
+  characterEntries,
+  selectedCharacterId,
+  characterDraft,
+  characterEditorDirty,
+  characterEditorBusy,
+  characterEditorFeedback,
   modelCatalogRevisionLabel,
   settingsDirty,
   settingsFeedback,
   onChangeAutoCollapseActionDockOnSend,
   onChangeUserMicrocopySlot,
   onChangeProviderEnabled,
+  onSelectCharacter,
+  onNewCharacter,
+  onChangeCharacterDraft,
+  onImportCharacterDefinitionFile,
+  onPickCharacterIcon,
+  onSaveCharacter,
+  onCancelCharacterEdit,
+  onSetDefaultCharacter,
+  onArchiveCharacter,
   onImportModelCatalog,
   onExportModelCatalog,
   onOpenAppLogFolder,
@@ -70,6 +104,9 @@ export function HomeSettingsContent({
   canResetMate = false,
   onSaveSettings,
 }: HomeSettingsContentProps) {
+  const characterImportInputRef = useRef<HTMLInputElement | null>(null);
+  const selectedCharacter = characterEntries.find((entry) => entry.id === selectedCharacterId) ?? null;
+
   return (
     <>
       <div className="settings-panel settings-panel-window">
@@ -133,6 +170,179 @@ export function HomeSettingsContent({
               </section>
             </>
           ) : null}
+
+          <section className="settings-section-card settings-character-section">
+            <div className="settings-field">
+              <div className="settings-section-head-row">
+                <strong>Characters</strong>
+                <button className="launch-toggle compact" type="button" onClick={onNewCharacter}>
+                  New
+                </button>
+              </div>
+              <div className="settings-character-editor">
+                <div className="settings-character-list" aria-label="Characters">
+                  {characterEntries.length === 0 ? (
+                    <p className="settings-note">登録済み Character はまだないよ。</p>
+                  ) : characterEntries.map((character) => (
+                    <button
+                      key={character.id}
+                      className={`settings-character-row${character.id === selectedCharacterId ? " selected" : ""}`}
+                      type="button"
+                      onClick={() => onSelectCharacter(character.id)}
+                    >
+                      <span
+                        className="settings-character-swatch"
+                        style={{ "--settings-character-swatch": character.theme.main } as CSSProperties}
+                        aria-hidden="true"
+                      />
+                      <span className="settings-character-row-copy">
+                        <span className="settings-character-row-name">
+                          {character.name}
+                          {character.isDefault ? <span className="settings-character-badge">Default</span> : null}
+                        </span>
+                        <span>{character.description || character.id}</span>
+                      </span>
+                    </button>
+                  ))}
+                </div>
+
+                <div className="settings-character-form">
+                  <div className="settings-character-form-grid">
+                    <label className="settings-provider-input">
+                      <span>Name</span>
+                      <input
+                        type="text"
+                        value={characterDraft.name}
+                        onChange={(event) => onChangeCharacterDraft({ name: event.target.value })}
+                      />
+                    </label>
+                    <label className="settings-provider-input">
+                      <span>Description</span>
+                      <input
+                        type="text"
+                        value={characterDraft.description}
+                        onChange={(event) => onChangeCharacterDraft({ description: event.target.value })}
+                      />
+                    </label>
+                    <label className="settings-provider-input">
+                      <span>Icon</span>
+                      <div className="settings-inline-input-row">
+                        <input
+                          type="text"
+                          value={characterDraft.iconFilePath}
+                          onChange={(event) => onChangeCharacterDraft({ iconFilePath: event.target.value })}
+                        />
+                        <button className="launch-toggle compact" type="button" onClick={onPickCharacterIcon}>
+                          Browse
+                        </button>
+                      </div>
+                    </label>
+                    <div className="settings-character-theme-fields">
+                      <label className="settings-provider-input">
+                        <span>Main</span>
+                        <input
+                          type="color"
+                          value={characterDraft.theme.main}
+                          onChange={(event) => onChangeCharacterDraft({
+                            theme: { ...characterDraft.theme, main: event.target.value },
+                          })}
+                        />
+                      </label>
+                      <label className="settings-provider-input">
+                        <span>Sub</span>
+                        <input
+                          type="color"
+                          value={characterDraft.theme.sub}
+                          onChange={(event) => onChangeCharacterDraft({
+                            theme: { ...characterDraft.theme, sub: event.target.value },
+                          })}
+                        />
+                      </label>
+                    </div>
+                  </div>
+
+                  <label className="settings-provider-input">
+                    <span>character.md</span>
+                    <textarea
+                      className="settings-character-markdown-textarea"
+                      value={characterDraft.definitionMarkdown}
+                      onChange={(event) => onChangeCharacterDraft({ definitionMarkdown: event.target.value })}
+                      rows={14}
+                      spellCheck={false}
+                    />
+                  </label>
+                  <label className="settings-provider-input">
+                    <span>character-notes.md</span>
+                    <textarea
+                      className="settings-character-notes-textarea"
+                      value={characterDraft.notesMarkdown}
+                      onChange={(event) => onChangeCharacterDraft({ notesMarkdown: event.target.value })}
+                      rows={5}
+                      spellCheck={false}
+                    />
+                  </label>
+                  <input
+                    ref={characterImportInputRef}
+                    type="file"
+                    accept=".md,text/markdown,text/plain"
+                    className="settings-character-import-input"
+                    onChange={(event) => {
+                      const file = event.target.files?.[0];
+                      if (file) {
+                        onImportCharacterDefinitionFile(file);
+                      }
+                      event.currentTarget.value = "";
+                    }}
+                  />
+                  <div className="settings-actions settings-character-actions">
+                    <button
+                      className="launch-toggle"
+                      type="button"
+                      onClick={() => characterImportInputRef.current?.click()}
+                      disabled={characterEditorBusy}
+                    >
+                      Import / Replace
+                    </button>
+                    <button
+                      className="launch-toggle"
+                      type="button"
+                      onClick={onSetDefaultCharacter}
+                      disabled={characterEditorBusy || characterDraft.mode !== "edit" || selectedCharacter?.isDefault}
+                    >
+                      Set Default
+                    </button>
+                    <button
+                      className="launch-toggle danger-button"
+                      type="button"
+                      onClick={onArchiveCharacter}
+                      disabled={characterEditorBusy || characterDraft.mode !== "edit"}
+                    >
+                      Archive
+                    </button>
+                    <button
+                      className="launch-toggle"
+                      type="button"
+                      onClick={onCancelCharacterEdit}
+                      disabled={characterEditorBusy || !characterEditorDirty}
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      className="launch-toggle start-session-button"
+                      type="button"
+                      onClick={onSaveCharacter}
+                      disabled={characterEditorBusy || !characterEditorDirty}
+                    >
+                      Save Character
+                    </button>
+                  </div>
+                  {characterEditorFeedback ? (
+                    <p className="settings-feedback">{characterEditorFeedback}</p>
+                  ) : null}
+                </div>
+              </div>
+            </div>
+          </section>
 
           <section className="settings-section-card">
             <div className="settings-field">

--- a/src/settings/SettingsContent.tsx
+++ b/src/settings/SettingsContent.tsx
@@ -1,9 +1,12 @@
-import { useRef, type CSSProperties } from "react";
+import type { CSSProperties } from "react";
 
 import type { AppSettings } from "../app-state.js";
 import type { CharacterCatalogEntry } from "../character/character-catalog.js";
 import { MICROCOPY_SLOTS, type MicrocopySlot } from "../microcopy-state.js";
-import type { SettingsCharacterEditorDraft } from "./settings-character-editor-state.js";
+import {
+  createNewCharacterEditorDraft,
+  type SettingsCharacterEditorDraft,
+} from "./settings-character-editor-state.js";
 import type { HomeProviderSettingRow } from "./settings-view-model.js";
 import {
   SETTINGS_ACTION_DOCK_AUTO_CLOSE_LABEL,
@@ -17,27 +20,27 @@ import {
 export type HomeSettingsContentProps = {
   settingsDraft: AppSettings;
   providerSettingRows: HomeProviderSettingRow[];
-  characterEntries: CharacterCatalogEntry[];
-  selectedCharacterId: string | null;
-  characterDraft: SettingsCharacterEditorDraft;
-  characterEditorDirty: boolean;
-  characterEditorBusy: boolean;
-  characterEditorFeedback: string;
+  characterEntries?: CharacterCatalogEntry[];
+  selectedCharacterId?: string | null;
+  characterDraft?: SettingsCharacterEditorDraft;
+  characterEditorDirty?: boolean;
+  characterEditorBusy?: boolean;
+  characterEditorFeedback?: string;
   modelCatalogRevisionLabel: string;
   settingsDirty: boolean;
   settingsFeedback: string;
   onChangeAutoCollapseActionDockOnSend: (enabled: boolean) => void;
   onChangeUserMicrocopySlot: (slot: MicrocopySlot, value: string) => void;
   onChangeProviderEnabled: (providerId: string, enabled: boolean) => void;
-  onSelectCharacter: (characterId: string) => void;
-  onNewCharacter: () => void;
-  onChangeCharacterDraft: (patch: Partial<SettingsCharacterEditorDraft>) => void;
-  onImportCharacterDefinitionFile: (file: File) => void;
-  onPickCharacterIcon: () => void;
-  onSaveCharacter: () => void;
-  onCancelCharacterEdit: () => void;
-  onSetDefaultCharacter: () => void;
-  onArchiveCharacter: () => void;
+  onSelectCharacter?: (characterId: string) => void;
+  onNewCharacter?: () => void;
+  onChangeCharacterDraft?: (patch: Partial<SettingsCharacterEditorDraft>) => void;
+  onImportCharacterDefinitionFile?: (file: File) => void;
+  onPickCharacterIcon?: () => void;
+  onSaveCharacter?: () => void;
+  onCancelCharacterEdit?: () => void;
+  onSetDefaultCharacter?: () => void;
+  onArchiveCharacter?: () => void;
   onImportModelCatalog: () => void;
   onExportModelCatalog: () => void;
   onOpenAppLogFolder: () => void;
@@ -71,30 +74,32 @@ const microcopyTextareaValue = (value: AppSettings["userMicrocopyCatalog"][Micro
   return (value ?? []).join("\n");
 };
 
+const CHARACTER_DEFINITION_IMPORT_INPUT_ID = "settings-character-definition-import";
+
 export function HomeSettingsContent({
   settingsDraft,
   providerSettingRows,
-  characterEntries,
-  selectedCharacterId,
-  characterDraft,
-  characterEditorDirty,
-  characterEditorBusy,
-  characterEditorFeedback,
+  characterEntries = [],
+  selectedCharacterId = null,
+  characterDraft = createNewCharacterEditorDraft(),
+  characterEditorDirty = false,
+  characterEditorBusy = false,
+  characterEditorFeedback = "",
   modelCatalogRevisionLabel,
   settingsDirty,
   settingsFeedback,
   onChangeAutoCollapseActionDockOnSend,
   onChangeUserMicrocopySlot,
   onChangeProviderEnabled,
-  onSelectCharacter,
-  onNewCharacter,
-  onChangeCharacterDraft,
-  onImportCharacterDefinitionFile,
-  onPickCharacterIcon,
-  onSaveCharacter,
-  onCancelCharacterEdit,
-  onSetDefaultCharacter,
-  onArchiveCharacter,
+  onSelectCharacter = () => undefined,
+  onNewCharacter = () => undefined,
+  onChangeCharacterDraft = () => undefined,
+  onImportCharacterDefinitionFile = () => undefined,
+  onPickCharacterIcon = () => undefined,
+  onSaveCharacter = () => undefined,
+  onCancelCharacterEdit = () => undefined,
+  onSetDefaultCharacter = () => undefined,
+  onArchiveCharacter = () => undefined,
   onImportModelCatalog,
   onExportModelCatalog,
   onOpenAppLogFolder,
@@ -104,7 +109,6 @@ export function HomeSettingsContent({
   canResetMate = false,
   onSaveSettings,
 }: HomeSettingsContentProps) {
-  const characterImportInputRef = useRef<HTMLInputElement | null>(null);
   const selectedCharacter = characterEntries.find((entry) => entry.id === selectedCharacterId) ?? null;
 
   return (
@@ -282,7 +286,7 @@ export function HomeSettingsContent({
                     />
                   </label>
                   <input
-                    ref={characterImportInputRef}
+                    id={CHARACTER_DEFINITION_IMPORT_INPUT_ID}
                     type="file"
                     accept=".md,text/markdown,text/plain"
                     className="settings-character-import-input"
@@ -298,7 +302,12 @@ export function HomeSettingsContent({
                     <button
                       className="launch-toggle"
                       type="button"
-                      onClick={() => characterImportInputRef.current?.click()}
+                      onClick={() => {
+                        if (typeof document === "undefined") {
+                          return;
+                        }
+                        document.getElementById(CHARACTER_DEFINITION_IMPORT_INPUT_ID)?.click();
+                      }}
                       disabled={characterEditorBusy}
                     >
                       Import / Replace

--- a/src/settings/SettingsContent.tsx
+++ b/src/settings/SettingsContent.tsx
@@ -179,7 +179,12 @@ export function HomeSettingsContent({
             <div className="settings-field">
               <div className="settings-section-head-row">
                 <strong>Characters</strong>
-                <button className="launch-toggle compact" type="button" onClick={onNewCharacter}>
+                <button
+                  className="launch-toggle compact"
+                  type="button"
+                  onClick={onNewCharacter}
+                  disabled={characterEditorBusy}
+                >
                   New
                 </button>
               </div>
@@ -193,6 +198,7 @@ export function HomeSettingsContent({
                       className={`settings-character-row${character.id === selectedCharacterId ? " selected" : ""}`}
                       type="button"
                       onClick={() => onSelectCharacter(character.id)}
+                      disabled={characterEditorBusy}
                     >
                       <span
                         className="settings-character-swatch"
@@ -218,6 +224,7 @@ export function HomeSettingsContent({
                         type="text"
                         value={characterDraft.name}
                         onChange={(event) => onChangeCharacterDraft({ name: event.target.value })}
+                        disabled={characterEditorBusy}
                       />
                     </label>
                     <label className="settings-provider-input">
@@ -226,6 +233,7 @@ export function HomeSettingsContent({
                         type="text"
                         value={characterDraft.description}
                         onChange={(event) => onChangeCharacterDraft({ description: event.target.value })}
+                        disabled={characterEditorBusy}
                       />
                     </label>
                     <label className="settings-provider-input">
@@ -235,8 +243,14 @@ export function HomeSettingsContent({
                           type="text"
                           value={characterDraft.iconFilePath}
                           onChange={(event) => onChangeCharacterDraft({ iconFilePath: event.target.value })}
+                          disabled={characterEditorBusy}
                         />
-                        <button className="launch-toggle compact" type="button" onClick={onPickCharacterIcon}>
+                        <button
+                          className="launch-toggle compact"
+                          type="button"
+                          onClick={onPickCharacterIcon}
+                          disabled={characterEditorBusy}
+                        >
                           Browse
                         </button>
                       </div>
@@ -250,6 +264,7 @@ export function HomeSettingsContent({
                           onChange={(event) => onChangeCharacterDraft({
                             theme: { ...characterDraft.theme, main: event.target.value },
                           })}
+                          disabled={characterEditorBusy}
                         />
                       </label>
                       <label className="settings-provider-input">
@@ -260,6 +275,7 @@ export function HomeSettingsContent({
                           onChange={(event) => onChangeCharacterDraft({
                             theme: { ...characterDraft.theme, sub: event.target.value },
                           })}
+                          disabled={characterEditorBusy}
                         />
                       </label>
                     </div>
@@ -273,6 +289,7 @@ export function HomeSettingsContent({
                       onChange={(event) => onChangeCharacterDraft({ definitionMarkdown: event.target.value })}
                       rows={14}
                       spellCheck={false}
+                      disabled={characterEditorBusy}
                     />
                   </label>
                   <label className="settings-provider-input">
@@ -283,6 +300,7 @@ export function HomeSettingsContent({
                       onChange={(event) => onChangeCharacterDraft({ notesMarkdown: event.target.value })}
                       rows={5}
                       spellCheck={false}
+                      disabled={characterEditorBusy}
                     />
                   </label>
                   <input
@@ -290,6 +308,7 @@ export function HomeSettingsContent({
                     type="file"
                     accept=".md,text/markdown,text/plain"
                     className="settings-character-import-input"
+                    disabled={characterEditorBusy}
                     onChange={(event) => {
                       const file = event.target.files?.[0];
                       if (file) {

--- a/src/settings/settings-character-editor-state.ts
+++ b/src/settings/settings-character-editor-state.ts
@@ -78,6 +78,32 @@ export function isSettingsCharacterDraftDirty(
     || draft.notesMarkdown !== persistedDetail.notesMarkdown;
 }
 
+export function updateSettingsCharacterEditorDraft(
+  current: SettingsCharacterEditorDraft,
+  patch: Partial<SettingsCharacterEditorDraft>,
+): SettingsCharacterEditorDraft {
+  const shouldRegenerateDefinition =
+    patch.name !== undefined
+    && patch.definitionMarkdown === undefined
+    && current.mode === "create"
+    && current.definitionMarkdown === buildDefaultCharacterDefinition(current.name);
+  const nextTheme = patch.theme
+    ? {
+        main: normalizeThemeColorDraft(patch.theme.main, current.theme.main),
+        sub: normalizeThemeColorDraft(patch.theme.sub, current.theme.sub),
+      }
+    : current.theme;
+
+  return {
+    ...current,
+    ...patch,
+    theme: nextTheme,
+    definitionMarkdown: shouldRegenerateDefinition
+      ? buildDefaultCharacterDefinition(patch.name ?? current.name)
+      : patch.definitionMarkdown ?? current.definitionMarkdown,
+  };
+}
+
 export function normalizeThemeColorDraft(value: string, fallback: string): string {
   const trimmed = value.trim();
   return /^#[0-9a-fA-F]{6}$/.test(trimmed) ? trimmed.toLowerCase() : fallback;

--- a/src/settings/settings-character-editor-state.ts
+++ b/src/settings/settings-character-editor-state.ts
@@ -1,0 +1,92 @@
+import {
+  DEFAULT_CHARACTER_THEME,
+  type CharacterCatalogEntry,
+  type CharacterDetail,
+  type CharacterTheme,
+} from "../character/character-catalog.js";
+
+export type SettingsCharacterEditorDraft = {
+  characterId: string | null;
+  name: string;
+  description: string;
+  iconFilePath: string;
+  theme: CharacterTheme;
+  definitionMarkdown: string;
+  notesMarkdown: string;
+  mode: "create" | "edit";
+};
+
+export function buildDefaultCharacterDefinition(name: string): string {
+  const normalizedName = name.trim() || "New Character";
+  return `---\nschema: withmate-character-v5\nname: ${normalizedName}\ndescription: \"\"\n---\n\n# Character Runtime Definition\n\n## Identity\n- ${normalizedName}\n`;
+}
+
+export function createNewCharacterEditorDraft(name = "New Character"): SettingsCharacterEditorDraft {
+  return {
+    characterId: null,
+    name,
+    description: "",
+    iconFilePath: "",
+    theme: { ...DEFAULT_CHARACTER_THEME },
+    definitionMarkdown: buildDefaultCharacterDefinition(name),
+    notesMarkdown: "# Character Notes\n",
+    mode: "create",
+  };
+}
+
+export function createCharacterEditorDraftFromDetail(detail: CharacterDetail): SettingsCharacterEditorDraft {
+  return {
+    characterId: detail.id,
+    name: detail.name,
+    description: detail.description,
+    iconFilePath: detail.iconFilePath,
+    theme: { ...detail.theme },
+    definitionMarkdown: detail.definitionMarkdown,
+    notesMarkdown: detail.notesMarkdown,
+    mode: "edit",
+  };
+}
+
+export function resolveSettingsCharacterSelection(
+  entries: readonly CharacterCatalogEntry[],
+  currentCharacterId: string | null,
+): string | null {
+  if (currentCharacterId && entries.some((entry) => entry.id === currentCharacterId)) {
+    return currentCharacterId;
+  }
+
+  return entries[0]?.id ?? null;
+}
+
+export function isSettingsCharacterDraftDirty(
+  draft: SettingsCharacterEditorDraft,
+  persistedDetail: CharacterDetail | null,
+): boolean {
+  if (draft.mode === "create") {
+    return true;
+  }
+  if (!persistedDetail || draft.characterId !== persistedDetail.id) {
+    return true;
+  }
+
+  return draft.name !== persistedDetail.name
+    || draft.description !== persistedDetail.description
+    || draft.iconFilePath !== persistedDetail.iconFilePath
+    || draft.theme.main !== persistedDetail.theme.main
+    || draft.theme.sub !== persistedDetail.theme.sub
+    || draft.definitionMarkdown !== persistedDetail.definitionMarkdown
+    || draft.notesMarkdown !== persistedDetail.notesMarkdown;
+}
+
+export function normalizeThemeColorDraft(value: string, fallback: string): string {
+  const trimmed = value.trim();
+  return /^#[0-9a-fA-F]{6}$/.test(trimmed) ? trimmed.toLowerCase() : fallback;
+}
+
+export function formatCharacterEditorError(error: unknown, fallback: string): string {
+  if (!(error instanceof Error)) {
+    return fallback;
+  }
+
+  return error.message;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -2288,6 +2288,133 @@ button:disabled {
   align-items: center;
 }
 
+.settings-section-head-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.settings-character-editor {
+  display: grid;
+  grid-template-columns: minmax(180px, 240px) minmax(0, 1fr);
+  gap: 14px;
+  align-items: start;
+}
+
+.settings-character-list {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.settings-character-row {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid rgba(203, 213, 225, 0.12);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--ink);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.settings-character-row:hover,
+.settings-character-row.selected {
+  border-color: color-mix(in srgb, var(--character-main) 42%, rgba(203, 213, 225, 0.18));
+  background: color-mix(in srgb, var(--character-main-soft) 34%, rgba(255, 255, 255, 0.04));
+}
+
+.settings-character-swatch {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: var(--settings-character-swatch, var(--character-main));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.46);
+}
+
+.settings-character-row-copy {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.settings-character-row-copy span {
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 0.78rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-character-row-copy .settings-character-row-name {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  color: var(--ink);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.settings-character-badge {
+  flex: 0 0 auto;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--character-sub-soft) 64%, rgba(255, 255, 255, 0.04));
+  color: color-mix(in srgb, var(--ink) 88%, var(--character-sub) 12%);
+  font-size: 0.66rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.settings-character-form {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+}
+
+.settings-character-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.settings-character-theme-fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.settings-character-theme-fields input[type="color"] {
+  min-height: 44px;
+  padding: 6px;
+}
+
+.settings-field textarea.settings-character-markdown-textarea {
+  min-height: 340px;
+  font-family: "Cascadia Code", "Consolas", monospace;
+  line-height: 1.65;
+}
+
+.settings-field textarea.settings-character-notes-textarea {
+  min-height: 130px;
+  font-family: "Cascadia Code", "Consolas", monospace;
+  line-height: 1.65;
+}
+
+.settings-character-import-input {
+  display: none;
+}
+
+.settings-character-actions {
+  justify-content: flex-end;
+}
+
 .settings-provider-input span {
   color: var(--muted);
   font-size: 0.78rem;
@@ -8351,6 +8478,9 @@ button:disabled {
   .character-form-grid,
   .theme-color-grid,
   .theme-rgb-grid,
+  .settings-character-editor,
+  .settings-character-form-grid,
+  .settings-character-theme-fields,
   .composer-settings,
   .editor-inline-field {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- Settings Window に V5 Core Characters section を追加
- Character 一覧、新規作成、metadata 編集、raw `character.md` / `character-notes.md` 編集、import / replace、save / cancel、default、archive を接続
- Character editor state helper と Settings UI test を追加し、`docs/design/settings-ui.md` の current scope を同期

## Scope
- Branch4: `feat/v5-character-settings-editor`
- Character storage / IPC は Branch3 の API を利用
- app settings の Save flow とは分離し、Character 操作は CharacterStorage IPC へ直接保存

## Non-goals
- section 単位の詳細 Editor
- revision / diff / rollback
- validator UI
- Character Update Workspace
- Character 定義自動生成
- Home / New Session / Companion 起動時の Character selector
- runtime prompt injection

## Verification
- `npm run typecheck`
- `node --import tsx --test scripts/tests/settings-ui.test.ts`
- `node --import tsx --test scripts/tests/character-storage.test.ts`
- `node --import tsx --test scripts/tests/main-ipc-registration.test.ts scripts/tests/preload-api.test.ts scripts/tests/renderer-withmate-api.test.ts`
- `git diff --check`

## Notes
- `character-storage.test.ts` は `node:sqlite` 対応 runtime で実行
