### PR TITLE
[codex] Homeのキャラクター一覧の文字色を安定化

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -917,7 +917,7 @@ button:disabled {
   background:
     linear-gradient(135deg, color-mix(in srgb, var(--card-main, #1a2230) 24%, rgba(255, 255, 255, 0.04) 76%), rgba(255, 255, 255, 0.035)),
     rgba(10, 14, 20, 0.74);
-  color: var(--card-ink, #f8fbff);
+  color: var(--ink);
   text-align: left;
   box-shadow: 0 10px 24px color-mix(in srgb, var(--card-shadow, rgba(0, 0, 0, 0.28)) 36%, transparent);
 }
@@ -946,13 +946,13 @@ button:disabled {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  color: var(--card-ink, #f8fbff);
+  color: var(--ink);
   font-size: 0.92rem;
   font-weight: 800;
 }
 
 .home-page .home-character-card-copy > span:not(.home-character-card-title) {
-  color: var(--card-muted, #c0cadb);
+  color: var(--muted);
   font-size: 0.78rem;
   line-height: 1.35;
 }
@@ -962,6 +962,7 @@ button:disabled {
 }
 
 .home-page .home-character-card-edit {
+  color: var(--ink);
   pointer-events: none;
 }
 


### PR DESCRIPTION
## 概要
- Home の Characters 一覧で、カード内テキスト色をキャラクター固有色由来ではなく Home の標準前景色に固定
- キャラクターごとのテーマ色はカード背景・枠線に残しつつ、名前・説明・更新日時・Edit 表示の可読性を安定化

## 背景
キャラクターの theme main に応じてカード用の ink/muted 色が変わるため、Home の暗いカード背景と組み合わせたときに文字が読みにくくなるケースがありました。

## 検証
- npm run typecheck
- git diff --check