### PR TITLE
[codex] Monitorにキャラアイコンを戻す

### DIFF
--- a/scripts/tests/home-components.test.tsx
+++ b/scripts/tests/home-components.test.tsx
@@ -485,7 +485,7 @@ describe("HomeRecentSessionsPanel", () => {
 describe("HomeMonitorContent", () => {
   const noOp = (..._args: unknown[]) => undefined;
 
-  it("Monitor カードは Mate アイコン画像なしでセッション情報を表示する", () => {
+  it("Monitor カードはキャラアイコン付きでセッション情報を表示する", () => {
     const entries: HomeMonitorEntry[] = [
       {
         kind: "agent",
@@ -525,8 +525,8 @@ describe("HomeMonitorContent", () => {
     assert.ok(html.includes("workspace"));
     assert.ok(html.includes("Companion task"));
     assert.ok(html.includes("demo"));
-    assert.ok(!html.includes("character-avatar"));
-    assert.ok(!html.includes("<img"));
+    assert.equal(html.match(/character-avatar tiny home-monitor-avatar/g)?.length, 2);
+    assert.equal(html.match(/<img src="file:\/\/\/mate.png"/g)?.length, 2);
   });
 });
 

--- a/src/home/HomeMonitorContent.tsx
+++ b/src/home/HomeMonitorContent.tsx
@@ -1,4 +1,5 @@
 import type { HomeMonitorEntry } from "./home-session-projection.js";
+import { CharacterAvatar } from "../ui-utils.js";
 
 export type HomeMonitorContentProps = {
   runningEntries: HomeMonitorEntry[];
@@ -33,6 +34,11 @@ export function HomeMonitorContent({
             type="button"
             onClick={() => onOpenCompanionReview(session.id)}
           >
+            <CharacterAvatar
+              character={{ name: session.character, iconPath: session.characterIconPath }}
+              size="tiny"
+              className="home-monitor-avatar"
+            />
             <div className="home-monitor-row-copy">
               <strong>{session.taskTitle}</strong>
               <span>{entry.groupLabel}</span>
@@ -54,6 +60,11 @@ export function HomeMonitorContent({
           type="button"
           onClick={() => onOpenSession(session.id)}
         >
+          <CharacterAvatar
+            character={{ name: session.character, iconPath: session.characterIconPath }}
+            size="tiny"
+            className="home-monitor-avatar"
+          />
           <div className="home-monitor-row-copy">
             <strong>{session.taskTitle}</strong>
             <span>{session.workspaceLabel || session.workspacePath || "workspace 未設定"}</span>

--- a/src/styles.css
+++ b/src/styles.css
@@ -987,9 +987,9 @@ button:disabled {
 
 .home-page .home-monitor-row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
   width: 100%;
   padding: 12px;
   border: 1px solid rgba(203, 213, 225, 0.1);
@@ -997,6 +997,13 @@ button:disabled {
   background: rgba(255, 255, 255, 0.04);
   color: var(--ink);
   text-align: left;
+  box-shadow: none;
+}
+
+.home-page .home-monitor-avatar {
+  width: 32px;
+  height: 32px;
+  border-width: 1px;
   box-shadow: none;
 }
 
@@ -5843,7 +5850,13 @@ button:disabled {
 }
 
 .home-page.home-page-monitor-window .home-monitor-row {
+  grid-template-columns: auto minmax(0, 1fr);
   padding: 10px;
+}
+
+.home-page.home-page-monitor-window .home-monitor-row-badges {
+  grid-column: 2;
+  justify-content: flex-start;
 }
 
 .home-page.home-page-monitor-window .home-monitor-row-copy strong {


### PR DESCRIPTION
## 概要

Monitor の session row に、V3 で表示していたキャラアイコンを復帰しました。

## 変更内容

- `HomeMonitorContent` で agent / companion の monitor row に既存 `CharacterAvatar` を表示
- Home 右ペインと独立 Monitor Window の両方で使う共通 component に適用
- 独立 Monitor Window の狭幅レイアウト向けに badge を下段へ回す CSS を追加
- component test の期待値を、キャラアイコン表示ありに更新

## 背景

Monitor entry には `characterIconPath` が残っていましたが、描画側が row copy と badge だけになっており、キャラアイコンが表示されなくなっていました。

## 検証

- `npx tsx --test scripts/tests/home-components.test.tsx`
- `npm run typecheck`
- `git diff --check`
