### PR TITLE
[codex] キャラ編集画面を全ウィンドウ表示にする

### DIFF
--- a/src-electron/window-defaults.ts
+++ b/src-electron/window-defaults.ts
@@ -34,7 +34,7 @@ export const COMPANION_REVIEW_WINDOW_DEFAULT_BOUNDS = {
 } as const;
 
 export const CHARACTER_EDITOR_WINDOW_DEFAULT_BOUNDS = {
-  width: 980,
+  width: 1280,
   height: 920,
   minWidth: 820,
   minHeight: 680,

--- a/src/CharacterEditorApp.tsx
+++ b/src/CharacterEditorApp.tsx
@@ -283,7 +283,7 @@ export default function CharacterEditorApp() {
 
   return (
     <div className="page-shell character-editor-page" style={themeStyle}>
-      <section className="panel character-editor-window rise-2">
+      <section className="character-editor-window">
         <header className="character-editor-window-header">
           <div className="character-editor-heading">
             <CharacterAvatar character={{ name: draft.name, iconPath: draft.iconFilePath }} size="large" />

--- a/src/styles.css
+++ b/src/styles.css
@@ -6585,9 +6585,11 @@ button:disabled {
 .character-editor-window {
   display: grid;
   grid-template-rows: auto auto minmax(0, 1fr) auto;
-  width: min(100%, 1120px);
-  min-height: min(880px, calc(100vh - 32px));
+  width: 100%;
+  height: 100%;
+  min-height: 0;
   overflow: hidden;
+  background: var(--surface);
 }
 
 .character-editor-window-header,
@@ -6640,20 +6642,20 @@ button:disabled {
 }
 
 .character-editor-header-actions,
-.character-editor-tabs {
+.character-editor-window .character-editor-tabs {
   display: inline-flex;
   align-items: center;
   gap: 8px;
   flex: 0 0 auto;
 }
 
-.character-editor-tabs {
+.character-editor-window .character-editor-tabs {
   padding: 12px 22px;
   border-bottom: 1px solid var(--line);
   overflow-x: auto;
 }
 
-.character-editor-tab {
+.character-editor-window .character-editor-tab {
   flex: 0 0 auto;
   padding: 8px 12px;
   border: 1px solid rgba(203, 213, 225, 0.12);
@@ -6662,15 +6664,17 @@ button:disabled {
   color: var(--muted);
   font-size: 0.82rem;
   font-weight: 800;
+  cursor: pointer;
 }
 
-.character-editor-tab.active {
+.character-editor-window .character-editor-tab.active {
   border-color: color-mix(in srgb, var(--character-sub, #6f8cff) 42%, rgba(255, 255, 255, 0.16));
   background: var(--character-sub-soft, rgba(111, 140, 255, 0.16));
   color: var(--ink);
 }
 
 .character-editor-window-body {
+  display: grid;
   min-height: 0;
   overflow: auto;
   padding: 22px;
@@ -6679,16 +6683,26 @@ button:disabled {
 .character-editor-card {
   display: grid;
   gap: 16px;
+  min-height: 0;
+  overflow: auto;
 }
 
 .character-editor-markdown-card {
-  min-height: 100%;
-  grid-template-rows: auto auto auto minmax(320px, 1fr);
+  height: 100%;
+  grid-template-rows: auto auto auto minmax(0, 1fr);
+  overflow: hidden;
+}
+
+.settings-character-import-input {
+  display: none;
 }
 
 .character-editor-textarea {
-  min-height: 380px;
-  resize: vertical;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  resize: none;
+  overflow: auto;
 }
 
 .character-editor-preview-grid {
@@ -6742,7 +6756,9 @@ button:disabled {
 }
 
 .character-editor-page {
-  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  grid-template-rows: minmax(0, 1fr);
+  gap: 0;
+  padding: 0;
   overflow: hidden;
   --surface: rgba(25, 29, 38, 0.94);
   --surface-strong: rgba(28, 33, 43, 0.98);


### PR DESCRIPTION
## 概要

Character Editor の外側 card / 最大幅制限を見直し、dedicated editor window として header / tabs / body / footer がウィンドウ全体を自然に使うようにしました。

## 変更内容

- `character-editor-window` から共通 `panel` / `rise-2` を外し、外側 card 感を除去
- `character-editor-page` / `character-editor-window` の余白と幅制限を調整し、全幅・全高利用へ変更
- character.md / character-notes.md の textarea が残り高さを使うように grid / overflow を調整
- hidden file input の表示を抑止
- Character Editor の初期ウィンドウ幅を 1280px に拡大

## 背景

従来は `.page-shell` の padding、共通 `.panel` の角丸・影、`.character-editor-window` の `width: min(100%, 1120px)` が重なり、ウィンドウを広げても編集面が全体を使い切れませんでした。

## 検証

- `npm run typecheck`
- `git diff --check`
- Vite dev server 上で `character-editor.html` を Browser から開き、通常ブラウザでは Electron 専用 fallback 表示になることを確認

## 残リスク

Electron 実ウィンドウでの目視確認は未実施です。通常ブラウザでは `desktopRuntime` がなく本体 UI に入れないため、実表示の最終確認は Electron 起動環境で行う必要があります。