### PR TITLE
[codex] Character editor UI の崩れを修正

### DIFF
--- a/scripts/tests/character-editor-state.test.ts
+++ b/scripts/tests/character-editor-state.test.ts
@@ -10,6 +10,7 @@ import {
   createNewCharacterEditorDraft,
   isCharacterEditorDraftDirty,
   replaceCharacterDefinitionDraft,
+  shouldBlockCharacterEditorBeforeUnload,
   updateCharacterEditorDraft,
 } from "../../src/character-editor/character-editor-state.js";
 
@@ -69,6 +70,13 @@ describe("Character editor state", () => {
     assert.equal(isCharacterEditorDraftDirty({ ...draft, description: "changed" }, detail), true);
     assert.equal(isCharacterEditorDraftDirty({ ...draft, state: "archived" }, detail), true);
     assert.equal(isCharacterEditorDraftDirty(createNewCharacterEditorDraft(), null), true);
+  });
+
+  it("close 確認済みの beforeunload は dirty draft でもブロックしない", () => {
+    assert.equal(shouldBlockCharacterEditorBeforeUnload({ dirty: true, saving: false, confirmedClose: false }), true);
+    assert.equal(shouldBlockCharacterEditorBeforeUnload({ dirty: true, saving: true, confirmedClose: false }), false);
+    assert.equal(shouldBlockCharacterEditorBeforeUnload({ dirty: false, saving: false, confirmedClose: false }), false);
+    assert.equal(shouldBlockCharacterEditorBeforeUnload({ dirty: true, saving: false, confirmedClose: true }), false);
   });
 
   it("create payload は default fallback を潰す setDefault false を渡さない", () => {

--- a/src/CharacterEditorApp.tsx
+++ b/src/CharacterEditorApp.tsx
@@ -11,6 +11,7 @@ import {
   formatCharacterEditorError,
   isCharacterEditorDraftDirty,
   replaceCharacterDefinitionDraft,
+  shouldBlockCharacterEditorBeforeUnload,
   type CharacterEditorDraft,
   type CharacterEditorTab,
   updateCharacterEditorDraft,
@@ -53,10 +54,12 @@ export default function CharacterEditorApp() {
   const [feedback, setFeedback] = useState("");
   const definitionImportInputRef = useRef<HTMLInputElement | null>(null);
   const notesImportInputRef = useRef<HTMLInputElement | null>(null);
+  const confirmedCloseRef = useRef(false);
 
   const validation = useMemo(() => buildCharacterEditorValidationSummary(draft), [draft]);
   const dirty = isCharacterEditorDraftDirty(draft, persistedDetail);
   const archived = draft.state === "archived";
+  const denseEditorBody = selectedTab === "definition" || selectedTab === "notes" || selectedTab === "preview";
   const themeStyle = useMemo(() => buildCharacterThemeStyle({
     main: draft.theme.main,
     sub: draft.theme.sub,
@@ -104,7 +107,7 @@ export default function CharacterEditorApp() {
 
   useEffect(() => {
     const beforeUnload = (event: BeforeUnloadEvent) => {
-      if (!dirty || saving) {
+      if (!shouldBlockCharacterEditorBeforeUnload({ dirty, saving, confirmedClose: confirmedCloseRef.current })) {
         return;
       }
       event.preventDefault();
@@ -239,6 +242,7 @@ export default function CharacterEditorApp() {
     if (dirty && !window.confirm("未保存の編集があります。\n\n保存せずに閉じますか？")) {
       return;
     }
+    confirmedCloseRef.current = true;
     window.close();
   };
 
@@ -304,8 +308,6 @@ export default function CharacterEditorApp() {
     reader.readAsText(file);
   };
 
-  const modeLabel = archived ? "Archived Character" : draft.mode === "create" ? "Create Character" : "Edit Character";
-
   if (!desktopRuntime) {
     return (
       <div className="page-shell character-editor-page">
@@ -323,7 +325,6 @@ export default function CharacterEditorApp() {
           <div className="character-editor-heading">
             <CharacterAvatar character={{ name: draft.name, iconPath: draft.iconFilePath }} size="large" />
             <div>
-              <p className="settings-note">{modeLabel}</p>
               <h1>{draft.name || "New Character"}</h1>
               <p>{draft.description || "No description"}</p>
             </div>
@@ -349,10 +350,10 @@ export default function CharacterEditorApp() {
           ))}
         </nav>
 
-        <main className="character-editor-window-body">
+        <main className={`character-editor-window-body ${denseEditorBody ? "character-editor-window-body-dense" : ""}`.trim()}>
           {loading ? <p className="settings-note">Character を読み込んでいます...</p> : null}
           {!loading && selectedTab === "profile" ? (
-            <section className="settings-section-card character-editor-card">
+            <section className="character-editor-profile-card">
               <div className="settings-character-form-grid">
                 <label className="settings-provider-input">
                   <span>Name</span>
@@ -415,7 +416,7 @@ export default function CharacterEditorApp() {
           ) : null}
 
           {!loading && selectedTab === "definition" ? (
-            <section className="settings-section-card character-editor-card character-editor-markdown-card">
+            <section className="character-editor-markdown-card">
               <div className="settings-section-head-row">
                 <strong>character.md</strong>
                 <button
@@ -454,7 +455,7 @@ export default function CharacterEditorApp() {
           ) : null}
 
           {!loading && selectedTab === "notes" ? (
-            <section className="settings-section-card character-editor-card character-editor-markdown-card">
+            <section className="character-editor-markdown-card">
               <div className="settings-section-head-row">
                 <strong>character-notes.md</strong>
                 <button
@@ -493,14 +494,14 @@ export default function CharacterEditorApp() {
           ) : null}
 
           {!loading && selectedTab === "preview" ? (
-            <section className="settings-section-card character-editor-card character-editor-preview-grid">
-              <div className="home-character-card-preview">
+            <section className="character-editor-preview-grid">
+              <div className="character-editor-preview-profile">
                 <CharacterAvatar character={{ name: draft.name, iconPath: draft.iconFilePath }} size="large" />
                 <strong>{draft.name || "New Character"}</strong>
                 <p>{draft.description || "No description"}</p>
                 {draft.isDefault ? <span className="settings-character-badge">Default</span> : null}
               </div>
-              <label className="settings-provider-input">
+              <label className="settings-provider-input character-editor-runtime-preview">
                 <span>Runtime prompt preview</span>
                 <textarea value={runtimePromptPreview} readOnly rows={14} spellCheck={false} />
               </label>

--- a/src/character-editor/character-editor-state.ts
+++ b/src/character-editor/character-editor-state.ts
@@ -169,6 +169,14 @@ export function isCharacterEditorDraftDirty(
     || draft.isDefault !== persistedDetail.isDefault;
 }
 
+export function shouldBlockCharacterEditorBeforeUnload(args: {
+  dirty: boolean;
+  saving: boolean;
+  confirmedClose: boolean;
+}): boolean {
+  return args.dirty && !args.saving && !args.confirmedClose;
+}
+
 export function normalizeThemeColorDraft(value: string, fallback: string): string {
   const trimmed = value.trim();
   return /^#[0-9a-fA-F]{6}$/.test(trimmed) ? trimmed.toLowerCase() : fallback;

--- a/src/styles.css
+++ b/src/styles.css
@@ -2390,6 +2390,7 @@ button:disabled {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;
+  align-items: start;
 }
 
 .settings-character-theme-fields {
@@ -6685,6 +6686,11 @@ button:disabled {
   display: flex;
   align-items: flex-start;
   gap: 14px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.character-editor-heading > div {
   min-width: 0;
 }
 
@@ -6722,7 +6728,7 @@ button:disabled {
 .character-editor-header-actions {
   justify-content: flex-end;
   flex-wrap: wrap;
-  max-width: 420px;
+  max-width: min(420px, 42%);
   min-width: 0;
 }
 
@@ -6770,6 +6776,10 @@ button:disabled {
   background: rgba(10, 14, 20, 0.44);
 }
 
+.character-editor-window-body-dense {
+  padding-block: 12px;
+}
+
 .character-editor-card {
   display: grid;
   gap: 16px;
@@ -6780,10 +6790,25 @@ button:disabled {
   color: var(--ink);
 }
 
+.character-editor-profile-card {
+  display: grid;
+  gap: 18px;
+  align-self: start;
+  align-content: start;
+  grid-template-rows: auto auto;
+  min-height: 0;
+  overflow: visible;
+  color: var(--ink);
+}
+
 .character-editor-markdown-card {
+  display: grid;
+  gap: 12px;
   height: 100%;
   grid-template-rows: auto auto auto minmax(0, 1fr);
+  min-height: 0;
   overflow: hidden;
+  color: var(--ink);
 }
 
 .settings-character-import-input {
@@ -6799,28 +6824,46 @@ button:disabled {
 }
 
 .character-editor-preview-grid {
+  display: grid;
   grid-template-columns: minmax(240px, 0.8fr) minmax(0, 1.2fr);
   align-items: stretch;
+  gap: 18px;
+  min-height: 0;
+  height: 100%;
+  color: var(--ink);
 }
 
-.home-character-card-preview {
+.character-editor-runtime-preview {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  align-content: stretch;
+  min-height: 0;
+  height: 100%;
+}
+
+.character-editor-runtime-preview textarea {
+  min-height: 0;
+  height: 100%;
+  resize: none;
+  overflow: auto;
+}
+
+.character-editor-preview-profile {
   display: grid;
   gap: 10px;
   align-content: start;
-  padding: 16px;
-  border: 1px solid rgba(203, 213, 225, 0.12);
-  border-radius: var(--radius-md);
-  background: rgba(255, 255, 255, 0.04);
+  min-height: 0;
+  padding: 16px 4px 16px 0;
 }
 
-.home-character-card-preview strong {
+.character-editor-preview-profile strong {
   color: var(--ink);
   font-size: 1rem;
   min-width: 0;
   overflow-wrap: anywhere;
 }
 
-.home-character-card-preview p {
+.character-editor-preview-profile p {
   margin: 0;
   color: var(--muted);
   line-height: 1.5;
@@ -7430,6 +7473,15 @@ button:disabled {
   flex: 1 1 0;
 }
 
+.character-editor-page .settings-actions {
+  align-items: center;
+}
+
+.character-editor-page .settings-actions .launch-toggle {
+  flex: 0 0 auto;
+  min-width: 112px;
+}
+
 .character-editor-header-actions {
   display: flex;
   align-items: center;
@@ -7451,8 +7503,12 @@ button:disabled {
 .character-editor-page .launch-toggle {
   min-width: 0;
   min-height: 38px;
-  white-space: normal;
-  overflow-wrap: anywhere;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 9px 14px;
+  line-height: 1.15;
+  white-space: nowrap;
   background: rgba(255, 255, 255, 0.06);
   color: var(--ink);
   box-shadow: inset 0 0 0 1px rgba(203, 213, 225, 0.12);
@@ -7460,6 +7516,7 @@ button:disabled {
 
 .character-editor-page .launch-toggle.compact {
   min-height: 34px;
+  padding: 7px 12px;
 }
 
 .character-editor-page .launch-toggle:disabled,


### PR DESCRIPTION
## 概要
- Character editor の profile / character.md / character-notes.md / preview から不要な外側カードを外し、作業面として自然に伸びるレイアウトへ整理
- Set Default ボタン、ヘッダーの名前表示、Runtime prompt preview の余白崩れを修正
- 新規 Character を未保存で閉じる確認で、OK 後に閉じられない問題を修正

## 背景
issue #200 で、Character editor のボタンサイズ、ヘッダー表示の重なり、未保存 close の挙動、各 tab のカード内カード風レイアウトが指摘されていたためです。

## 検証
- `npx tsx --test scripts/tests/character-editor-state.test.ts`
- `npm run typecheck`
- `git diff --check`
- Electron hidden window で profile / markdown / preview のレイアウトを実測確認

Closes #200