### PR TITLE
[codex] V6 memory contract validation

### DIFF
--- a/docs/design/v6-memory-foundation.md
+++ b/docs/design/v6-memory-foundation.md
@@ -374,7 +374,11 @@ contract / pure validationで扱う:
 - owner / scope allowlist shape
 - duplicate tags
 - length / null byte
+- well-formed Unicode
 - provider-specific unknown field rejection
+
+Phase 1aではrequest contractとpure request validationに限定する。
+response / state contractはPhase 1bで固定する。
 
 service層で扱う:
 
@@ -385,6 +389,9 @@ service層で扱う:
 - referenced entry ownership
 - idempotency persistence
 - transaction integrity
+
+文字列長のPhase 1a validationはJavaScript文字列のUTF-16 code unit数を基準にする。
+transport / HTTP / IPCのbyte size limitはAPI境界で別途検証する。
 
 app側で行わないこと:
 
@@ -404,6 +411,22 @@ type MemoryForgetRequest = {
   idempotencyKey?: string;
 };
 ```
+
+### Tag Canonicalization
+
+request上のtagはdisplay valueとして`type` / `value`を保持する。
+同一性判定にはcanonical keyを使う。
+
+Phase 1aのcanonical algorithm:
+
+```ts
+value.normalize("NFC").toLowerCase()
+```
+
+- 同一request内のduplicate tagはcanonical keyでdedupeする。
+- 最初に現れたdisplay valueを保持する。
+- Phase 2 storageではraw display valueだけをunique keyにしない。
+- tag catalogはcanonical type / valueへunique constraintを持つ。
 
 ## CLI Contract
 

--- a/docs/plans/20260621-v6-memory-foundation/plan.md
+++ b/docs/plans/20260621-v6-memory-foundation/plan.md
@@ -83,21 +83,20 @@ scripts/tests/database-schema-v6.test.ts
 - V6 project scopeを専用tableで新設する。
 - legacy `project_scopes` / `project_memory_entries`を再利用しない。
 
-## Phase 1: Shared Contract
+## Phase 1a: Request Contract And Validation
 
 候補path:
 
 ```text
 src/memory-v6/memory-contract.ts
-src/memory-v6/memory-state.ts
 src/memory-v6/memory-validation.ts
 scripts/tests/memory-v6-contract.test.ts
 ```
 
 内容:
 
-- versioned request / response
-- refs / kind / state / tags
+- search / append / forget request contract
+- refs / kind / tags
 - machine-readable error
 - normalization / validation
 - pure TypeScriptのみで、DB / provider / CLI / runtime bindingに依存しない
@@ -108,6 +107,34 @@ scripts/tests/memory-v6-contract.test.ts
 - null byte / size / duplicate tagsを正規化する。
 - contractにprovider固有型を含めない。
 - project pathのGit解決、Character `current`解決、permission判定はservice層に残す。
+
+## Phase 1b: Response And State Contract
+
+候補path:
+
+```text
+src/memory-v6/memory-state.ts
+src/memory-v6/memory-response-contract.ts
+scripts/tests/memory-v6-response-contract.test.ts
+```
+
+内容:
+
+- `MemoryEntry`
+- owner / scope / source
+- search hit / pagination
+- get / tags / append / forget response
+- versioned error envelope
+- responseに含めるstate / body / preview境界
+
+完了条件:
+
+- all responseに`schemaVersion`がある。
+- search hitにfull bodyを含めない。
+- normal search responseにforgotten / superseded entryを出さない。
+- cursorはopaque stringとして扱う。
+- append retryで同じentry responseを返せるshapeを持つ。
+- forget responseで対象IDごとの結果を表現できる。
 
 ## Phase 2: Storage
 

--- a/scripts/tests/memory-v6-contract.test.ts
+++ b/scripts/tests/memory-v6-contract.test.ts
@@ -1,0 +1,203 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { MEMORY_V6_SCHEMA_VERSION } from "../../src/memory-v6/memory-contract.js";
+import {
+  validateMemoryAppendRequest,
+  validateMemoryForgetRequest,
+  validateMemorySearchRequest,
+} from "../../src/memory-v6/memory-validation.js";
+
+const projectTarget = {
+  owner: "project",
+  scope: "project",
+  project: { type: "path", path: "../repo-a" },
+};
+
+const characterTarget = {
+  owner: "character",
+  scope: "character",
+  character: { type: "current" },
+};
+
+describe("memory-v6 contract validation", () => {
+  it("valid search request を正規化できる", () => {
+    const result = validateMemorySearchRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      targets: [projectTarget],
+      query: "  approval mode  ",
+      kinds: ["decision", "decision", "context"],
+      tags: [
+        { type: " topic ", value: " V6 " },
+        { type: "topic", value: "v6" },
+      ],
+      limit: 10,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.value.query, "approval mode");
+    assert.deepEqual(result.value.kinds, ["decision", "context"]);
+    assert.deepEqual(result.value.tags, [{ type: "topic", value: "V6" }]);
+  });
+
+  it("valid append request を正規化できる", () => {
+    const result = validateMemoryAppendRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      target: characterTarget,
+      kind: "preference",
+      title: " 呼び方 ",
+      body: "ユーザーは短い呼び方を好む。",
+      preview: "短い呼び方を好む。",
+      tags: [{ type: "relationship", value: "tone" }],
+      supersedes: ["entry-a", "entry-a"],
+      idempotencyKey: " key-1 ",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.value.title, "呼び方");
+    assert.deepEqual(result.value.supersedes, ["entry-a"]);
+    assert.equal(result.value.idempotencyKey, "key-1");
+  });
+
+  it("valid forget request を正規化できる", () => {
+    const result = validateMemoryForgetRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      entryIds: [" entry-a ", "entry-a", "entry-b"],
+      reason: "privacy",
+    });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.value.entryIds, ["entry-a", "entry-b"]);
+    assert.equal(result.value.reason, "privacy");
+  });
+
+  it("invalid schemaVersion を拒否する", () => {
+    const result = validateMemorySearchRequest({
+      schemaVersion: "withmate-memory-v0",
+      targets: [projectTarget],
+      query: "test",
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error.code, "MEMORY_INVALID_SCHEMA_VERSION");
+  });
+
+  it("empty query を拒否する", () => {
+    const result = validateMemorySearchRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      targets: [projectTarget],
+      query: "   ",
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error.field, "query");
+  });
+
+  it("target なしの search を拒否する", () => {
+    const result = validateMemorySearchRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      targets: [],
+      query: "test",
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error.code, "MEMORY_TARGET_REQUIRED");
+  });
+
+  it("invalid owner / scope combination を拒否する", () => {
+    const result = validateMemoryAppendRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      target: {
+        owner: "project",
+        scope: "character",
+        project: { type: "id", id: "project-a" },
+        character: { type: "id", id: "char-a" },
+      },
+      kind: "decision",
+      title: "title",
+      body: "body",
+      preview: "preview",
+      tags: [],
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error.code, "MEMORY_INVALID_TARGET");
+  });
+
+  it("oversized title / body / preview を拒否する", () => {
+    const titleResult = validateMemoryAppendRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      target: projectTarget,
+      kind: "decision",
+      title: "x".repeat(161),
+      body: "body",
+      preview: "preview",
+      tags: [],
+    });
+    assert.equal(titleResult.ok, false);
+    assert.equal(titleResult.error.field, "title");
+
+    const bodyResult = validateMemoryAppendRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      target: projectTarget,
+      kind: "decision",
+      title: "title",
+      body: "x".repeat(8_001),
+      preview: "preview",
+      tags: [],
+    });
+    assert.equal(bodyResult.ok, false);
+    assert.equal(bodyResult.error.field, "body");
+
+    const previewResult = validateMemoryAppendRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      target: projectTarget,
+      kind: "decision",
+      title: "title",
+      body: "body",
+      preview: "x".repeat(281),
+      tags: [],
+    });
+    assert.equal(previewResult.ok, false);
+    assert.equal(previewResult.error.field, "preview");
+  });
+
+  it("null byte を拒否する", () => {
+    const result = validateMemoryAppendRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      target: projectTarget,
+      kind: "decision",
+      title: "title",
+      body: "bad\0body",
+      preview: "preview",
+      tags: [],
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error.field, "body");
+  });
+
+  it("invalid forget reason を拒否する", () => {
+    const result = validateMemoryForgetRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      entryIds: ["entry-a"],
+      reason: "purge",
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error.field, "reason");
+  });
+
+  it("provider-specific unknown field を拒否する", () => {
+    const result = validateMemorySearchRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      targets: [projectTarget],
+      query: "test",
+      providerId: "codex",
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error.code, "MEMORY_UNKNOWN_FIELD");
+    assert.equal(result.error.field, "request.providerId");
+  });
+});

--- a/scripts/tests/memory-v6-contract.test.ts
+++ b/scripts/tests/memory-v6-contract.test.ts
@@ -37,7 +37,7 @@ describe("memory-v6 contract validation", () => {
     assert.equal(result.ok, true);
     assert.equal(result.value.query, "approval mode");
     assert.deepEqual(result.value.kinds, ["decision", "context"]);
-    assert.deepEqual(result.value.tags, [{ type: "topic", value: "V6" }]);
+    assert.deepEqual(result.value.tags, [{ type: "topic", value: "V6", canonicalType: "topic", canonicalValue: "v6" }]);
   });
 
   it("valid append request を正規化できる", () => {
@@ -57,6 +57,31 @@ describe("memory-v6 contract validation", () => {
     assert.equal(result.value.title, "呼び方");
     assert.deepEqual(result.value.supersedes, ["entry-a"]);
     assert.equal(result.value.idempotencyKey, "key-1");
+  });
+
+  it("appendでtags省略を拒否し、空tagsは許可する", () => {
+    const missingTags = validateMemoryAppendRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      target: projectTarget,
+      kind: "decision",
+      title: "title",
+      body: "body",
+      preview: "preview",
+    });
+    assert.equal(missingTags.ok, false);
+    assert.equal(missingTags.error.field, "tags");
+
+    const emptyTags = validateMemoryAppendRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      target: projectTarget,
+      kind: "decision",
+      title: "title",
+      body: "body",
+      preview: "preview",
+      tags: [],
+    });
+    assert.equal(emptyTags.ok, true);
+    assert.deepEqual(emptyTags.value.tags, []);
   });
 
   it("valid forget request を正規化できる", () => {
@@ -124,6 +149,116 @@ describe("memory-v6 contract validation", () => {
     assert.equal(result.error.code, "MEMORY_INVALID_TARGET");
   });
 
+  it("target variant外fieldを拒否する", () => {
+    const characterCurrentWithId = validateMemoryAppendRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      target: {
+        owner: "character",
+        scope: "character",
+        character: { type: "current", id: "char-a" },
+      },
+      kind: "preference",
+      title: "title",
+      body: "body",
+      preview: "preview",
+      tags: [],
+    });
+    assert.equal(characterCurrentWithId.ok, false);
+    assert.equal(characterCurrentWithId.error.field, "target.character.id");
+
+    const characterScopeWithProject = validateMemoryAppendRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      target: {
+        owner: "character",
+        scope: "character",
+        character: { type: "id", id: "char-a" },
+        project: { type: "id", id: "project-a" },
+      },
+      kind: "preference",
+      title: "title",
+      body: "body",
+      preview: "preview",
+      tags: [],
+    });
+    assert.equal(characterScopeWithProject.ok, false);
+    assert.equal(characterScopeWithProject.error.field, "target.project");
+
+    const projectIdWithPath = validateMemorySearchRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      targets: [{ owner: "project", scope: "project", project: { type: "id", id: "project-a", path: "." } }],
+      query: "test",
+    });
+    assert.equal(projectIdWithPath.ok, false);
+    assert.equal(projectIdWithPath.error.field, "targets[0].project.path");
+
+    const projectTargetWithCharacter = validateMemorySearchRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      targets: [{
+        owner: "project",
+        scope: "project",
+        project: { type: "id", id: "project-a" },
+        character: { type: "id", id: "char-a" },
+      }],
+      query: "test",
+    });
+    assert.equal(projectTargetWithCharacter.ok, false);
+    assert.equal(projectTargetWithCharacter.error.field, "targets[0].character");
+  });
+
+  it("targets上限とduplicate targetを拒否する", () => {
+    const tooManyTargets = validateMemorySearchRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      targets: Array.from({ length: 6 }, (_, index) => ({
+        owner: "project",
+        scope: "project",
+        project: { type: "id", id: `project-${index}` },
+      })),
+      query: "test",
+    });
+    assert.equal(tooManyTargets.ok, false);
+    assert.equal(tooManyTargets.error.field, "targets");
+
+    const duplicateTargets = validateMemorySearchRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      targets: [
+        { owner: "project", scope: "project", project: { type: "id", id: "project-a" } },
+        { owner: "project", scope: "project", project: { type: "id", id: "project-a" } },
+      ],
+      query: "test",
+    });
+    assert.equal(duplicateTargets.ok, false);
+    assert.equal(duplicateTargets.error.code, "MEMORY_DUPLICATE_TARGET");
+  });
+
+  it("kindsのempty / duplicate / 上限を固定する", () => {
+    const emptyKinds = validateMemorySearchRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      targets: [projectTarget],
+      query: "test",
+      kinds: [],
+    });
+    assert.equal(emptyKinds.ok, true);
+    assert.equal(emptyKinds.value.kinds, undefined);
+
+    const duplicateKinds = validateMemorySearchRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      targets: [projectTarget],
+      query: "test",
+      kinds: ["decision", "decision", "note"],
+    });
+    assert.equal(duplicateKinds.ok, true);
+    assert.deepEqual(duplicateKinds.value.kinds, ["decision", "note"]);
+
+    const tooManyKinds = validateMemorySearchRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      targets: [projectTarget],
+      query: "test",
+      kinds: Array.from({ length: 10 }, () => "decision"),
+    });
+    assert.equal(tooManyKinds.ok, false);
+    assert.equal(tooManyKinds.error.field, "kinds");
+  });
+
   it("oversized title / body / preview を拒否する", () => {
     const titleResult = validateMemoryAppendRequest({
       schemaVersion: MEMORY_V6_SCHEMA_VERSION,
@@ -175,6 +310,63 @@ describe("memory-v6 contract validation", () => {
 
     assert.equal(result.ok, false);
     assert.equal(result.error.field, "body");
+  });
+
+  it("well-formedでないUnicodeを拒否し、valid surrogate pairは許可する", () => {
+    const highSurrogate = validateMemoryAppendRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      target: projectTarget,
+      kind: "decision",
+      title: "title",
+      body: "\uD800",
+      preview: "preview",
+      tags: [],
+    });
+    assert.equal(highSurrogate.ok, false);
+    assert.equal(highSurrogate.error.field, "body");
+
+    const lowSurrogate = validateMemoryAppendRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      target: projectTarget,
+      kind: "decision",
+      title: "title",
+      body: "\uDC00",
+      preview: "preview",
+      tags: [],
+    });
+    assert.equal(lowSurrogate.ok, false);
+    assert.equal(lowSurrogate.error.field, "body");
+
+    const validPair = validateMemoryAppendRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      target: projectTarget,
+      kind: "decision",
+      title: "title",
+      body: "emoji 😀",
+      preview: "emoji 😀",
+      tags: [{ type: "mood", value: "😀" }],
+    });
+    assert.equal(validPair.ok, true);
+  });
+
+  it("tag canonical keyをNFC lowercaseで固定する", () => {
+    const result = validateMemorySearchRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      targets: [projectTarget],
+      query: "test",
+      tags: [
+        { type: "Topic", value: "e\u0301" },
+        { type: "topic", value: "\u00e9" },
+      ],
+    });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.value.tags, [{
+      type: "Topic",
+      value: "e\u0301",
+      canonicalType: "topic",
+      canonicalValue: "\u00e9",
+    }]);
   });
 
   it("invalid forget reason を拒否する", () => {

--- a/src/memory-v6/memory-contract.ts
+++ b/src/memory-v6/memory-contract.ts
@@ -1,0 +1,78 @@
+export const MEMORY_V6_SCHEMA_VERSION = "withmate-memory-v1" as const;
+
+export type MemoryV6SchemaVersion = typeof MEMORY_V6_SCHEMA_VERSION;
+
+export type MemoryEntryState = "active" | "superseded" | "forgotten";
+
+export type MemoryEntryKind =
+  | "decision"
+  | "constraint"
+  | "convention"
+  | "context"
+  | "deferred"
+  | "preference"
+  | "relationship"
+  | "boundary"
+  | "note";
+
+export type ProjectTargetRef =
+  | { type: "id"; id: string }
+  | { type: "path"; path: string }
+  | { type: "alias"; alias: string };
+
+export type CharacterTargetRef =
+  | { type: "id"; id: string }
+  | { type: "current" };
+
+export type MemoryTargetSelector =
+  | { owner: "project"; project: ProjectTargetRef; scope: "project" }
+  | { owner: "character"; character: CharacterTargetRef; scope: "character" }
+  | { owner: "character"; character: CharacterTargetRef; scope: "project"; project: ProjectTargetRef };
+
+export type MemoryTag = {
+  type: string;
+  value: string;
+};
+
+export type MemorySearchRequest = {
+  schemaVersion: MemoryV6SchemaVersion;
+  targets: MemoryTargetSelector[];
+  query: string;
+  kinds?: MemoryEntryKind[];
+  tags?: MemoryTag[];
+  limit?: number;
+  cursor?: string;
+};
+
+export type MemoryAppendRequest = {
+  schemaVersion: MemoryV6SchemaVersion;
+  target: MemoryTargetSelector;
+  kind: MemoryEntryKind;
+  title: string;
+  body: string;
+  preview: string;
+  tags: MemoryTag[];
+  supersedes?: string[];
+  sourceMessageId?: string;
+  idempotencyKey?: string;
+};
+
+export type MemoryForgetReason = "user_request" | "incorrect" | "outdated" | "privacy" | "other";
+
+export type MemoryForgetRequest = {
+  schemaVersion: MemoryV6SchemaVersion;
+  entryIds: string[];
+  reason?: MemoryForgetReason;
+  sourceMessageId?: string;
+  idempotencyKey?: string;
+};
+
+export type MemoryError = {
+  code: string;
+  message: string;
+  field?: string;
+};
+
+export type MemoryValidationResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: MemoryError };

--- a/src/memory-v6/memory-contract.ts
+++ b/src/memory-v6/memory-contract.ts
@@ -34,12 +34,17 @@ export type MemoryTag = {
   value: string;
 };
 
+export type NormalizedMemoryTag = MemoryTag & {
+  canonicalType: string;
+  canonicalValue: string;
+};
+
 export type MemorySearchRequest = {
   schemaVersion: MemoryV6SchemaVersion;
   targets: MemoryTargetSelector[];
   query: string;
   kinds?: MemoryEntryKind[];
-  tags?: MemoryTag[];
+  tags?: NormalizedMemoryTag[];
   limit?: number;
   cursor?: string;
 };
@@ -51,7 +56,7 @@ export type MemoryAppendRequest = {
   title: string;
   body: string;
   preview: string;
-  tags: MemoryTag[];
+  tags: NormalizedMemoryTag[];
   supersedes?: string[];
   sourceMessageId?: string;
   idempotencyKey?: string;

--- a/src/memory-v6/memory-validation.ts
+++ b/src/memory-v6/memory-validation.ts
@@ -6,9 +6,9 @@ import {
   type MemoryForgetReason,
   type MemoryForgetRequest,
   type MemorySearchRequest,
-  type MemoryTag,
   type MemoryTargetSelector,
   type MemoryValidationResult,
+  type NormalizedMemoryTag,
   type ProjectTargetRef,
 } from "./memory-contract.js";
 
@@ -46,10 +46,15 @@ const APPEND_REQUEST_KEYS = new Set([
   "idempotencyKey",
 ]);
 const FORGET_REQUEST_KEYS = new Set(["schemaVersion", "entryIds", "reason", "sourceMessageId", "idempotencyKey"]);
-const PROJECT_TARGET_KEYS = new Set(["type", "id", "path", "alias"]);
-const CHARACTER_TARGET_KEYS = new Set(["type", "id"]);
+const PROJECT_TARGET_ID_KEYS = new Set(["type", "id"]);
+const PROJECT_TARGET_PATH_KEYS = new Set(["type", "path"]);
+const PROJECT_TARGET_ALIAS_KEYS = new Set(["type", "alias"]);
+const CHARACTER_TARGET_ID_KEYS = new Set(["type", "id"]);
+const CHARACTER_TARGET_CURRENT_KEYS = new Set(["type"]);
 const MEMORY_TAG_KEYS = new Set(["type", "value"]);
-const MEMORY_TARGET_KEYS = new Set(["owner", "scope", "project", "character"]);
+const PROJECT_PROJECT_TARGET_KEYS = new Set(["owner", "scope", "project"]);
+const CHARACTER_CHARACTER_TARGET_KEYS = new Set(["owner", "scope", "character"]);
+const CHARACTER_PROJECT_TARGET_KEYS = new Set(["owner", "scope", "character", "project"]);
 
 const MAX_SEARCH_QUERY_LENGTH = 500;
 const MAX_TITLE_LENGTH = 160;
@@ -63,6 +68,7 @@ const MAX_LIMIT = 50;
 const MAX_TAGS = 20;
 const MAX_SUPERSEDES = 20;
 const MAX_FORGET_ENTRY_IDS = 50;
+const MAX_TARGETS = 5;
 
 function error(code: string, message: string, field?: string): MemoryValidationResult<never> {
   return {
@@ -85,6 +91,29 @@ function rejectUnknownKeys(value: Record<string, unknown>, allowedKeys: Set<stri
   return { ok: true, value: undefined };
 }
 
+function hasUnpairedSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return true;
+      }
+      index += 1;
+      continue;
+    }
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function canonicalizeMemoryTagPart(value: string): string {
+  return value.normalize("NFC").toLowerCase();
+}
+
 function normalizeText(value: unknown, field: string, options: { maxLength: number; required?: boolean }): MemoryValidationResult<string> {
   if (typeof value !== "string") {
     if (options.required === false && value === undefined) {
@@ -95,6 +124,9 @@ function normalizeText(value: unknown, field: string, options: { maxLength: numb
 
   if (value.includes("\0")) {
     return error("MEMORY_INVALID_FIELD", `${field} must not contain null bytes.`, field);
+  }
+  if (hasUnpairedSurrogate(value)) {
+    return error("MEMORY_INVALID_FIELD", `${field} must be well-formed Unicode.`, field);
   }
 
   const normalized = value.trim();
@@ -172,20 +204,28 @@ function normalizeProjectTarget(value: unknown, field: string): MemoryValidation
   if (!isRecord(value)) {
     return error("MEMORY_INVALID_FIELD", `${field} must be an object.`, field);
   }
-  const unknownKeys = rejectUnknownKeys(value, PROJECT_TARGET_KEYS, field);
-  if (!unknownKeys.ok) {
-    return unknownKeys;
-  }
 
   if (value.type === "id") {
+    const unknownKeys = rejectUnknownKeys(value, PROJECT_TARGET_ID_KEYS, field);
+    if (!unknownKeys.ok) {
+      return unknownKeys;
+    }
     const id = normalizeText(value.id, `${field}.id`, { maxLength: MAX_ID_LENGTH });
     return id.ok ? { ok: true, value: { type: "id", id: id.value } } : id;
   }
   if (value.type === "path") {
+    const unknownKeys = rejectUnknownKeys(value, PROJECT_TARGET_PATH_KEYS, field);
+    if (!unknownKeys.ok) {
+      return unknownKeys;
+    }
     const projectPath = normalizeText(value.path, `${field}.path`, { maxLength: 1_000 });
     return projectPath.ok ? { ok: true, value: { type: "path", path: projectPath.value } } : projectPath;
   }
   if (value.type === "alias") {
+    const unknownKeys = rejectUnknownKeys(value, PROJECT_TARGET_ALIAS_KEYS, field);
+    if (!unknownKeys.ok) {
+      return unknownKeys;
+    }
     const alias = normalizeText(value.alias, `${field}.alias`, { maxLength: MAX_ID_LENGTH });
     return alias.ok ? { ok: true, value: { type: "alias", alias: alias.value } } : alias;
   }
@@ -197,15 +237,19 @@ function normalizeCharacterTarget(value: unknown, field: string): MemoryValidati
   if (!isRecord(value)) {
     return error("MEMORY_INVALID_FIELD", `${field} must be an object.`, field);
   }
-  const unknownKeys = rejectUnknownKeys(value, CHARACTER_TARGET_KEYS, field);
-  if (!unknownKeys.ok) {
-    return unknownKeys;
-  }
 
   if (value.type === "current") {
+    const unknownKeys = rejectUnknownKeys(value, CHARACTER_TARGET_CURRENT_KEYS, field);
+    if (!unknownKeys.ok) {
+      return unknownKeys;
+    }
     return { ok: true, value: { type: "current" } };
   }
   if (value.type === "id") {
+    const unknownKeys = rejectUnknownKeys(value, CHARACTER_TARGET_ID_KEYS, field);
+    if (!unknownKeys.ok) {
+      return unknownKeys;
+    }
     const id = normalizeText(value.id, `${field}.id`, { maxLength: MAX_ID_LENGTH });
     return id.ok ? { ok: true, value: { type: "id", id: id.value } } : id;
   }
@@ -217,22 +261,30 @@ function normalizeMemoryTarget(value: unknown, field: string): MemoryValidationR
   if (!isRecord(value)) {
     return error("MEMORY_INVALID_FIELD", `${field} must be an object.`, field);
   }
-  const unknownKeys = rejectUnknownKeys(value, MEMORY_TARGET_KEYS, field);
-  if (!unknownKeys.ok) {
-    return unknownKeys;
-  }
 
   if (value.owner === "project" && value.scope === "project") {
+    const unknownKeys = rejectUnknownKeys(value, PROJECT_PROJECT_TARGET_KEYS, field);
+    if (!unknownKeys.ok) {
+      return unknownKeys;
+    }
     const project = normalizeProjectTarget(value.project, `${field}.project`);
     return project.ok ? { ok: true, value: { owner: "project", scope: "project", project: project.value } } : project;
   }
 
   if (value.owner === "character" && value.scope === "character") {
+    const unknownKeys = rejectUnknownKeys(value, CHARACTER_CHARACTER_TARGET_KEYS, field);
+    if (!unknownKeys.ok) {
+      return unknownKeys;
+    }
     const character = normalizeCharacterTarget(value.character, `${field}.character`);
     return character.ok ? { ok: true, value: { owner: "character", scope: "character", character: character.value } } : character;
   }
 
   if (value.owner === "character" && value.scope === "project") {
+    const unknownKeys = rejectUnknownKeys(value, CHARACTER_PROJECT_TARGET_KEYS, field);
+    if (!unknownKeys.ok) {
+      return unknownKeys;
+    }
     const character = normalizeCharacterTarget(value.character, `${field}.character`);
     if (!character.ok) {
       return character;
@@ -250,21 +302,33 @@ function normalizeTargets(value: unknown): MemoryValidationResult<MemoryTargetSe
   if (!Array.isArray(value) || value.length === 0) {
     return error("MEMORY_TARGET_REQUIRED", "At least one memory target is required.", "targets");
   }
+  if (value.length > MAX_TARGETS) {
+    return error("MEMORY_FIELD_TOO_LARGE", `targets supports at most ${MAX_TARGETS} items.`, "targets");
+  }
 
   const normalized: MemoryTargetSelector[] = [];
+  const seen = new Set<string>();
   for (let index = 0; index < value.length; index += 1) {
     const target = normalizeMemoryTarget(value[index], `targets[${index}]`);
     if (!target.ok) {
       return target;
     }
+    const key = JSON.stringify(target.value);
+    if (seen.has(key)) {
+      return error("MEMORY_DUPLICATE_TARGET", "targets must not contain duplicates.", `targets[${index}]`);
+    }
+    seen.add(key);
     normalized.push(target.value);
   }
 
   return { ok: true, value: normalized };
 }
 
-function normalizeTags(value: unknown, field = "tags"): MemoryValidationResult<MemoryTag[]> {
+function normalizeTags(value: unknown, field = "tags", options: { required?: boolean } = {}): MemoryValidationResult<NormalizedMemoryTag[]> {
   if (value === undefined) {
+    if (options.required) {
+      return error("MEMORY_INVALID_FIELD", `${field} is required.`, field);
+    }
     return { ok: true, value: [] };
   }
   if (!Array.isArray(value)) {
@@ -274,7 +338,7 @@ function normalizeTags(value: unknown, field = "tags"): MemoryValidationResult<M
     return error("MEMORY_FIELD_TOO_LARGE", `${field} has too many items.`, field);
   }
 
-  const normalized: MemoryTag[] = [];
+  const normalized: NormalizedMemoryTag[] = [];
   const seen = new Set<string>();
   for (let index = 0; index < value.length; index += 1) {
     const tag = value[index];
@@ -293,12 +357,14 @@ function normalizeTags(value: unknown, field = "tags"): MemoryValidationResult<M
     if (!tagValue.ok) {
       return tagValue;
     }
-    const key = `${type.value.toLowerCase()}\0${tagValue.value.toLowerCase()}`;
+    const canonicalType = canonicalizeMemoryTagPart(type.value);
+    const canonicalValue = canonicalizeMemoryTagPart(tagValue.value);
+    const key = `${canonicalType}\0${canonicalValue}`;
     if (seen.has(key)) {
       continue;
     }
     seen.add(key);
-    normalized.push({ type: type.value, value: tagValue.value });
+    normalized.push({ type: type.value, value: tagValue.value, canonicalType, canonicalValue });
   }
 
   return { ok: true, value: normalized };
@@ -310,6 +376,9 @@ function normalizeKinds(value: unknown): MemoryValidationResult<MemoryEntryKind[
   }
   if (!Array.isArray(value)) {
     return error("MEMORY_INVALID_FIELD", "kinds must be an array.", "kinds");
+  }
+  if (value.length > MEMORY_ENTRY_KINDS.size) {
+    return error("MEMORY_FIELD_TOO_LARGE", "kinds has too many items.", "kinds");
   }
 
   const normalized: MemoryEntryKind[] = [];
@@ -326,7 +395,7 @@ function normalizeKinds(value: unknown): MemoryValidationResult<MemoryEntryKind[
     normalized.push(kind.value);
   }
 
-  return { ok: true, value: normalized };
+  return { ok: true, value: normalized.length > 0 ? normalized : undefined };
 }
 
 export function validateMemorySearchRequest(value: unknown): MemoryValidationResult<MemorySearchRequest> {
@@ -416,7 +485,7 @@ export function validateMemoryAppendRequest(value: unknown): MemoryValidationRes
   if (!preview.ok) {
     return preview;
   }
-  const tags = normalizeTags(value.tags);
+  const tags = normalizeTags(value.tags, "tags", { required: true });
   if (!tags.ok) {
     return tags;
   }

--- a/src/memory-v6/memory-validation.ts
+++ b/src/memory-v6/memory-validation.ts
@@ -1,0 +1,494 @@
+import {
+  MEMORY_V6_SCHEMA_VERSION,
+  type CharacterTargetRef,
+  type MemoryAppendRequest,
+  type MemoryEntryKind,
+  type MemoryForgetReason,
+  type MemoryForgetRequest,
+  type MemorySearchRequest,
+  type MemoryTag,
+  type MemoryTargetSelector,
+  type MemoryValidationResult,
+  type ProjectTargetRef,
+} from "./memory-contract.js";
+
+const MEMORY_ENTRY_KINDS = new Set<MemoryEntryKind>([
+  "decision",
+  "constraint",
+  "convention",
+  "context",
+  "deferred",
+  "preference",
+  "relationship",
+  "boundary",
+  "note",
+]);
+
+const MEMORY_FORGET_REASONS = new Set<MemoryForgetReason>([
+  "user_request",
+  "incorrect",
+  "outdated",
+  "privacy",
+  "other",
+]);
+
+const SEARCH_REQUEST_KEYS = new Set(["schemaVersion", "targets", "query", "kinds", "tags", "limit", "cursor"]);
+const APPEND_REQUEST_KEYS = new Set([
+  "schemaVersion",
+  "target",
+  "kind",
+  "title",
+  "body",
+  "preview",
+  "tags",
+  "supersedes",
+  "sourceMessageId",
+  "idempotencyKey",
+]);
+const FORGET_REQUEST_KEYS = new Set(["schemaVersion", "entryIds", "reason", "sourceMessageId", "idempotencyKey"]);
+const PROJECT_TARGET_KEYS = new Set(["type", "id", "path", "alias"]);
+const CHARACTER_TARGET_KEYS = new Set(["type", "id"]);
+const MEMORY_TAG_KEYS = new Set(["type", "value"]);
+const MEMORY_TARGET_KEYS = new Set(["owner", "scope", "project", "character"]);
+
+const MAX_SEARCH_QUERY_LENGTH = 500;
+const MAX_TITLE_LENGTH = 160;
+const MAX_PREVIEW_LENGTH = 280;
+const MAX_BODY_LENGTH = 8_000;
+const MAX_TAG_TYPE_LENGTH = 48;
+const MAX_TAG_VALUE_LENGTH = 96;
+const MAX_ID_LENGTH = 200;
+const MAX_CURSOR_LENGTH = 500;
+const MAX_LIMIT = 50;
+const MAX_TAGS = 20;
+const MAX_SUPERSEDES = 20;
+const MAX_FORGET_ENTRY_IDS = 50;
+
+function error(code: string, message: string, field?: string): MemoryValidationResult<never> {
+  return {
+    ok: false,
+    error: field ? { code, message, field } : { code, message },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function rejectUnknownKeys(value: Record<string, unknown>, allowedKeys: Set<string>, field: string): MemoryValidationResult<void> {
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) {
+      return error("MEMORY_UNKNOWN_FIELD", `Unknown field: ${field}.${key}`, `${field}.${key}`);
+    }
+  }
+
+  return { ok: true, value: undefined };
+}
+
+function normalizeText(value: unknown, field: string, options: { maxLength: number; required?: boolean }): MemoryValidationResult<string> {
+  if (typeof value !== "string") {
+    if (options.required === false && value === undefined) {
+      return { ok: true, value: "" };
+    }
+    return error("MEMORY_INVALID_FIELD", `${field} must be a string.`, field);
+  }
+
+  if (value.includes("\0")) {
+    return error("MEMORY_INVALID_FIELD", `${field} must not contain null bytes.`, field);
+  }
+
+  const normalized = value.trim();
+  if (options.required !== false && normalized.length === 0) {
+    return error("MEMORY_INVALID_FIELD", `${field} must not be empty.`, field);
+  }
+
+  if (normalized.length > options.maxLength) {
+    return error("MEMORY_FIELD_TOO_LARGE", `${field} is too long.`, field);
+  }
+
+  return { ok: true, value: normalized };
+}
+
+function normalizeOptionalText(value: unknown, field: string, maxLength = MAX_ID_LENGTH): MemoryValidationResult<string | undefined> {
+  if (value === undefined) {
+    return { ok: true, value: undefined };
+  }
+
+  const normalized = normalizeText(value, field, { maxLength });
+  if (!normalized.ok) {
+    return normalized;
+  }
+
+  return { ok: true, value: normalized.value };
+}
+
+function validateSchemaVersion(value: Record<string, unknown>): MemoryValidationResult<void> {
+  if (value.schemaVersion !== MEMORY_V6_SCHEMA_VERSION) {
+    return error("MEMORY_INVALID_SCHEMA_VERSION", "Unsupported memory schemaVersion.", "schemaVersion");
+  }
+
+  return { ok: true, value: undefined };
+}
+
+function normalizeStringArray(value: unknown, field: string, options: { maxItems: number; maxLength: number }): MemoryValidationResult<string[] | undefined> {
+  if (value === undefined) {
+    return { ok: true, value: undefined };
+  }
+
+  if (!Array.isArray(value)) {
+    return error("MEMORY_INVALID_FIELD", `${field} must be an array.`, field);
+  }
+
+  if (value.length > options.maxItems) {
+    return error("MEMORY_FIELD_TOO_LARGE", `${field} has too many items.`, field);
+  }
+
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+  for (let index = 0; index < value.length; index += 1) {
+    const item = normalizeText(value[index], `${field}[${index}]`, { maxLength: options.maxLength });
+    if (!item.ok) {
+      return item;
+    }
+    if (seen.has(item.value)) {
+      continue;
+    }
+    seen.add(item.value);
+    normalized.push(item.value);
+  }
+
+  return { ok: true, value: normalized };
+}
+
+function validateMemoryKind(value: unknown, field: string): MemoryValidationResult<MemoryEntryKind> {
+  if (typeof value !== "string" || !MEMORY_ENTRY_KINDS.has(value as MemoryEntryKind)) {
+    return error("MEMORY_INVALID_FIELD", `${field} must be a valid memory kind.`, field);
+  }
+
+  return { ok: true, value: value as MemoryEntryKind };
+}
+
+function normalizeProjectTarget(value: unknown, field: string): MemoryValidationResult<ProjectTargetRef> {
+  if (!isRecord(value)) {
+    return error("MEMORY_INVALID_FIELD", `${field} must be an object.`, field);
+  }
+  const unknownKeys = rejectUnknownKeys(value, PROJECT_TARGET_KEYS, field);
+  if (!unknownKeys.ok) {
+    return unknownKeys;
+  }
+
+  if (value.type === "id") {
+    const id = normalizeText(value.id, `${field}.id`, { maxLength: MAX_ID_LENGTH });
+    return id.ok ? { ok: true, value: { type: "id", id: id.value } } : id;
+  }
+  if (value.type === "path") {
+    const projectPath = normalizeText(value.path, `${field}.path`, { maxLength: 1_000 });
+    return projectPath.ok ? { ok: true, value: { type: "path", path: projectPath.value } } : projectPath;
+  }
+  if (value.type === "alias") {
+    const alias = normalizeText(value.alias, `${field}.alias`, { maxLength: MAX_ID_LENGTH });
+    return alias.ok ? { ok: true, value: { type: "alias", alias: alias.value } } : alias;
+  }
+
+  return error("MEMORY_INVALID_FIELD", `${field}.type must be id, path, or alias.`, `${field}.type`);
+}
+
+function normalizeCharacterTarget(value: unknown, field: string): MemoryValidationResult<CharacterTargetRef> {
+  if (!isRecord(value)) {
+    return error("MEMORY_INVALID_FIELD", `${field} must be an object.`, field);
+  }
+  const unknownKeys = rejectUnknownKeys(value, CHARACTER_TARGET_KEYS, field);
+  if (!unknownKeys.ok) {
+    return unknownKeys;
+  }
+
+  if (value.type === "current") {
+    return { ok: true, value: { type: "current" } };
+  }
+  if (value.type === "id") {
+    const id = normalizeText(value.id, `${field}.id`, { maxLength: MAX_ID_LENGTH });
+    return id.ok ? { ok: true, value: { type: "id", id: id.value } } : id;
+  }
+
+  return error("MEMORY_INVALID_FIELD", `${field}.type must be id or current.`, `${field}.type`);
+}
+
+function normalizeMemoryTarget(value: unknown, field: string): MemoryValidationResult<MemoryTargetSelector> {
+  if (!isRecord(value)) {
+    return error("MEMORY_INVALID_FIELD", `${field} must be an object.`, field);
+  }
+  const unknownKeys = rejectUnknownKeys(value, MEMORY_TARGET_KEYS, field);
+  if (!unknownKeys.ok) {
+    return unknownKeys;
+  }
+
+  if (value.owner === "project" && value.scope === "project") {
+    const project = normalizeProjectTarget(value.project, `${field}.project`);
+    return project.ok ? { ok: true, value: { owner: "project", scope: "project", project: project.value } } : project;
+  }
+
+  if (value.owner === "character" && value.scope === "character") {
+    const character = normalizeCharacterTarget(value.character, `${field}.character`);
+    return character.ok ? { ok: true, value: { owner: "character", scope: "character", character: character.value } } : character;
+  }
+
+  if (value.owner === "character" && value.scope === "project") {
+    const character = normalizeCharacterTarget(value.character, `${field}.character`);
+    if (!character.ok) {
+      return character;
+    }
+    const project = normalizeProjectTarget(value.project, `${field}.project`);
+    return project.ok
+      ? { ok: true, value: { owner: "character", scope: "project", character: character.value, project: project.value } }
+      : project;
+  }
+
+  return error("MEMORY_INVALID_TARGET", "Unsupported memory owner / scope combination.", field);
+}
+
+function normalizeTargets(value: unknown): MemoryValidationResult<MemoryTargetSelector[]> {
+  if (!Array.isArray(value) || value.length === 0) {
+    return error("MEMORY_TARGET_REQUIRED", "At least one memory target is required.", "targets");
+  }
+
+  const normalized: MemoryTargetSelector[] = [];
+  for (let index = 0; index < value.length; index += 1) {
+    const target = normalizeMemoryTarget(value[index], `targets[${index}]`);
+    if (!target.ok) {
+      return target;
+    }
+    normalized.push(target.value);
+  }
+
+  return { ok: true, value: normalized };
+}
+
+function normalizeTags(value: unknown, field = "tags"): MemoryValidationResult<MemoryTag[]> {
+  if (value === undefined) {
+    return { ok: true, value: [] };
+  }
+  if (!Array.isArray(value)) {
+    return error("MEMORY_INVALID_FIELD", `${field} must be an array.`, field);
+  }
+  if (value.length > MAX_TAGS) {
+    return error("MEMORY_FIELD_TOO_LARGE", `${field} has too many items.`, field);
+  }
+
+  const normalized: MemoryTag[] = [];
+  const seen = new Set<string>();
+  for (let index = 0; index < value.length; index += 1) {
+    const tag = value[index];
+    if (!isRecord(tag)) {
+      return error("MEMORY_INVALID_FIELD", `${field}[${index}] must be an object.`, `${field}[${index}]`);
+    }
+    const unknownKeys = rejectUnknownKeys(tag, MEMORY_TAG_KEYS, `${field}[${index}]`);
+    if (!unknownKeys.ok) {
+      return unknownKeys;
+    }
+    const type = normalizeText(tag.type, `${field}[${index}].type`, { maxLength: MAX_TAG_TYPE_LENGTH });
+    if (!type.ok) {
+      return type;
+    }
+    const tagValue = normalizeText(tag.value, `${field}[${index}].value`, { maxLength: MAX_TAG_VALUE_LENGTH });
+    if (!tagValue.ok) {
+      return tagValue;
+    }
+    const key = `${type.value.toLowerCase()}\0${tagValue.value.toLowerCase()}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    normalized.push({ type: type.value, value: tagValue.value });
+  }
+
+  return { ok: true, value: normalized };
+}
+
+function normalizeKinds(value: unknown): MemoryValidationResult<MemoryEntryKind[] | undefined> {
+  if (value === undefined) {
+    return { ok: true, value: undefined };
+  }
+  if (!Array.isArray(value)) {
+    return error("MEMORY_INVALID_FIELD", "kinds must be an array.", "kinds");
+  }
+
+  const normalized: MemoryEntryKind[] = [];
+  const seen = new Set<MemoryEntryKind>();
+  for (let index = 0; index < value.length; index += 1) {
+    const kind = validateMemoryKind(value[index], `kinds[${index}]`);
+    if (!kind.ok) {
+      return kind;
+    }
+    if (seen.has(kind.value)) {
+      continue;
+    }
+    seen.add(kind.value);
+    normalized.push(kind.value);
+  }
+
+  return { ok: true, value: normalized };
+}
+
+export function validateMemorySearchRequest(value: unknown): MemoryValidationResult<MemorySearchRequest> {
+  if (!isRecord(value)) {
+    return error("MEMORY_INVALID_REQUEST", "Search request must be an object.");
+  }
+  const unknownKeys = rejectUnknownKeys(value, SEARCH_REQUEST_KEYS, "request");
+  if (!unknownKeys.ok) {
+    return unknownKeys;
+  }
+  const schema = validateSchemaVersion(value);
+  if (!schema.ok) {
+    return schema;
+  }
+  const targets = normalizeTargets(value.targets);
+  if (!targets.ok) {
+    return targets;
+  }
+  const query = normalizeText(value.query, "query", { maxLength: MAX_SEARCH_QUERY_LENGTH });
+  if (!query.ok) {
+    return query;
+  }
+  const kinds = normalizeKinds(value.kinds);
+  if (!kinds.ok) {
+    return kinds;
+  }
+  const tags = normalizeTags(value.tags);
+  if (!tags.ok) {
+    return tags;
+  }
+  const cursor = normalizeOptionalText(value.cursor, "cursor", MAX_CURSOR_LENGTH);
+  if (!cursor.ok) {
+    return cursor;
+  }
+
+  let limit: number | undefined;
+  if (value.limit !== undefined) {
+    if (typeof value.limit !== "number" || !Number.isInteger(value.limit) || value.limit < 1 || value.limit > MAX_LIMIT) {
+      return error("MEMORY_INVALID_FIELD", `limit must be an integer from 1 to ${MAX_LIMIT}.`, "limit");
+    }
+    limit = value.limit;
+  }
+
+  return {
+    ok: true,
+    value: {
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      targets: targets.value,
+      query: query.value,
+      ...(kinds.value ? { kinds: kinds.value } : {}),
+      ...(tags.value.length > 0 ? { tags: tags.value } : {}),
+      ...(limit !== undefined ? { limit } : {}),
+      ...(cursor.value !== undefined ? { cursor: cursor.value } : {}),
+    },
+  };
+}
+
+export function validateMemoryAppendRequest(value: unknown): MemoryValidationResult<MemoryAppendRequest> {
+  if (!isRecord(value)) {
+    return error("MEMORY_INVALID_REQUEST", "Append request must be an object.");
+  }
+  const unknownKeys = rejectUnknownKeys(value, APPEND_REQUEST_KEYS, "request");
+  if (!unknownKeys.ok) {
+    return unknownKeys;
+  }
+  const schema = validateSchemaVersion(value);
+  if (!schema.ok) {
+    return schema;
+  }
+  const target = normalizeMemoryTarget(value.target, "target");
+  if (!target.ok) {
+    return target;
+  }
+  const kind = validateMemoryKind(value.kind, "kind");
+  if (!kind.ok) {
+    return kind;
+  }
+  const title = normalizeText(value.title, "title", { maxLength: MAX_TITLE_LENGTH });
+  if (!title.ok) {
+    return title;
+  }
+  const body = normalizeText(value.body, "body", { maxLength: MAX_BODY_LENGTH });
+  if (!body.ok) {
+    return body;
+  }
+  const preview = normalizeText(value.preview, "preview", { maxLength: MAX_PREVIEW_LENGTH });
+  if (!preview.ok) {
+    return preview;
+  }
+  const tags = normalizeTags(value.tags);
+  if (!tags.ok) {
+    return tags;
+  }
+  const supersedes = normalizeStringArray(value.supersedes, "supersedes", { maxItems: MAX_SUPERSEDES, maxLength: MAX_ID_LENGTH });
+  if (!supersedes.ok) {
+    return supersedes;
+  }
+  const sourceMessageId = normalizeOptionalText(value.sourceMessageId, "sourceMessageId");
+  if (!sourceMessageId.ok) {
+    return sourceMessageId;
+  }
+  const idempotencyKey = normalizeOptionalText(value.idempotencyKey, "idempotencyKey");
+  if (!idempotencyKey.ok) {
+    return idempotencyKey;
+  }
+
+  return {
+    ok: true,
+    value: {
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      target: target.value,
+      kind: kind.value,
+      title: title.value,
+      body: body.value,
+      preview: preview.value,
+      tags: tags.value,
+      ...(supersedes.value && supersedes.value.length > 0 ? { supersedes: supersedes.value } : {}),
+      ...(sourceMessageId.value !== undefined ? { sourceMessageId: sourceMessageId.value } : {}),
+      ...(idempotencyKey.value !== undefined ? { idempotencyKey: idempotencyKey.value } : {}),
+    },
+  };
+}
+
+export function validateMemoryForgetRequest(value: unknown): MemoryValidationResult<MemoryForgetRequest> {
+  if (!isRecord(value)) {
+    return error("MEMORY_INVALID_REQUEST", "Forget request must be an object.");
+  }
+  const unknownKeys = rejectUnknownKeys(value, FORGET_REQUEST_KEYS, "request");
+  if (!unknownKeys.ok) {
+    return unknownKeys;
+  }
+  const schema = validateSchemaVersion(value);
+  if (!schema.ok) {
+    return schema;
+  }
+  const entryIds = normalizeStringArray(value.entryIds, "entryIds", { maxItems: MAX_FORGET_ENTRY_IDS, maxLength: MAX_ID_LENGTH });
+  if (!entryIds.ok) {
+    return entryIds;
+  }
+  if (!entryIds.value || entryIds.value.length === 0) {
+    return error("MEMORY_INVALID_FIELD", "entryIds must not be empty.", "entryIds");
+  }
+  if (value.reason !== undefined && (typeof value.reason !== "string" || !MEMORY_FORGET_REASONS.has(value.reason as MemoryForgetReason))) {
+    return error("MEMORY_INVALID_FIELD", "reason must be a valid forget reason.", "reason");
+  }
+  const sourceMessageId = normalizeOptionalText(value.sourceMessageId, "sourceMessageId");
+  if (!sourceMessageId.ok) {
+    return sourceMessageId;
+  }
+  const idempotencyKey = normalizeOptionalText(value.idempotencyKey, "idempotencyKey");
+  if (!idempotencyKey.ok) {
+    return idempotencyKey;
+  }
+
+  return {
+    ok: true,
+    value: {
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      entryIds: entryIds.value,
+      ...(value.reason !== undefined ? { reason: value.reason as MemoryForgetReason } : {}),
+      ...(sourceMessageId.value !== undefined ? { sourceMessageId: sourceMessageId.value } : {}),
+      ...(idempotencyKey.value !== undefined ? { idempotencyKey: idempotencyKey.value } : {}),
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- V6 Memory の request contract 型を追加しました。
- search / append / forget の pure validation を追加しました。
- provider 固有 field rejection、owner/scope allowlist、size/null byte、duplicate tag normalization をテストで固定しました。

## Validation

- `npx tsx --test scripts/tests/memory-v6-contract.test.ts`
- `npm run typecheck`

## Review Notes

- DB / provider / CLI / runtime binding には触れていません。
- この PR は `codex/v6-develop` を base にした stacked PR です。