### PR TITLE
[codex] Companion V4 audit storage の実行経路を修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "5.0.0-preview.9",
+  "version": "5.0.0-preview.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "5.0.0-preview.9",
+      "version": "5.0.0-preview.10",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "5.0.0-preview.9",
+  "version": "5.0.0-preview.10",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/scripts/migrate-database-v3-to-v4.ts
+++ b/scripts/migrate-database-v3-to-v4.ts
@@ -11,6 +11,7 @@ import { APP_DATABASE_V3_FILENAME, isValidV3Database } from "../src-electron/dat
 import { APP_DATABASE_V4_FILENAME, CREATE_V4_SCHEMA_SQL } from "../src-electron/database-schema-v4.js";
 import { AuditLogStorage } from "../src-electron/audit-log-storage.js";
 import { AuditLogStorageV3 } from "../src-electron/audit-log-storage-v3.js";
+import { CompanionAuditLogStorage } from "../src-electron/companion-audit-log-storage.js";
 import { CompanionAuditLogStorageV3 } from "../src-electron/companion-audit-log-storage-v3.js";
 import { CompanionStorage } from "../src-electron/companion-storage.js";
 import { CompanionStorageV3 } from "../src-electron/companion-storage-v3.js";
@@ -383,7 +384,7 @@ async function migrateCompanionData(input: {
     input.sourceDatabaseFile,
     input.sourceBlobRootPath,
   );
-  const targetCompanionAuditStorage = new CompanionAuditLogStorageV3(
+  const targetCompanionAuditStorage = new CompanionAuditLogStorage(
     input.targetDatabaseFile,
     input.targetBlobRootPath,
   );

--- a/scripts/tests/companion-audit-log-storage.test.ts
+++ b/scripts/tests/companion-audit-log-storage.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { describe, it } from "node:test";
+
+import { DEFAULT_APPROVAL_MODE } from "../../src/approval-mode.js";
+import { DEFAULT_CODEX_SANDBOX_MODE } from "../../src/codex-sandbox-mode.js";
+import type { CompanionGroup, CompanionSession } from "../../src/companion-state.js";
+import { DEFAULT_CATALOG_REVISION, DEFAULT_MODEL_ID, DEFAULT_REASONING_EFFORT } from "../../src/model-catalog.js";
+import { CompanionAuditLogStorage } from "../../src-electron/companion-audit-log-storage.js";
+import { CompanionStorage } from "../../src-electron/companion-storage.js";
+
+function createGroup(): CompanionGroup {
+  return {
+    id: "group-1",
+    repoRoot: "F:/work/demo",
+    displayName: "demo",
+    createdAt: "2026-04-26 10:00",
+    updatedAt: "2026-04-26 10:00",
+  };
+}
+
+function createSession(groupId: string): CompanionSession {
+  return {
+    id: "session-1",
+    groupId,
+    taskTitle: "Companion task",
+    status: "active",
+    repoRoot: "F:/work/demo",
+    focusPath: "src",
+    targetBranch: "main",
+    baseSnapshotRef: "refs/withmate/companion/session-1/base",
+    baseSnapshotCommit: "abc123",
+    companionBranch: "withmate/companion/session-1",
+    worktreePath: "F:/app/companion-worktrees/group-1/session-1",
+    selectedPaths: [],
+    changedFiles: [],
+    siblingWarnings: [],
+    allowedAdditionalDirectories: [],
+    runState: "idle",
+    threadId: "",
+    provider: "codex",
+    catalogRevision: DEFAULT_CATALOG_REVISION,
+    model: DEFAULT_MODEL_ID,
+    reasoningEffort: DEFAULT_REASONING_EFFORT,
+    customAgentName: "",
+    approvalMode: DEFAULT_APPROVAL_MODE,
+    codexSandboxMode: DEFAULT_CODEX_SANDBOX_MODE,
+    characterId: "char-1",
+    character: "Mia",
+    characterRoleMarkdown: "落ち着いて伴走する。",
+    characterIconPath: "icon.png",
+    characterThemeColors: {
+      main: "#6f8cff",
+      sub: "#6fb8c7",
+    },
+    createdAt: "2026-04-26 10:01",
+    updatedAt: "2026-04-26 10:01",
+    messages: [],
+  };
+}
+
+describe("CompanionAuditLogStorage", () => {
+  it("V4 CompanionStorage schema で audit log を更新できる", async () => {
+    const tempDirectory = await mkdtemp(path.join(os.tmpdir(), "withmate-companion-audit-log-"));
+    const dbPath = path.join(tempDirectory, "withmate-v4.db");
+    const blobRootPath = path.join(tempDirectory, "blobs", "v3");
+    let companionStorage: CompanionStorage | null = null;
+    let auditStorage: CompanionAuditLogStorage | null = null;
+
+    try {
+      companionStorage = new CompanionStorage(dbPath);
+      const group = companionStorage.ensureGroup(createGroup());
+      companionStorage.createSession(createSession(group.id));
+
+      const db = new DatabaseSync(dbPath);
+      try {
+        const columns = (db.prepare("PRAGMA table_info(companion_sessions)").all() as Array<{ name: string }>)
+          .map((column) => column.name);
+        assert.equal(columns.includes("character_role_markdown"), true);
+        assert.equal(columns.includes("character_role_blob_id"), false);
+      } finally {
+        db.close();
+      }
+
+      auditStorage = new CompanionAuditLogStorage(dbPath, blobRootPath);
+      const created = await auditStorage.createAuditLog({
+        sessionId: "session-1",
+        createdAt: "2026-04-27T10:00:00.000Z",
+        phase: "running",
+        provider: "codex",
+        model: "gpt-5.4-mini",
+        reasoningEffort: "medium",
+        approvalMode: DEFAULT_APPROVAL_MODE,
+        threadId: "thread-v4",
+        logicalPrompt: {
+          systemText: "system",
+          inputText: "input",
+          composedText: "system\ninput",
+        },
+        transportPayload: null,
+        assistantText: "",
+        operations: [],
+        rawItemsJson: "[]",
+        usage: null,
+        errorMessage: "",
+      });
+
+      const updated = await auditStorage.updateAuditLog(created.id, {
+        ...created,
+        phase: "completed",
+        assistantText: "完了したよ。",
+      });
+
+      assert.equal(updated.phase, "completed");
+      assert.equal(updated.assistantText, "完了したよ。");
+      assert.equal((await auditStorage.listSessionAuditLogs("session-1"))[0]?.phase, "completed");
+    } finally {
+      auditStorage?.close();
+      companionStorage?.close();
+      await rm(tempDirectory, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/tests/companion-runtime-service.test.ts
+++ b/scripts/tests/companion-runtime-service.test.ts
@@ -356,4 +356,266 @@ describe("CompanionRuntimeService", () => {
       console.warn = originalWarn;
     }
   });
+
+  it("完了時の audit 更新に失敗しても CompanionSession を completed 状態で保存する", async () => {
+    let storedSession = createCompanionSession();
+    const storedSessions: CompanionSession[] = [];
+    const adapter: ProviderCodingAdapter = {
+      composePrompt() {
+        return {
+          systemBodyText: "system",
+          inputBodyText: "input",
+          logicalPrompt: { systemText: "system", inputText: "input", composedText: "system\ninput" },
+          imagePaths: [],
+          additionalDirectories: [],
+        };
+      },
+      async getProviderQuotaTelemetry() {
+        return null;
+      },
+      invalidateSessionThread() {},
+      invalidateAllSessionThreads() {},
+      async runSessionTurn() {
+        return {
+          threadId: "thread-after-update-failure",
+          assistantText: "完了したよ。",
+          logicalPrompt: { systemText: "system", inputText: "input", composedText: "system\ninput" },
+          transportPayload: null,
+          operations: [],
+          rawItemsJson: "[]",
+          usage: null,
+        };
+      },
+    };
+    const originalWarn = console.warn;
+    console.warn = () => {};
+
+    try {
+      const service = new CompanionRuntimeService({
+        getCompanionSession(sessionId) {
+          return sessionId === storedSession.id ? storedSession : null;
+        },
+        updateCompanionSession(nextSession) {
+          storedSession = nextSession;
+          storedSessions.push(nextSession);
+          return nextSession;
+        },
+        async resolveComposerPreview() {
+          return { attachments: [], errors: [] } satisfies ComposerPreview;
+        },
+        getAppSettings() {
+          return normalizeAppSettings({});
+        },
+        resolveProviderCatalog() {
+          const provider = createProviderCatalog();
+          return { snapshot: { revision: 1, providers: [provider] }, provider };
+        },
+        getProviderCodingAdapter() {
+          return adapter;
+        },
+        createAuditLog(input) {
+          return { ...input, id: 7 };
+        },
+        async updateAuditLog() {
+          throw new Error("audit update failed");
+        },
+        setLiveSessionRun() {},
+        getLiveSessionRun() {
+          return null;
+        },
+        async waitForApprovalDecision(): Promise<LiveApprovalDecision> {
+          return "approve";
+        },
+        async waitForElicitationResponse() {
+          return { action: "cancel" } as const;
+        },
+        setProviderQuotaTelemetry(_telemetry: ProviderQuotaTelemetry) {},
+        setSessionContextTelemetry(_telemetry: SessionContextTelemetry) {},
+        invalidateProviderSessionThread() {},
+        scheduleProviderQuotaTelemetryRefresh() {},
+        clearWorkspaceFileIndex() {},
+        broadcastCompanionSessions() {},
+        resolvePendingApprovalRequest() {},
+        resolvePendingElicitationRequest() {},
+        currentTimestampLabel: () => "2026-04-26 10:04",
+      });
+
+      const result = await service.runSessionTurn(storedSession.id, { userMessage: "実行して" });
+
+      assert.equal(result.runState, "idle");
+      assert.equal(result.messages.at(-1)?.role, "assistant");
+      assert.equal(result.messages.at(-1)?.text, "完了したよ。");
+      assert.equal(storedSessions[0]?.runState, "running");
+      assert.equal(storedSessions[1]?.runState, "idle");
+      assert.equal(service.isRunInFlight(storedSession.id), false);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it("失敗時の audit 更新に失敗しても CompanionSession を error 状態で保存する", async () => {
+    let storedSession = createCompanionSession();
+    const adapter: ProviderCodingAdapter = {
+      composePrompt() {
+        return {
+          systemBodyText: "system",
+          inputBodyText: "input",
+          logicalPrompt: { systemText: "system", inputText: "input", composedText: "system\ninput" },
+          imagePaths: [],
+          additionalDirectories: [],
+        };
+      },
+      async getProviderQuotaTelemetry() {
+        return null;
+      },
+      invalidateSessionThread() {},
+      invalidateAllSessionThreads() {},
+      async runSessionTurn() {
+        throw new Error("provider failed");
+      },
+    };
+    const originalWarn = console.warn;
+    console.warn = () => {};
+
+    try {
+      const service = new CompanionRuntimeService({
+        getCompanionSession(sessionId) {
+          return sessionId === storedSession.id ? storedSession : null;
+        },
+        updateCompanionSession(nextSession) {
+          storedSession = nextSession;
+          return nextSession;
+        },
+        async resolveComposerPreview() {
+          return { attachments: [], errors: [] } satisfies ComposerPreview;
+        },
+        getAppSettings() {
+          return normalizeAppSettings({});
+        },
+        resolveProviderCatalog() {
+          const provider = createProviderCatalog();
+          return { snapshot: { revision: 1, providers: [provider] }, provider };
+        },
+        getProviderCodingAdapter() {
+          return adapter;
+        },
+        createAuditLog(input) {
+          return { ...input, id: 7 };
+        },
+        async updateAuditLog() {
+          throw new Error("audit update failed");
+        },
+        setLiveSessionRun() {},
+        getLiveSessionRun() {
+          return null;
+        },
+        async waitForApprovalDecision(): Promise<LiveApprovalDecision> {
+          return "approve";
+        },
+        async waitForElicitationResponse() {
+          return { action: "cancel" } as const;
+        },
+        setProviderQuotaTelemetry(_telemetry: ProviderQuotaTelemetry) {},
+        setSessionContextTelemetry(_telemetry: SessionContextTelemetry) {},
+        invalidateProviderSessionThread() {},
+        scheduleProviderQuotaTelemetryRefresh() {},
+        clearWorkspaceFileIndex() {},
+        broadcastCompanionSessions() {},
+        resolvePendingApprovalRequest() {},
+        resolvePendingElicitationRequest() {},
+        currentTimestampLabel: () => "2026-04-26 10:05",
+      });
+
+      const result = await service.runSessionTurn(storedSession.id, { userMessage: "実行して" });
+
+      assert.equal(result.runState, "error");
+      assert.match(result.messages.at(-1)?.text ?? "", /provider failed/);
+      assert.equal(service.isRunInFlight(storedSession.id), false);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it("起動時 recovery は running の Companion audit log を failed に閉じる", async () => {
+    let storedSession = createCompanionSession({
+      runState: "running",
+      messages: [{ role: "user", text: "続けて" }],
+    });
+    const auditUpdates: Array<Omit<AuditLogEntry, "id">> = [];
+    const service = new CompanionRuntimeService({
+      getCompanionSession(sessionId) {
+        return sessionId === storedSession.id ? storedSession : null;
+      },
+      listCompanionSessionSummaries() {
+        return [{ ...storedSession, latestMergeRun: null }];
+      },
+      updateCompanionSession(nextSession) {
+        storedSession = nextSession;
+        return nextSession;
+      },
+      async resolveComposerPreview() {
+        return { attachments: [], errors: [] } satisfies ComposerPreview;
+      },
+      getAppSettings() {
+        return normalizeAppSettings({});
+      },
+      resolveProviderCatalog() {
+        const provider = createProviderCatalog();
+        return { snapshot: { revision: 1, providers: [provider] }, provider };
+      },
+      getProviderCodingAdapter() {
+        throw new Error("unexpected provider access");
+      },
+      listAuditLogs() {
+        return [{
+          id: 10,
+          sessionId: storedSession.id,
+          createdAt: "2026-04-26T10:00:00.000Z",
+          phase: "running",
+          provider: "codex",
+          model: "gpt-5.4",
+          reasoningEffort: "medium",
+          approvalMode: DEFAULT_APPROVAL_MODE,
+          threadId: "",
+          logicalPrompt: { systemText: "", inputText: "", composedText: "" },
+          transportPayload: null,
+          assistantText: "",
+          operations: [],
+          rawItemsJson: "[]",
+          usage: null,
+          errorMessage: "",
+        }];
+      },
+      updateAuditLog(_id, entry) {
+        auditUpdates.push(entry);
+        return { ...entry, id: 10 };
+      },
+      setLiveSessionRun() {},
+      getLiveSessionRun() {
+        return null;
+      },
+      async waitForApprovalDecision(): Promise<LiveApprovalDecision> {
+        return "approve";
+      },
+      async waitForElicitationResponse() {
+        return { action: "cancel" } as const;
+      },
+      setProviderQuotaTelemetry(_telemetry: ProviderQuotaTelemetry) {},
+      setSessionContextTelemetry(_telemetry: SessionContextTelemetry) {},
+      invalidateProviderSessionThread() {},
+      scheduleProviderQuotaTelemetryRefresh() {},
+      clearWorkspaceFileIndex() {},
+      broadcastCompanionSessions() {},
+      resolvePendingApprovalRequest() {},
+      resolvePendingElicitationRequest() {},
+      currentTimestampLabel: () => "2026-04-26 10:06",
+    });
+
+    await service.recoverInterruptedSessions();
+
+    assert.equal(storedSession.runState, "error");
+    assert.equal(auditUpdates.length, 1);
+    assert.equal(auditUpdates[0]?.phase, "failed");
+    assert.match(auditUpdates[0]?.errorMessage ?? "", /中断/);
+  });
 });

--- a/src-electron/companion-audit-log-storage-v3.ts
+++ b/src-electron/companion-audit-log-storage-v3.ts
@@ -282,7 +282,9 @@ const LIST_AUDIT_LOG_OPERATION_BLOB_IDS_SQL = `
   FROM companion_audit_log_operations
 `;
 
-const LIVE_BLOB_REF_QUERIES = [
+type LiveBlobRefQuery = string;
+
+const LIVE_BLOB_REF_QUERIES: readonly LiveBlobRefQuery[] = [
   "SELECT 1 FROM session_messages WHERE text_blob_id = ? LIMIT 1",
   "SELECT 1 FROM session_message_artifacts WHERE artifact_blob_id = ? LIMIT 1",
   "SELECT 1 FROM audit_log_details WHERE logical_prompt_blob_id = ? OR transport_payload_blob_id = ? OR assistant_text_blob_id = ? OR raw_items_blob_id = ? OR usage_blob_id = ? LIMIT 1",
@@ -291,6 +293,11 @@ const LIVE_BLOB_REF_QUERIES = [
   "SELECT 1 FROM companion_messages WHERE text_blob_id = ? LIMIT 1",
   "SELECT 1 FROM companion_message_artifacts WHERE artifact_blob_id = ? LIMIT 1",
   "SELECT 1 FROM companion_merge_runs WHERE diff_snapshot_blob_id = ? LIMIT 1",
+  "SELECT 1 FROM companion_audit_log_details WHERE logical_prompt_blob_id = ? OR transport_payload_blob_id = ? OR assistant_text_blob_id = ? OR raw_items_blob_id = ? OR usage_blob_id = ? LIMIT 1",
+  "SELECT 1 FROM companion_audit_log_operations WHERE details_blob_id = ? LIMIT 1",
+] as const;
+
+export const V4_COMPANION_AUDIT_LIVE_BLOB_REF_QUERIES: readonly LiveBlobRefQuery[] = [
   "SELECT 1 FROM companion_audit_log_details WHERE logical_prompt_blob_id = ? OR transport_payload_blob_id = ? OR assistant_text_blob_id = ? OR raw_items_blob_id = ? OR usage_blob_id = ? LIMIT 1",
   "SELECT 1 FROM companion_audit_log_operations WHERE details_blob_id = ? LIMIT 1",
 ] as const;
@@ -703,8 +710,8 @@ function collectAllAuditLogBlobIds(db: DatabaseSync): string[] {
   ]);
 }
 
-function isBlobReferenced(db: DatabaseSync, blobId: string): boolean {
-  return LIVE_BLOB_REF_QUERIES.some((query) => {
+function isBlobReferenced(db: DatabaseSync, blobId: string, liveBlobRefQueries: readonly LiveBlobRefQuery[]): boolean {
+  return liveBlobRefQueries.some((query) => {
     const parameterCount = (query.match(/\?/g) ?? []).length;
     try {
       return db.prepare(query).get(...Array.from({ length: parameterCount }, () => blobId)) !== undefined;
@@ -734,11 +741,15 @@ function ensureCompanionSessionAuditLogCountColumn(db: DatabaseSync): void {
   }
 }
 
-function deleteUnreferencedBlobObjectRows(db: DatabaseSync, blobIds: readonly string[]): string[] {
+function deleteUnreferencedBlobObjectRows(
+  db: DatabaseSync,
+  blobIds: readonly string[],
+  liveBlobRefQueries: readonly LiveBlobRefQuery[],
+): string[] {
   const deletedBlobIds: string[] = [];
   const deleteBlobObjectStatement = db.prepare(DELETE_BLOB_OBJECT_SQL);
   for (const blobId of compactBlobIds(blobIds)) {
-    if (isBlobReferenced(db, blobId)) {
+    if (isBlobReferenced(db, blobId, liveBlobRefQueries)) {
       continue;
     }
     deleteBlobObjectStatement.run(blobId);
@@ -767,7 +778,11 @@ export class CompanionAuditLogStorageV3 {
   private readonly dbPath: string;
   private readonly blobStore: TextBlobStore;
 
-  constructor(dbPath: string, blobRootPath: string) {
+  constructor(
+    dbPath: string,
+    blobRootPath: string,
+    private readonly liveBlobRefQueries: readonly LiveBlobRefQuery[] = LIVE_BLOB_REF_QUERIES,
+  ) {
     this.dbPath = dbPath;
     this.blobStore = new TextBlobStore(blobRootPath);
     this.withDb((db) => {
@@ -1171,7 +1186,7 @@ export class CompanionAuditLogStorageV3 {
             );
           });
 
-          const blobIdsToDelete = deleteUnreferencedBlobObjectRows(db, previousBlobIds);
+          const blobIdsToDelete = deleteUnreferencedBlobObjectRows(db, previousBlobIds, this.liveBlobRefQueries);
           db.exec("COMMIT");
           return blobIdsToDelete;
         } catch (error) {
@@ -1199,7 +1214,7 @@ export class CompanionAuditLogStorageV3 {
         const previousBlobIds = collectAllAuditLogBlobIds(db);
         db.prepare(DELETE_AUDIT_LOGS_SQL).run();
         db.prepare(RESET_SESSION_AUDIT_LOG_COUNTS_SQL).run();
-        const blobIdsToDelete = deleteUnreferencedBlobObjectRows(db, previousBlobIds);
+        const blobIdsToDelete = deleteUnreferencedBlobObjectRows(db, previousBlobIds, this.liveBlobRefQueries);
         db.exec("COMMIT");
         return blobIdsToDelete;
       } catch (error) {

--- a/src-electron/companion-audit-log-storage.ts
+++ b/src-electron/companion-audit-log-storage.ts
@@ -1,0 +1,10 @@
+import {
+  CompanionAuditLogStorageV3,
+  V4_COMPANION_AUDIT_LIVE_BLOB_REF_QUERIES,
+} from "./companion-audit-log-storage-v3.js";
+
+export class CompanionAuditLogStorage extends CompanionAuditLogStorageV3 {
+  constructor(dbPath: string, blobRootPath: string) {
+    super(dbPath, blobRootPath, V4_COMPANION_AUDIT_LIVE_BLOB_REF_QUERIES);
+  }
+}

--- a/src-electron/companion-runtime-service.ts
+++ b/src-electron/companion-runtime-service.ts
@@ -42,6 +42,7 @@ export type CompanionRuntimeServiceDeps = {
   getProviderCodingAdapter(providerId: string | null | undefined): ProviderCodingAdapter;
   createAuditLog?: (input: CreateAuditLogInput) => Awaitable<AuditLogEntry>;
   updateAuditLog?: (id: number, entry: CreateAuditLogInput) => Awaitable<void | AuditLogEntry>;
+  listAuditLogs?: (sessionId: string) => Awaitable<AuditLogEntry[]>;
   setLiveSessionRun(sessionId: string, state: LiveSessionRunState | null): void;
   getLiveSessionRun(sessionId: string): LiveSessionRunState | null;
   waitForApprovalDecision(
@@ -270,6 +271,7 @@ export class CompanionRuntimeService {
         updatedAt: currentTimestampLabel(),
         messages,
       });
+      await this.closeRunningAuditLogsAfterRecovery(session.id, interruptedMessage);
       this.deps.setLiveSessionRun(session.id, null);
       recovered = true;
     }
@@ -281,6 +283,44 @@ export class CompanionRuntimeService {
 
   isRunInFlight(sessionId: string): boolean {
     return this.inFlightRuns.has(sessionId);
+  }
+
+  private async closeRunningAuditLogsAfterRecovery(sessionId: string, errorMessage: string): Promise<void> {
+    if (!this.deps.listAuditLogs || !this.deps.updateAuditLog) {
+      return;
+    }
+
+    try {
+      const auditLogs = await this.deps.listAuditLogs(sessionId);
+      for (const auditLog of auditLogs) {
+        if (auditLog.phase !== "running") {
+          continue;
+        }
+
+        const { id, ...entry } = auditLog;
+        await this.updateAuditLogSafely(id, {
+          ...entry,
+          phase: "failed",
+          errorMessage,
+        }, "failed to close recovered companion audit log");
+      }
+    } catch (error) {
+      console.warn("[companion] failed to recover running audit logs", error);
+    }
+  }
+
+  private async updateAuditLogSafely(id: number, entry: CreateAuditLogInput, logMessage: string): Promise<boolean> {
+    if (!this.deps.updateAuditLog) {
+      return false;
+    }
+
+    try {
+      await this.deps.updateAuditLog(id, entry);
+      return true;
+    } catch (error) {
+      console.warn(`[companion] ${logMessage}`, error);
+      return false;
+    }
   }
 
   cancelRun(sessionId: string): void {
@@ -401,8 +441,14 @@ export class CompanionRuntimeService {
       if (!runningAuditLog || !this.deps.updateAuditLog) {
         return;
       }
-      await this.deps.updateAuditLog(runningAuditLog.id, entry);
-      runningAuditEntry = entry;
+      const updated = await this.updateAuditLogSafely(
+        runningAuditLog.id,
+        entry,
+        "failed to update companion audit log",
+      );
+      if (updated) {
+        runningAuditEntry = entry;
+      }
     };
 
     const runProviderTurn = (turnSession: CompanionSession) => {

--- a/src-electron/main.ts
+++ b/src-electron/main.ts
@@ -81,6 +81,7 @@ import { ProjectMemoryStorage } from "./project-memory-storage.js";
 import { CompanionReviewService } from "./companion-review-service.js";
 import { CompanionRuntimeService } from "./companion-runtime-service.js";
 import { CompanionSessionService } from "./companion-session-service.js";
+import { CompanionAuditLogStorage } from "./companion-audit-log-storage.js";
 import { CompanionAuditLogStorageV3 } from "./companion-audit-log-storage-v3.js";
 import { CompanionStorage } from "./companion-storage.js";
 import { CompanionStorageV3 } from "./companion-storage-v3.js";
@@ -234,7 +235,7 @@ let sessionElicitationService: SessionElicitationService | null = null;
 let auditLogService: AuditLogService | null = null;
 let sessionMemorySupportService: SessionMemorySupportService | null = null;
 let companionSessionService: CompanionSessionService | null = null;
-let companionAuditLogStorage: CompanionAuditLogStorageV3 | null = null;
+let companionAuditLogStorage: CompanionAuditLogStorage | CompanionAuditLogStorageV3 | null = null;
 let companionAuditLogService: AuditLogService | null = null;
 let companionRuntimeService: CompanionRuntimeService | null = null;
 let companionReviewService: CompanionReviewService | null = null;
@@ -1458,12 +1459,14 @@ function canUseCompanionAuditLogStorage(): boolean {
   return dbPath.length > 0 && (isValidV3Database(dbPath) || isValidV4Database(dbPath));
 }
 
-function requireCompanionAuditLogStorage(): CompanionAuditLogStorageV3 {
+function requireCompanionAuditLogStorage(): CompanionAuditLogStorage | CompanionAuditLogStorageV3 {
   if (!companionAuditLogStorage) {
     if (!canUseCompanionAuditLogStorage()) {
       throw new Error("companion audit log storage は V3/V4 DB でだけ利用できます。");
     }
-    companionAuditLogStorage = new CompanionAuditLogStorageV3(dbPath, path.join(path.dirname(dbPath), "blobs", "v3"));
+    companionAuditLogStorage = isValidV3Database(dbPath)
+      ? new CompanionAuditLogStorageV3(dbPath, path.join(path.dirname(dbPath), "blobs", "v3"))
+      : new CompanionAuditLogStorage(dbPath, path.join(path.dirname(dbPath), "blobs", "v3"));
   }
 
   return companionAuditLogStorage;
@@ -1672,6 +1675,7 @@ function requireCompanionRuntimeService(): CompanionRuntimeService {
         ? {
             createAuditLog: (entry) => requireCompanionAuditLogService().createAuditLog(entry),
             updateAuditLog: (id, entry) => requireCompanionAuditLogService().updateAuditLog(id, entry),
+            listAuditLogs: (sessionId) => requireCompanionAuditLogService().listSessionAuditLogs(sessionId),
           }
         : {}),
       setLiveSessionRun,


### PR DESCRIPTION
## 概要

Companion mode の V4 DB runtime で、V4 Companion storage と V3 Companion audit cleanup 前提が混在して `character_role_blob_id` 不在エラーになる問題を修正します。

## 変更内容

- V4 runtime 用の `CompanionAuditLogStorage` を追加し、V4 Companion 本体 table の V3 blob column を参照しない cleanup 経路へ分離
- `main.ts` と V3 -> V4 migration の target audit storage を V4 用 storage に切り替え
- Companion runtime で terminal audit update が失敗しても completed/error session state を保存するように変更
- 起動時 recovery で running の Companion audit log を failed に閉じる処理を追加
- アプリバージョンを `5.0.0-preview.10` に更新

## 検証

- `npx tsx --test scripts/tests/companion-audit-log-storage.test.ts scripts/tests/companion-audit-log-storage-v3.test.ts scripts/tests/companion-runtime-service.test.ts scripts/tests/database-v3-to-v4-migration.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run build`
- version bump 後に再度 `npm run typecheck`