### PR TITLE
[codex] Restore provider file settings

### DIFF
--- a/docs/design/database-schema.md
+++ b/docs/design/database-schema.md
@@ -1,7 +1,7 @@
 # Database Schema
 
 - 作成日: 2026-03-27
-- 更新日: 2026-05-25
+- 更新日: 2026-06-16
 - 対象: WithMate の current 保存構造
 
 ## Goal
@@ -423,12 +423,16 @@ current 実装の key:
   "codex": {
     "enabled": true,
     "apiKey": "",
-    "skillRootPath": ""
+    "skillRootPath": "",
+    "skillRelativePath": "",
+    "instructionRelativePath": ""
   },
   "copilot": {
     "enabled": true,
     "apiKey": "",
-    "skillRootPath": ""
+    "skillRootPath": "",
+    "skillRelativePath": "",
+    "instructionRelativePath": ""
   }
 }
 ```

--- a/docs/design/provider-adapter.md
+++ b/docs/design/provider-adapter.md
@@ -372,8 +372,9 @@ CodexAdapter は `workspacePath + allowedAdditionalDirectories` ごとに proces
 ## Agent / Skill Mapping
 
 - skill 探索元は次を使う
-  - `codingProviderSettings[providerId].skillRootPath`
+  - `codingProviderSettings[providerId].skillRootPath` と任意の `skillRelativePath` から解決した provider skill root
   - workspace 標準 skill roots (`skills`, `.github/skills`, `.copilot/skills`, `.codex/skills`, `.claude/skills`)
+- `codingProviderSettings[providerId].instructionRelativePath` は provider ごとの instruction file 設定として保持するが、V5 current の skill 探索や prompt composition では参照しない
 - 同名 skill は workspace 優先で dedupe する
 - adapter は選択済み skill を provider ごとの prompt / option へ変換する
   - Codex: `$skill-name` mention

--- a/docs/design/settings-ui.md
+++ b/docs/design/settings-ui.md
@@ -1,7 +1,7 @@
 # Settings UI
 
 - 作成日: 2026-03-14
-- 更新日: 2026-06-14
+- 更新日: 2026-06-16
 - 対象: 独立した `Settings Window`
 
 ## Goal
@@ -15,7 +15,7 @@
 - app 共通 system prompt を編集する旧設定項目は廃止する
 - V5 current では Character 定義は `Characters` editor で管理し、session / companion 開始時の `CharacterRuntimeSnapshot` を runtime prompt の主経路にする
 - provider instruction sync は V5 Character 注入の主経路ではなく、Settings current UI には置かない
-- current 実装では `Session Window`、`Default Microcopy`、`Characters`、`Coding Agent Providers`、`Diagnostics`、`Mate Reset`、`Model Catalog` を置く
+- current 実装では `Session Window`、`Default Microcopy`、`Coding Agent Providers`、`Diagnostics`、`Mate Reset`、`Model Catalog` を置く
 - `Settings Window` は縦方向の余白を少し増やしつつ、内容が増えた場合は window 内スクロールで末尾まで操作できるようにする
 - file picker / save dialog は Main Process 側で開く
 - current 実装では Main Process 側の settings / catalog 更新は `src-electron/settings-catalog-service.ts` に寄せ、renderer 側の provider row 組み立ては `src/home-settings-view-model.ts` に寄せる
@@ -24,7 +24,7 @@
 
 1. ユーザーが Home toolbar の `Settings` を押す
 2. 独立した `Settings Window` が開く
-3. Session 表示設定、microcopy、Character、coding provider の enable / disable を編集して保存する。window が小さいときは内部スクロールで下端まで移動し、`Import Models` / `Export Models` も実行できる
+3. Session 表示設定、microcopy、coding provider の enable / disable と provider file settings を編集して保存する。window が小さいときは内部スクロールで下端まで移動し、`Import Models` / `Export Models` も実行できる
 4. 結果は window 内の短いフィードバックで返す
 
 ## Layout
@@ -36,15 +36,12 @@
 - Settings Window
   - `Session Window`
     - `送信後に Action Dock を自動で閉じる`
-  - `Characters`
-    - Character 一覧
-    - name / description / icon path / theme
-    - raw `character.md` editor
-    - optional `character-notes.md` editor
-    - import / replace
-    - save / cancel / set default / archive
   - `Coding Agent Providers`
-    - provider 名を左、enable checkbox を右に置いた 1 行 row
+    - provider 名を左、enable checkbox を右に置く
+    - provider ごとの `Provider File Settings`
+      - `Root Directory`
+      - `Skill Relative Path`
+      - `Instruction Relative Path`
   - `Diagnostics`
     - app log / crash dump folder
   - `Mate Reset`
@@ -57,15 +54,12 @@
 ## Current Scope
 
 - `Session Window` の `送信後に Action Dock を自動で閉じる` の保存
-- V5 Core Character の最低限 editor
-  - Character 一覧
-  - 新規作成
-  - metadata 編集
-  - raw `character.md` import / replace / 保存
-  - optional `character-notes.md` 保存
-  - default 切替
-  - archive
 - coding provider ごとの enable / disable
+- coding provider ごとの provider file settings
+  - `Root Directory` は provider ごとの file 設定の基準 directory として保持される
+  - `Skill Relative Path` がある場合は root 配下の相対 path として解決される
+  - `Instruction Relative Path` は root 配下の instruction file 設定として保持される
+  - V5 current では skill folder だけが runtime の skill 探索元になり、instruction file は Provider Instruction Sync を再起動せず設定値として保持する
 - Diagnostics の folder open
 - legacy Mate reset
 - `model catalog` の import
@@ -80,6 +74,7 @@
 - `model catalog export` の document 取得も `SettingsCatalogService` が担当する
 - renderer 側では `HomeApp.tsx` が storage 正規化を直接持たず、`home-settings-view-model` の derived data を使って provider row を描画する
 - renderer 側の provider settings draft 更新は `home-settings-draft` の pure function を経由する
+- provider file settings の directory / file picker は、`Root Directory` 配下で選ばれた path だけを相対 path として draft へ反映する
 - `HomeApp.tsx` は provider settings を別 state で持たず、単一の `AppSettings draft` を編集する
 - save 時の payload は `home-settings-view-model` が resolved model / reasoning を反映した `persisted settings` として組み立てる
 - Settings Window の `loading` 派生状態は `HomeApp.tsx` が組み立てる

--- a/scripts/tests/app-settings-storage.test.ts
+++ b/scripts/tests/app-settings-storage.test.ts
@@ -27,11 +27,15 @@ describe("AppSettingsStorage", () => {
             enabled: false,
             apiKey: "codex-key",
             skillRootPath: "C:/skills/codex",
+            skillRelativePath: ".codex/skills",
+            instructionRelativePath: "AGENTS.md",
           },
           copilot: {
             enabled: true,
             apiKey: "copilot-key",
             skillRootPath: "C:/skills/copilot",
+            skillRelativePath: "skills",
+            instructionRelativePath: "copilot-instructions.md",
           },
         },
         memoryExtractionProviderSettings: {
@@ -109,11 +113,15 @@ describe("AppSettingsStorage", () => {
             enabled: false,
             apiKey: "custom-key",
             skillRootPath: "C:/skills/codex",
+            skillRelativePath: ".codex/skills",
+            instructionRelativePath: "AGENTS.md",
           },
           copilot: {
             enabled: true,
             apiKey: "copilot-key",
             skillRootPath: "C:/skills/copilot",
+            skillRelativePath: "skills",
+            instructionRelativePath: "copilot-instructions.md",
           },
         },
         memoryExtractionProviderSettings: {

--- a/scripts/tests/home-components.test.tsx
+++ b/scripts/tests/home-components.test.tsx
@@ -97,6 +97,12 @@ describe("HomeSettingsContent", () => {
     onChangeAutoCollapseActionDockOnSend: noOp,
     onChangeUserMicrocopySlot: noOp,
     onChangeProviderEnabled: noOp,
+    onChangeProviderSkillRootPath: noOp,
+    onChangeProviderSkillRelativePath: noOp,
+    onChangeProviderInstructionRelativePath: noOp,
+    onBrowseProviderSkillRootPath: noOp,
+    onBrowseProviderSkillRelativePath: noOp,
+    onBrowseProviderInstructionRelativePath: noOp,
     onImportModelCatalog: noOp,
     onExportModelCatalog: noOp,
     onOpenAppLogFolder: noOp,
@@ -142,8 +148,6 @@ describe("HomeSettingsContent", () => {
     const html = renderSettings();
 
     assert.ok(!html.includes("Provider Instruction Sync"));
-    assert.ok(!html.includes("Root Directory"));
-    assert.ok(!html.includes("Instruction Relative Path"));
     assert.ok(!html.includes("Write Mode"));
     assert.ok(!html.includes("Fail Policy"));
     assert.ok(!html.includes("Mate Embedding"));
@@ -154,6 +158,15 @@ describe("HomeSettingsContent", () => {
     assert.ok(!html.includes("settings-character-section"));
     assert.ok(!html.includes("Save Character"));
     assert.ok(!html.includes("character-notes.md"));
+  });
+
+  it("provider ごとの file settings を表示する", () => {
+    const html = renderSettings();
+
+    assert.ok(html.includes("Provider File Settings"));
+    assert.ok(html.includes("Root Directory"));
+    assert.ok(html.includes("Skill Relative Path"));
+    assert.ok(html.includes("Instruction Relative Path"));
   });
 
   it("provider row が 0 件でも Coding Agent Providers section と empty state を表示する", () => {

--- a/scripts/tests/home-settings-actions.test.ts
+++ b/scripts/tests/home-settings-actions.test.ts
@@ -9,6 +9,9 @@ import {
   saveHomeSettings,
   type HomeSettingsApi,
 } from "../../src/settings/settings-actions.js";
+import { buildSettingsCommandHandlers } from "../../src/settings/settings-command-handlers.js";
+import type { AppSettings } from "../../src/provider-settings-state.js";
+import type { WithMateWindowApi } from "../../src/withmate-window-api.js";
 
 function createApi(overrides?: Partial<HomeSettingsApi>): HomeSettingsApi {
   return {
@@ -23,6 +26,10 @@ function createApi(overrides?: Partial<HomeSettingsApi>): HomeSettingsApi {
     }),
     ...overrides,
   };
+}
+
+async function flushAsyncHandlers(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 describe("home-settings-actions", () => {
@@ -82,6 +89,175 @@ describe("home-settings-actions", () => {
     assert.deepEqual(canceledResult, {
       kind: "canceled",
     });
+  });
+
+  it("provider skill root picker は選択 path を draft に反映する", async () => {
+    const settings = createDefaultAppSettings();
+    settings.codingProviderSettings.codex = {
+      enabled: true,
+      apiKey: "key",
+      skillRootPath: "C:/before",
+      skillRelativePath: ".codex/skills",
+      instructionRelativePath: "AGENTS.md",
+    };
+    let draft: AppSettings = settings;
+    let feedback = "";
+    const handlers = buildSettingsCommandHandlers({
+      getApi: () => ({
+        pickDirectory: async (initialPath) => {
+          assert.equal(initialPath, "C:/before");
+          return "C:/after";
+        },
+      } as Partial<WithMateWindowApi> as WithMateWindowApi),
+      persistedSettingsDraft: settings,
+      setAppSettings: () => undefined,
+      setSettingsDraft: (nextSettings) => {
+        draft = nextSettings;
+      },
+      setSettingsFeedback: (nextFeedback) => {
+        feedback = nextFeedback;
+      },
+    });
+
+    handlers.onBrowseProviderSkillRootPath("codex");
+    await flushAsyncHandlers();
+
+    assert.equal(draft.codingProviderSettings.codex.skillRootPath, "C:/after");
+    assert.equal(draft.codingProviderSettings.codex.skillRelativePath, ".codex/skills");
+    assert.equal(draft.codingProviderSettings.codex.instructionRelativePath, "AGENTS.md");
+    assert.equal(draft.codingProviderSettings.codex.enabled, true);
+    assert.match(feedback, /反映した/);
+  });
+
+  it("provider skill relative picker は Root Directory 配下の相対 path を draft に反映する", async () => {
+    const settings = createDefaultAppSettings();
+    settings.codingProviderSettings.codex = {
+      enabled: true,
+      apiKey: "key",
+      skillRootPath: "C:/workspace",
+      skillRelativePath: "",
+      instructionRelativePath: "AGENTS.md",
+    };
+    let draft: AppSettings = settings;
+    let feedback = "";
+    const handlers = buildSettingsCommandHandlers({
+      getApi: () => ({
+        pickDirectory: async (initialPath) => {
+          assert.equal(initialPath, "C:/workspace");
+          return "C:/workspace/.codex/skills";
+        },
+      } as Partial<WithMateWindowApi> as WithMateWindowApi),
+      persistedSettingsDraft: settings,
+      setAppSettings: () => undefined,
+      setSettingsDraft: (nextSettings) => {
+        draft = nextSettings;
+      },
+      setSettingsFeedback: (nextFeedback) => {
+        feedback = nextFeedback;
+      },
+    });
+
+    handlers.onBrowseProviderSkillRelativePath("codex");
+    await flushAsyncHandlers();
+
+    assert.equal(draft.codingProviderSettings.codex.skillRootPath, "C:/workspace");
+    assert.equal(draft.codingProviderSettings.codex.skillRelativePath, ".codex/skills");
+    assert.equal(draft.codingProviderSettings.codex.instructionRelativePath, "AGENTS.md");
+    assert.match(feedback, /Skill Relative Path/);
+  });
+
+  it("provider instruction relative picker は Root Directory 配下の相対 path を draft に反映する", async () => {
+    const settings = createDefaultAppSettings();
+    settings.codingProviderSettings.codex = {
+      enabled: true,
+      apiKey: "key",
+      skillRootPath: "C:/workspace",
+      skillRelativePath: ".codex/skills",
+      instructionRelativePath: "",
+    };
+    let draft: AppSettings = settings;
+    let feedback = "";
+    const handlers = buildSettingsCommandHandlers({
+      getApi: () => ({
+        pickFile: async (initialPath) => {
+          assert.equal(initialPath, "C:/workspace");
+          return "C:/workspace/AGENTS.md";
+        },
+      } as Partial<WithMateWindowApi> as WithMateWindowApi),
+      persistedSettingsDraft: settings,
+      setAppSettings: () => undefined,
+      setSettingsDraft: (nextSettings) => {
+        draft = nextSettings;
+      },
+      setSettingsFeedback: (nextFeedback) => {
+        feedback = nextFeedback;
+      },
+    });
+
+    handlers.onBrowseProviderInstructionRelativePath("codex");
+    await flushAsyncHandlers();
+
+    assert.equal(draft.codingProviderSettings.codex.skillRootPath, "C:/workspace");
+    assert.equal(draft.codingProviderSettings.codex.skillRelativePath, ".codex/skills");
+    assert.equal(draft.codingProviderSettings.codex.instructionRelativePath, "AGENTS.md");
+    assert.match(feedback, /Instruction Relative Path/);
+  });
+
+  it("provider instruction relative picker は Root Directory 外の選択を反映しない", async () => {
+    const settings = createDefaultAppSettings();
+    settings.codingProviderSettings.codex = {
+      enabled: true,
+      apiKey: "key",
+      skillRootPath: "C:/workspace",
+      skillRelativePath: ".codex/skills",
+      instructionRelativePath: "AGENTS.md",
+    };
+    let draft: AppSettings = settings;
+    let feedback = "";
+    const handlers = buildSettingsCommandHandlers({
+      getApi: () => ({
+        pickFile: async () => "D:/other/AGENTS.md",
+      } as Partial<WithMateWindowApi> as WithMateWindowApi),
+      persistedSettingsDraft: settings,
+      setAppSettings: () => undefined,
+      setSettingsDraft: (nextSettings) => {
+        draft = nextSettings;
+      },
+      setSettingsFeedback: (nextFeedback) => {
+        feedback = nextFeedback;
+      },
+    });
+
+    handlers.onBrowseProviderInstructionRelativePath("codex");
+    await flushAsyncHandlers();
+
+    assert.equal(draft, settings);
+    assert.match(feedback, /Root Directory 配下/);
+  });
+
+  it("provider skill root picker cancel は draft を変更しない", async () => {
+    const settings = createDefaultAppSettings();
+    let draft: AppSettings = settings;
+    let feedback = "";
+    const handlers = buildSettingsCommandHandlers({
+      getApi: () => ({
+        pickDirectory: async () => null,
+      } as Partial<WithMateWindowApi> as WithMateWindowApi),
+      persistedSettingsDraft: settings,
+      setAppSettings: () => undefined,
+      setSettingsDraft: (nextSettings) => {
+        draft = nextSettings;
+      },
+      setSettingsFeedback: (nextFeedback) => {
+        feedback = nextFeedback;
+      },
+    });
+
+    handlers.onBrowseProviderSkillRootPath("codex");
+    await flushAsyncHandlers();
+
+    assert.equal(draft, settings);
+    assert.match(feedback, /キャンセル/);
   });
 
 });

--- a/scripts/tests/home-settings-draft.test.ts
+++ b/scripts/tests/home-settings-draft.test.ts
@@ -13,6 +13,8 @@ import {
   updateCodingProviderApiKeyDraft,
   updateCodingProviderEnabled,
   updateCodingProviderEnabledDraft,
+  updateCodingProviderInstructionRelativePath,
+  updateCodingProviderInstructionRelativePathDraft,
   updateCodingProviderSkillRelativePath,
   updateCodingProviderSkillRelativePathDraft,
   updateCodingProviderSkillRootPath,
@@ -48,6 +50,7 @@ import {
   handleChangeMemoryExtractionThreshold as handleChangeMemoryExtractionThresholdAction,
   handleChangeMemoryExtractionTimeoutSeconds as handleChangeMemoryExtractionTimeoutSecondsAction,
   handleChangeProviderEnabled as handleChangeProviderEnabledAction,
+  handleChangeProviderInstructionRelativePath as handleChangeProviderInstructionRelativePathAction,
   handleChangeProviderSkillRelativePath as handleChangeProviderSkillRelativePathAction,
   handleChangeProviderSkillRootPath as handleChangeProviderSkillRootPathAction,
   handleChangeUserMicrocopySlot as handleChangeUserMicrocopySlotAction,
@@ -124,11 +127,17 @@ describe("home-settings-draft", () => {
       "codex",
       "skills/codex",
     );
+    const instructionRelativePath = updateCodingProviderInstructionRelativePath(
+      { ...draft, codingProviderSettings: skillRelativePath },
+      "codex",
+      "AGENTS.md",
+    );
 
-    assert.equal(skillRelativePath.codex.enabled, false);
-    assert.equal(skillRelativePath.codex.apiKey, "next-key");
-    assert.equal(skillRelativePath.codex.skillRootPath, "C:/skills");
-    assert.equal(skillRelativePath.codex.skillRelativePath, "skills/codex");
+    assert.equal(instructionRelativePath.codex.enabled, false);
+    assert.equal(instructionRelativePath.codex.apiKey, "next-key");
+    assert.equal(instructionRelativePath.codex.skillRootPath, "C:/skills");
+    assert.equal(instructionRelativePath.codex.skillRelativePath, "skills/codex");
+    assert.equal(instructionRelativePath.codex.instructionRelativePath, "AGENTS.md");
   });
 
   it("provider skill root は Root Directory と Skill Relative Path から解決する", () => {
@@ -204,25 +213,29 @@ describe("home-settings-draft", () => {
       updateMemoryExtractionTimeoutSecondsDraft(
         updateMemoryExtractionReasoningEffortDraft(
           updateMemoryExtractionModelDraft(
-            updateCodingProviderSkillRelativePathDraft(
-              updateCodingProviderSkillRootPathDraft(
-                updateCodingProviderApiKeyDraft(
-                  updateCodingProviderEnabledDraft(
-                    updateAutoCollapseActionDockOnSend(
-                      updateMemoryGenerationEnabled(draft, false),
+            updateCodingProviderInstructionRelativePathDraft(
+              updateCodingProviderSkillRelativePathDraft(
+                updateCodingProviderSkillRootPathDraft(
+                  updateCodingProviderApiKeyDraft(
+                    updateCodingProviderEnabledDraft(
+                      updateAutoCollapseActionDockOnSend(
+                        updateMemoryGenerationEnabled(draft, false),
+                        false,
+                      ),
+                      "codex",
                       false,
                     ),
                     "codex",
-                    false,
+                    "key",
                   ),
                   "codex",
-                  "key",
+                  "C:/skills",
                 ),
                 "codex",
-                "C:/skills",
+                "skills/codex",
               ),
               "codex",
-              "skills/codex",
+              "AGENTS.md",
             ),
             providerCatalog,
             "codex",
@@ -244,6 +257,7 @@ describe("home-settings-draft", () => {
     assert.equal(next.codingProviderSettings.codex.apiKey, "key");
     assert.equal(next.codingProviderSettings.codex.skillRootPath, "C:/skills");
     assert.equal(next.codingProviderSettings.codex.skillRelativePath, "skills/codex");
+    assert.equal(next.codingProviderSettings.codex.instructionRelativePath, "AGENTS.md");
     assert.equal(next.memoryExtractionProviderSettings.codex.outputTokensThreshold, 321);
     assert.equal(next.memoryExtractionProviderSettings.codex.timeoutSeconds, 240);
   });
@@ -332,6 +346,18 @@ describe("home-settings-draft", () => {
     });
 
     assert.equal(state.draft.codingProviderSettings.codex.skillRelativePath, "skills/codex");
+  });
+
+  it("action: provider instructionRelativePath を draft 更新で反映できる", () => {
+    const state = createDraftTracker();
+
+    handleChangeProviderInstructionRelativePathAction({
+      providerId: "codex",
+      instructionRelativePath: "AGENTS.md",
+      setSettingsDraft: state.setSettingsDraft,
+    });
+
+    assert.equal(state.draft.codingProviderSettings.codex.instructionRelativePath, "AGENTS.md");
   });
 
   it("action: memory generation と auto collapse を draft 更新で反映できる", () => {

--- a/scripts/tests/main-query-service.test.ts
+++ b/scripts/tests/main-query-service.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import type { Session, SessionSummary } from "../../src/app-state.js";
+import { createDefaultAppSettings } from "../../src/provider-settings-state.js";
 import { MainQueryService } from "../../src-electron/main-query-service.js";
 
 function createSession(overrides?: Partial<Session>): Session {
@@ -143,6 +144,60 @@ test("MainQueryService は path 参照なし draft の preview を早期 return 
   const preview = await service.previewComposerInput("session-1", "hello");
   assert.deepEqual(preview, { attachments: [], errors: [] });
   assert.equal(getSessionSummariesCalls, 0);
+});
+
+test("MainQueryService は session provider ごとの skill directory を discovery に渡す", async () => {
+  const providerSkillRoots: Array<{ workspacePath: string; skillRootPath: string | null }> = [];
+  const settings = createDefaultAppSettings();
+  settings.codingProviderSettings.codex = {
+    enabled: true,
+    apiKey: "",
+    skillRootPath: "C:/provider-files/codex",
+    skillRelativePath: ".codex/skills",
+    instructionRelativePath: "AGENTS.md",
+  };
+  settings.codingProviderSettings.copilot = {
+    enabled: true,
+    apiKey: "",
+    skillRootPath: "C:/provider-files/copilot",
+    skillRelativePath: "skills",
+    instructionRelativePath: "copilot-instructions.md",
+  };
+  const service = new MainQueryService({
+    getSessionSummaries: () => [
+      createSessionSummary({ id: "codex-session", provider: "codex", workspacePath: "C:/workspace" }),
+      createSessionSummary({ id: "copilot-session", provider: "copilot", workspacePath: "C:/workspace" }),
+    ],
+    getSession: () => null,
+    getSessionMessageArtifact: () => null,
+    getAuditLogs: () => [],
+    getAuditLogSummaries: () => [],
+    getAuditLogSummaryPage: () => ({ entries: [], nextCursor: null, hasMore: false, total: 0 }),
+    getAuditLogDetail: () => null,
+    getAuditLogDetailSection: () => null,
+    getAuditLogOperationDetail: () => null,
+    getAppSettings: () => settings,
+    async discoverSessionSkills(workspacePath, skillRootPath) {
+      providerSkillRoots.push({ workspacePath, skillRootPath });
+      return [];
+    },
+    discoverSessionCustomAgents: async () => [],
+    async resolveComposerPreview() {
+      return { attachments: [], errors: [] };
+    },
+    async searchWorkspaceFiles() {
+      return [];
+    },
+    async launchTerminalAtPath() {},
+  });
+
+  await service.listSessionSkills("codex-session");
+  await service.listSessionSkills("copilot-session");
+
+  assert.deepEqual(providerSkillRoots, [
+    { workspacePath: "C:/workspace", skillRootPath: "C:/provider-files/codex/.codex/skills" },
+    { workspacePath: "C:/workspace", skillRootPath: "C:/provider-files/copilot/skills" },
+  ]);
 });
 
 test("MainQueryService は一覧を summary に射影して detail payload を含めない", async () => {

--- a/scripts/tests/model-catalog-settings.test.ts
+++ b/scripts/tests/model-catalog-settings.test.ts
@@ -88,12 +88,14 @@ describe("app settings provider helpers", () => {
       apiKey: "codex-key",
       skillRootPath: "",
       skillRelativePath: "",
+      instructionRelativePath: "",
     });
     assert.deepEqual(getProviderAppSettings(settings, "copilot"), {
       enabled: true,
       apiKey: "copilot-key",
       skillRootPath: "",
       skillRelativePath: "",
+      instructionRelativePath: "",
     });
   });
 
@@ -119,6 +121,7 @@ describe("app settings provider helpers", () => {
         apiKey: "canonical-key",
         skillRootPath: "",
         skillRelativePath: "",
+        instructionRelativePath: "",
       },
     });
     assert.deepEqual(getProviderAppSettings(settings, "codex"), {
@@ -126,6 +129,7 @@ describe("app settings provider helpers", () => {
       apiKey: "canonical-key",
       skillRootPath: "",
       skillRelativePath: "",
+      instructionRelativePath: "",
     });
   });
 
@@ -159,6 +163,7 @@ describe("app settings provider helpers", () => {
           enabled: false,
           apiKey: "codex-key",
           skillRootPath: "C:/skills",
+          instructionRelativePath: "AGENTS.md",
         },
       },
       memoryExtractionProviderSettings: {
@@ -177,6 +182,7 @@ describe("app settings provider helpers", () => {
         apiKey: "codex-key",
         skillRootPath: "C:/skills",
         skillRelativePath: "",
+        instructionRelativePath: "AGENTS.md",
       },
       memoryExtraction: {
         model: "gpt-5.1-mini",

--- a/src/provider-settings-state.ts
+++ b/src/provider-settings-state.ts
@@ -25,6 +25,7 @@ export type ProviderAppSettings = {
   apiKey: string;
   skillRootPath: string;
   skillRelativePath?: string;
+  instructionRelativePath?: string;
 };
 
 export type MemoryExtractionProviderSettings = {
@@ -56,6 +57,7 @@ export const DEFAULT_PROVIDER_APP_SETTINGS: ProviderAppSettings = {
   apiKey: "",
   skillRootPath: "",
   skillRelativePath: "",
+  instructionRelativePath: "",
 };
 
 export const DEFAULT_MEMORY_EXTRACTION_OUTPUT_TOKENS_THRESHOLD = 300_000;
@@ -95,6 +97,7 @@ export function createDefaultAppSettings(): AppSettings {
         apiKey: "",
         skillRootPath: "",
         skillRelativePath: "",
+        instructionRelativePath: "",
       },
     },
     memoryExtractionProviderSettings: {
@@ -124,6 +127,7 @@ function normalizeProviderAppSettings(value: unknown, defaultEnabled: boolean): 
       apiKey: "",
       skillRootPath: "",
       skillRelativePath: "",
+      instructionRelativePath: "",
     };
   }
 
@@ -133,6 +137,7 @@ function normalizeProviderAppSettings(value: unknown, defaultEnabled: boolean): 
     apiKey: typeof candidate.apiKey === "string" ? candidate.apiKey : "",
     skillRootPath: typeof candidate.skillRootPath === "string" ? candidate.skillRootPath : "",
     skillRelativePath: typeof candidate.skillRelativePath === "string" ? candidate.skillRelativePath : "",
+    instructionRelativePath: typeof candidate.instructionRelativePath === "string" ? candidate.instructionRelativePath : "",
   };
 }
 

--- a/src/settings/SettingsContent.tsx
+++ b/src/settings/SettingsContent.tsx
@@ -8,6 +8,16 @@ import {
   SETTINGS_DIAGNOSTICS_LABEL,
   SETTINGS_OPEN_LOG_FOLDER_LABEL,
   SETTINGS_OPEN_CRASH_DUMP_FOLDER_LABEL,
+  SETTINGS_PROVIDER_FILE_SETTINGS_HELP,
+  SETTINGS_PROVIDER_FILE_SETTINGS_LABEL,
+  SETTINGS_PROVIDER_INSTRUCTION_RELATIVE_PATH_HELP,
+  SETTINGS_PROVIDER_INSTRUCTION_RELATIVE_PATH_LABEL,
+  SETTINGS_PROVIDER_INSTRUCTION_RELATIVE_PATH_PLACEHOLDER,
+  SETTINGS_PROVIDER_SKILL_RELATIVE_PATH_HELP,
+  SETTINGS_PROVIDER_SKILL_RELATIVE_PATH_LABEL,
+  SETTINGS_PROVIDER_SKILL_RELATIVE_PATH_PLACEHOLDER,
+  SETTINGS_PROVIDER_ROOT_DIRECTORY_LABEL,
+  SETTINGS_PROVIDER_ROOT_DIRECTORY_PLACEHOLDER,
 } from "./settings-ui.js";
 
 export type HomeSettingsContentProps = {
@@ -20,6 +30,12 @@ export type HomeSettingsContentProps = {
   onChangeAutoCollapseActionDockOnSend: (enabled: boolean) => void;
   onChangeUserMicrocopySlot: (slot: MicrocopySlot, value: string) => void;
   onChangeProviderEnabled: (providerId: string, enabled: boolean) => void;
+  onChangeProviderSkillRootPath: (providerId: string, skillRootPath: string) => void;
+  onChangeProviderSkillRelativePath: (providerId: string, skillRelativePath: string) => void;
+  onChangeProviderInstructionRelativePath: (providerId: string, instructionRelativePath: string) => void;
+  onBrowseProviderSkillRootPath: (providerId: string) => void;
+  onBrowseProviderSkillRelativePath: (providerId: string) => void;
+  onBrowseProviderInstructionRelativePath: (providerId: string) => void;
   onImportModelCatalog: () => void;
   onExportModelCatalog: () => void;
   onOpenAppLogFolder: () => void;
@@ -63,6 +79,12 @@ export function HomeSettingsContent({
   onChangeAutoCollapseActionDockOnSend,
   onChangeUserMicrocopySlot,
   onChangeProviderEnabled,
+  onChangeProviderSkillRootPath,
+  onChangeProviderSkillRelativePath,
+  onChangeProviderInstructionRelativePath,
+  onBrowseProviderSkillRootPath,
+  onBrowseProviderSkillRelativePath,
+  onBrowseProviderInstructionRelativePath,
   onImportModelCatalog,
   onExportModelCatalog,
   onOpenAppLogFolder,
@@ -118,7 +140,7 @@ export function HomeSettingsContent({
               {providerSettingRows.length > 0 ? (
                 <div className="settings-provider-list">
                   {providerSettingRows.map(({ provider, settings }) => (
-                    <section key={provider.id} className="settings-provider-card settings-provider-toggle-card">
+                    <section key={provider.id} className="settings-provider-card">
                       <label className="settings-provider-toggle-row">
                         <span className="settings-provider-name">{provider.label}</span>
                         <input
@@ -127,6 +149,74 @@ export function HomeSettingsContent({
                           onChange={(event) => onChangeProviderEnabled(provider.id, event.target.checked)}
                         />
                       </label>
+                      <div className="settings-provider-file-settings">
+                        <div>
+                          <strong>{SETTINGS_PROVIDER_FILE_SETTINGS_LABEL}</strong>
+                          <p className="settings-help">{SETTINGS_PROVIDER_FILE_SETTINGS_HELP}</p>
+                        </div>
+                        <label className="settings-provider-input">
+                          <span>{SETTINGS_PROVIDER_ROOT_DIRECTORY_LABEL}</span>
+                          <div className="settings-inline-input-row">
+                            <input
+                              type="text"
+                              value={settings.skillRootPath}
+                              onChange={(event) => onChangeProviderSkillRootPath(provider.id, event.target.value)}
+                              placeholder={SETTINGS_PROVIDER_ROOT_DIRECTORY_PLACEHOLDER}
+                              autoComplete="off"
+                              spellCheck={false}
+                            />
+                            <button
+                              className="launch-toggle"
+                              type="button"
+                              onClick={() => onBrowseProviderSkillRootPath(provider.id)}
+                            >
+                              選択
+                            </button>
+                          </div>
+                        </label>
+                        <label className="settings-provider-input">
+                          <span>{SETTINGS_PROVIDER_SKILL_RELATIVE_PATH_LABEL}</span>
+                          <div className="settings-inline-input-row">
+                            <input
+                              type="text"
+                              value={settings.skillRelativePath ?? ""}
+                              onChange={(event) => onChangeProviderSkillRelativePath(provider.id, event.target.value)}
+                              placeholder={SETTINGS_PROVIDER_SKILL_RELATIVE_PATH_PLACEHOLDER}
+                              autoComplete="off"
+                              spellCheck={false}
+                            />
+                            <button
+                              className="launch-toggle"
+                              type="button"
+                              onClick={() => onBrowseProviderSkillRelativePath(provider.id)}
+                            >
+                              選択
+                            </button>
+                          </div>
+                          <p className="settings-help">{SETTINGS_PROVIDER_SKILL_RELATIVE_PATH_HELP}</p>
+                        </label>
+                        <label className="settings-provider-input">
+                          <span>{SETTINGS_PROVIDER_INSTRUCTION_RELATIVE_PATH_LABEL}</span>
+                          <div className="settings-inline-input-row">
+                            <input
+                              type="text"
+                              value={settings.instructionRelativePath ?? ""}
+                              onChange={(event) => onChangeProviderInstructionRelativePath(provider.id, event.target.value)}
+                              placeholder={SETTINGS_PROVIDER_INSTRUCTION_RELATIVE_PATH_PLACEHOLDER}
+                              autoComplete="off"
+                              spellCheck={false}
+                            />
+                            <button
+                              className="launch-toggle"
+                              type="button"
+                              onClick={() => onBrowseProviderInstructionRelativePath(provider.id)}
+                            >
+                              選択
+                            </button>
+                          </div>
+                          <p className="settings-help">{SETTINGS_PROVIDER_INSTRUCTION_RELATIVE_PATH_HELP}</p>
+                        </label>
+                      </div>
                     </section>
                   ))}
                 </div>

--- a/src/settings/settings-command-handlers.ts
+++ b/src/settings/settings-command-handlers.ts
@@ -1,10 +1,11 @@
-import type { AppSettings } from "../provider-settings-state.js";
+import { getProviderAppSettings, type AppSettings } from "../provider-settings-state.js";
 import type { HomeSettingsContentBaseProps } from "./home-settings-content-props.js";
 import {
   exportHomeModelCatalog,
   importHomeModelCatalog,
   saveHomeSettings,
 } from "./settings-actions.js";
+import { resolveProviderRelativePathFromSelection } from "./settings-view-model.js";
 import type { WithMateWindowApi } from "../withmate-window-api.js";
 
 type SettingsCommandHandlersContext = {
@@ -21,6 +22,9 @@ export type SettingsCommandHandlers = Pick<
   | "onExportModelCatalog"
   | "onOpenAppLogFolder"
   | "onOpenCrashDumpFolder"
+  | "onBrowseProviderSkillRootPath"
+  | "onBrowseProviderSkillRelativePath"
+  | "onBrowseProviderInstructionRelativePath"
   | "onSaveSettings"
 >;
 
@@ -38,6 +42,38 @@ export function buildSettingsCommandHandlers({
     }
 
     await callback(api);
+  };
+  const updateProviderSettings = (
+    providerId: string,
+    patch: Partial<ReturnType<typeof getProviderAppSettings>>,
+  ) => {
+    const currentProviderSettings = getProviderAppSettings(persistedSettingsDraft, providerId);
+    setSettingsDraft({
+      ...persistedSettingsDraft,
+      codingProviderSettings: {
+        ...persistedSettingsDraft.codingProviderSettings,
+        [providerId]: {
+          ...currentProviderSettings,
+          ...patch,
+        },
+      },
+    });
+  };
+
+  const resolveRelativePathSelection = (
+    providerId: string,
+    selectedPath: string,
+    fieldLabel: string,
+  ): string | null => {
+    const currentProviderSettings = getProviderAppSettings(persistedSettingsDraft, providerId);
+    const rootDirectory = currentProviderSettings.skillRootPath.trim();
+    const relativePath = resolveProviderRelativePathFromSelection(rootDirectory, selectedPath);
+    if (relativePath === null) {
+      setSettingsFeedback(`Root Directory 配下の ${fieldLabel} を選んでね。`);
+      return null;
+    }
+
+    return relativePath;
   };
 
   return {
@@ -76,6 +112,79 @@ export function buildSettingsCommandHandlers({
           setSettingsFeedback("クラッシュダンプフォルダを開いたよ。");
         } catch (error) {
           setSettingsFeedback(error instanceof Error ? error.message : "クラッシュダンプフォルダを開けなかったよ。");
+        }
+      });
+    },
+    onBrowseProviderSkillRootPath: (providerId) => {
+      void withApi(async (api) => {
+        try {
+          const currentProviderSettings = getProviderAppSettings(persistedSettingsDraft, providerId);
+          const selectedPath = await api.pickDirectory(currentProviderSettings.skillRootPath || null);
+          if (!selectedPath) {
+            setSettingsFeedback("Root Directory の選択をキャンセルしたよ。");
+            return;
+          }
+
+          updateProviderSettings(providerId, { skillRootPath: selectedPath });
+          setSettingsFeedback("Root Directory を反映したよ。保存すると有効になるよ。");
+        } catch (error) {
+          setSettingsFeedback(error instanceof Error ? error.message : "Root Directory を選択できなかったよ。");
+        }
+      });
+    },
+    onBrowseProviderSkillRelativePath: (providerId) => {
+      void withApi(async (api) => {
+        try {
+          const currentProviderSettings = getProviderAppSettings(persistedSettingsDraft, providerId);
+          const rootDirectory = currentProviderSettings.skillRootPath.trim();
+          if (!rootDirectory) {
+            setSettingsFeedback("Skill folder を選ぶ前に Root Directory を指定してね。");
+            return;
+          }
+
+          const selectedPath = await api.pickDirectory(rootDirectory);
+          if (!selectedPath) {
+            setSettingsFeedback("Skill Relative Path の選択をキャンセルしたよ。");
+            return;
+          }
+
+          const relativePath = resolveRelativePathSelection(providerId, selectedPath, "Skill folder");
+          if (relativePath === null) {
+            return;
+          }
+
+          updateProviderSettings(providerId, { skillRelativePath: relativePath });
+          setSettingsFeedback("Skill Relative Path を反映したよ。保存すると有効になるよ。");
+        } catch (error) {
+          setSettingsFeedback(error instanceof Error ? error.message : "Skill Relative Path を選択できなかったよ。");
+        }
+      });
+    },
+    onBrowseProviderInstructionRelativePath: (providerId) => {
+      void withApi(async (api) => {
+        try {
+          const currentProviderSettings = getProviderAppSettings(persistedSettingsDraft, providerId);
+          const rootDirectory = currentProviderSettings.skillRootPath.trim();
+          if (!rootDirectory) {
+            setSettingsFeedback("Instruction file を選ぶ前に Root Directory を指定してね。");
+            return;
+          }
+
+          const selectedPath = await api.pickFile(rootDirectory);
+          if (!selectedPath) {
+            setSettingsFeedback("Instruction Relative Path の選択をキャンセルしたよ。");
+            return;
+          }
+
+          const relativePath = resolveRelativePathSelection(providerId, selectedPath, "Instruction file");
+          if (relativePath === null) {
+            return;
+          }
+
+          updateProviderSettings(providerId, { instructionRelativePath: relativePath });
+          setSettingsFeedback("Instruction Relative Path を反映したよ。保存すると有効になるよ。");
+        } catch (error) {
+          setSettingsFeedback(error instanceof Error ? error.message : "Instruction Relative Path を選択できなかったよ。");
         }
       });
     },

--- a/src/settings/settings-draft-actions.ts
+++ b/src/settings/settings-draft-actions.ts
@@ -6,6 +6,7 @@ import {
   removeMateMemoryGenerationPriorityDraft,
   updateAutoCollapseActionDockOnSend,
   updateCodingProviderEnabledDraft,
+  updateCodingProviderInstructionRelativePathDraft,
   updateCodingProviderSkillRelativePathDraft,
   updateCodingProviderSkillRootPathDraft,
   updateMateMemoryGenerationPriorityModelDraft,
@@ -55,6 +56,14 @@ export function handleChangeProviderSkillRelativePath(input: SettingsDraftAction
 }): void {
   input.setSettingsDraft((current) =>
     updateCodingProviderSkillRelativePathDraft(current, input.providerId, input.skillRelativePath));
+}
+
+export function handleChangeProviderInstructionRelativePath(input: SettingsDraftActionInput & {
+  providerId: string;
+  instructionRelativePath: string;
+}): void {
+  input.setSettingsDraft((current) =>
+    updateCodingProviderInstructionRelativePathDraft(current, input.providerId, input.instructionRelativePath));
 }
 
 export function handleChangeMemoryGenerationEnabled(input: SettingsDraftActionInput & {

--- a/src/settings/settings-draft-handlers.ts
+++ b/src/settings/settings-draft-handlers.ts
@@ -3,7 +3,10 @@ import type { AppSettings } from "../provider-settings-state.js";
 import type { HomeSettingsContentBaseProps } from "./home-settings-content-props.js";
 import {
   handleChangeAutoCollapseActionDockOnSend,
+  handleChangeProviderInstructionRelativePath,
   handleChangeProviderEnabled,
+  handleChangeProviderSkillRelativePath,
+  handleChangeProviderSkillRootPath,
   handleChangeUserMicrocopySlot,
 } from "./settings-draft-actions.js";
 
@@ -16,6 +19,9 @@ export type SettingsDraftHandlers = Pick<
   | "onChangeAutoCollapseActionDockOnSend"
   | "onChangeUserMicrocopySlot"
   | "onChangeProviderEnabled"
+  | "onChangeProviderInstructionRelativePath"
+  | "onChangeProviderSkillRootPath"
+  | "onChangeProviderSkillRelativePath"
 >;
 
 export function buildSettingsDraftHandlers({
@@ -30,6 +36,15 @@ export function buildSettingsDraftHandlers({
     },
     onChangeProviderEnabled: (providerId, enabled) => {
       handleChangeProviderEnabled({ providerId, enabled, setSettingsDraft });
+    },
+    onChangeProviderSkillRootPath: (providerId, skillRootPath) => {
+      handleChangeProviderSkillRootPath({ providerId, skillRootPath, setSettingsDraft });
+    },
+    onChangeProviderSkillRelativePath: (providerId, skillRelativePath) => {
+      handleChangeProviderSkillRelativePath({ providerId, skillRelativePath, setSettingsDraft });
+    },
+    onChangeProviderInstructionRelativePath: (providerId, instructionRelativePath) => {
+      handleChangeProviderInstructionRelativePath({ providerId, instructionRelativePath, setSettingsDraft });
     },
   };
 }

--- a/src/settings/settings-draft.ts
+++ b/src/settings/settings-draft.ts
@@ -88,6 +88,17 @@ export function updateCodingProviderSkillRelativePathDraft(
   };
 }
 
+export function updateCodingProviderInstructionRelativePathDraft(
+  draft: AppSettings,
+  providerId: string,
+  instructionRelativePath: string,
+): AppSettings {
+  return {
+    ...draft,
+    codingProviderSettings: updateCodingProviderInstructionRelativePath(draft, providerId, instructionRelativePath),
+  };
+}
+
 export function updateCodingProviderEnabled(
   draft: AppSettings,
   providerId: string,
@@ -140,6 +151,20 @@ export function updateCodingProviderSkillRelativePath(
     [providerId]: {
       ...getProviderAppSettings(draft, providerId),
       skillRelativePath,
+    },
+  };
+}
+
+export function updateCodingProviderInstructionRelativePath(
+  draft: AppSettings,
+  providerId: string,
+  instructionRelativePath: string,
+): Record<string, ProviderAppSettings> {
+  return {
+    ...draft.codingProviderSettings,
+    [providerId]: {
+      ...getProviderAppSettings(draft, providerId),
+      instructionRelativePath,
     },
   };
 }

--- a/src/settings/settings-ui.ts
+++ b/src/settings/settings-ui.ts
@@ -7,6 +7,19 @@ import {
 
 export const SETTINGS_SKILL_ROOT_LABEL = "Skill Root";
 export const SETTINGS_SKILL_ROOT_PLACEHOLDER = "skill folder の親ディレクトリを入力";
+export const SETTINGS_PROVIDER_FILE_SETTINGS_LABEL = "Provider File Settings";
+export const SETTINGS_PROVIDER_ROOT_DIRECTORY_LABEL = "Root Directory";
+export const SETTINGS_PROVIDER_ROOT_DIRECTORY_PLACEHOLDER = "Provider 設定の root directory";
+export const SETTINGS_PROVIDER_SKILL_RELATIVE_PATH_LABEL = "Skill Relative Path";
+export const SETTINGS_PROVIDER_SKILL_RELATIVE_PATH_PLACEHOLDER = "skills";
+export const SETTINGS_PROVIDER_INSTRUCTION_RELATIVE_PATH_LABEL = "Instruction Relative Path";
+export const SETTINGS_PROVIDER_INSTRUCTION_RELATIVE_PATH_PLACEHOLDER = "AGENTS.md";
+export const SETTINGS_PROVIDER_FILE_SETTINGS_HELP =
+  "Provider ごとに skill folder と instruction file の基準 path を指定する。Root Directory が空欄の場合、skill は workspace 内の既定 directory だけを使う。";
+export const SETTINGS_PROVIDER_SKILL_RELATIVE_PATH_HELP =
+  "Root Directory 配下の skill folder を相対パスで指定する。例: skills";
+export const SETTINGS_PROVIDER_INSTRUCTION_RELATIVE_PATH_HELP =
+  "Root Directory 配下の instruction file を相対パスで指定する。V5では同期実行せず、provider ごとの設定値として保持する。";
 export const SETTINGS_API_KEY_LABEL = "OpenAI API Key (Coding Agent)";
 export const SETTINGS_API_KEY_PLACEHOLDER = "Coding Agent 用 OpenAI API Key を入力";
 export const SETTINGS_CODING_CREDENTIALS_HELP =

--- a/src/settings/settings-view-model.ts
+++ b/src/settings/settings-view-model.ts
@@ -11,6 +11,39 @@ import {
   type ModelCatalogSnapshot,
 } from "../model-catalog.js";
 
+function normalizeSelectablePath(filePath: string): string {
+  return filePath.trim().replace(/\\/g, "/").replace(/\/+$/g, "");
+}
+
+function normalizePathComparisonKey(filePath: string): string {
+  const normalized = normalizeSelectablePath(filePath);
+  return /^[a-z]:\//i.test(normalized) ? normalized.toLowerCase() : normalized;
+}
+
+export function resolveProviderRelativePathFromSelection(
+  rootDirectory: string,
+  selectedPath: string,
+): string | null {
+  const normalizedRoot = normalizeSelectablePath(rootDirectory);
+  const normalizedSelectedPath = normalizeSelectablePath(selectedPath);
+  if (!normalizedRoot || !normalizedSelectedPath) {
+    return null;
+  }
+
+  const rootKey = normalizePathComparisonKey(normalizedRoot);
+  const selectedKey = normalizePathComparisonKey(normalizedSelectedPath);
+  if (selectedKey === rootKey) {
+    return "";
+  }
+
+  const prefix = `${rootKey}/`;
+  if (!selectedKey.startsWith(prefix)) {
+    return null;
+  }
+
+  return normalizedSelectedPath.slice(normalizedRoot.length + 1);
+}
+
 export type HomeProviderSettingRow = {
   provider: ModelCatalogProvider;
   settings: ProviderAppSettings;

--- a/src/styles.css
+++ b/src/styles.css
@@ -2322,6 +2322,18 @@ button:disabled {
   gap: 0;
 }
 
+.settings-provider-file-settings {
+  display: grid;
+  gap: 10px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(203, 213, 225, 0.1);
+}
+
+.settings-provider-file-settings strong {
+  color: var(--ink);
+  font-size: 0.86rem;
+}
+
 .settings-provider-name {
   margin: 0;
   color: var(--ink);


### PR DESCRIPTION
## 概要

- Coding provider ごとの Provider File Settings を Settings UI に戻しました。
- `Root Directory`、`Skill Relative Path`、`Instruction Relative Path` を `codingProviderSettings` で保持します。
- Session の Skill 選択が provider ごとの `Root Directory + Skill Relative Path` を使って一覧化する経路をテストで固定しました。

## 背景

Issue #201 で V4 に残っていた provider ごとの設定を V5 向けに戻す必要がありました。旧 `Provider Instruction Sync` 全体は戻さず、V5 current で必要な file path 設定だけを再実装しています。

## 影響

- Skill discovery は provider ごとの skill directory を追加探索元として使います。
- Instruction file path は現時点では設定値として保持し、同期処理や prompt composition には使いません。
- 旧 sync の write mode / fail policy / sync status は復活させていません。

## 検証

- `npx tsx --test scripts/tests/home-settings-actions.test.ts scripts/tests/home-components.test.tsx scripts/tests/home-settings-draft.test.ts scripts/tests/provider-settings-state.test.ts scripts/tests/app-settings-storage.test.ts scripts/tests/model-catalog-settings.test.ts scripts/tests/approval-mode.test.ts scripts/tests/home-launch-projection.test.ts`
- `npx tsx --test scripts/tests/main-query-service.test.ts scripts/tests/skill-discovery.test.ts scripts/tests/home-settings-draft.test.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Closes #201