### PR TITLE
[codex] Character Editor の入力 UI を調整

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -6634,6 +6634,7 @@ button:disabled {
   min-height: 0;
   overflow: hidden;
   background: rgba(21, 26, 35, 0.98);
+  color: var(--ink);
 }
 
 .character-editor-window-header,
@@ -6708,25 +6709,37 @@ button:disabled {
   justify-content: flex-end;
   flex-wrap: wrap;
   max-width: 420px;
+  min-width: 0;
 }
 
 .character-editor-window .character-editor-tabs {
   padding: 12px 22px;
   border-bottom: 1px solid var(--line);
   overflow-x: auto;
+  scrollbar-gutter: stable;
   background: rgba(15, 19, 26, 0.72);
 }
 
 .character-editor-window .character-editor-tab {
-  flex: 0 0 auto;
-  padding: 8px 12px;
+  flex: 1 0 132px;
+  min-width: 0;
+  min-height: 38px;
+  padding: 8px 14px;
   border: 1px solid rgba(203, 213, 225, 0.12);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.04);
-  color: var(--muted);
+  color: #c8d2e2;
   font-size: 0.82rem;
   font-weight: 800;
+  line-height: 1.25;
+  text-align: center;
+  overflow-wrap: anywhere;
   cursor: pointer;
+}
+
+.character-editor-window .character-editor-tab:hover:not(.active) {
+  background: rgba(255, 255, 255, 0.08);
+  color: #edf2f7;
 }
 
 .character-editor-window .character-editor-tab.active {
@@ -6750,6 +6763,7 @@ button:disabled {
   overflow: auto;
   border-radius: var(--radius-md);
   background: rgba(15, 19, 26, 0.92);
+  color: var(--ink);
 }
 
 .character-editor-markdown-card {
@@ -6788,12 +6802,15 @@ button:disabled {
 .home-character-card-preview strong {
   color: var(--ink);
   font-size: 1rem;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .home-character-card-preview p {
   margin: 0;
   color: var(--muted);
   line-height: 1.5;
+  overflow-wrap: anywhere;
 }
 
 .character-editor-validation-list {
@@ -6831,6 +6848,12 @@ button:disabled {
   --line: rgba(203, 213, 225, 0.12);
   --ink: #edf2f7;
   --muted: #98a2b3;
+  --control-bg: rgba(13, 17, 23, 0.92);
+  --control-bg-hover: rgba(18, 24, 34, 0.96);
+  --control-bg-disabled: rgba(13, 17, 23, 0.58);
+  --control-border: rgba(203, 213, 225, 0.16);
+  --control-border-hover: rgba(203, 213, 225, 0.24);
+  --control-placeholder: #8793a7;
   --orange: #6f8cff;
   --orange-soft: rgba(111, 140, 255, 0.16);
   --teal: #6fb8c7;
@@ -6839,6 +6862,94 @@ button:disabled {
   background:
     radial-gradient(circle at top left, rgba(111, 140, 255, 0.12), transparent 28%),
     linear-gradient(180deg, #0f131a 0%, #151a22 100%);
+}
+
+.character-editor-page .settings-note,
+.character-editor-page .settings-help,
+.character-editor-page .settings-feedback {
+  background: rgba(255, 255, 255, 0.045);
+  box-shadow: inset 0 0 0 1px rgba(203, 213, 225, 0.08);
+  color: #aab5c7;
+}
+
+.character-editor-page .settings-provider-input {
+  min-width: 0;
+  color: var(--ink);
+}
+
+.character-editor-page .settings-provider-input > span,
+.character-editor-page .settings-field strong {
+  min-width: 0;
+  color: #c8d2e2;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.character-editor-page .settings-inline-input-row {
+  min-width: 0;
+}
+
+.character-editor-page input,
+.character-editor-page textarea,
+.character-editor-page select {
+  width: 100%;
+  min-width: 0;
+  min-height: 44px;
+  border: 1px solid var(--control-border);
+  border-radius: 14px;
+  background: var(--control-bg);
+  color: #f4f7fb;
+  font: inherit;
+  line-height: 1.5;
+  outline: none;
+}
+
+.character-editor-page input,
+.character-editor-page select {
+  padding: 11px 13px;
+}
+
+.character-editor-page textarea {
+  padding: 14px 16px;
+}
+
+.character-editor-page input::placeholder,
+.character-editor-page textarea::placeholder {
+  color: var(--control-placeholder);
+  opacity: 1;
+}
+
+.character-editor-page input:hover:not(:disabled),
+.character-editor-page textarea:hover:not(:disabled),
+.character-editor-page select:hover:not(:disabled) {
+  border-color: var(--control-border-hover);
+  background: var(--control-bg-hover);
+}
+
+.character-editor-page input:focus,
+.character-editor-page textarea:focus,
+.character-editor-page select:focus {
+  border-color: color-mix(in srgb, var(--character-sub) 62%, rgba(203, 213, 225, 0.18));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--character-sub) 22%, transparent);
+}
+
+.character-editor-page input:disabled,
+.character-editor-page textarea:disabled,
+.character-editor-page select:disabled {
+  border-color: rgba(203, 213, 225, 0.1);
+  background: var(--control-bg-disabled);
+  color: #9ca8bb;
+  opacity: 1;
+}
+
+.character-editor-page select option {
+  background: #0f131a;
+  color: #f3f6fb;
+}
+
+.character-editor-page input[type="color"] {
+  min-height: 46px;
+  padding: 6px;
 }
 
 .character-editor-layout {
@@ -7324,9 +7435,26 @@ button:disabled {
 .character-editor-page .drawer-toggle,
 .character-editor-page .browse-button,
 .character-editor-page .launch-toggle {
+  min-width: 0;
+  min-height: 38px;
+  white-space: normal;
+  overflow-wrap: anywhere;
   background: rgba(255, 255, 255, 0.06);
   color: var(--ink);
   box-shadow: inset 0 0 0 1px rgba(203, 213, 225, 0.12);
+}
+
+.character-editor-page .launch-toggle.compact {
+  min-height: 34px;
+}
+
+.character-editor-page .launch-toggle:disabled,
+.character-editor-page .drawer-toggle:disabled,
+.character-editor-page .browse-button:disabled {
+  color: #8f9bad;
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.035);
+  box-shadow: inset 0 0 0 1px rgba(203, 213, 225, 0.08);
 }
 
 .character-editor-page .launch-dialog {
@@ -8617,9 +8745,43 @@ button:disabled {
 }
 
 @media (max-width: 640px) {
+  .character-editor-window-header,
+  .character-editor-window-footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
   .character-editor-header-actions {
     width: 100%;
     justify-content: flex-start;
+  }
+
+  .character-editor-header-actions > .launch-toggle,
+  .character-editor-window-footer > .launch-toggle {
+    width: 100%;
+  }
+
+  .character-editor-window .character-editor-tabs {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    padding-inline: 14px;
+    overflow: visible;
+  }
+
+  .character-editor-window .character-editor-tab {
+    width: 100%;
+    flex-basis: auto;
+  }
+
+  .character-editor-window-body {
+    padding: 14px;
+  }
+
+  .character-editor-page .settings-inline-input-row,
+  .character-editor-page .settings-character-form-grid,
+  .character-editor-page .settings-character-theme-fields,
+  .character-editor-preview-grid {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .character-editor-actions {


### PR DESCRIPTION
## 概要
- Character Editor の入力欄、textarea、select を dark surface に合わせた配色へ統一
- placeholder / disabled / focus / hover の contrast を Character Editor スコープで補強
- tab / button / preview text / mobile layout の sizing と wrapping を調整

## 背景
Character Editor full-window 化後、Settings 系の白い form control 背景が暗い画面に残り、文字や placeholder が読みづらい箇所があったため、既存 theme token と Character Editor スコープに寄せて調整しました。

## 検証
- npm run typecheck
- npm test
- git diff --check
- Vite + Browser で一時 harness を使い、desktop / narrow width の computed style と横 overflow を確認

## 残リスク
- Electron API が必要な実 Character Editor window の最終目視は未実施です。