### PR TITLE
feat(character): Home launchにCharacter selectorを追加

### DIFF
--- a/scripts/tests/home-components.test.tsx
+++ b/scripts/tests/home-components.test.tsx
@@ -383,6 +383,7 @@ describe("HomeLaunchDialog", () => {
   const renderHomeLaunchDialog = (
     mode: "session" | "companion",
     options = characterOptions,
+    charactersLoaded = true,
   ) => renderToStaticMarkup(
     <HomeLaunchDialog
       open={true}
@@ -394,6 +395,7 @@ describe("HomeLaunchDialog", () => {
       selectedLaunchProviderId="codex"
       characterOptions={options}
       selectedCharacterId={options[0]?.id ?? null}
+      charactersLoaded={charactersLoaded}
       canStartSession={true}
       launchFeedback=""
       launchStarting={false}
@@ -428,6 +430,14 @@ describe("HomeLaunchDialog", () => {
 
     assert.ok(html.includes("WithMate"));
     assert.ok(html.includes("Neutral"));
+  });
+
+  it("Character catalog 読み込み前は neutral fallback を表示しない", () => {
+    const html = renderHomeLaunchDialog("session", [], false);
+
+    assert.ok(html.includes("読み込み中"));
+    assert.ok(html.includes("Character を読み込んでるよ..."));
+    assert.ok(!html.includes("Neutral"));
   });
 
 });

--- a/scripts/tests/home-components.test.tsx
+++ b/scripts/tests/home-components.test.tsx
@@ -367,7 +367,23 @@ describe("HomeMateSetupPanel", () => {
 describe("HomeLaunchDialog", () => {
   const noOp = (..._args: unknown[]) => undefined;
 
-  const renderHomeLaunchDialog = (mode: "session" | "companion") => renderToStaticMarkup(
+  const characterOptions = [{
+    id: "mia",
+    name: "Mia",
+    description: "Default character",
+    iconFilePath: "",
+    theme: { main: "#111111", sub: "#eeeeee" },
+    state: "active" as const,
+    isDefault: true,
+    createdAt: "",
+    updatedAt: "",
+    archivedAt: null,
+  }];
+
+  const renderHomeLaunchDialog = (
+    mode: "session" | "companion",
+    options = characterOptions,
+  ) => renderToStaticMarkup(
     <HomeLaunchDialog
       open={true}
       mode={mode}
@@ -376,6 +392,8 @@ describe("HomeLaunchDialog", () => {
       launchWorkspacePathLabel="workspace"
       enabledLaunchProviders={[{ id: "codex", label: "Codex" }]}
       selectedLaunchProviderId="codex"
+      characterOptions={options}
+      selectedCharacterId={options[0]?.id ?? null}
       canStartSession={true}
       launchFeedback=""
       launchStarting={false}
@@ -384,26 +402,32 @@ describe("HomeLaunchDialog", () => {
       onChangeTitle={noOp}
       onBrowseWorkspace={noOp}
       onSelectProvider={noOp}
+      onSelectCharacter={noOp}
       onStartSession={noOp}
     />,
   );
 
-  it("session mode でダイアログにキャラ選択 UI が含まれない", () => {
+  it("session mode でダイアログに Character selector が含まれる", () => {
     const html = renderHomeLaunchDialog("session");
 
-    assert.ok(!html.includes("launch-search-row"));
-    assert.ok(!html.includes("キャラクターを選ぶ"));
-    assert.ok(!html.includes("キャラを選んでね"));
-    assert.ok(!html.includes("Add Character"));
+    assert.ok(html.includes("Character"));
+    assert.ok(html.includes("Mia"));
+    assert.ok(html.includes("Default"));
+    assert.ok(html.includes("Default character"));
   });
 
-  it("companion mode でもダイアログにキャラ選択 UI が含まれない", () => {
+  it("companion mode でも Character selector が含まれる", () => {
     const html = renderHomeLaunchDialog("companion");
 
-    assert.ok(!html.includes("launch-search-row"));
-    assert.ok(!html.includes("キャラクターを選ぶ"));
-    assert.ok(!html.includes("キャラを選んでね"));
-    assert.ok(!html.includes("Add Character"));
+    assert.ok(html.includes("Character"));
+    assert.ok(html.includes("Mia"));
+  });
+
+  it("Character 0 件なら neutral fallback を表示する", () => {
+    const html = renderHomeLaunchDialog("session", []);
+
+    assert.ok(html.includes("WithMate"));
+    assert.ok(html.includes("Neutral"));
   });
 
 });

--- a/scripts/tests/home-launch-actions.test.ts
+++ b/scripts/tests/home-launch-actions.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
+import type { CharacterCatalogEntry } from "../../src/character/character-catalog.js";
 import type { CompanionSession, CompanionSessionSummary } from "../../src/companion-state.js";
 import { startHomeLaunch } from "../../src/home/home-launch-actions.js";
 import {
@@ -38,7 +39,23 @@ function createReadyDraft(mode: HomeLaunchDraft["mode"] = "session"): HomeLaunch
     mode,
     title: "Task",
     providerId: "codex",
+    characterId: "mia",
   };
+}
+
+function createCharacterEntries(): CharacterCatalogEntry[] {
+  return [{
+    id: "mia",
+    name: "Mia",
+    description: "Character profile",
+    iconFilePath: "character.png",
+    theme: { main: "#222222", sub: "#eeeeee" },
+    state: "active",
+    isDefault: true,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    archivedAt: null,
+  }];
 }
 
 function createCompanionSession(): CompanionSession {
@@ -130,6 +147,7 @@ function createStartHomeLaunchHarness(overrides: Partial<Parameters<typeof start
       launchStarting: false,
       mateState: "active" as const,
       mateProfile: createMateProfile(),
+      characterEntries: createCharacterEntries(),
       selectedProviderId: "codex",
       sessions: [],
       createSession: async () => createSessionSummary(),
@@ -184,9 +202,15 @@ describe("home-launch-actions", () => {
 
   it("session を作成して window を開く", async () => {
     const harness = createStartHomeLaunchHarness();
+    let capturedCharacterId = "";
 
+    harness.input.createSession = async (input) => {
+      capturedCharacterId = input.characterId;
+      return createSessionSummary();
+    };
     await startHomeLaunch(harness.input);
 
+    assert.equal(capturedCharacterId, "mia");
     assert.deepEqual(harness.feedback, ["Session を開始してるよ..."]);
     assert.deepEqual(harness.startingStates, [true, false]);
     assert.equal(harness.closeCount, 1);
@@ -199,6 +223,7 @@ describe("home-launch-actions", () => {
     const harness = createStartHomeLaunchHarness({
       mateState: "not_created",
       mateProfile: null,
+      characterEntries: [],
       createSession: async (input) => {
         capturedCharacterId = input.characterId;
         return createSessionSummary();
@@ -217,9 +242,16 @@ describe("home-launch-actions", () => {
       draft: createReadyDraft("companion"),
       requestedMode: "companion",
     });
+    let capturedCharacter = "";
+
+    harness.input.createCompanionSession = async (input) => {
+      capturedCharacter = input.character;
+      return createCompanionSession();
+    };
 
     await startHomeLaunch(harness.input);
 
+    assert.equal(capturedCharacter, "Mia");
     assert.deepEqual(harness.feedback, ["Companion を開始してるよ..."]);
     assert.deepEqual(harness.startingStates, [true, false]);
     assert.equal(harness.closeCount, 1);

--- a/scripts/tests/home-launch-handlers.test.ts
+++ b/scripts/tests/home-launch-handlers.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type { CharacterCatalogEntry } from "../../src/character/character-catalog.js";
+import { buildHomeLaunchHandlers } from "../../src/home/home-launch-handlers.js";
+import { createClosedLaunchDraft, type HomeLaunchDraft } from "../../src/home/home-launch-state.js";
+import type { ModelCatalogProvider } from "../../src/model-catalog.js";
+
+function createCharacterEntry(partial: Partial<CharacterCatalogEntry> & Pick<CharacterCatalogEntry, "id" | "name">): CharacterCatalogEntry {
+  return {
+    id: partial.id,
+    name: partial.name,
+    description: partial.description ?? "",
+    iconFilePath: partial.iconFilePath ?? "",
+    theme: partial.theme ?? { main: "#6f8cff", sub: "#6fb8c7" },
+    state: partial.state ?? "active",
+    isDefault: partial.isDefault ?? false,
+    createdAt: partial.createdAt ?? "",
+    updatedAt: partial.updatedAt ?? "",
+    archivedAt: partial.archivedAt ?? null,
+  };
+}
+
+function createProvider(): ModelCatalogProvider {
+  return {
+    id: "codex",
+    label: "Codex",
+    defaultModelId: "gpt-5.4",
+    defaultReasoningEffort: "high",
+    models: [{ id: "gpt-5.4", label: "GPT-5.4", reasoningEfforts: ["high"] }],
+  };
+}
+
+describe("home-launch-handlers", () => {
+  it("launch dialog を開く直前に Character catalog を再取得して選択を更新する", async () => {
+    let draft: HomeLaunchDraft = {
+      ...createClosedLaunchDraft(),
+      characterId: "old",
+    };
+    const latestEntries = [
+      createCharacterEntry({ id: "new-default", name: "New Default", isDefault: true }),
+    ];
+    const feedback: string[] = [];
+    let refreshCount = 0;
+
+    const handlers = buildHomeLaunchHandlers({
+      launchDraft: draft,
+      launchStarting: false,
+      mateState: "active",
+      mateProfile: null,
+      enabledLaunchProviders: [createProvider()],
+      characterEntries: [createCharacterEntry({ id: "old", name: "Old" })],
+      selectedLaunchProviderId: "codex",
+      sessions: [],
+      refreshCharacterEntries: async () => {
+        refreshCount += 1;
+        return latestEntries;
+      },
+      setLaunchFeedback: (message) => feedback.push(message),
+      setLaunchStarting: () => undefined,
+      setLaunchDraft: (updater) => {
+        draft = typeof updater === "function" ? updater(draft) : updater;
+      },
+      pickWorkspaceDirectory: async () => null,
+      openSessionWindow: async () => undefined,
+      openCompanionReviewWindow: async () => undefined,
+      createSession: async () => null,
+      createCompanionSession: async () => null,
+      upsertSessionSummary: () => undefined,
+      upsertCompanionSessionSummary: () => undefined,
+    });
+
+    await handlers.onOpenLaunchDialog();
+
+    assert.equal(refreshCount, 1);
+    assert.equal(draft.open, true);
+    assert.equal(draft.characterId, "new-default");
+    assert.deepEqual(feedback, [""]);
+  });
+});

--- a/scripts/tests/home-launch-projection.test.ts
+++ b/scripts/tests/home-launch-projection.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
+import type { CharacterCatalogEntry } from "../../src/character/character-catalog.js";
 import { createDefaultAppSettings } from "../../src/provider-settings-state.js";
 import type { ModelCatalogSnapshot } from "../../src/model-catalog.js";
 import { buildHomeLaunchProjection, inferWorkspaceFromPath } from "../../src/home/home-launch-projection.js";
@@ -27,6 +28,35 @@ function createCatalog(): ModelCatalogSnapshot {
   };
 }
 
+function createCharacters(): CharacterCatalogEntry[] {
+  return [
+    {
+      id: "mia",
+      name: "Mia",
+      description: "default",
+      iconFilePath: "",
+      theme: { main: "#111111", sub: "#eeeeee" },
+      state: "active",
+      isDefault: true,
+      createdAt: "",
+      updatedAt: "",
+      archivedAt: null,
+    },
+    {
+      id: "noa",
+      name: "Noa",
+      description: "",
+      iconFilePath: "",
+      theme: { main: "#222222", sub: "#dddddd" },
+      state: "active",
+      isDefault: false,
+      createdAt: "",
+      updatedAt: "",
+      archivedAt: null,
+    },
+  ];
+}
+
 describe("home-launch-projection", () => {
   it("workspace path から launch workspace を作る", () => {
     assert.deepEqual(inferWorkspaceFromPath("F:/work/demo"), {
@@ -48,12 +78,14 @@ describe("home-launch-projection", () => {
       launchProviderId: "",
       launchTitle: "",
       launchWorkspace: null,
+      characterEntries: createCharacters(),
       appSettings: settings,
       modelCatalog: createCatalog(),
     });
 
     assert.deepEqual(projection.enabledLaunchProviders.map((provider) => provider.id), []);
     assert.equal(projection.selectedLaunchProvider, null);
+    assert.equal(projection.selectedCharacter?.id, "mia");
     assert.equal(projection.canStartSession, false);
   });
 
@@ -69,12 +101,16 @@ describe("home-launch-projection", () => {
       launchProviderId: "",
       launchTitle: "task",
       launchWorkspace: { label: "demo", path: "F:/work/demo", branch: "" },
+      launchCharacterId: "noa",
+      characterEntries: createCharacters(),
       appSettings: settings,
       modelCatalog: createCatalog(),
     });
 
     assert.deepEqual(enabledOnlyCodex.enabledLaunchProviders.map((provider) => provider.id), ["codex"]);
     assert.equal(enabledOnlyCodex.selectedLaunchProvider?.id, "codex");
+    assert.equal(enabledOnlyCodex.selectedCharacter?.id, "noa");
+    assert.deepEqual(enabledOnlyCodex.characterOptions.map((character) => character.id), ["mia", "noa"]);
     assert.equal(enabledOnlyCodex.launchWorkspacePathLabel, "F:/work/demo");
     assert.equal(enabledOnlyCodex.canStartSession, true);
   });
@@ -84,11 +120,13 @@ describe("home-launch-projection", () => {
       launchProviderId: "codex",
       launchTitle: "",
       launchWorkspace: null,
+      characterEntries: [],
       appSettings: createDefaultAppSettings(),
       modelCatalog: createCatalog(),
     });
 
     assert.equal(projection.selectedLaunchProvider?.id, "codex");
+    assert.equal(projection.selectedCharacter, null);
     assert.equal(projection.canStartSession, false);
   });
 });

--- a/scripts/tests/home-launch-projection.test.ts
+++ b/scripts/tests/home-launch-projection.test.ts
@@ -115,6 +115,22 @@ describe("home-launch-projection", () => {
     assert.equal(enabledOnlyCodex.canStartSession, true);
   });
 
+  it("Character catalog 読み込み前は開始不可にする", () => {
+    const projection = buildHomeLaunchProjection({
+      launchProviderId: "codex",
+      launchTitle: "task",
+      launchWorkspace: { label: "demo", path: "F:/work/demo", branch: "" },
+      characterEntries: [],
+      charactersLoaded: false,
+      appSettings: createDefaultAppSettings(),
+      modelCatalog: createCatalog(),
+    });
+
+    assert.equal(projection.charactersLoaded, false);
+    assert.equal(projection.selectedCharacter, null);
+    assert.equal(projection.canStartSession, false);
+  });
+
   it("削除済み launch mode は通常 session と同じ開始条件を使う", () => {
     const projection = buildHomeLaunchProjection({
       launchProviderId: "codex",

--- a/scripts/tests/home-launch-state.test.ts
+++ b/scripts/tests/home-launch-state.test.ts
@@ -5,6 +5,7 @@ import { DEFAULT_APPROVAL_MODE } from "../../src/approval-mode.js";
 import { DEFAULT_CODEX_SANDBOX_MODE } from "../../src/codex-sandbox-mode.js";
 import { DEFAULT_MODEL_ID, DEFAULT_REASONING_EFFORT, type ModelCatalogProvider } from "../../src/model-catalog.js";
 import type { SessionSummary } from "../../src/app-state.js";
+import type { CharacterCatalogEntry } from "../../src/character/character-catalog.js";
 import {
   buildCreateCompanionSessionInputFromLaunchDraft,
   buildCreateSessionInputFromLaunchDraft,
@@ -12,8 +13,10 @@ import {
   createClosedLaunchDraft,
   openLaunchDraft,
   resolveLastUsedSessionSelection,
+  resolveLaunchCharacterId,
   resolveLaunchValidationMessage,
   setLaunchWorkspaceFromPath,
+  updateLaunchDraftForCharacterSelection,
   updateLaunchDraftForProviderSelection,
 } from "../../src/home/home-launch-state.js";
 import type { MateProfile } from "../../src/mate/mate-state.js";
@@ -40,6 +43,21 @@ function createMateProfile(partial: Partial<MateProfile> & Pick<MateProfile, "id
   };
 }
 
+function createCharacterEntry(partial: Partial<CharacterCatalogEntry> & Pick<CharacterCatalogEntry, "id" | "name">): CharacterCatalogEntry {
+  return {
+    id: partial.id,
+    name: partial.name,
+    description: partial.description ?? "",
+    iconFilePath: partial.iconFilePath ?? "",
+    theme: partial.theme ?? { main: "#6f8cff", sub: "#6fb8c7" },
+    state: partial.state ?? "active",
+    isDefault: partial.isDefault ?? false,
+    createdAt: partial.createdAt ?? "",
+    updatedAt: partial.updatedAt ?? "",
+    archivedAt: partial.archivedAt ?? null,
+  };
+}
+
 describe("home-launch-state", () => {
   it("open と close で launch draft を reset する", () => {
     const opened = openLaunchDraft(
@@ -51,6 +69,8 @@ describe("home-launch-state", () => {
         providerId: "old",
       },
       "codex",
+      "session",
+      "mia",
     );
 
     assert.deepEqual(opened, {
@@ -59,6 +79,7 @@ describe("home-launch-state", () => {
       title: "",
       workspace: null,
       providerId: "codex",
+      characterId: "mia",
       model: DEFAULT_MODEL_ID,
       reasoningEffort: DEFAULT_REASONING_EFFORT,
       approvalMode: DEFAULT_APPROVAL_MODE,
@@ -71,6 +92,7 @@ describe("home-launch-state", () => {
       title: "",
       workspace: null,
       providerId: "",
+      characterId: "",
       model: DEFAULT_MODEL_ID,
       reasoningEffort: DEFAULT_REASONING_EFFORT,
       approvalMode: DEFAULT_APPROVAL_MODE,
@@ -123,6 +145,23 @@ describe("home-launch-state", () => {
     assert.equal(draft.providerId, "missing");
     assert.equal(draft.model, "gpt-5.4-mini");
     assert.equal(draft.reasoningEffort, "medium");
+  });
+
+  it("character 選択時に launch draft の characterId を更新する", () => {
+    const draft = updateLaunchDraftForCharacterSelection(createClosedLaunchDraft(), "mia");
+
+    assert.equal(draft.characterId, "mia");
+  });
+
+  it("character selection は既存選択、default順の先頭、空文字の順で解決する", () => {
+    const entries = [
+      createCharacterEntry({ id: "mia", name: "Mia", isDefault: true }),
+      createCharacterEntry({ id: "noa", name: "Noa" }),
+    ];
+
+    assert.equal(resolveLaunchCharacterId(entries, "noa"), "noa");
+    assert.equal(resolveLaunchCharacterId(entries, "missing"), "mia");
+    assert.equal(resolveLaunchCharacterId([], "missing"), "");
   });
 
   it("launch validation message は既存の優先順位で返す", () => {
@@ -190,6 +229,7 @@ describe("home-launch-state", () => {
         title: "  task  ",
         workspace: { label: "demo", path: "F:/work/demo", branch: "main" },
         providerId: "codex",
+        characterId: "mia",
       },
       mateProfile: createMateProfile({
         id: "mate-a",
@@ -200,6 +240,16 @@ describe("home-launch-state", () => {
       }),
       selectedProviderId: "codex",
       approvalMode: DEFAULT_APPROVAL_MODE,
+      characterEntries: [
+        createCharacterEntry({
+          id: "mia",
+          name: "Mia",
+          description: "assistant profile",
+          iconFilePath: "icon.png",
+          theme: { main: "#000000", sub: "#ffffff" },
+          isDefault: true,
+        }),
+      ],
       lastUsedSelection: {
         model: "gpt-5.4-mini",
         reasoningEffort: "medium",
@@ -213,7 +263,7 @@ describe("home-launch-state", () => {
       workspaceLabel: "demo",
       workspacePath: "F:/work/demo",
       branch: "main",
-      characterId: "mate-a",
+      characterId: "mia",
       character: "Mia",
       characterIconPath: "icon.png",
       characterThemeColors: {
@@ -283,6 +333,7 @@ describe("home-launch-state", () => {
         title: "  task  ",
         workspace: { label: "demo", path: "F:/work/demo", branch: "main" },
         providerId: "codex",
+        characterId: "mia",
       },
       mateProfile: createMateProfile({
         id: "mate-a",
@@ -290,6 +341,15 @@ describe("home-launch-state", () => {
         description: "assistant profile",
       }),
       selectedProviderId: "codex",
+      characterEntries: [
+        createCharacterEntry({
+          id: "mia",
+          name: "Mia",
+          description: "assistant profile",
+          iconFilePath: "icon.png",
+          theme: { main: "#000000", sub: "#ffffff" },
+        }),
+      ],
       lastUsedSelection: {
         model: "gpt-5.4-mini",
         reasoningEffort: "medium",

--- a/scripts/tests/home-launch-state.test.ts
+++ b/scripts/tests/home-launch-state.test.ts
@@ -164,6 +164,15 @@ describe("home-launch-state", () => {
     assert.equal(resolveLaunchCharacterId([], "missing"), "");
   });
 
+  it("character selection は archived Character を候補にしない", () => {
+    const entries = [
+      createCharacterEntry({ id: "mia", name: "Mia", state: "archived" }),
+      createCharacterEntry({ id: "noa", name: "Noa" }),
+    ];
+
+    assert.equal(resolveLaunchCharacterId(entries, "mia"), "noa");
+  });
+
   it("launch validation message は既存の優先順位で返す", () => {
     const baseDraft = {
       ...createClosedLaunchDraft(),
@@ -300,6 +309,29 @@ describe("home-launch-state", () => {
     });
   });
 
+  it("archived Character が draft に残っていても active Character で session input を組み立てる", () => {
+    const input = buildCreateSessionInputFromLaunchDraft({
+      draft: {
+        ...createClosedLaunchDraft(),
+        open: true,
+        title: "task",
+        workspace: { label: "demo", path: "F:/work/demo", branch: "main" },
+        providerId: "codex",
+        characterId: "mia",
+      },
+      mateProfile: null,
+      selectedProviderId: "codex",
+      approvalMode: DEFAULT_APPROVAL_MODE,
+      characterEntries: [
+        createCharacterEntry({ id: "mia", name: "Mia", state: "archived" }),
+        createCharacterEntry({ id: "noa", name: "Noa", description: "active profile" }),
+      ],
+    });
+
+    assert.equal(input?.characterId, "noa");
+    assert.equal(input?.character, "Noa");
+  });
+
   it("Mate 未作成でも neutral character で Companion input を組み立てる", () => {
     const input = buildCreateCompanionSessionInputFromLaunchDraft({
       draft: {
@@ -360,6 +392,28 @@ describe("home-launch-state", () => {
     assert.equal(input?.model, "gpt-5.4-mini");
     assert.equal(input?.reasoningEffort, "medium");
     assert.equal(input?.customAgentName, "reviewer");
+  });
+
+  it("active Character がない時だけ Companion input は neutral fallback を使う", () => {
+    const input = buildCreateCompanionSessionInputFromLaunchDraft({
+      draft: {
+        ...createClosedLaunchDraft(),
+        open: true,
+        mode: "companion",
+        title: "task",
+        workspace: { label: "demo", path: "F:/work/demo", branch: "main" },
+        providerId: "codex",
+        characterId: "mia",
+      },
+      mateProfile: null,
+      selectedProviderId: "codex",
+      characterEntries: [
+        createCharacterEntry({ id: "mia", name: "Mia", state: "archived" }),
+      ],
+    });
+
+    assert.equal(input?.characterId, "withmate-neutral-character");
+    assert.equal(input?.character, "WithMate");
   });
 
   it("selected provider の直近 session から last-used selection を引く", () => {

--- a/src/HomeApp.tsx
+++ b/src/HomeApp.tsx
@@ -15,6 +15,7 @@ import {
 import { buildHomeLaunchDialogProps } from "./home/home-launch-dialog-props.js";
 import {
   createClosedLaunchDraft,
+  resolveLaunchCharacterId,
   type HomeLaunchDraft,
 } from "./home/home-launch-state.js";
 import { resolveSelectedLaunchProviderDraftId } from "./launch/launch-provider-selection.js";
@@ -135,6 +136,10 @@ export default function HomeApp() {
     preferredCharacterId?: string | null,
   ) => {
     setCharacterEntries(entries);
+    setLaunchDraft((current) => ({
+      ...current,
+      characterId: resolveLaunchCharacterId(entries, current.characterId),
+    }));
     const nextSelectedCharacterId = resolveSettingsCharacterSelection(entries, preferredCharacterId ?? selectedCharacterId);
     setSelectedCharacterId(nextSelectedCharacterId);
 
@@ -279,10 +284,12 @@ export default function HomeApp() {
       launchMode: launchDraft.mode,
       launchTitle: launchDraft.title,
       launchWorkspace: launchDraft.workspace,
+      launchCharacterId: launchDraft.characterId,
+      characterEntries,
       appSettings,
       modelCatalog,
     }),
-    [appSettings, launchDraft, modelCatalog],
+    [appSettings, characterEntries, launchDraft, modelCatalog],
   );
   const { enabledLaunchProviders, selectedLaunchProvider } = launchProjection;
 
@@ -312,6 +319,7 @@ export default function HomeApp() {
     mateState,
     mateProfile,
     enabledLaunchProviders,
+    characterEntries,
     selectedLaunchProviderId: selectedLaunchProvider?.id ?? null,
     sessions,
     setLaunchFeedback,
@@ -645,6 +653,7 @@ export default function HomeApp() {
       onChangeTitle: homeLaunchHandlers.onChangeTitle,
       onBrowseWorkspace: () => void homeLaunchHandlers.onBrowseWorkspace(),
       onSelectProvider: homeLaunchHandlers.onSelectLaunchProvider,
+      onSelectCharacter: homeLaunchHandlers.onSelectLaunchCharacter,
       onStartSession: (mode) => void homeLaunchHandlers.onStartSession(mode),
     }),
   });

--- a/src/HomeApp.tsx
+++ b/src/HomeApp.tsx
@@ -89,6 +89,7 @@ export default function HomeApp() {
   const [settingsDraft, setSettingsDraft] = useState<AppSettings>(createDefaultAppSettings());
   const [modelCatalog, setModelCatalog] = useState<ModelCatalogSnapshot | null>(null);
   const [characterEntries, setCharacterEntries] = useState<CharacterCatalogEntry[]>([]);
+  const [charactersLoaded, setCharactersLoaded] = useState(false);
   const [selectedCharacterId, setSelectedCharacterId] = useState<string | null>(null);
   const [selectedCharacterDetail, setSelectedCharacterDetail] = useState<CharacterDetail | null>(null);
   const [characterDraft, setCharacterDraft] = useState<SettingsCharacterEditorDraft>(() => createNewCharacterEditorDraft());
@@ -159,9 +160,11 @@ export default function HomeApp() {
   const refreshCharacterEntries = async (
     api: NonNullable<ReturnType<typeof getWithMateApi>>,
     preferredCharacterId?: string | null,
-  ) => {
+  ): Promise<CharacterCatalogEntry[]> => {
     const entries = await api.listCharacters();
     await applyLoadedCharacterEntries(api, entries, preferredCharacterId);
+    setCharactersLoaded(true);
+    return entries;
   };
 
   useEffect(() => {
@@ -286,10 +289,11 @@ export default function HomeApp() {
       launchWorkspace: launchDraft.workspace,
       launchCharacterId: launchDraft.characterId,
       characterEntries,
+      charactersLoaded,
       appSettings,
       modelCatalog,
     }),
-    [appSettings, characterEntries, launchDraft, modelCatalog],
+    [appSettings, characterEntries, charactersLoaded, launchDraft, modelCatalog],
   );
   const { enabledLaunchProviders, selectedLaunchProvider } = launchProjection;
 
@@ -322,6 +326,13 @@ export default function HomeApp() {
     characterEntries,
     selectedLaunchProviderId: selectedLaunchProvider?.id ?? null,
     sessions,
+    refreshCharacterEntries: async () => {
+      const api = getWithMateApi();
+      if (!api) {
+        throw new Error("Character 一覧の再読み込みには desktop runtime が必要だよ。");
+      }
+      return refreshCharacterEntries(api);
+    },
     setLaunchFeedback,
     setLaunchStarting,
     setLaunchDraft,

--- a/src/home/HomeLaunchDialog.tsx
+++ b/src/home/HomeLaunchDialog.tsx
@@ -3,7 +3,10 @@ import { useRef } from "react";
 import { focusRovingItemByKey, useDialogA11y } from "../a11y.js";
 import { LaunchDialogFooter, LaunchDialogShell } from "../launch/launch-dialog-shell.js";
 import { ProviderLaunchField } from "../launch/provider-launch-picker.js";
+import { buildCharacterThemeStyle } from "../theme-utils.js";
+import { CharacterAvatar } from "../ui-utils.js";
 import type { LaunchWorkspace } from "./home-launch-projection.js";
+import type { CharacterCatalogEntry } from "../character/character-catalog.js";
 
 export type HomeLaunchDialogProps = {
   open: boolean;
@@ -13,6 +16,8 @@ export type HomeLaunchDialogProps = {
   launchWorkspacePathLabel: string;
   enabledLaunchProviders: Array<{ id: string; label: string }>;
   selectedLaunchProviderId: string | null;
+  characterOptions: CharacterCatalogEntry[];
+  selectedCharacterId: string | null;
   canStartSession: boolean;
   launchFeedback: string;
   launchStarting: boolean;
@@ -21,6 +26,7 @@ export type HomeLaunchDialogProps = {
   onChangeTitle: (value: string) => void;
   onBrowseWorkspace: () => void;
   onSelectProvider: (providerId: string) => void;
+  onSelectCharacter: (characterId: string) => void;
   onStartSession: (mode: "session" | "companion") => void;
 };
 
@@ -32,6 +38,8 @@ export function HomeLaunchDialog({
   launchWorkspacePathLabel,
   enabledLaunchProviders,
   selectedLaunchProviderId,
+  characterOptions,
+  selectedCharacterId,
   canStartSession,
   launchFeedback,
   launchStarting,
@@ -40,6 +48,7 @@ export function HomeLaunchDialog({
   onChangeTitle,
   onBrowseWorkspace,
   onSelectProvider,
+  onSelectCharacter,
   onStartSession,
 }: HomeLaunchDialogProps) {
   const titleInputRef = useRef<HTMLInputElement | null>(null);
@@ -133,6 +142,53 @@ export function HomeLaunchDialog({
         selectedProviderId={selectedLaunchProviderId}
         onSelectProvider={onSelectProvider}
       />
+
+      <section className="launch-section minimal">
+        <div className="launch-field">
+          <span className="launch-field-label">Character</span>
+          {characterOptions.length === 0 ? (
+            <div className="launch-character-neutral">
+              <span className="character-avatar tiny" aria-hidden="true">W</span>
+              <div className="launch-character-copy">
+                <strong>WithMate</strong>
+                <span>Neutral</span>
+              </div>
+            </div>
+          ) : (
+            <div
+              className="launch-character-list"
+              role="radiogroup"
+              aria-label="Character"
+              onKeyDown={(event) => {
+                focusRovingItemByKey(event, { orientation: "vertical", activateOnFocus: true });
+              }}
+            >
+              {characterOptions.map((character) => (
+                <button
+                  key={character.id}
+                  className={`launch-character-option${character.id === selectedCharacterId ? " selected" : ""}`}
+                  type="button"
+                  role="radio"
+                  aria-checked={character.id === selectedCharacterId}
+                  tabIndex={character.id === selectedCharacterId ? 0 : -1}
+                  style={buildCharacterThemeStyle(character.theme)}
+                  onClick={() => onSelectCharacter(character.id)}
+                >
+                  <CharacterAvatar
+                    character={{ name: character.name, iconPath: character.iconFilePath }}
+                    size="tiny"
+                  />
+                  <span className="launch-character-copy">
+                    <strong>{character.name}</strong>
+                    <span>{character.description || character.id}</span>
+                  </span>
+                  {character.isDefault ? <span className="launch-character-badge">Default</span> : null}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
     </LaunchDialogShell>
   );
 }

--- a/src/home/HomeLaunchDialog.tsx
+++ b/src/home/HomeLaunchDialog.tsx
@@ -18,6 +18,7 @@ export type HomeLaunchDialogProps = {
   selectedLaunchProviderId: string | null;
   characterOptions: CharacterCatalogEntry[];
   selectedCharacterId: string | null;
+  charactersLoaded: boolean;
   canStartSession: boolean;
   launchFeedback: string;
   launchStarting: boolean;
@@ -40,6 +41,7 @@ export function HomeLaunchDialog({
   selectedLaunchProviderId,
   characterOptions,
   selectedCharacterId,
+  charactersLoaded,
   canStartSession,
   launchFeedback,
   launchStarting,
@@ -146,7 +148,15 @@ export function HomeLaunchDialog({
       <section className="launch-section minimal">
         <div className="launch-field">
           <span className="launch-field-label">Character</span>
-          {characterOptions.length === 0 ? (
+          {!charactersLoaded ? (
+            <div className="launch-character-neutral">
+              <span className="character-avatar tiny" aria-hidden="true">W</span>
+              <div className="launch-character-copy">
+                <strong>読み込み中</strong>
+                <span>Character を読み込んでるよ...</span>
+              </div>
+            </div>
+          ) : characterOptions.length === 0 ? (
             <div className="launch-character-neutral">
               <span className="character-avatar tiny" aria-hidden="true">W</span>
               <div className="launch-character-copy">

--- a/src/home/home-launch-actions.ts
+++ b/src/home/home-launch-actions.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_APPROVAL_MODE } from "../approval-mode.js";
+import type { CharacterCatalogEntry } from "../character/character-catalog.js";
 import type { CompanionSession, CompanionSessionSummary, CreateCompanionSessionInput } from "../companion-state.js";
 import { createCompanionSessionSummary } from "../companion-state.js";
 import type { MateProfile, MateStorageState } from "../mate/mate-state.js";
@@ -22,6 +23,7 @@ export type StartHomeLaunchInput = {
   launchStarting: boolean;
   mateState: MateStorageState | null;
   mateProfile: MateProfile | null;
+  characterEntries: readonly CharacterCatalogEntry[];
   selectedProviderId: string | null;
   sessions: readonly SessionSummary[];
   createSession: HomeLaunchSessionCreator;
@@ -62,6 +64,7 @@ export async function startHomeLaunch(input: StartHomeLaunchInput): Promise<void
         draft: input.draft,
         mateProfile: input.mateProfile,
         selectedProviderId: input.selectedProviderId,
+        characterEntries: input.characterEntries,
         lastUsedSelection,
       });
       if (!companionInput) {
@@ -86,6 +89,7 @@ export async function startHomeLaunch(input: StartHomeLaunchInput): Promise<void
       mateProfile: input.mateProfile,
       selectedProviderId: input.selectedProviderId,
       approvalMode: DEFAULT_APPROVAL_MODE,
+      characterEntries: input.characterEntries,
       lastUsedSelection,
     });
     if (!sessionInput) {

--- a/src/home/home-launch-dialog-props.ts
+++ b/src/home/home-launch-dialog-props.ts
@@ -13,6 +13,7 @@ type HomeLaunchDialogPropsInput = {
   onChangeTitle: (value: string) => void;
   onBrowseWorkspace: () => void;
   onSelectProvider: (providerId: string) => void;
+  onSelectCharacter: (characterId: string) => void;
   onStartSession: (mode: HomeLaunchDraft["mode"]) => void;
 };
 
@@ -27,6 +28,7 @@ export function buildHomeLaunchDialogProps({
   onChangeTitle,
   onBrowseWorkspace,
   onSelectProvider,
+  onSelectCharacter,
   onStartSession,
 }: HomeLaunchDialogPropsInput): HomeLaunchDialogProps {
   return {
@@ -37,6 +39,8 @@ export function buildHomeLaunchDialogProps({
     launchWorkspacePathLabel: projection.launchWorkspacePathLabel,
     enabledLaunchProviders: projection.enabledLaunchProviders,
     selectedLaunchProviderId: projection.selectedLaunchProvider?.id ?? null,
+    characterOptions: projection.characterOptions,
+    selectedCharacterId: projection.selectedCharacter?.id ?? null,
     canStartSession: projection.canStartSession && canUsePrimaryFeatures,
     launchFeedback,
     launchStarting,
@@ -45,6 +49,7 @@ export function buildHomeLaunchDialogProps({
     onChangeTitle,
     onBrowseWorkspace,
     onSelectProvider,
+    onSelectCharacter,
     onStartSession,
   };
 }

--- a/src/home/home-launch-dialog-props.ts
+++ b/src/home/home-launch-dialog-props.ts
@@ -41,6 +41,7 @@ export function buildHomeLaunchDialogProps({
     selectedLaunchProviderId: projection.selectedLaunchProvider?.id ?? null,
     characterOptions: projection.characterOptions,
     selectedCharacterId: projection.selectedCharacter?.id ?? null,
+    charactersLoaded: projection.charactersLoaded,
     canStartSession: projection.canStartSession && canUsePrimaryFeatures,
     launchFeedback,
     launchStarting,

--- a/src/home/home-launch-handlers.ts
+++ b/src/home/home-launch-handlers.ts
@@ -24,6 +24,7 @@ type HomeLaunchHandlersContext = {
   characterEntries: readonly CharacterCatalogEntry[];
   selectedLaunchProviderId: string | null;
   sessions: readonly SessionSummary[];
+  refreshCharacterEntries: () => Promise<readonly CharacterCatalogEntry[]>;
   setLaunchFeedback: (message: string) => void;
   setLaunchStarting: (launchStarting: boolean) => void;
   setLaunchDraft: (updater: HomeLaunchDraft | ((draft: HomeLaunchDraft) => HomeLaunchDraft)) => void;
@@ -38,7 +39,7 @@ type HomeLaunchHandlersContext = {
 
 export type HomeLaunchHandlers = {
   onBrowseWorkspace: () => void;
-  onOpenLaunchDialog: () => void;
+  onOpenLaunchDialog: () => Promise<void>;
   onCloseLaunchDialog: () => void;
   onSelectLaunchProvider: (providerId: string) => void;
   onSelectLaunchCharacter: (characterId: string) => void;
@@ -56,6 +57,7 @@ export function buildHomeLaunchHandlers({
   characterEntries,
   selectedLaunchProviderId,
   sessions,
+  refreshCharacterEntries,
   setLaunchFeedback,
   setLaunchStarting,
   setLaunchDraft,
@@ -77,14 +79,18 @@ export function buildHomeLaunchHandlers({
     setLaunchDraft((current) => setLaunchWorkspaceFromPath(current, selectedPath));
   };
 
-  const onOpenLaunchDialog = () => {
+  const onOpenLaunchDialog = async () => {
     setLaunchFeedback("");
+    const latestCharacterEntries = await refreshCharacterEntries().catch((error) => {
+      setLaunchFeedback(error instanceof Error ? error.message : "Character 一覧の再読み込みに失敗したよ。");
+      return characterEntries;
+    });
     setLaunchDraft((current) =>
       openLaunchDraft(
         current,
         enabledLaunchProviders[0]?.id ?? "",
         "session",
-        resolveLaunchCharacterId(characterEntries, current.characterId),
+        resolveLaunchCharacterId(latestCharacterEntries, current.characterId),
       ),
     );
   };

--- a/src/home/home-launch-handlers.ts
+++ b/src/home/home-launch-handlers.ts
@@ -1,4 +1,5 @@
 import type { CompanionSessionSummary } from "../companion-state.js";
+import type { CharacterCatalogEntry } from "../character/character-catalog.js";
 import type { CreateSessionInput, SessionSummary } from "../session-state.js";
 import type { MateProfile, MateStorageState } from "../mate/mate-state.js";
 import type { CreateCompanionSessionInput, CompanionSession } from "../companion-state.js";
@@ -7,7 +8,9 @@ import type { HomeLaunchDraft } from "./home-launch-state.js";
 import {
   closeLaunchDraft,
   openLaunchDraft,
+  resolveLaunchCharacterId,
   setLaunchWorkspaceFromPath,
+  updateLaunchDraftForCharacterSelection,
   updateLaunchDraftForProviderSelection,
 } from "./home-launch-state.js";
 import { startHomeLaunch } from "./home-launch-actions.js";
@@ -18,6 +21,7 @@ type HomeLaunchHandlersContext = {
   mateState: MateStorageState | null;
   mateProfile: MateProfile | null;
   enabledLaunchProviders: readonly ModelCatalogProvider[];
+  characterEntries: readonly CharacterCatalogEntry[];
   selectedLaunchProviderId: string | null;
   sessions: readonly SessionSummary[];
   setLaunchFeedback: (message: string) => void;
@@ -37,6 +41,7 @@ export type HomeLaunchHandlers = {
   onOpenLaunchDialog: () => void;
   onCloseLaunchDialog: () => void;
   onSelectLaunchProvider: (providerId: string) => void;
+  onSelectLaunchCharacter: (characterId: string) => void;
   onChangeMode: (mode: HomeLaunchDraft["mode"]) => void;
   onChangeTitle: (value: string) => void;
   onStartSession: (mode?: HomeLaunchDraft["mode"]) => void;
@@ -48,6 +53,7 @@ export function buildHomeLaunchHandlers({
   mateState,
   mateProfile,
   enabledLaunchProviders,
+  characterEntries,
   selectedLaunchProviderId,
   sessions,
   setLaunchFeedback,
@@ -73,7 +79,14 @@ export function buildHomeLaunchHandlers({
 
   const onOpenLaunchDialog = () => {
     setLaunchFeedback("");
-    setLaunchDraft((current) => openLaunchDraft(current, enabledLaunchProviders[0]?.id ?? ""));
+    setLaunchDraft((current) =>
+      openLaunchDraft(
+        current,
+        enabledLaunchProviders[0]?.id ?? "",
+        "session",
+        resolveLaunchCharacterId(characterEntries, current.characterId),
+      ),
+    );
   };
 
   const onCloseLaunchDialog = () => {
@@ -95,6 +108,7 @@ export function buildHomeLaunchHandlers({
       mateState,
       mateProfile,
       selectedProviderId: selectedLaunchProviderId,
+      characterEntries,
       sessions,
       createSession,
       createCompanionSession,
@@ -113,6 +127,10 @@ export function buildHomeLaunchHandlers({
     onOpenLaunchDialog,
     onCloseLaunchDialog,
     onSelectLaunchProvider,
+    onSelectLaunchCharacter: (characterId) => {
+      setLaunchFeedback("");
+      setLaunchDraft((current) => updateLaunchDraftForCharacterSelection(current, characterId));
+    },
     onChangeMode: (mode) => {
       setLaunchFeedback("");
       setLaunchDraft((current) => ({ ...current, mode }));

--- a/src/home/home-launch-projection.ts
+++ b/src/home/home-launch-projection.ts
@@ -1,6 +1,8 @@
+import type { CharacterCatalogEntry } from "../character/character-catalog.js";
 import type { ModelCatalogProvider, ModelCatalogSnapshot } from "../model-catalog.js";
 import { getProviderAppSettings, type AppSettings } from "../provider-settings-state.js";
 import { resolveSelectedLaunchProviderId } from "../launch/launch-provider-selection.js";
+import { resolveLaunchCharacterId } from "./home-launch-state.js";
 
 export type LaunchWorkspace = {
   label: string;
@@ -11,6 +13,8 @@ export type LaunchWorkspace = {
 export type HomeLaunchProjection = {
   enabledLaunchProviders: ModelCatalogProvider[];
   selectedLaunchProvider: ModelCatalogProvider | null;
+  characterOptions: CharacterCatalogEntry[];
+  selectedCharacter: CharacterCatalogEntry | null;
   launchWorkspacePathLabel: string;
   canStartSession: boolean;
 };
@@ -32,6 +36,8 @@ export function buildHomeLaunchProjection({
   launchMode,
   launchTitle,
   launchWorkspace,
+  launchCharacterId,
+  characterEntries = [],
   appSettings,
   modelCatalog,
 }: {
@@ -39,6 +45,8 @@ export function buildHomeLaunchProjection({
   launchMode?: "session" | "companion";
   launchTitle: string;
   launchWorkspace: LaunchWorkspace | null;
+  launchCharacterId?: string;
+  characterEntries?: readonly CharacterCatalogEntry[];
   appSettings: AppSettings;
   modelCatalog: ModelCatalogSnapshot | null;
 }): HomeLaunchProjection {
@@ -48,10 +56,16 @@ export function buildHomeLaunchProjection({
   const selectedLaunchProviderId = resolveSelectedLaunchProviderId(enabledLaunchProviders, launchProviderId);
   const selectedLaunchProvider =
     enabledLaunchProviders.find((provider) => provider.id === selectedLaunchProviderId) ?? null;
+  const activeCharacterEntries = characterEntries.filter((character) => character.state === "active");
+  const selectedCharacterId = resolveLaunchCharacterId(activeCharacterEntries, launchCharacterId);
+  const selectedCharacter =
+    activeCharacterEntries.find((character) => character.id === selectedCharacterId) ?? null;
 
   return {
     enabledLaunchProviders,
     selectedLaunchProvider,
+    characterOptions: [...activeCharacterEntries],
+    selectedCharacter,
     launchWorkspacePathLabel: launchWorkspace ? launchWorkspace.path : "workspace",
     canStartSession: !!launchTitle.trim() && !!launchWorkspace && !!selectedLaunchProvider,
   };

--- a/src/home/home-launch-projection.ts
+++ b/src/home/home-launch-projection.ts
@@ -15,6 +15,7 @@ export type HomeLaunchProjection = {
   selectedLaunchProvider: ModelCatalogProvider | null;
   characterOptions: CharacterCatalogEntry[];
   selectedCharacter: CharacterCatalogEntry | null;
+  charactersLoaded: boolean;
   launchWorkspacePathLabel: string;
   canStartSession: boolean;
 };
@@ -38,6 +39,7 @@ export function buildHomeLaunchProjection({
   launchWorkspace,
   launchCharacterId,
   characterEntries = [],
+  charactersLoaded = true,
   appSettings,
   modelCatalog,
 }: {
@@ -47,6 +49,7 @@ export function buildHomeLaunchProjection({
   launchWorkspace: LaunchWorkspace | null;
   launchCharacterId?: string;
   characterEntries?: readonly CharacterCatalogEntry[];
+  charactersLoaded?: boolean;
   appSettings: AppSettings;
   modelCatalog: ModelCatalogSnapshot | null;
 }): HomeLaunchProjection {
@@ -66,7 +69,8 @@ export function buildHomeLaunchProjection({
     selectedLaunchProvider,
     characterOptions: [...activeCharacterEntries],
     selectedCharacter,
+    charactersLoaded,
     launchWorkspacePathLabel: launchWorkspace ? launchWorkspace.path : "workspace",
-    canStartSession: !!launchTitle.trim() && !!launchWorkspace && !!selectedLaunchProvider,
+    canStartSession: charactersLoaded && !!launchTitle.trim() && !!launchWorkspace && !!selectedLaunchProvider,
   };
 }

--- a/src/home/home-launch-state.ts
+++ b/src/home/home-launch-state.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_APPROVAL_MODE, type ApprovalMode } from "../approval-mode.js";
 import type { CreateSessionInput, SessionSummary } from "../app-state.js";
 import { DEFAULT_CHARACTER_THEME_COLORS, type CharacterThemeColors } from "../character-state.js";
+import type { CharacterCatalogEntry } from "../character/character-catalog.js";
 import { DEFAULT_CODEX_SANDBOX_MODE, type CodexSandboxMode } from "../codex-sandbox-mode.js";
 import type { CreateCompanionSessionInput } from "../companion-state.js";
 import { inferWorkspaceFromPath, type LaunchWorkspace } from "./home-launch-projection.js";
@@ -35,6 +36,7 @@ export type HomeLaunchDraft = {
   title: string;
   workspace: LaunchWorkspace | null;
   providerId: string;
+  characterId: string;
   model: string;
   reasoningEffort: ModelReasoningEffort;
   approvalMode: ApprovalMode;
@@ -48,6 +50,7 @@ export function createClosedLaunchDraft(): HomeLaunchDraft {
     title: "",
     workspace: null,
     providerId: "",
+    characterId: "",
     model: DEFAULT_MODEL_ID,
     reasoningEffort: DEFAULT_REASONING_EFFORT,
     approvalMode: DEFAULT_APPROVAL_MODE,
@@ -59,6 +62,7 @@ export function openLaunchDraft(
   draft: HomeLaunchDraft,
   defaultProviderId: string,
   mode: HomeLaunchDraft["mode"] = "session",
+  defaultCharacterId = "",
 ): HomeLaunchDraft {
   return {
     ...draft,
@@ -67,6 +71,7 @@ export function openLaunchDraft(
     title: "",
     workspace: null,
     providerId: defaultProviderId,
+    characterId: defaultCharacterId,
     model: DEFAULT_MODEL_ID,
     reasoningEffort: DEFAULT_REASONING_EFFORT,
     approvalMode: draft.approvalMode,
@@ -79,17 +84,19 @@ export function buildCreateCompanionSessionInputFromLaunchDraft({
   mateProfile,
   selectedProviderId,
   lastUsedSelection,
+  characterEntries = [],
 }: {
   draft: HomeLaunchDraft;
   mateProfile: MateProfile | null;
   selectedProviderId: string | null;
   lastUsedSelection?: Pick<CreateSessionInput, "model" | "reasoningEffort" | "customAgentName"> | null;
+  characterEntries?: readonly CharacterCatalogEntry[];
 }): CreateCompanionSessionInput | null {
   const normalizedTitle = draft.title.trim();
   if (!normalizedTitle || !draft.workspace || !selectedProviderId) {
     return null;
   }
-  const characterSnapshot = buildLaunchCharacterSnapshot(mateProfile);
+  const characterSnapshot = buildLaunchCharacterSnapshot(characterEntries, draft.characterId);
 
   const companionModel = draft.mode === "companion"
     ? lastUsedSelection?.model ?? draft.model
@@ -122,6 +129,7 @@ export function closeLaunchDraft(draft: HomeLaunchDraft): HomeLaunchDraft {
     title: "",
     workspace: null,
     providerId: "",
+    characterId: "",
   };
 }
 
@@ -148,6 +156,16 @@ export function updateLaunchDraftForProviderSelection(
     providerId,
     model: model?.id ?? draft.model,
     reasoningEffort: model?.reasoningEfforts[0] ?? provider?.defaultReasoningEffort ?? draft.reasoningEffort,
+  };
+}
+
+export function updateLaunchDraftForCharacterSelection(
+  draft: HomeLaunchDraft,
+  characterId: string,
+): HomeLaunchDraft {
+  return {
+    ...draft,
+    characterId,
   };
 }
 
@@ -201,18 +219,20 @@ export function buildCreateSessionInputFromLaunchDraft({
   selectedProviderId,
   approvalMode,
   lastUsedSelection,
+  characterEntries = [],
 }: {
   draft: HomeLaunchDraft;
   mateProfile: MateProfile | null;
   selectedProviderId: string | null;
   approvalMode: ApprovalMode;
   lastUsedSelection?: Pick<CreateSessionInput, "model" | "reasoningEffort" | "customAgentName"> | null;
+  characterEntries?: readonly CharacterCatalogEntry[];
 }): CreateSessionInput | null {
   const normalizedTitle = draft.title.trim();
   if (!normalizedTitle || !draft.workspace || !selectedProviderId) {
     return null;
   }
-  const characterSnapshot = buildLaunchCharacterSnapshot(mateProfile);
+  const characterSnapshot = buildLaunchCharacterSnapshot(characterEntries, draft.characterId);
 
   return {
     provider: selectedProviderId,
@@ -231,8 +251,31 @@ export function buildCreateSessionInputFromLaunchDraft({
   };
 }
 
-function buildLaunchCharacterSnapshot(mateProfile: MateProfile | null): LaunchCharacterSnapshot {
-  if (!mateProfile) {
+export function resolveLaunchCharacterId(
+  entries: readonly CharacterCatalogEntry[],
+  currentCharacterId: string | null | undefined,
+): string {
+  if (currentCharacterId && entries.some((entry) => entry.id === currentCharacterId)) {
+    return currentCharacterId;
+  }
+
+  return entries[0]?.id ?? "";
+}
+
+function resolveLaunchCharacterEntry(
+  entries: readonly CharacterCatalogEntry[],
+  characterId: string | null | undefined,
+): CharacterCatalogEntry | null {
+  const resolvedCharacterId = resolveLaunchCharacterId(entries, characterId);
+  return entries.find((entry) => entry.id === resolvedCharacterId) ?? null;
+}
+
+function buildLaunchCharacterSnapshot(
+  entries: readonly CharacterCatalogEntry[],
+  characterId: string | null | undefined,
+): LaunchCharacterSnapshot {
+  const character = resolveLaunchCharacterEntry(entries, characterId);
+  if (!character) {
     return {
       characterId: NEUTRAL_CHARACTER_ID,
       character: NEUTRAL_CHARACTER_NAME,
@@ -243,19 +286,13 @@ function buildLaunchCharacterSnapshot(mateProfile: MateProfile | null): LaunchCh
   }
 
   return {
-    characterId: mateProfile.id,
-    character: mateProfile.displayName,
-    characterRoleMarkdown: mateProfile.description ?? "",
-    characterIconPath: mateProfile.avatarFilePath,
-    characterThemeColors: buildCharacterThemeColorsFromMateProfile(mateProfile),
-  };
-}
-
-function buildCharacterThemeColorsFromMateProfile(
-  mateProfile: Pick<MateProfile, "themeMain" | "themeSub">,
-): CharacterThemeColors {
-  return {
-    main: mateProfile.themeMain || "#000000",
-    sub: mateProfile.themeSub || "#ffffff",
+    characterId: character.id,
+    character: character.name,
+    characterRoleMarkdown: character.description,
+    characterIconPath: character.iconFilePath,
+    characterThemeColors: {
+      main: character.theme.main,
+      sub: character.theme.sub,
+    },
   };
 }

--- a/src/home/home-launch-state.ts
+++ b/src/home/home-launch-state.ts
@@ -255,11 +255,12 @@ export function resolveLaunchCharacterId(
   entries: readonly CharacterCatalogEntry[],
   currentCharacterId: string | null | undefined,
 ): string {
-  if (currentCharacterId && entries.some((entry) => entry.id === currentCharacterId)) {
+  const activeEntries = entries.filter((entry) => entry.state === "active");
+  if (currentCharacterId && activeEntries.some((entry) => entry.id === currentCharacterId)) {
     return currentCharacterId;
   }
 
-  return entries[0]?.id ?? "";
+  return activeEntries[0]?.id ?? "";
 }
 
 function resolveLaunchCharacterEntry(
@@ -267,7 +268,7 @@ function resolveLaunchCharacterEntry(
   characterId: string | null | undefined,
 ): CharacterCatalogEntry | null {
   const resolvedCharacterId = resolveLaunchCharacterId(entries, characterId);
-  return entries.find((entry) => entry.id === resolvedCharacterId) ?? null;
+  return entries.find((entry) => entry.state === "active" && entry.id === resolvedCharacterId) ?? null;
 }
 
 function buildLaunchCharacterSnapshot(

--- a/src/styles.css
+++ b/src/styles.css
@@ -2415,6 +2415,70 @@ button:disabled {
   justify-content: flex-end;
 }
 
+.launch-character-list {
+  display: grid;
+  gap: 8px;
+}
+
+.launch-character-option,
+.launch-character-neutral {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid rgba(203, 213, 225, 0.12);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--ink);
+  text-align: left;
+}
+
+.launch-character-option {
+  font: inherit;
+  cursor: pointer;
+}
+
+.launch-character-option:hover,
+.launch-character-option.selected {
+  border-color: color-mix(in srgb, var(--character-main) 42%, rgba(203, 213, 225, 0.18));
+  background: color-mix(in srgb, var(--character-main-soft) 34%, rgba(255, 255, 255, 0.04));
+}
+
+.launch-character-copy {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.launch-character-copy strong,
+.launch-character-copy span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.launch-character-copy strong {
+  color: var(--ink);
+  font-size: 0.9rem;
+}
+
+.launch-character-copy span {
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.launch-character-badge {
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--character-sub-soft) 64%, rgba(255, 255, 255, 0.04));
+  color: color-mix(in srgb, var(--ink) 88%, var(--character-sub) 12%);
+  font-size: 0.66rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
 .settings-provider-input span {
   color: var(--muted);
   font-size: 0.78rem;


### PR DESCRIPTION
## Summary
- Home launch dialog に Character selector を追加
- default Character を初期選択し、選択 Character の name / icon / theme を session / companion 作成 payload へ渡す
- Character 0 件時は neutral fallback を維持

## Scope
- Branch5: `feat/v5-character-launch-selection`
- Home / New Session / Companion 起動時の Character selection
- 既存の Character storage / IPC catalog を利用

## Non-goals
- session / companion の CharacterRuntimeSnapshot 保存
- runtime prompt injection
- `character.md` 本文の prompt 合成
- Character Update Workspace
- Character 定義自動生成

## Verification
- `npm run typecheck`
- `node --import tsx --test scripts/tests/home-launch-state.test.ts scripts/tests/home-launch-projection.test.ts scripts/tests/home-launch-actions.test.ts scripts/tests/home-components.test.tsx scripts/tests/home-launch-commands.test.ts`
- `git diff --check`