### PR TITLE
[codex] Character authoring sessionをHomeに表示する

### DIFF
--- a/docs/design/desktop-ui.md
+++ b/docs/design/desktop-ui.md
@@ -72,10 +72,11 @@ Electron デスクトップアプリとして、`Home Window` / `Character Edito
   - section action として `New Session`
   - resume picker
   - session search input
-    - `taskTitle / workspace`
+    - `taskTitle / workspace / kind label`
     - 部分一致
   - card list は全 session を正本として表示し、storage 既定の `last_active_at DESC` を崩さない
   - `sessionKind === "character-update"` の update 専用 session はこの一覧から除外する
+  - `sessionKind === "character-authoring"` の Character authoring session は通常 session と同じ削除・再開導線へ到達できるよう表示する
   - card 常時表示情報
     - `avatar / taskTitle / runState badge / workspacePath / updatedAt`
     - `taskSummary` は 1 行補助情報として、空なら省略可

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "5.0.0-preview.8",
+  "version": "5.0.0-preview.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "5.0.0-preview.8",
+      "version": "5.0.0-preview.9",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "5.0.0-preview.8",
+  "version": "5.0.0-preview.9",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/scripts/tests/home-components.test.tsx
+++ b/scripts/tests/home-components.test.tsx
@@ -8,6 +8,8 @@ import { HomeMonitorContent } from "../../src/home/HomeMonitorContent.js";
 import { HomeRecentSessionsPanel } from "../../src/home/HomeRecentSessionsPanel.js";
 import { HomeRightPane } from "../../src/home/HomeRightPane.js";
 import type { HomeMonitorEntry } from "../../src/home/home-session-projection.js";
+import type { SessionSummary } from "../../src/session-state.js";
+import type { CompanionSessionSummary } from "../../src/companion-state.js";
 import { HomeMateSetupPanel } from "../../src/mate/MateSetupPanel.js";
 import { HomeSettingsContent } from "../../src/settings/SettingsContent.js";
 import { createDefaultAppSettings } from "../../src/provider-settings-state.js";
@@ -466,13 +468,79 @@ describe("HomeLaunchDialog", () => {
 
 describe("HomeRecentSessionsPanel", () => {
   const noOp = (..._args: unknown[]) => undefined;
+  const createSessionSummary = (partial: Partial<SessionSummary> & Pick<SessionSummary, "id" | "taskTitle">): SessionSummary => ({
+    status: "idle",
+    updatedAt: "2026-06-17T00:00:00.000Z",
+    provider: "codex",
+    catalogRevision: 1,
+    workspaceLabel: "workspace",
+    workspacePath: "C:/workspace",
+    branch: "main",
+    sessionKind: "default",
+    accessMode: "active",
+    sourceSchemaVersion: 4,
+    characterId: "char-1",
+    character: "Mia",
+    characterIconPath: "",
+    characterThemeColors: { main: "#223344", sub: "#88bbcc" },
+    runState: "idle",
+    approvalMode: "untrusted",
+    codexSandboxMode: "danger-full-access",
+    model: "gpt-5.4",
+    reasoningEffort: "high",
+    customAgentName: "",
+    allowedAdditionalDirectories: [],
+    threadId: "",
+    ...partial,
+  });
+  const createCompanionSummary = (
+    partial: Partial<CompanionSessionSummary> & Pick<CompanionSessionSummary, "id" | "taskTitle">,
+  ): CompanionSessionSummary => ({
+    status: "active",
+    updatedAt: "2026-06-17T00:00:00.000Z",
+    groupId: "group-1",
+    repoRoot: "C:/workspace/repo",
+    focusPath: "",
+    targetBranch: "main",
+    baseSnapshotRef: "refs/withmate/base/1",
+    baseSnapshotCommit: "base-1",
+    selectedPaths: [],
+    changedFiles: [],
+    siblingWarnings: [],
+    allowedAdditionalDirectories: [],
+    runState: "idle",
+    threadId: "",
+    provider: "codex",
+    model: "gpt-5.4",
+    reasoningEffort: "high",
+    approvalMode: "untrusted",
+    codexSandboxMode: "danger-full-access",
+    character: "Mia",
+    characterRoleMarkdown: "",
+    characterIconPath: "",
+    characterThemeColors: { main: "#223344", sub: "#88bbcc" },
+    latestMergeRun: null,
+    ...partial,
+  });
 
-  const renderHomeRecentSessions = (canUsePrimaryFeatures = true) => renderToStaticMarkup(
+  const renderHomeRecentSessions = ({
+    canUsePrimaryFeatures = true,
+    filteredSessionEntries = [],
+    companionSessions = [],
+    normalizedSessionSearch = "",
+    searchText = "",
+  }: {
+    canUsePrimaryFeatures?: boolean;
+    filteredSessionEntries?: React.ComponentProps<typeof HomeRecentSessionsPanel>["filteredSessionEntries"];
+    companionSessions?: CompanionSessionSummary[];
+    normalizedSessionSearch?: string;
+    searchText?: string;
+  } = {}) => renderToStaticMarkup(
     <HomeRecentSessionsPanel
-      filteredSessionEntries={[]}
-      companionSessions={[]}
-      normalizedSessionSearch=""
-      searchText=""
+      filteredSessionEntries={filteredSessionEntries}
+      companionSessions={companionSessions}
+      normalizedSessionSearch={normalizedSessionSearch}
+      searchText={searchText}
       searchIcon={<span />}
       onChangeSearchText={noOp}
       onOpenLaunchDialog={noOp}
@@ -483,7 +551,7 @@ describe("HomeRecentSessionsPanel", () => {
   );
 
   it("canUsePrimaryFeatures false の時は New Session が無効化される", () => {
-    const html = renderHomeRecentSessions(false);
+    const html = renderHomeRecentSessions({ canUsePrimaryFeatures: false });
     const disabledButtons = html.match(/<button class="start-session-button"[^>]*disabled=""/g);
     assert.equal(disabledButtons?.length, 1);
   });
@@ -492,6 +560,39 @@ describe("HomeRecentSessionsPanel", () => {
     const html = renderHomeRecentSessions();
     const newSessionButtons = html.match(/<button class="start-session-button"/g);
     assert.equal(newSessionButtons?.length, 1);
+  });
+
+  it("character authoring session は Character badge で表示する", () => {
+    const html = renderHomeRecentSessions({
+      filteredSessionEntries: [
+        {
+          kind: "agent",
+          session: createSessionSummary({
+            id: "authoring",
+            taskTitle: "Mia の character.md 改善",
+            sessionKind: "character-authoring",
+          }),
+          state: { kind: "neutral", label: "idle" },
+        },
+      ],
+    });
+
+    assert.ok(html.includes("Mia の character.md 改善"));
+    assert.ok(html.includes("session-mode-badge character"));
+    assert.ok(html.includes(">Character<"));
+  });
+
+  it("companion kind label で Companion session を検索できる", () => {
+    const html = renderHomeRecentSessions({
+      companionSessions: [
+        createCompanionSummary({ id: "companion-1", taskTitle: "Review task" }),
+      ],
+      normalizedSessionSearch: "companion",
+      searchText: "companion",
+    });
+
+    assert.ok(html.includes("Review task"));
+    assert.ok(html.includes(">Companion<"));
   });
 });
 

--- a/scripts/tests/home-session-projection.test.ts
+++ b/scripts/tests/home-session-projection.test.ts
@@ -113,7 +113,7 @@ describe("home-session-projection", () => {
     assert.equal(projection.monitorCompletedEmptyMessage, "一致するセッションはないよ。");
   });
 
-  it("character-update / character-authoring session を Home 一覧と monitor から除外する", () => {
+  it("character-authoring session は Home に表示し、character-update session は除外する", () => {
     const projection = buildHomeSessionProjection(
       [
         createSession({ id: "main", taskTitle: "Main Task", branch: "main" }),
@@ -144,11 +144,27 @@ describe("home-session-projection", () => {
       false,
     );
     assert.equal(
-      shouldDisplayHomeSession(createSession({ id: "hidden-authoring", taskTitle: "hidden", branch: "main", sessionKind: "character-authoring" })),
-      false,
+      shouldDisplayHomeSession(createSession({ id: "visible-authoring", taskTitle: "visible", branch: "main", sessionKind: "character-authoring" })),
+      true,
     );
-    assert.deepEqual(projection.filteredSessionEntries.map(({ session }) => session.id), ["main"]);
-    assert.deepEqual(projection.monitorEntries.map(({ session }) => session.id), ["main"]);
+    assert.deepEqual(projection.filteredSessionEntries.map(({ session }) => session.id), ["main", "authoring"]);
+    assert.deepEqual(projection.monitorEntries.map(({ session }) => session.id), ["main", "authoring"]);
+  });
+
+  it("session kind label でも Home session を検索できる", () => {
+    const sessions = [
+      createSession({ id: "agent", taskTitle: "Main Task", sessionKind: "default" }),
+      createSession({ id: "authoring", taskTitle: "Muse の作成", sessionKind: "character-authoring" }),
+    ];
+
+    assert.deepEqual(
+      buildHomeSessionProjection(sessions, [], "agent").filteredSessionEntries.map(({ session }) => session.id),
+      ["agent", "authoring"],
+    );
+    assert.deepEqual(
+      buildHomeSessionProjection(sessions, [], "character").filteredSessionEntries.map(({ session }) => session.id),
+      ["authoring"],
+    );
   });
 
   it("Monitor entries に Companion session と group 表示情報を含める", () => {

--- a/src/home/HomeRecentSessionsPanel.tsx
+++ b/src/home/HomeRecentSessionsPanel.tsx
@@ -18,6 +18,20 @@ export type HomeRecentSessionsPanelProps = {
   canUsePrimaryFeatures?: boolean;
 };
 
+function getAgentSessionModeBadge(session: SessionSummary): { className: string; label: string } {
+  if (session.sessionKind === "character-authoring") {
+    return {
+      className: "session-mode-badge character",
+      label: "Character",
+    };
+  }
+
+  return {
+    className: "session-mode-badge agent",
+    label: "Agent",
+  };
+}
+
 export function HomeRecentSessionsPanel({
   filteredSessionEntries,
   companionSessions,
@@ -53,6 +67,7 @@ export function HomeRecentSessionsPanel({
       return true;
     }
     const haystack = [
+      "companion",
       session.taskTitle,
       session.character,
       session.repoRoot,
@@ -140,6 +155,7 @@ export function HomeRecentSessionsPanel({
 
           const { session, state } = item.entry;
           const isReadOnly = isLegacyReadOnlySession(session);
+          const modeBadge = getAgentSessionModeBadge(session);
           return (
             <button
               key={`agent-${session.id}`}
@@ -154,7 +170,7 @@ export function HomeRecentSessionsPanel({
                 <div className="session-card-topline home-session-card-topline">
                   <strong>{session.taskTitle}</strong>
                   <div className="home-session-card-badges">
-                    <span className="session-mode-badge agent">Agent</span>
+                    <span className={modeBadge.className}>{modeBadge.label}</span>
                     {isReadOnly ? <span className="session-status home-session-status neutral">閲覧専用</span> : null}
                     <span className={`session-status home-session-status ${state.kind}`.trim()}>{state.label}</span>
                   </div>

--- a/src/home/home-session-projection.ts
+++ b/src/home/home-session-projection.ts
@@ -34,7 +34,15 @@ export type HomeSessionProjection = {
 };
 
 export function shouldDisplayHomeSession(session: SessionSummary): boolean {
-  return session.sessionKind !== "character-update" && session.sessionKind !== "character-authoring";
+  return session.sessionKind !== "character-update";
+}
+
+export function getHomeSessionKindSearchLabels(session: SessionSummary): string[] {
+  if (session.sessionKind === "character-authoring") {
+    return ["character", "character authoring", "authoring", "agent"];
+  }
+
+  return ["agent", session.sessionKind];
 }
 
 export function getHomeSessionState(session: SessionSummary): HomeSessionState {
@@ -196,7 +204,12 @@ export function buildHomeSessionProjection(
         return true;
       }
 
-      const haystacks = [session.taskTitle, session.workspacePath, session.workspaceLabel]
+      const haystacks = [
+        session.taskTitle,
+        session.workspacePath,
+        session.workspaceLabel,
+        ...getHomeSessionKindSearchLabels(session),
+      ]
         .map((value) => value.toLocaleLowerCase());
       return haystacks.some((value) => value.includes(normalizedSessionSearch));
     })

--- a/src/styles.css
+++ b/src/styles.css
@@ -1121,6 +1121,11 @@ button:disabled {
   background: rgba(111, 184, 199, 0.14);
 }
 
+.home-page .session-mode-badge.character {
+  border-color: rgba(125, 211, 168, 0.34);
+  background: rgba(125, 211, 168, 0.18);
+}
+
 .home-page .home-session-chip-status.running,
 .home-page .home-session-status.running,
 .home-page .home-monitor-status.running {


### PR DESCRIPTION
## Summary
- Character authoring session を Home の Recent Sessions / Monitor に表示する
- Home の session 検索対象に kind label を追加し、agent / character / companion で絞り込めるようにする
- Character authoring session 用の badge とテストを追加する
- アプリバージョンを 5.0.0-preview.9 に更新する

## Root Cause
Character authoring session は通常 session として DB に保存される一方、Home projection で `character-authoring` が除外されていたため、session window を閉じると再オープンして削除する導線がなくなっていた。

## Validation
- `npx tsx --test scripts/tests/home-session-projection.test.ts scripts/tests/home-components.test.tsx`
- `npm run typecheck`
- `npm run build`
- `git diff --check`