### PR TITLE
release: prepare WithMate 5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ WithMate は、`Codex CLI / GitHub Copilot CLI` 相当の coding agent 体験を
   - turn ごとの結果確認
   - 監査ログ確認
 - `Character Editor Window`
-  - キャラクター作成、編集、削除
+  - キャラクター作成、編集、既定設定、archive
 
 設計の詳細は `docs/design/window-architecture.md` を参照してください。
 
@@ -170,7 +170,9 @@ npm run typecheck
 
 - Electron 実行を正本とする desktop アプリ構成です
 - セッション情報は Electron 側で保持され、キャラクター情報はアプリ管理領域のストレージから読み込みます
-- Settings Window では `Session Window`、`Coding Agent Providers`、`Provider Instruction Sync`、`Skill Roots`、`Memory Extraction`、`Character Reflection`、`Diagnostics`、`Model Catalog` を管理します
+- Settings Window では `Session Window`、`Default Microcopy`、`Coding Agent Providers`、`Diagnostics`、`Mate Reset`、`Model Catalog` を管理します
+- Character 定義は Home の `Characters` panel から開く独立 `Character Editor Window` で管理し、V5 の runtime prompt には session / companion 開始時点の `CharacterRuntimeSnapshot` を使います
+- Provider Instruction Sync、Memory Extraction、Character Reflection の既存設定や保存領域は legacy 互換として残る場合がありますが、current UI には表示せず、V5 Character runtime prompt の主経路にも使いません
 
 ## 補足
 

--- a/docs/design/database-schema.md
+++ b/docs/design/database-schema.md
@@ -698,7 +698,7 @@ Settings の `DB を初期化` で対象にできるのは次の 6 系統。
 - V4 DB は V1 互換 runtime table と V4 Mate table を同じ DB に持つ
 - V4 DB の作成時は `PRAGMA user_version = 4` を設定する
 - DB file は `withmate-v4.db` のまま維持するが、新規 agent session の `sessions.source_schema_version` は 5 とする
-- `source_schema_version < 5` または `access_mode = 'legacy_readonly'` の agent session は旧互換 session として扱い、Home では `閲覧専用` 表示にする。履歴閲覧のため Session Window は開けるが、update / send は拒否する
+- `source_schema_version < 5` または `access_mode = 'legacy_readonly'` の agent session は旧互換 session として扱い、Home では `閲覧専用` 表示にする。履歴閲覧のため Session Window は開けるが、update / send / model 変更 / approval 変更などの永続更新は拒否する
 - Mate Profile / Growth / provider instruction sync の SQLite schema は `docs/design/mate-storage-schema.md` を正本にする
 - `mate/*.md` と provider instruction block は generated projection であり、正本は SQLite の Mate table と revision である
 - fresh install では `withmate-v4.db` を選ぶが、path 解決だけでは DB file を作成しない

--- a/docs/design/settings-ui.md
+++ b/docs/design/settings-ui.md
@@ -1,7 +1,7 @@
 # Settings UI
 
 - 作成日: 2026-03-14
-- 更新日: 2026-06-16
+- 更新日: 2026-06-21
 - 対象: 独立した `Settings Window`
 
 ## Goal
@@ -80,8 +80,8 @@
 - Settings Window の `loading` 派生状態は `HomeApp.tsx` が組み立てる
 - Settings Window の `import / export / save` の文言組み立てと戻り値解釈は `home-settings-actions` が担当する
 - Settings 保存成功時は renderer 側で戻り値の `appSettings` を draft に同期し、dirty 状態を解消する
-- Character editor は app settings draft とは分離し、`CharacterStorage` IPC を直接呼び出して保存する。
-- `character.md` の validation error は raw editor の操作結果として Settings Window 内に表示する。
+- Character editor は Settings Window から分離し、Home の `Characters` panel から開く独立 `Character Editor Window` で扱う。
+- `character.md` の validation error は `Character Editor Window` の raw editor 操作結果として表示する。
 
 ## Future Scope
 

--- a/docs/design/v5-character-core-release-gate.md
+++ b/docs/design/v5-character-core-release-gate.md
@@ -52,7 +52,7 @@ npm run dist:win
 - Settings Window に Character raw editor は表示されない
 - session / companion は開始時点の Character snapshot を保存し、catalog 現在値ではなく saved snapshot を runtime prompt に使う
 - `character-notes.md`、Memory / Growth history、provider instruction sync は V5 Core runtime prompt に常設注入されない
-- legacy session / legacy DB / existing session summary が壊れず、snapshot が無い session は空 system prompt のまま動く
+- legacy session / legacy DB / existing session summary が壊れず、`source_schema_version < 5` または `legacy_readonly` の agent session は閲覧専用として開ける。messages / audit / diff など既存情報は確認できるが、send / update / model 変更 / approval 変更は拒否される
 
 ## Release Note Draft
 
@@ -62,6 +62,7 @@ npm run dist:win
 - 複数 Character catalog を再導入し、Home から Character 一覧を確認して、独立した Character Editor Window で作成・編集・既定設定・archive できるようにしました。
 - New Session と Companion 起動時に Character を選択できるようにしました。Character が 0 件の場合も neutral fallback で起動できます。
 - session / companion 開始時点の `character.md` を runtime snapshot として保存し、その保存済み snapshot を coding agent prompt に注入します。後から Character catalog を編集しても、既存 session の人格定義は開始時点の snapshot を使います。
+- V4 以前の agent session は V5 では閲覧専用として扱います。Home 履歴と Session Window から過去の messages / audit / diff は確認できますが、旧 session への送信や設定更新は行わず、新しい V5 session を作成して続行します。
 - `character-notes.md`、Memory / Growth history、provider instruction sync への Character 書き込みは V5 Core では未実装です。
 - Character 定義自動生成、詳細 section editor、revision / diff / rollback、Character Update Workspace は後続 scope です。
 ```
@@ -72,7 +73,7 @@ npm run dist:win
 | --- | --- |
 | Character 定義品質の自動評価がない | V5 Core では Character Editor Window の raw `character.md` editor / import validation までを scope とし、自動生成・人格品質 validator は後続 scope に送る |
 | `character-notes.md` が runtime prompt に入らない | 意図した境界。補助ファイルとして保存するが、常設 prompt 注入はしない |
-| 既存 session は CharacterRuntimeSnapshot を持たない | legacy compatibility として許容。snapshot が無い session は従来通り空 system prompt で動く |
+| V4 以前の agent session は `CharacterRuntimeSnapshot` を持たない | legacy compatibility として閲覧専用で許容。messages / audit / diff の確認は維持し、send / update は拒否する |
 | Character catalog 更新が既存 session に反映されない | 意図した snapshot 境界。既存 session は開始時点の `character.md` を正本にする |
 | Windows packaging は native module rebuild、cross build、外部 download、signing に左右される | release candidate 前に `npm run dist:win` を別 gate として実行し、失敗時は packaging environment / installer / binary download / signing 由来かを切り分ける |
 

--- a/docs/design/v5-character-preview-release.md
+++ b/docs/design/v5-character-preview-release.md
@@ -8,12 +8,12 @@
 
 ### V5 Character Core Preview
 
-WithMate V5 preview では、Character-first の初期実装として、複数 Character catalog、Settings の最低限 Character editor、New Session / Companion での Character 選択、session 開始時点の runtime snapshot、provider prompt への `character.md` 注入を追加した。
+WithMate V5 preview では、Character-first の初期実装として、複数 Character catalog、Home 起点の独立 Character Editor Window、New Session / Companion での Character 選択、session 開始時点の runtime snapshot、provider prompt への `character.md` 注入を追加した。
 
 Added:
 
 - 複数 Character catalog を再導入
-- Settings の `Characters` section
+- Home の `Characters` panel と独立 `Character Editor Window`
   - Character 一覧
   - 新規作成
   - name / description / icon path / theme 編集
@@ -45,7 +45,8 @@ Not included:
 
 Compatibility:
 
-- `CharacterRuntimeSnapshot` を持たない既存 session は、Character system prompt なしで従来通り実行できる。
+- V4 以前の agent session、または `source_schema_version < 5` / `legacy_readonly` の session は閲覧専用で開ける。messages / audit / diff など既存情報は確認できるが、send / update / model 変更 / approval 変更は拒否する。
+- `CharacterRuntimeSnapshot` を持たない V5 active session は、Character system prompt なしで実行できる。
 - Character catalog 更新は既存 session へ自動反映されない。既存 session は開始時点の snapshot を runtime 正本として使う。
 - `character-notes.md`、Memory / Growth history、provider instruction sync 由来の Character 書き込みは V5 Core runtime prompt へ常設注入されない。
 
@@ -84,7 +85,7 @@ Manual V5C Gate:
 - [ ] V5C-006 Snapshot boundary
 - [ ] V5C-007 Prompt boundary
 - [ ] V5C-008 Markdown fence boundary
-- [ ] V5C-009 Legacy compatibility
+- [ ] V5C-009 Legacy read-only compatibility
 - [ ] V5C-010 Summary performance boundary
 
 Cleanup confirmation:

--- a/docs/manual-test-checklist.md
+++ b/docs/manual-test-checklist.md
@@ -32,7 +32,7 @@ npm run electron:start
 | V5C-006 | Snapshot boundary | Character A で session を作成した後、Character Editor Window で Character A の `character.md` を別内容へ変更し、既存 session で 1 turn 実行する | provider prompt は session 作成時点の saved snapshot を使い、現在の catalog 内容へ置き換わらない |
 | V5C-007 | Prompt boundary | `character.md` と `character-notes.md` の両方を持つ Character で 1 turn 実行し、Audit Log の `Logical Prompt` / `Transport Payload` を確認する | `character.md` snapshot は system 側に入る。`character-notes.md`、Memory / Growth history、provider instruction sync 由来の Character 書き込みは常設注入されない |
 | V5C-008 | Markdown fence boundary | `character.md` に triple backtick と quadruple backtick の code fence を含め、session を作成して 1 turn 実行する | Character Definition Snapshot section の外側 fence が壊れず、definition 全体が 1 つの markdown block として扱われる |
-| V5C-009 | Legacy compatibility | V5 Core 前に作られた session、または `CharacterRuntimeSnapshot` を持たない session を開いて 1 turn 実行する | session は壊れず実行できる。snapshot が無い session は Character system prompt を空として扱い、messages / audit / approval / thread は従来通り動く |
+| V5C-009 | Legacy read-only compatibility | V5 Core 前に作られた session、または `source_schema_version < 5` / `legacy_readonly` の session を Home から開く | Home 履歴に `閲覧専用` として残り、Session Window で messages / audit / diff など既存情報を確認できる。send、model 変更、approval 変更、その他永続更新は拒否され、新しい V5 session 作成へ誘導される |
 | V5C-010 | Summary performance boundary | Character A / B の `character.md` を大きめにして複数 session / companion session を作り、Home session list と Companion summaries を表示する | summary 表示は `character.md` 本文を読み込む必要がなく、一覧表示で大きな定義本文が UI cache や summary payload に出ない |
 
 ## 項目
@@ -47,7 +47,7 @@ npm run electron:start
 | MT-003B | Character Editor Window edit | Home の Character card または `Edit` を押す | 該当 Character の Editor Window が edit mode で開き、同じ Character を再度開いた場合は既存 window が前面に出る |
 | MT-003C | Character editor validation / notes boundary | Character Editor Window で invalid `character.md` と `character-notes.md` を編集する | 保存前 validation issue が読め、`character-notes.md` は runtime prompt に常設注入しない補助メモであることが表示される |
 | MT-003D | Character editor archive / dirty close | 既存 Character を編集し、未保存のまま close と archive をそれぞれ試す | close は未保存変更の破棄確認を出し、archive は destructive confirmation を挟む。archive 後は Home list と launch selector から消える |
-| MT-004 | Settings Window | Home の `Settings` を押す | 独立した `Settings Window` が開き、保存済み設定の読込完了までは loading が出る。読み込み後は `Session Window` / `Default Microcopy` / `Coding Agent Providers` / `Diagnostics` / `Model Catalog` が既存値で表示され、Character editor と `Mate Reset` は出ない |
+| MT-004 | Settings Window | Home の `Settings` を押す | 独立した `Settings Window` が開き、保存済み設定の読込完了までは loading が出る。読み込み後は `Session Window` / `Default Microcopy` / `Coding Agent Providers` / `Diagnostics` / `Mate Reset` / `Model Catalog` が既存値で表示され、Character editor は出ない |
 | MT-004H | Settings window shell layout | `Settings Window` を wide 幅で開き、縦に長い内容まで scroll する | panel は window 幅に追従し、`Home / Close` の header は出ない。本文は inner scroll で最後まで到達でき、scrollbar が shell の角丸に隠れない |
 | MT-004A | Settings provider row layout | `Settings Window` を開いて `Coding Agent Providers` を確認する | provider 名が左、checkbox が右の row で揃って見え、どの provider を on/off しているか即判別できる |
 | MT-004G | Cursor-based window placement | cursor を画面端寄りへ移動してから `Settings Window`、`Session Window`、`Diff Window`、`Session Monitor Window` を新規に開く | `Home Window` 以外の新規 window は cursor がある display 付近に開き、workArea 外へはみ出さない。既に開いている window を再度開いた時は位置を変えず focus だけが前面へ来る |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "5.0.0-preview.13",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "5.0.0-preview.13",
+      "version": "5.0.0",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "5.0.0-preview.13",
+  "version": "5.0.0",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",


### PR DESCRIPTION
## Summary

- アプリ version を `5.0.0-preview.13` から `5.0.0` へ更新
- V5 release gate と manual checklist を legacy session read-only 方針へ同期
- README / Settings docs / preview release docs を current UI に合わせて更新
- Companion 作成時の provider / model / reasoning / catalog revision / Character snapshot と discard cleanup を確認

## Validation

- `npm run typecheck`
- `npm run build`
- `npx tsx --test scripts/tests/companion-session-service.test.ts scripts/tests/companion-review-service.test.ts scripts/tests/companion-runtime-service.test.ts`
- Companion smoke: 一時 git repo + 空 Character snapshot で session 作成、worktree / base ref / branch 確認、discard cleanup まで pass
- `git diff --check`

## Notes

- Windows `npm run dist:win` と installer smoke はこのローカル環境では未実行です。正式 release gate では Windows runner / installer artifact で別途確認が必要です。