### PR TITLE
[codex] Companion の model catalog 移行漏れを修正

### DIFF
--- a/docs/design/model-catalog.md
+++ b/docs/design/model-catalog.md
@@ -1,7 +1,7 @@
 # Model Catalog
 
 - 作成日: 2026-03-14
-- 更新日: 2026-03-17
+- 更新日: 2026-06-17
 - 対象: WithMate の provider-aware model / reasoning depth catalog
 
 ## Goal
@@ -16,9 +16,9 @@ WithMate の model catalog を SQLite で管理し、Session Window と provider
 - catalog の import / export 形式は versionless JSON にする
 - 初回起動で active catalog が無ければ、アプリ同梱の `public/model-catalog.json` を import して seed する
 - import のたびに内部 revision を新規採番し、active revision を切り替える
-- Session は `provider / model / reasoningEffort / catalogRevision` を保持する
+- Agent / Auxiliary / Companion の runtime session は `provider / model / reasoningEffort / catalogRevision` を保持する
 - Session Window の model 設定は catalog 選択のみとし、自由入力は許可しない
-- catalog import 時は既存 session も新 active revision へ自動 migrate する
+- catalog import 時は既存 Agent / Auxiliary / Companion session も新 active revision へ自動 migrate する
 
 ## JSON Format
 
@@ -90,16 +90,16 @@ SQLite では次の 4 テーブルで保持する。
 - active catalog は常に 1 revision
 - import 時は既存 revision を破壊更新しない
 - 新 revision を作って `is_active = 1` に切り替える
-- Session には `catalogRevision` を保存する
+- Agent / Auxiliary / Companion session には `catalogRevision` を保存する
 
 ### current 実装
 
 - Session Window の選択肢は常に current active revision を正本にして表示する
 - Session 内で model / depth を変更した場合は current active revision に乗り換える
-- import 成功時は、active revision の切り替えと同じタイミングで既存 session も自動 migrate 対象にする
+- import 成功時は、active revision の切り替えと同じタイミングで既存 Agent / Auxiliary / Companion session も自動 migrate 対象にする
 - `catalogRevision` は `旧 revision を保持し続ける pin` の説明よりも、`その session に現在反映されている revision` を示す値として扱う
 - import 後に旧 revision を長く抱えたまま UI と実行が分岐する状態は current milestone の目標にしない
-- migration では provider / model / reasoningEffort を新 active revision に合わせて正規化し、選択が変わった session は thread をリセットしてよい
+- migration では provider / model / reasoningEffort を新 active revision に合わせて正規化し、選択が変わった runtime session は thread をリセットしてよい
 
 ## Seed Policy
 
@@ -120,7 +120,7 @@ SQLite では次の 4 テーブルで保持する。
 
 - `Settings Window` から `Import Models` / `Export Models` を実行できる
 - file picker / save dialog は Main Process が開く
-- import 成功時は active revision を切り替え、既存 session も同じタイミングで migrate する
+- import 成功時は active revision を切り替え、既存 Agent / Auxiliary / Companion session も同じタイミングで migrate する
 - current milestone では model / depth を出さない
 - new session は active catalog の provider default で作る
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "5.0.0-preview.10",
+  "version": "5.0.0-preview.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "5.0.0-preview.10",
+      "version": "5.0.0-preview.11",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "5.0.0-preview.10",
+  "version": "5.0.0-preview.11",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/scripts/tests/settings-catalog-service.test.ts
+++ b/scripts/tests/settings-catalog-service.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 
 import type { Session } from "../../src/app-state.js";
 import type { AuxiliarySession } from "../../src/auxiliary-session-state.js";
+import type { CompanionSession } from "../../src/companion-state.js";
 import { createDefaultAppSettings, type AppSettings } from "../../src/provider-settings-state.js";
 import type { ModelCatalogDocument, ModelCatalogSnapshot } from "../../src/model-catalog.js";
 import { SettingsCatalogService } from "../../src-electron/settings-catalog-service.js";
@@ -55,6 +56,45 @@ function createAuxiliarySession(overrides?: Partial<AuxiliarySession>): Auxiliar
     createdAt: "2026-03-28T00:00:00.000Z",
     updatedAt: "2026-03-28T00:00:00.000Z",
     closedAt: "",
+    ...overrides,
+  };
+}
+
+function createCompanionSession(overrides?: Partial<CompanionSession>): CompanionSession {
+  return {
+    id: "companion-1",
+    groupId: "group-1",
+    taskTitle: "Companion",
+    status: "active",
+    repoRoot: "C:/workspace",
+    focusPath: "src",
+    targetBranch: "main",
+    baseSnapshotRef: "refs/withmate/companion/companion-1/base",
+    baseSnapshotCommit: "abc123",
+    companionBranch: "withmate/companion/companion-1",
+    worktreePath: "C:/workspace/.withmate/companion-1",
+    selectedPaths: [],
+    changedFiles: [],
+    siblingWarnings: [],
+    allowedAdditionalDirectories: [],
+    runState: "idle",
+    threadId: "companion-thread-1",
+    provider: "codex",
+    catalogRevision: 1,
+    model: "gpt-5.4",
+    reasoningEffort: "high",
+    customAgentName: "",
+    approvalMode: "on-request",
+    codexSandboxMode: "workspace-write",
+    characterId: "char",
+    character: "A",
+    characterRoleMarkdown: "伴走する。",
+    characterIconPath: "",
+    characterThemeColors: { main: "#000", sub: "#111" },
+    characterRuntimeSnapshot: null,
+    createdAt: "2026-03-28T00:00:00.000Z",
+    updatedAt: "2026-03-28T00:00:00.000Z",
+    messages: [{ role: "assistant", text: "companion result" }],
     ...overrides,
   };
 }
@@ -476,6 +516,90 @@ describe("SettingsCatalogService", () => {
     assert.deepEqual(invalidated, ["codex:aux-1"]);
   });
 
+  it("model catalog import で companion metadata も新 revision に移行する", async () => {
+    const previousSessions = [createSession()];
+    const previousCompanionSessions = [
+      createCompanionSession({
+        model: "missing-model",
+        reasoningEffort: "high",
+        threadId: "companion-thread-1",
+      }),
+    ];
+    const importedDocument: ModelCatalogDocument = {
+      providers: createCatalogSnapshot(2).providers,
+    };
+    const invalidated: string[] = [];
+    let replacedCompanionSessions: CompanionSession[] = [];
+
+    const service = new SettingsCatalogService({
+      hasInFlightSessionRuns() {
+        return false;
+      },
+      isSessionRunInFlight() {
+        return false;
+      },
+      isRunningSession() {
+        return false;
+      },
+      listSessions() {
+        return previousSessions;
+      },
+      listAuxiliarySessions() {
+        return [];
+      },
+      listCompanionSessions() {
+        return previousCompanionSessions;
+      },
+      getAppSettings() {
+        return createDefaultAppSettings();
+      },
+      updateAppSettings(settings) {
+        return settings;
+      },
+      getModelCatalog() {
+        return createCatalogSnapshot(1);
+      },
+      ensureModelCatalogSeeded() {
+        return createCatalogSnapshot(1);
+      },
+      importModelCatalogDocument(document) {
+        return {
+          revision: 2,
+          providers: document.providers,
+        };
+      },
+      exportModelCatalogDocument() {
+        return { providers: createCatalogSnapshot(1).providers };
+      },
+      replaceAllSessions(nextSessions) {
+        return nextSessions;
+      },
+      replaceAuxiliarySessions(nextSessions) {
+        return nextSessions;
+      },
+      replaceCompanionSessions(nextSessions) {
+        replacedCompanionSessions = nextSessions;
+        return nextSessions;
+      },
+      clearProviderQuotaTelemetry() {},
+      clearSessionContextTelemetry() {},
+      invalidateProviderSessionThread(providerId, sessionId) {
+        invalidated.push(`${providerId}:${sessionId}`);
+      },
+      broadcastSessions() {},
+      broadcastAppSettings() {},
+      broadcastModelCatalog() {},
+    });
+
+    await service.importModelCatalogDocument(importedDocument);
+
+    assert.equal(replacedCompanionSessions[0]?.catalogRevision, 2);
+    assert.equal(replacedCompanionSessions[0]?.model, "gpt-5.4");
+    assert.equal(replacedCompanionSessions[0]?.threadId, "");
+    assert.deepEqual(replacedCompanionSessions[0]?.messages, previousCompanionSessions[0].messages);
+    assert.deepEqual(invalidated, ["codex:companion-1"]);
+  });
+
   it("model catalog export は storage の document をそのまま返す", () => {
     const document = { providers: createCatalogSnapshot(1).providers };
     const service = new SettingsCatalogService({
@@ -760,6 +884,101 @@ describe("SettingsCatalogService", () => {
     assert.equal(replacedAuxiliarySessions[0]?.threadId, "");
     assert.deepEqual(replacedAuxiliarySessions[0]?.messages, auxiliarySessions[0].messages);
     assert.deepEqual(invalidated, ["codex:aux-1"]);
+  });
+
+  it("model catalog reset で companion metadata も bundled catalog へ移行する", async () => {
+    const sessions = [createSession()];
+    const companionSessions = [
+      createCompanionSession({
+        model: "missing-model",
+        reasoningEffort: "high",
+        threadId: "companion-thread-1",
+      }),
+    ];
+    const invalidated: string[] = [];
+    let replacedCompanionSessions: CompanionSession[] = [];
+
+    const service = new SettingsCatalogService({
+      hasInFlightSessionRuns() {
+        return false;
+      },
+      isSessionRunInFlight() {
+        return false;
+      },
+      isRunningSession() {
+        return false;
+      },
+      listSessions() {
+        return sessions;
+      },
+      listAuxiliarySessions() {
+        return [];
+      },
+      listCompanionSessions() {
+        return companionSessions;
+      },
+      getAppSettings() {
+        return createDefaultAppSettings();
+      },
+      updateAppSettings(settings) {
+        return settings;
+      },
+      getModelCatalog() {
+        return createCatalogSnapshot(3);
+      },
+      ensureModelCatalogSeeded() {
+        return createCatalogSnapshot(3);
+      },
+      importModelCatalogDocument() {
+        return createCatalogSnapshot(3);
+      },
+      exportModelCatalogDocument() {
+        return { providers: createCatalogSnapshot(3).providers };
+      },
+      replaceAllSessions(nextSessions) {
+        return nextSessions;
+      },
+      replaceAuxiliarySessions(nextSessions) {
+        return nextSessions;
+      },
+      replaceCompanionSessions(nextSessions) {
+        replacedCompanionSessions = nextSessions;
+        return nextSessions;
+      },
+      clearProviderQuotaTelemetry() {},
+      clearSessionContextTelemetry() {},
+      invalidateProviderSessionThread(providerId, sessionId) {
+        invalidated.push(`${providerId}:${sessionId}`);
+      },
+      clearAuditLogs() {},
+      resetAppSettings() {
+        return createDefaultAppSettings();
+      },
+      resetModelCatalogToBundled() {
+        return createCatalogSnapshot(3);
+      },
+      clearProjectMemories() {},
+      resetSessionRuntime() {},
+      clearAllProviderQuotaTelemetry() {},
+      clearAllSessionContextTelemetry() {},
+      clearAllSessionBackgroundActivities() {},
+      invalidateAllProviderSessionThreads() {},
+      closeResetTargetWindows() {},
+      async recreateDatabaseFile() {
+        return createCatalogSnapshot(3);
+      },
+      broadcastSessions() {},
+      broadcastAppSettings() {},
+      broadcastModelCatalog() {},
+    });
+
+    await service.resetAppDatabase({ targets: ["modelCatalog"] });
+
+    assert.equal(replacedCompanionSessions[0]?.catalogRevision, 3);
+    assert.equal(replacedCompanionSessions[0]?.model, "gpt-5.4");
+    assert.equal(replacedCompanionSessions[0]?.threadId, "");
+    assert.deepEqual(replacedCompanionSessions[0]?.messages, companionSessions[0].messages);
+    assert.deepEqual(invalidated, ["codex:companion-1"]);
   });
 });
 

--- a/src-electron/main.ts
+++ b/src-electron/main.ts
@@ -1799,6 +1799,11 @@ function requireSettingsCatalogService(): SettingsCatalogService {
       isRunningSession,
       listSessions: listFullStoredSessions,
       listAuxiliarySessions: () => requireAuxiliarySessionService().listAllAuxiliarySessions(),
+      listCompanionSessions: async () => {
+        const summaries = await requireCompanionStorage().listSessionSummaries();
+        const sessions = await Promise.all(summaries.map((summary) => requireCompanionStorage().getSession(summary.id)));
+        return sessions.filter((session): session is NonNullable<typeof session> => session !== null);
+      },
       getAppSettings: () => requireAppSettingsStorage().getSettings(),
       updateAppSettings,
       getModelCatalog,
@@ -1809,6 +1814,8 @@ function requireSettingsCatalogService(): SettingsCatalogService {
         requireMainSessionPersistenceFacade().replaceAllSessions(nextSessions, options),
       replaceAuxiliarySessions: (nextSessions) =>
         requireAuxiliarySessionService().replaceAuxiliarySessions(nextSessions),
+      replaceCompanionSessions: async (nextSessions) =>
+        Promise.all(nextSessions.map((session) => requireCompanionStorage().updateSession(session))),
       clearProviderQuotaTelemetry,
       clearSessionContextTelemetry,
       invalidateProviderSessionThread,

--- a/src-electron/settings-catalog-service.ts
+++ b/src-electron/settings-catalog-service.ts
@@ -25,6 +25,7 @@ import type {
   ResetAppDatabaseTarget,
 } from "../src/withmate-window-types.js";
 import type { AuxiliarySession } from "../src/auxiliary-session-state.js";
+import type { CompanionSession } from "../src/companion-state.js";
 import type { Awaitable } from "./persistent-store-lifecycle-service.js";
 
 export type SettingsCatalogServiceDeps = {
@@ -33,6 +34,7 @@ export type SettingsCatalogServiceDeps = {
   isRunningSession(session: Session): boolean;
   listSessions(): Awaitable<Session[]>;
   listAuxiliarySessions(): Awaitable<AuxiliarySession[]>;
+  listCompanionSessions?: () => Awaitable<CompanionSession[]>;
   getAppSettings(): AppSettings;
   updateAppSettings(settings: AppSettings): Awaitable<AppSettings>;
   getModelCatalog(revision?: number | null): ModelCatalogSnapshot | null;
@@ -50,6 +52,7 @@ export type SettingsCatalogServiceDeps = {
     },
   ): Awaitable<Session[]>;
   replaceAuxiliarySessions(nextSessions: AuxiliarySession[]): Awaitable<AuxiliarySession[]>;
+  replaceCompanionSessions?: (nextSessions: CompanionSession[]) => Awaitable<CompanionSession[]>;
   clearProviderQuotaTelemetry(providerId: string): void;
   clearSessionContextTelemetry(sessionId: string): void;
   invalidateProviderSessionThread(providerId: string | null | undefined, sessionId: string): void;
@@ -119,6 +122,10 @@ function migrateSessionToCatalog(session: Session, snapshot: ModelCatalogSnapsho
 }
 
 function migrateAuxiliarySessionToCatalog(session: AuxiliarySession, snapshot: ModelCatalogSnapshot): AuxiliarySession {
+  return migrateProviderRuntimeMetadata(session, snapshot);
+}
+
+function migrateCompanionSessionToCatalog(session: CompanionSession, snapshot: ModelCatalogSnapshot): CompanionSession {
   return migrateProviderRuntimeMetadata(session, snapshot);
 }
 
@@ -293,12 +300,16 @@ export class SettingsCatalogService {
 
     const previousSessions = await this.deps.listSessions();
     const previousAuxiliarySessions = await this.deps.listAuxiliarySessions();
+    const previousCompanionSessions = await this.deps.listCompanionSessions?.() ?? [];
     const normalizedDocument = parseModelCatalogDocument(document);
     for (const session of previousSessions) {
       migrateSessionToCatalog(session, { revision: previousSnapshot.revision, providers: normalizedDocument.providers });
     }
     for (const session of previousAuxiliarySessions) {
       migrateAuxiliarySessionToCatalog(session, { revision: previousSnapshot.revision, providers: normalizedDocument.providers });
+    }
+    for (const session of previousCompanionSessions) {
+      migrateCompanionSessionToCatalog(session, { revision: previousSnapshot.revision, providers: normalizedDocument.providers });
     }
 
     let importedSnapshot: ModelCatalogSnapshot | null = null;
@@ -309,18 +320,30 @@ export class SettingsCatalogService {
       const migratedAuxiliarySessions = previousAuxiliarySessions.map((session) =>
         migrateAuxiliarySessionToCatalog(session, nextSnapshot),
       );
+      const migratedCompanionSessions = previousCompanionSessions.map((session) =>
+        migrateCompanionSessionToCatalog(session, nextSnapshot),
+      );
       const { invalidatedIds: invalidatedSessionIds } = collectRuntimeThreadResets(previousSessions, migratedSessions);
       const { invalidatedIds: invalidatedAuxiliarySessionIds } = collectRuntimeThreadResets(
         previousAuxiliarySessions,
         migratedAuxiliarySessions,
+      );
+      const { invalidatedIds: invalidatedCompanionSessionIds } = collectRuntimeThreadResets(
+        previousCompanionSessions,
+        migratedCompanionSessions,
       );
       await this.deps.replaceAllSessions(migratedSessions, {
         broadcast: false,
         invalidateSessionIds: invalidatedSessionIds,
       });
       await this.deps.replaceAuxiliarySessions(migratedAuxiliarySessions);
+      await this.deps.replaceCompanionSessions?.(migratedCompanionSessions);
       for (const sessionId of invalidatedAuxiliarySessionIds) {
         const sessionProvider = previousAuxiliarySessions.find((session) => session.id === sessionId)?.provider ?? null;
+        this.deps.invalidateProviderSessionThread(sessionProvider, sessionId);
+      }
+      for (const sessionId of invalidatedCompanionSessionIds) {
+        const sessionProvider = previousCompanionSessions.find((session) => session.id === sessionId)?.provider ?? null;
         this.deps.invalidateProviderSessionThread(sessionProvider, sessionId);
       }
       this.deps.broadcastSessions(migratedSessions.map((session) => session.id));
@@ -335,6 +358,7 @@ export class SettingsCatalogService {
         this.deps.importModelCatalogDocument(previousCatalogDocument, "rollback");
         await this.deps.replaceAllSessions(previousSessions, { broadcast: false });
         await this.deps.replaceAuxiliarySessions(previousAuxiliarySessions);
+        await this.deps.replaceCompanionSessions?.(previousCompanionSessions);
       } catch (rollbackError) {
         throw new AggregateError(
           [error, rollbackError],
@@ -391,9 +415,13 @@ export class SettingsCatalogService {
         if (!appliedTargets.has("sessions")) {
           const previousCatalogSessions = await this.deps.listSessions();
           const previousCatalogAuxiliarySessions = await this.deps.listAuxiliarySessions();
+          const previousCatalogCompanionSessions = await this.deps.listCompanionSessions?.() ?? [];
           const migratedSessions = previousCatalogSessions.map((session) => migrateSessionToCatalog(session, resetSnapshot));
           const migratedAuxiliarySessions = previousCatalogAuxiliarySessions.map((session) =>
             migrateAuxiliarySessionToCatalog(session, resetSnapshot),
+          );
+          const migratedCompanionSessions = previousCatalogCompanionSessions.map((session) =>
+            migrateCompanionSessionToCatalog(session, resetSnapshot),
           );
           const { invalidatedIds: invalidatedSessionIds } = collectRuntimeThreadResets(
             previousCatalogSessions,
@@ -403,14 +431,24 @@ export class SettingsCatalogService {
             previousCatalogAuxiliarySessions,
             migratedAuxiliarySessions,
           );
+          const { invalidatedIds: invalidatedCompanionSessionIds } = collectRuntimeThreadResets(
+            previousCatalogCompanionSessions,
+            migratedCompanionSessions,
+          );
           await this.deps.replaceAllSessions(migratedSessions, {
             broadcast: false,
             invalidateSessionIds: invalidatedSessionIds,
           });
           await this.deps.replaceAuxiliarySessions(migratedAuxiliarySessions);
+          await this.deps.replaceCompanionSessions?.(migratedCompanionSessions);
           for (const sessionId of invalidatedAuxiliarySessionIds) {
             const sessionProvider =
               previousCatalogAuxiliarySessions.find((session) => session.id === sessionId)?.provider ?? null;
+            this.deps.invalidateProviderSessionThread(sessionProvider, sessionId);
+          }
+          for (const sessionId of invalidatedCompanionSessionIds) {
+            const sessionProvider =
+              previousCatalogCompanionSessions.find((session) => session.id === sessionId)?.provider ?? null;
             this.deps.invalidateProviderSessionThread(sessionProvider, sessionId);
           }
         }


### PR DESCRIPTION
## 概要
- model catalog import / reset 時に Companion session の provider runtime metadata も移行するように修正
- Companion session の model / reasoningEffort / catalogRevision が新 active catalog に追従し、選択変更時は thread をリセットする
- model catalog 設計メモに Agent / Auxiliary / Companion の runtime session が migration 対象であることを明記
- アプリバージョンを 5.0.0-preview.11 に更新

## 原因
SettingsCatalogService の model catalog migration 対象が通常 Session と AuxiliarySession に限られており、CompanionSession が旧 catalogRevision / stale model を保持したままになっていました。そのため Companion 実行時に selected model が active model catalog に存在しない状態になっていました。

## 検証
- `npx tsx --test scripts/tests/settings-catalog-service.test.ts`
- `npm run typecheck`
- `npx tsx --test scripts/tests/settings-catalog-service.test.ts scripts/tests/companion-runtime-service.test.ts scripts/tests/model-catalog-settings.test.ts scripts/tests/runtime-option-state.test.ts scripts/tests/auxiliary-session-state.test.ts`
- `npm test`
- `npm run build`
- `git diff --check`
- `git diff --cached --check`