### PR TITLE
[codex] Details の command overflow を修正

### DIFF
--- a/scripts/tests/session-context-pane-style.test.ts
+++ b/scripts/tests/session-context-pane-style.test.ts
@@ -17,3 +17,37 @@ test("Reasoning live details は内側 pre スクロールを作らない", asyn
     /\.live-reasoning-details pre\s*{\s*max-height:\s*none;\s*overflow:\s*visible;\s*}/,
   );
 });
+
+test("Command details は長い command と single-line result を折り返せる", async () => {
+  const stylesSource = await readFile("src/styles.css", "utf8");
+
+  assert.match(
+    stylesSource,
+    /\.live-run-command-text\s*{[\s\S]*?display:\s*block;[\s\S]*?min-width:\s*0;[\s\S]*?overflow-wrap:\s*anywhere;[\s\S]*?word-break:\s*break-word;[\s\S]*?}/,
+  );
+  assert.match(
+    stylesSource,
+    /\.live-run-step-details summary\s*{[\s\S]*?min-width:\s*0;[\s\S]*?overflow-wrap:\s*anywhere;[\s\S]*?word-break:\s*break-word;[\s\S]*?}/,
+  );
+  assert.match(
+    stylesSource,
+    /\.live-run-step-details pre\s*{[\s\S]*?min-width:\s*0;[\s\S]*?white-space:\s*pre-wrap;[\s\S]*?overflow-wrap:\s*anywhere;[\s\S]*?word-break:\s*break-word;[\s\S]*?}/,
+  );
+});
+
+test("Artifact result details は長い path と本文を折り返せる", async () => {
+  const stylesSource = await readFile("src/styles.css", "utf8");
+
+  assert.match(
+    stylesSource,
+    /\.session-page \.artifact-file-meta code\s*{[\s\S]*?white-space:\s*normal;[\s\S]*?overflow-wrap:\s*anywhere;[\s\S]*?word-break:\s*break-word;[\s\S]*?}/,
+  );
+  assert.match(
+    stylesSource,
+    /\.session-page \.artifact-operation-item p,\s*\.session-page \.artifact-operation-item pre,\s*\.session-page \.artifact-operation-message\s*{[\s\S]*?overflow-wrap:\s*anywhere;[\s\S]*?word-break:\s*break-word;[\s\S]*?}/,
+  );
+  assert.match(
+    stylesSource,
+    /\.session-page \.artifact-operation-item pre\s*{[\s\S]*?white-space:\s*pre-wrap;[\s\S]*?}/,
+  );
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -4829,6 +4829,7 @@ button:disabled {
 }
 
 .live-run-command-text {
+  display: block;
   min-width: 0;
   margin: 0;
   color: inherit;
@@ -4941,14 +4942,18 @@ button:disabled {
 }
 
 .live-run-step-details summary {
+  min-width: 0;
   cursor: pointer;
   color: var(--muted);
   font-size: 0.8rem;
+  overflow-wrap: anywhere;
   user-select: none;
+  word-break: break-word;
 }
 
 .live-run-step-details pre {
   margin: 0;
+  min-width: 0;
   max-height: 160px;
   overflow: auto;
   padding: 10px 12px;
@@ -4958,6 +4963,8 @@ button:disabled {
   color: rgba(245, 245, 247, 0.92);
   font: 0.82rem/1.55 "IBM Plex Mono", monospace;
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .live-reasoning-details pre {
@@ -5070,8 +5077,10 @@ button:disabled {
 
 .command-monitor-confirmed-summary {
   margin: 0;
+  min-width: 0;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .live-run-usage {
@@ -5174,6 +5183,30 @@ button:disabled {
 }
 
 .session-page .artifact-file-meta,
+.session-page .artifact-file-meta code,
+.session-page .artifact-file-item,
+.session-page .artifact-operation-body,
+.session-page .artifact-operation-item p,
+.session-page .artifact-operation-item pre,
+.session-page .artifact-operation-message,
+.command-monitor-confirmed-summary,
+.live-run-step-details pre,
+.live-run-step-details summary,
+.live-run-command-text {
+  min-width: 0;
+}
+
+.session-page .artifact-file-meta {
+  flex-wrap: wrap;
+}
+
+.session-page .artifact-file-meta code {
+  white-space: normal;
+  overflow: visible;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 .session-page .artifact-fold-summary-copy span,
 .session-page .check-item span,
 .session-page .artifact-operation-type,
@@ -5187,6 +5220,17 @@ button:disabled {
 .session-page .audit-log-operation-head span,
 .session-page .audit-log-empty {
   color: var(--muted);
+}
+
+.session-page .artifact-operation-item p,
+.session-page .artifact-operation-item pre,
+.session-page .artifact-operation-message {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.session-page .artifact-operation-item pre {
+  white-space: pre-wrap;
 }
 
 .artifact-toggle {


### PR DESCRIPTION
## 概要
- Details の command 表示で長い command title/body が見切れないよう CSS の幅制約と折り返しを調整
- confirmed details と artifact result details の長い path / single-line body も同種の overflow が起きにくいように調整
- overflow 対策 CSS を維持する style test を追加

## 背景
Issue #51 で、Details の command title と command 本文が見切れる問題が報告されていました。右ペインの grid/flex 内で長い単語や path が縮まず、折り返しに必要な `min-width: 0` と wrapping 指定が不足していたことが原因です。

Closes #51

## 検証
- `npx tsx --test scripts/tests/session-context-pane-style.test.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## 残リスク
- 実 Electron 画面でのスクリーンショット目視は未実施です。代替として CSS guard test、typecheck、renderer/electron build で確認しています。