### PR TITLE
[codex] V6 Provider Binding Spikeを完了

### DIFF
--- a/docs/design/coding-agent-capability-matrix.md
+++ b/docs/design/coding-agent-capability-matrix.md
@@ -63,6 +63,7 @@
 | apps / mcp / plugins | provider 拡張機能を session から扱う | 一部対応 | 一部対応 | 未着手 | Codex は `/apps` `/mcp`、Copilot は plugin 系がある |
 | sandbox / allowlist 拡張 | read dir 追加や tool allowlist を wrapper から制御する | 一部対応 | 一部対応 | 一部実装 | Codex は `read-only / workspace-write / workspace-write + network / danger-full-access` を session metadata から SDK runtime option へ渡す。Copilot は現時点で sandbox dropdown を出さない |
 | app-level approval callback | app 側で approve / deny を返す | 非対応 | 一部対応 | 一部実装 | Copilot provider-controlled では Session UI の approval card から `approve / deny` を返せる。Codex は current SDK surface では未対応 |
+| Memory runtime binding injection | turn ごとの短命 opaque reference を provider process へ渡す | 対応 | 対応 | 一部実装 | Codex は `Codex` client options、Copilot は `CopilotClient` options の env injection を使う。WithMate は `ProviderMemoryBindingRuntimeProjection` と provider cache key 分離まで実装済み。binding registry / principal 解決は次 phase |
 
 ## Current Read
 

--- a/docs/design/provider-adapter.md
+++ b/docs/design/provider-adapter.md
@@ -40,11 +40,12 @@ type ProviderCodingAdapter = {
     session: Session;
     sessionMemory: SessionMemory;
     projectMemoryEntries: ProjectMemoryEntry[];
-    character: CharacterProfile;
+    character?: CharacterProfile;
     providerCatalog: ModelCatalogProvider;
     userMessage: string;
     appSettings: AppSettings;
     attachments: ComposerAttachment[];
+    memoryBinding?: ProviderMemoryBindingRuntimeProjection | null;
     signal?: AbortSignal;
     onApprovalRequest?: (request: LiveApprovalRequest) => Promise<"approve" | "deny">;
     onProviderQuotaTelemetry?: (telemetry: ProviderQuotaTelemetry) => void | Promise<void>;
@@ -52,6 +53,8 @@ type ProviderCodingAdapter = {
   }, onProgress?: (state: LiveSessionRunState) => void | Promise<void>): Promise<ProviderTurnResult>;
 };
 ```
+
+`memoryBinding`はV6 Memory用の短命runtime projectionである。provider adapterはproviderごとのtransport差分を閉じ、Codex / GitHub Copilot CLIではclient construction時のenvironmentへopaque referenceだけを注入する。bindingの生成、revoke、principal / permission検証はadapterではなくMain Process側のbinding runtimeとMemory API側に置く。
 
 ```ts
 type ProviderBackgroundAdapter = {

--- a/docs/design/v6-memory-foundation.md
+++ b/docs/design/v6-memory-foundation.md
@@ -607,8 +607,12 @@ bindingは次のlifecycleで失効する。
 環境変数に入れる値はcredentialではなく、短命opaque referenceとする。
 runtime API側はbinding reference、active session lifecycle、provider run、permission、owner / scope accessを再検証する。
 
-providerへのbinding伝達はprovider spikeで確認する。
-第一候補はturnごとのenv injection、fallbackはsession-local context file、どちらも無理なproviderはunsupportedとする。
+providerへのbinding伝達はPhase 5 spikeで確認済み。
+Codex / GitHub Copilot CLIはいずれもSDK client construction時のenvironment injectionを使う。
+WithMateはprovider turnごとの`ProviderMemoryBindingRuntimeProjection`を`RunSessionTurnInput`へ渡し、adapterはbinding IDベースのsettings keyをclient cache keyに含めてturn / binding境界を分離する。
+env injectionに載せるのは短命opaque referenceだけで、runtime API secretやprincipal detailは載せない。
+fallbackとして`context_file` transportを型として予約するが、Codex / Copilotのcurrent strategyでは使わない。
+binding transport未確認のproviderは`unsupported`として扱う。
 
 ### Target Selection
 
@@ -699,6 +703,11 @@ type MemoryBindingInjectionStrategy = {
 ```
 
 - provider SDKからprovider process / agent shell childへturnごとの環境変数を注入できるか確認する。
+- current Codex / GitHub Copilot CLIは`env` injectionを使う。
+- binding projectionは`src-electron/provider-memory-binding.ts`で共有し、`src-electron/session-runtime-service.ts`のoptional hookからadapterへ渡す。
+- Codexは`Codex` client optionsの`env`へprojectionを重ねる。SDKが`env`指定時に`process.env`を継承しないため、WithMate側でdefined envだけをmergeする。
+- GitHub Copilot CLIは`CopilotClient` optionsの`env`へprojectionを重ねる。
+- どちらもbinding settings keyをprovider client/session cache keyへ含め、異なるbindingでcached provider process/sessionを再利用しない。settings keyにはbinding reference本体を含めない。
 - env injection不可の場合だけsession-local context fileを検討する。
 - working directoryから暗黙探索しない。
 - provider runtimeがbinding非対応なら、current Characterなどruntime binding必須のcapabilityをそのproviderへ表示しない。

--- a/docs/plans/20260621-v6-memory-foundation/plan.md
+++ b/docs/plans/20260621-v6-memory-foundation/plan.md
@@ -305,6 +305,8 @@ scripts/tests/withmate-memory-cli.test.ts
 
 ## Phase 5: Provider Binding Spike
 
+Status: 完了。Codex / GitHub Copilot CLI はどちらも env injection を採用する。`context_file` はfallback transportとして型予約し、未確認 provider は `unsupported` とする。
+
 Codex / Copilotで別々に確認する。
 このspikeは実装branchと混ぜず、Phase 0/1と並行して早期に行う。CLI contract確定後に最終検証するが、turnごとのenv injection / session-local context file / unsupportedの見通しはstorage実装前に固定する。
 
@@ -320,9 +322,23 @@ Codex / Copilotで別々に確認する。
 
 成果物:
 
-- capability matrix更新
-- provider別strategy決定
-- unsupported時のfallback
+- capability matrix更新 - 完了
+- provider別strategy決定 - 完了。Codex / GitHub Copilot CLI は env injection
+- unsupported時のfallback - 完了。`ProviderMemoryBindingTransport`で`context_file`と`unsupported`を予約
+
+実装:
+
+- `src-electron/provider-memory-binding.ts`
+- `src-electron/provider-runtime.ts`
+- `src-electron/session-runtime-service.ts`
+- `src-electron/codex-adapter.ts`
+- `src-electron/copilot-adapter.ts`
+- `src-electron/provider-support.ts`
+- `scripts/tests/provider-memory-binding.test.ts`
+
+検証:
+
+- `node --test --import tsx scripts/tests/provider-memory-binding.test.ts scripts/tests/provider-support.test.ts scripts/tests/copilot-adapter.test.ts scripts/tests/session-runtime-service.test.ts`
 
 ## Phase 6: Binding Runtime
 

--- a/scripts/tests/codex-adapter.test.ts
+++ b/scripts/tests/codex-adapter.test.ts
@@ -972,6 +972,75 @@ describe("CodexAdapter thread settings", () => {
     }
   });
 
+  it("Memory binding 付き Codex client は turn-local として cache に残さない", () => {
+    const adapter = new CodexAdapter() as unknown as {
+      clients: Map<string, unknown>;
+      getClient(
+        providerId: string,
+        appSettings: ReturnType<typeof createDefaultAppSettings>,
+        memoryBinding?: RunSessionTurnInput["memoryBinding"],
+      ): { client: unknown; clientKey: string };
+    };
+    const appSettings = createDefaultAppSettings();
+    const memoryBinding = {
+      bindingId: "binding-1",
+      bindingReference: "ref-1",
+      transport: "env",
+    } satisfies NonNullable<RunSessionTurnInput["memoryBinding"]>;
+
+    const unboundClient = adapter.getClient("codex", appSettings);
+    const nextUnboundClient = adapter.getClient("codex", appSettings);
+    const boundClient = adapter.getClient("codex", appSettings, memoryBinding);
+    const nextBoundClient = adapter.getClient("codex", appSettings, memoryBinding);
+
+    assert.equal(nextUnboundClient.client, unboundClient.client);
+    assert.notEqual(nextBoundClient.client, boundClient.client);
+    assert.equal(adapter.clients.size, 1);
+  });
+
+  it("Memory binding 付き Codex thread は turn-local として cache に残さない", () => {
+    const adapter = new CodexAdapter() as unknown as {
+      threads: Map<string, unknown>;
+      getClient(): { client: unknown; clientKey: string };
+      getThread(input: RunSessionTurnInput): { thread: { id: string } };
+    };
+    let threadIndex = 0;
+    adapter.getClient = () => ({
+      client: {
+        startThread: () => ({ id: `thread-${++threadIndex}` }),
+        resumeThread: (threadId: string) => ({ id: threadId }),
+      },
+      clientKey: "client-key",
+    });
+    const input = createCodexRunSessionTurnInput("F:/repo");
+    const boundInput: RunSessionTurnInput = {
+      ...input,
+      memoryBinding: {
+        bindingId: "binding-1",
+        bindingReference: "ref-1",
+        transport: "env",
+      },
+    };
+
+    const unboundThread = adapter.getThread(input);
+    const nextUnboundThread = adapter.getThread(input);
+    const boundThread = adapter.getThread(boundInput);
+    const nextBoundThread = adapter.getThread(boundInput);
+    const unboundAfterBoundThread = adapter.getThread({
+      ...input,
+      session: {
+        ...input.session,
+        threadId: boundThread.thread.id,
+      },
+    });
+
+    assert.equal(nextUnboundThread.thread, unboundThread.thread);
+    assert.notEqual(nextBoundThread.thread, boundThread.thread);
+    assert.equal(unboundAfterBoundThread.thread.id, boundThread.thread.id);
+    assert.notEqual(unboundAfterBoundThread.thread, unboundThread.thread);
+    assert.equal(adapter.threads.size, 1);
+  });
+
   it("model / reasoning 変更後の thread settings は新 options と settingsKey を反映する", () => {
     const previousSession = createSession({
       threadId: "thread-1",

--- a/scripts/tests/copilot-adapter.test.ts
+++ b/scripts/tests/copilot-adapter.test.ts
@@ -266,6 +266,17 @@ describe("CopilotAdapter env", () => {
     assert.equal(env[WITHMATE_MEMORY_BINDING_REFERENCE_ENV], "ref-1");
   });
 
+  it("Copilot child CLI env は baseEnv の stale Memory binding env を引き継がない", () => {
+    const env = buildCopilotClientEnv({
+      PATH: "test-path",
+      [WITHMATE_MEMORY_BINDING_REFERENCE_ENV]: "stale-ref",
+    });
+
+    assert.equal(env.NODE_NO_WARNINGS, "1");
+    assert.equal(env.PATH, "test-path");
+    assert.equal(env[WITHMATE_MEMORY_BINDING_REFERENCE_ENV], undefined);
+  });
+
   it("Memory binding 付き Copilot client は turn-local として cache に残さない", () => {
     const adapter = new CopilotAdapter() as unknown as {
       clients: Map<string, unknown>;

--- a/scripts/tests/copilot-adapter.test.ts
+++ b/scripts/tests/copilot-adapter.test.ts
@@ -42,6 +42,7 @@ import {
   type RunSessionTurnInput,
   type RunSessionTurnResult,
 } from "../../src-electron/provider-runtime.js";
+import { WITHMATE_MEMORY_BINDING_REFERENCE_ENV } from "../../src-electron/provider-memory-binding.js";
 
 const TEST_STRUCTURED_OUTPUT_SCHEMA = {
   type: "object",
@@ -248,6 +249,94 @@ describe("CopilotAdapter env", () => {
     assert.equal(env.NODE_NO_WARNINGS, "1");
     assert.equal(env.PATH, "test-path");
     assert.equal(env.ELECTRON_RUN_AS_NODE, "1");
+  });
+
+  it("Copilot child CLI env に Memory binding reference を重ねる", () => {
+    const env = buildCopilotClientEnv(
+      { PATH: "test-path" },
+      {
+        bindingId: "binding-1",
+        bindingReference: "ref-1",
+        transport: "env",
+      },
+    );
+
+    assert.equal(env.NODE_NO_WARNINGS, "1");
+    assert.equal(env.PATH, "test-path");
+    assert.equal(env[WITHMATE_MEMORY_BINDING_REFERENCE_ENV], "ref-1");
+  });
+
+  it("Memory binding 付き Copilot client は turn-local として cache に残さない", () => {
+    const adapter = new CopilotAdapter() as unknown as {
+      clients: Map<string, unknown>;
+      getClient(providerId: string, input: RunSessionTurnInput): { client: unknown; clientKey: string };
+    };
+    const input = createRunSessionInput();
+    const boundInput: RunSessionTurnInput = {
+      ...input,
+      memoryBinding: {
+        bindingId: "binding-1",
+        bindingReference: "ref-1",
+        transport: "env",
+      },
+    };
+
+    const unboundClient = adapter.getClient("copilot", input);
+    const nextUnboundClient = adapter.getClient("copilot", input);
+    const boundClient = adapter.getClient("copilot", boundInput);
+    const nextBoundClient = adapter.getClient("copilot", boundInput);
+
+    assert.equal(nextUnboundClient.client, unboundClient.client);
+    assert.notEqual(nextBoundClient.client, boundClient.client);
+    assert.equal(adapter.clients.size, 1);
+  });
+
+  it("Memory binding 付き Copilot session は turn-local として cache に残さない", async () => {
+    const adapter = new CopilotAdapter() as unknown as {
+      sessions: Map<string, unknown>;
+      getClient(): { client: unknown; clientKey: string };
+      getSession(input: RunSessionTurnInput, prompt: ProviderPromptComposition): Promise<{ session: { sessionId: string } }>;
+    };
+    let sessionIndex = 0;
+    const createSession = () => ({
+      sessionId: `session-${++sessionIndex}`,
+      disconnect: async () => undefined,
+      on: () => () => undefined,
+    });
+    adapter.getClient = () => ({
+      client: {
+        createSession,
+        resumeSession: async (threadId: string) => ({ ...createSession(), sessionId: threadId }),
+      },
+      clientKey: "client-key",
+    });
+    const input = createRunSessionInput();
+    const boundInput: RunSessionTurnInput = {
+      ...input,
+      memoryBinding: {
+        bindingId: "binding-1",
+        bindingReference: "ref-1",
+        transport: "env",
+      },
+    };
+
+    const unboundSession = await adapter.getSession(input, EMPTY_PROMPT);
+    const nextUnboundSession = await adapter.getSession(input, EMPTY_PROMPT);
+    const boundSession = await adapter.getSession(boundInput, EMPTY_PROMPT);
+    const nextBoundSession = await adapter.getSession(boundInput, EMPTY_PROMPT);
+    const unboundAfterBoundSession = await adapter.getSession({
+      ...input,
+      session: {
+        ...input.session,
+        threadId: boundSession.session.sessionId,
+      },
+    }, EMPTY_PROMPT);
+
+    assert.equal(nextUnboundSession.session, unboundSession.session);
+    assert.notEqual(nextBoundSession.session, boundSession.session);
+    assert.equal(unboundAfterBoundSession.session.sessionId, boundSession.session.sessionId);
+    assert.notEqual(unboundAfterBoundSession.session, unboundSession.session);
+    assert.equal(adapter.sessions.size, 1);
   });
 
   it("platform / arch から native Copilot package 名を決める", () => {

--- a/scripts/tests/provider-memory-binding.test.ts
+++ b/scripts/tests/provider-memory-binding.test.ts
@@ -49,12 +49,31 @@ test("binding settings key は reference 本体を含めず provider cache 分�
   );
 });
 
-test("Codex client env 用 merge は undefined を落として binding env を重ねる", () => {
+test("provider client env 用 merge は undefined と stale binding env を落として binding env を重ねる", () => {
   assert.deepEqual(
     mergeDefinedEnv(
-      { PATH: "bin", EMPTY: undefined },
+      {
+        PATH: "bin",
+        EMPTY: undefined,
+        [WITHMATE_MEMORY_BINDING_REFERENCE_ENV]: "stale-ref",
+        [WITHMATE_MEMORY_BINDING_CONTEXT_FILE_ENV]: "C:/stale/binding.json",
+      },
       { [WITHMATE_MEMORY_BINDING_REFERENCE_ENV]: "ref-1" },
     ),
     { PATH: "bin", [WITHMATE_MEMORY_BINDING_REFERENCE_ENV]: "ref-1" },
+  );
+});
+
+test("provider client env 用 merge は binding overlay が無い場合も stale binding env を落とす", () => {
+  assert.deepEqual(
+    mergeDefinedEnv(
+      {
+        PATH: "bin",
+        [WITHMATE_MEMORY_BINDING_REFERENCE_ENV]: "stale-ref",
+        [WITHMATE_MEMORY_BINDING_CONTEXT_FILE_ENV]: "C:/stale/binding.json",
+      },
+      {},
+    ),
+    { PATH: "bin" },
   );
 });

--- a/scripts/tests/provider-memory-binding.test.ts
+++ b/scripts/tests/provider-memory-binding.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  WITHMATE_MEMORY_BINDING_CONTEXT_FILE_ENV,
+  WITHMATE_MEMORY_BINDING_REFERENCE_ENV,
+  buildProviderMemoryBindingEnv,
+  buildProviderMemoryBindingSettingsKey,
+  getProviderMemoryBindingCapability,
+  mergeDefinedEnv,
+  type ProviderMemoryBindingRuntimeProjection,
+} from "../../src-electron/provider-memory-binding.js";
+
+const envProjection: ProviderMemoryBindingRuntimeProjection = {
+  bindingId: "binding-1",
+  bindingReference: "ref-1",
+  transport: "env",
+  expiresAt: "2026-06-26T00:00:00.000Z",
+};
+
+test("Provider Memory binding capability は Codex / Copilot を env injection として固定する", () => {
+  assert.equal(getProviderMemoryBindingCapability("codex").transport, "env");
+  assert.equal(getProviderMemoryBindingCapability("copilot").transport, "env");
+  assert.equal(getProviderMemoryBindingCapability("unknown").transport, "unsupported");
+});
+
+test("env projection は opaque reference だけを provider process 用 env に出す", () => {
+  assert.deepEqual(buildProviderMemoryBindingEnv(envProjection), {
+    [WITHMATE_MEMORY_BINDING_REFERENCE_ENV]: "ref-1",
+  });
+  assert.deepEqual(buildProviderMemoryBindingEnv({
+    ...envProjection,
+    transport: "context_file",
+    contextFilePath: "C:/runtime/binding.json",
+  }), {
+    [WITHMATE_MEMORY_BINDING_CONTEXT_FILE_ENV]: "C:/runtime/binding.json",
+  });
+  assert.deepEqual(buildProviderMemoryBindingEnv(null), {});
+});
+
+test("binding settings key は reference 本体を含めず provider cache 分離に使える", () => {
+  assert.equal(
+    buildProviderMemoryBindingSettingsKey(envProjection),
+    buildProviderMemoryBindingSettingsKey({ ...envProjection, bindingReference: "ref-2" }),
+  );
+  assert.notEqual(
+    buildProviderMemoryBindingSettingsKey(envProjection),
+    buildProviderMemoryBindingSettingsKey({ ...envProjection, bindingId: "binding-2" }),
+  );
+});
+
+test("Codex client env 用 merge は undefined を落として binding env を重ねる", () => {
+  assert.deepEqual(
+    mergeDefinedEnv(
+      { PATH: "bin", EMPTY: undefined },
+      { [WITHMATE_MEMORY_BINDING_REFERENCE_ENV]: "ref-1" },
+    ),
+    { PATH: "bin", [WITHMATE_MEMORY_BINDING_REFERENCE_ENV]: "ref-1" },
+  );
+});

--- a/scripts/tests/provider-support.test.ts
+++ b/scripts/tests/provider-support.test.ts
@@ -131,6 +131,7 @@ test("getProviderRuntimeCapabilities は provider と background policy から�
   assert.equal(capabilities.providerSupported, true);
   assert.equal(capabilities.instructionSyncSupported, true);
   assert.equal(capabilities.tokenUsageSupported, true);
+  assert.equal(capabilities.memoryBindingTransport, "env");
 });
 
 test("getProviderRuntimeCapabilities は MVP 対象外 provider の support flag を false にする", () => {
@@ -139,4 +140,5 @@ test("getProviderRuntimeCapabilities は MVP 対象外 provider の support flag
   assert.equal(capabilities.instructionSyncSupported, false);
   assert.equal(capabilities.tokenUsageSupported, false);
   assert.equal(capabilities.providerSupported, false);
+  assert.equal(capabilities.memoryBindingTransport, "unsupported");
 });

--- a/scripts/tests/session-runtime-service.test.ts
+++ b/scripts/tests/session-runtime-service.test.ts
@@ -648,7 +648,9 @@ describe("SessionRuntimeService", () => {
       setSessionContextTelemetry() {},
       invalidateProviderSessionThread() {},
       scheduleProviderQuotaTelemetryRefresh() {},
-      clearWorkspaceFileIndex() {},
+      clearWorkspaceFileIndex() {
+        calls.push("clearWorkspaceFileIndex");
+      },
       createProviderMemoryBinding() {
         calls.push("create");
         return {
@@ -660,7 +662,9 @@ describe("SessionRuntimeService", () => {
       revokeProviderMemoryBinding(nextBinding) {
         calls.push(`revoke:${nextBinding.bindingId}`);
       },
-      broadcastLiveSessionRun() {},
+      broadcastLiveSessionRun() {
+        calls.push("broadcast");
+      },
       resolvePendingApprovalRequest() {
         calls.push("approval:deny");
       },
@@ -684,6 +688,8 @@ describe("SessionRuntimeService", () => {
       "approval:deny",
       "elicitation:cancel",
       "upsert:error",
+      "clearWorkspaceFileIndex",
+      "broadcast",
     ]);
     assert.equal(liveStates.at(-1), null);
   });

--- a/scripts/tests/session-runtime-service.test.ts
+++ b/scripts/tests/session-runtime-service.test.ts
@@ -379,6 +379,315 @@ describe("SessionRuntimeService", () => {
     assert.equal(hasCharacterKey, false);
     assert.equal(result.runState, "idle");
   });
+
+  it("provider memory binding を turn input に渡し、完了時に revoke する", async () => {
+    const session = createSession();
+    const binding = {
+      bindingId: "binding-1",
+      bindingReference: "ref-1",
+      transport: "env" as const,
+    };
+    const calls: string[] = [];
+
+    const adapter: ProviderCodingAdapter = {
+      composePrompt(input) {
+        calls.push(`compose:${input.memoryBinding?.bindingId ?? ""}`);
+        return {
+          systemBodyText: "system",
+          inputBodyText: "input",
+          logicalPrompt: { systemText: "system", inputText: "input", composedText: "system\ninput" },
+          imagePaths: [],
+          additionalDirectories: [],
+        };
+      },
+      async getProviderQuotaTelemetry() {
+        return null;
+      },
+      invalidateSessionThread() {},
+      invalidateAllSessionThreads() {},
+      runSessionTurn(input) {
+        calls.push(`run:${input.memoryBinding?.bindingReference ?? ""}`);
+        return Promise.resolve(createPartialResult({
+          threadId: "thread-1",
+          assistantText: "完了したよ。",
+        }));
+      },
+    };
+
+    const service = new SessionRuntimeService({
+      getSession(sessionId) {
+        return sessionId === session.id ? session : null;
+      },
+      upsertSession(next) {
+        return next;
+      },
+      async resolveComposerPreview() {
+        return { attachments: [], errors: [] } satisfies ComposerPreview;
+      },
+      getAppSettings() {
+        return normalizeAppSettings({});
+      },
+      resolveProviderCatalog() {
+        return { snapshot: { revision: 1, providers: [createProviderCatalog()] }, provider: createProviderCatalog() };
+      },
+      getProviderCodingAdapter() {
+        return adapter;
+      },
+      getSessionMemory(current) {
+        return createSessionMemory(current.id);
+      },
+      resolveProjectMemoryEntriesForPrompt() {
+        return [];
+      },
+      createAuditLog(input) {
+        return createAuditLogBase(input);
+      },
+      updateAuditLog() {},
+      setLiveSessionRun() {},
+      getLiveSessionRun() {
+        return null;
+      },
+      async waitForApprovalDecision(): Promise<LiveApprovalDecision> {
+        return "approve";
+      },
+      async waitForElicitationResponse() {
+        return { action: "cancel" } as const;
+      },
+      setProviderQuotaTelemetry() {},
+      setSessionContextTelemetry() {},
+      invalidateProviderSessionThread() {},
+      scheduleProviderQuotaTelemetryRefresh() {},
+      clearWorkspaceFileIndex() {},
+      createProviderMemoryBinding(input) {
+        calls.push(`create:${input.session.id}:${input.provider.id}:${input.character?.id ?? "none"}`);
+        return binding;
+      },
+      revokeProviderMemoryBinding(nextBinding) {
+        calls.push(`revoke:${nextBinding.bindingId}`);
+      },
+      broadcastLiveSessionRun() {},
+      resolvePendingApprovalRequest() {},
+      resolvePendingElicitationRequest() {},
+      currentTimestampLabel,
+    });
+
+    const result = await service.runSessionTurn(session.id, { userMessage: "お願い" });
+
+    assert.equal(result.runState, "idle");
+    assert.deepEqual(calls, [
+      `create:${session.id}:codex:none`,
+      "compose:binding-1",
+      "run:ref-1",
+      "revoke:binding-1",
+    ]);
+  });
+
+  it("provider memory binding revoke が失敗しても turn cleanup は継続する", async () => {
+    const session = createSession();
+    const liveStates: Array<LiveSessionRunState | null> = [];
+    const adapter: ProviderCodingAdapter = {
+      composePrompt() {
+        return {
+          systemBodyText: "system",
+          inputBodyText: "input",
+          logicalPrompt: { systemText: "system", inputText: "input", composedText: "system\ninput" },
+          imagePaths: [],
+          additionalDirectories: [],
+        };
+      },
+      async getProviderQuotaTelemetry() {
+        return null;
+      },
+      invalidateSessionThread() {},
+      invalidateAllSessionThreads() {},
+      runSessionTurn() {
+        return Promise.resolve(createPartialResult({
+          threadId: "thread-1",
+          assistantText: "完了したよ。",
+        }));
+      },
+    };
+
+    const service = new SessionRuntimeService({
+      getSession(sessionId) {
+        return sessionId === session.id ? session : null;
+      },
+      upsertSession(next) {
+        return next;
+      },
+      async resolveComposerPreview() {
+        return { attachments: [], errors: [] } satisfies ComposerPreview;
+      },
+      getAppSettings() {
+        return normalizeAppSettings({});
+      },
+      resolveProviderCatalog() {
+        return { snapshot: { revision: 1, providers: [createProviderCatalog()] }, provider: createProviderCatalog() };
+      },
+      getProviderCodingAdapter() {
+        return adapter;
+      },
+      getSessionMemory(current) {
+        return createSessionMemory(current.id);
+      },
+      resolveProjectMemoryEntriesForPrompt() {
+        return [];
+      },
+      createAuditLog(input) {
+        return createAuditLogBase(input);
+      },
+      updateAuditLog() {},
+      setLiveSessionRun(_sessionId, state) {
+        liveStates.push(state);
+      },
+      getLiveSessionRun() {
+        return liveStates.at(-1) ?? null;
+      },
+      async waitForApprovalDecision(): Promise<LiveApprovalDecision> {
+        return "approve";
+      },
+      async waitForElicitationResponse() {
+        return { action: "cancel" } as const;
+      },
+      setProviderQuotaTelemetry() {},
+      setSessionContextTelemetry() {},
+      invalidateProviderSessionThread() {},
+      scheduleProviderQuotaTelemetryRefresh() {},
+      clearWorkspaceFileIndex() {},
+      createProviderMemoryBinding() {
+        return {
+          bindingId: "binding-1",
+          bindingReference: "ref-1",
+          transport: "env",
+        };
+      },
+      revokeProviderMemoryBinding() {
+        throw new Error("revoke failed");
+      },
+      broadcastLiveSessionRun() {},
+      resolvePendingApprovalRequest() {},
+      resolvePendingElicitationRequest() {},
+      currentTimestampLabel,
+    });
+
+    const result = await service.runSessionTurn(session.id, { userMessage: "お願い" });
+
+    assert.equal(result.runState, "idle");
+    assert.equal(liveStates.at(-1), null);
+  });
+
+  it("provider memory binding 作成後の setup 失敗でも revoke して live state を掃除する", async () => {
+    const session = createSession();
+    const calls: string[] = [];
+    const liveStates: Array<LiveSessionRunState | null> = [];
+    const adapter: ProviderCodingAdapter = {
+      composePrompt() {
+        calls.push("compose");
+        return {
+          systemBodyText: "system",
+          inputBodyText: "input",
+          logicalPrompt: { systemText: "system", inputText: "input", composedText: "system\ninput" },
+          imagePaths: [],
+          additionalDirectories: [],
+        };
+      },
+      async getProviderQuotaTelemetry() {
+        return null;
+      },
+      invalidateSessionThread() {},
+      invalidateAllSessionThreads() {},
+      runSessionTurn() {
+        throw new Error("provider should not run");
+      },
+    };
+
+    const service = new SessionRuntimeService({
+      getSession(sessionId) {
+        return sessionId === session.id ? session : null;
+      },
+      upsertSession(next) {
+        calls.push(`upsert:${next.runState}`);
+        return next;
+      },
+      async resolveComposerPreview() {
+        return { attachments: [], errors: [] } satisfies ComposerPreview;
+      },
+      getAppSettings() {
+        return normalizeAppSettings({});
+      },
+      resolveProviderCatalog() {
+        return { snapshot: { revision: 1, providers: [createProviderCatalog()] }, provider: createProviderCatalog() };
+      },
+      getProviderCodingAdapter() {
+        return adapter;
+      },
+      getSessionMemory(current) {
+        return createSessionMemory(current.id);
+      },
+      resolveProjectMemoryEntriesForPrompt() {
+        return [];
+      },
+      createAuditLog() {
+        calls.push("createAuditLog");
+        throw new Error("audit failed");
+      },
+      updateAuditLog() {},
+      setLiveSessionRun(_sessionId, state) {
+        liveStates.push(state);
+      },
+      getLiveSessionRun() {
+        return liveStates.at(-1) ?? null;
+      },
+      async waitForApprovalDecision(): Promise<LiveApprovalDecision> {
+        return "approve";
+      },
+      async waitForElicitationResponse() {
+        return { action: "cancel" } as const;
+      },
+      setProviderQuotaTelemetry() {},
+      setSessionContextTelemetry() {},
+      invalidateProviderSessionThread() {},
+      scheduleProviderQuotaTelemetryRefresh() {},
+      clearWorkspaceFileIndex() {},
+      createProviderMemoryBinding() {
+        calls.push("create");
+        return {
+          bindingId: "binding-1",
+          bindingReference: "ref-1",
+          transport: "env",
+        };
+      },
+      revokeProviderMemoryBinding(nextBinding) {
+        calls.push(`revoke:${nextBinding.bindingId}`);
+      },
+      broadcastLiveSessionRun() {},
+      resolvePendingApprovalRequest() {
+        calls.push("approval:deny");
+      },
+      resolvePendingElicitationRequest() {
+        calls.push("elicitation:cancel");
+      },
+      currentTimestampLabel,
+    });
+
+    await assert.rejects(
+      service.runSessionTurn(session.id, { userMessage: "お願い" }),
+      /audit failed/,
+    );
+
+    assert.deepEqual(calls, [
+      "create",
+      "compose",
+      "upsert:running",
+      "createAuditLog",
+      "revoke:binding-1",
+      "approval:deny",
+      "elicitation:cancel",
+      "upsert:error",
+    ]);
+    assert.equal(liveStates.at(-1), null);
+  });
+
   it("成功時に running -> idle を保存し、Memory / reflection background task は起動しない", async () => {
     const session = createSession();
     const storedSessions: Session[] = [];

--- a/src-electron/codex-adapter.ts
+++ b/src-electron/codex-adapter.ts
@@ -59,6 +59,12 @@ import {
 import { parseSessionMemoryDeltaText } from "./session-memory-extraction.js";
 import { resolvePackagedProviderBinaryPath } from "./provider-binary-paths.js";
 import {
+  buildProviderMemoryBindingEnv,
+  buildProviderMemoryBindingSettingsKey,
+  mergeDefinedEnv,
+  type ProviderMemoryBindingRuntimeProjection,
+} from "./provider-memory-binding.js";
+import {
   boundAuditRawItem,
   stringifyBoundedAuditValue,
   stringifyBoundedAuditRawItems,
@@ -1467,26 +1473,44 @@ export class CodexAdapter implements ProviderTurnAdapter {
     };
   }
 
-  private getClient(providerId: string, appSettings: AppSettings): { client: Codex; clientKey: string } {
+  private getClient(
+    providerId: string,
+    appSettings: AppSettings,
+    memoryBinding?: ProviderMemoryBindingRuntimeProjection | null,
+  ): { client: Codex; clientKey: string } {
     const codingApiKey = getProviderAppSettings(appSettings, providerId).apiKey.trim();
     const codexPathOverride = resolvePackagedProviderBinaryPath("codex");
-    const clientKey = JSON.stringify([providerId, codingApiKey || null, codexPathOverride]);
-    const cached = this.clients.get(clientKey);
-    if (cached) {
-      return { client: cached, clientKey };
+    const memoryBindingKey = buildProviderMemoryBindingSettingsKey(memoryBinding);
+    const clientKey = JSON.stringify([providerId, codingApiKey || null, codexPathOverride, memoryBindingKey]);
+    const memoryBindingEnv = buildProviderMemoryBindingEnv(memoryBinding);
+    const isMemoryBoundClient = Object.keys(memoryBindingEnv).length > 0;
+    if (!isMemoryBoundClient) {
+      const cached = this.clients.get(clientKey);
+      if (cached) {
+        return { client: cached, clientKey };
+      }
     }
 
     const clientOptions = {
       ...(codingApiKey ? { apiKey: codingApiKey } : {}),
       ...(codexPathOverride ? { codexPathOverride } : {}),
+      ...(Object.keys(memoryBindingEnv).length > 0
+        ? { env: mergeDefinedEnv(process.env, memoryBindingEnv) }
+        : {}),
     };
     const client = new Codex(clientOptions);
-    this.clients.set(clientKey, client);
+    if (!isMemoryBoundClient) {
+      this.clients.set(clientKey, client);
+    }
     return { client, clientKey };
   }
 
   private getThread(input: RunSessionTurnInput): { thread: Thread; selection: ResolvedModelSelection } {
-    const { client, clientKey } = this.getClient(input.providerCatalog.id, input.appSettings);
+    const { client, clientKey } = this.getClient(input.providerCatalog.id, input.appSettings, input.memoryBinding);
+    const isMemoryBoundThread = Object.keys(buildProviderMemoryBindingEnv(input.memoryBinding)).length > 0;
+    if (isMemoryBoundThread) {
+      this.threads.delete(input.session.id);
+    }
     const nextSettings = buildCodexThreadSettings(
       input.session,
       input.providerCatalog,
@@ -1494,17 +1518,19 @@ export class CodexAdapter implements ProviderTurnAdapter {
       resolveRunWorkspacePath(input),
     );
     const resolved = resolveCodexThreadForSettings({
-      cached: this.threads.get(input.session.id),
+      cached: isMemoryBoundThread ? undefined : this.threads.get(input.session.id),
       nextSettingsKey: nextSettings.settingsKey,
       threadId: input.session.threadId,
       options: nextSettings.options,
       client,
     });
 
-    this.threads.set(input.session.id, {
-      thread: resolved.thread,
-      settingsKey: nextSettings.settingsKey,
-    });
+    if (!isMemoryBoundThread) {
+      this.threads.set(input.session.id, {
+        thread: resolved.thread,
+        settingsKey: nextSettings.settingsKey,
+      });
+    }
     return {
       thread: resolved.thread,
       selection: nextSettings.selection,

--- a/src-electron/copilot-adapter.ts
+++ b/src-electron/copilot-adapter.ts
@@ -65,6 +65,11 @@ import {
   resolveProviderBinarySpec,
 } from "./provider-binary-paths.js";
 import {
+  buildProviderMemoryBindingEnv,
+  buildProviderMemoryBindingSettingsKey,
+  type ProviderMemoryBindingRuntimeProjection,
+} from "./provider-memory-binding.js";
+import {
   boundAuditRawItem,
   stringifyBoundedAuditRawItems,
   toAuditTextPreview,
@@ -128,12 +133,16 @@ const COPILOT_DROPPED_RAW_EVENT_TYPES = new Set([
 
 const require = createRequire(import.meta.url);
 
-export function buildCopilotClientEnv(baseEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+export function buildCopilotClientEnv(
+  baseEnv: NodeJS.ProcessEnv,
+  memoryBinding?: ProviderMemoryBindingRuntimeProjection | null,
+): NodeJS.ProcessEnv {
   // Copilot SDK は child CLI の stderr を bootstrap failure 扱いするため、
   // Node.js の ExperimentalWarning だけで false error にならないように抑止する。
   return {
     ...baseEnv,
     NODE_NO_WARNINGS: "1",
+    ...buildProviderMemoryBindingEnv(memoryBinding),
   };
 }
 
@@ -170,13 +179,17 @@ export function resolveCopilotCliPath(
   return commandFileName;
 }
 
-function buildCopilotClientKeyFromAppSettings(providerId: string, appSettings: RunSessionTurnInput["appSettings"]): string {
+function buildCopilotClientKeyFromAppSettings(
+  providerId: string,
+  appSettings: RunSessionTurnInput["appSettings"],
+  memoryBinding?: ProviderMemoryBindingRuntimeProjection | null,
+): string {
   const codingApiKey = getProviderAppSettings(appSettings, providerId).apiKey.trim();
-  return JSON.stringify([providerId, codingApiKey || null]);
+  return JSON.stringify([providerId, codingApiKey || null, buildProviderMemoryBindingSettingsKey(memoryBinding)]);
 }
 
 function buildCopilotClientKey(providerId: string, input: RunSessionTurnInput): string {
-  return buildCopilotClientKeyFromAppSettings(providerId, input.appSettings);
+  return buildCopilotClientKeyFromAppSettings(providerId, input.appSettings, input.memoryBinding);
 }
 
 export function isRecoverableCopilotConnectionErrorMessage(message: string): boolean {
@@ -2002,18 +2015,24 @@ export class CopilotAdapter implements ProviderTurnAdapter {
   private getClient(providerId: string, input: RunSessionTurnInput): { client: CopilotClient; clientKey: string } {
     const codingApiKey = getProviderAppSettings(input.appSettings, providerId).apiKey.trim();
     const clientKey = buildCopilotClientKey(providerId, input);
-    const cached = this.clients.get(clientKey);
-    if (cached) {
-      return { client: cached, clientKey };
+    const memoryBindingEnv = buildProviderMemoryBindingEnv(input.memoryBinding);
+    const isMemoryBoundClient = Object.keys(memoryBindingEnv).length > 0;
+    if (!isMemoryBoundClient) {
+      const cached = this.clients.get(clientKey);
+      if (cached) {
+        return { client: cached, clientKey };
+      }
     }
 
     const cliPath = resolveCopilotCliPath();
     const client = new CopilotClient({
       connection: RuntimeConnection.forStdio({ path: cliPath }),
-      env: buildCopilotClientEnv(process.env),
+      env: buildCopilotClientEnv(process.env, input.memoryBinding),
       ...(codingApiKey ? { gitHubToken: codingApiKey, useLoggedInUser: false } : {}),
     });
-    this.clients.set(clientKey, client);
+    if (!isMemoryBoundClient) {
+      this.clients.set(clientKey, client);
+    }
     return { client, clientKey };
   }
 
@@ -2184,8 +2203,12 @@ export class CopilotAdapter implements ProviderTurnAdapter {
     prompt: ProviderPromptComposition,
   ): Promise<{ session: CopilotSession; selection: ResolvedModelSelection }> {
     const { client, clientKey } = this.getClient(input.providerCatalog.id, input);
+    const isMemoryBoundSession = Object.keys(buildProviderMemoryBindingEnv(input.memoryBinding)).length > 0;
+    if (isMemoryBoundSession) {
+      await this.disposeSessionCache(input.session.id);
+    }
     const nextSettings = buildCopilotSessionSettings(input, prompt, clientKey);
-    const cached = this.sessions.get(input.session.id);
+    const cached = isMemoryBoundSession ? undefined : this.sessions.get(input.session.id);
     const resolved = await resolveCopilotSessionForSettings({
       cached,
       nextSettingsKey: nextSettings.settingsKey,
@@ -2200,14 +2223,16 @@ export class CopilotAdapter implements ProviderTurnAdapter {
       };
     }
 
-    this.sessions.set(input.session.id, {
-      session: resolved.session,
-      settingsKey: nextSettings.settingsKey,
-      backgroundTasks: new Map<string, LiveBackgroundTask>(),
-    });
-    const nextCached = this.sessions.get(input.session.id);
-    if (nextCached) {
-      this.attachBackgroundTaskObserver(input.session.id, nextCached);
+    if (!isMemoryBoundSession) {
+      this.sessions.set(input.session.id, {
+        session: resolved.session,
+        settingsKey: nextSettings.settingsKey,
+        backgroundTasks: new Map<string, LiveBackgroundTask>(),
+      });
+      const nextCached = this.sessions.get(input.session.id);
+      if (nextCached) {
+        this.attachBackgroundTaskObserver(input.session.id, nextCached);
+      }
     }
 
     return {
@@ -2468,6 +2493,9 @@ export class CopilotAdapter implements ProviderTurnAdapter {
     } finally {
       unsubscribe();
       input.signal?.removeEventListener("abort", handleAbort);
+      if (Object.keys(buildProviderMemoryBindingEnv(input.memoryBinding)).length > 0) {
+        await session.disconnect().catch(() => undefined);
+      }
     }
   }
 

--- a/src-electron/copilot-adapter.ts
+++ b/src-electron/copilot-adapter.ts
@@ -67,6 +67,7 @@ import {
 import {
   buildProviderMemoryBindingEnv,
   buildProviderMemoryBindingSettingsKey,
+  mergeDefinedEnv,
   type ProviderMemoryBindingRuntimeProjection,
 } from "./provider-memory-binding.js";
 import {
@@ -139,11 +140,10 @@ export function buildCopilotClientEnv(
 ): NodeJS.ProcessEnv {
   // Copilot SDK は child CLI の stderr を bootstrap failure 扱いするため、
   // Node.js の ExperimentalWarning だけで false error にならないように抑止する。
-  return {
-    ...baseEnv,
+  return mergeDefinedEnv(baseEnv, {
     NODE_NO_WARNINGS: "1",
     ...buildProviderMemoryBindingEnv(memoryBinding),
-  };
+  });
 }
 
 export function resolveNativeCopilotPackageName(

--- a/src-electron/provider-memory-binding.ts
+++ b/src-electron/provider-memory-binding.ts
@@ -80,6 +80,12 @@ export function mergeDefinedEnv(
 ): Record<string, string> {
   const merged: Record<string, string> = {};
   for (const [key, value] of Object.entries(baseEnv)) {
+    if (
+      key === WITHMATE_MEMORY_BINDING_REFERENCE_ENV ||
+      key === WITHMATE_MEMORY_BINDING_CONTEXT_FILE_ENV
+    ) {
+      continue;
+    }
     if (value !== undefined) {
       merged[key] = value;
     }

--- a/src-electron/provider-memory-binding.ts
+++ b/src-electron/provider-memory-binding.ts
@@ -1,0 +1,91 @@
+export const WITHMATE_MEMORY_BINDING_REFERENCE_ENV = "WITHMATE_MEMORY_BINDING_REFERENCE";
+export const WITHMATE_MEMORY_BINDING_CONTEXT_FILE_ENV = "WITHMATE_MEMORY_BINDING_CONTEXT_FILE";
+
+export type ProviderMemoryBindingTransport = "env" | "context_file" | "unsupported";
+
+export type ProviderMemoryBindingRuntimeProjection = {
+  bindingId: string;
+  bindingReference: string;
+  transport: ProviderMemoryBindingTransport;
+  contextFilePath?: string;
+  expiresAt?: string | null;
+};
+
+export type ProviderMemoryBindingCapability = {
+  providerId: string;
+  transport: ProviderMemoryBindingTransport;
+  reason: string;
+};
+
+export function getProviderMemoryBindingCapability(providerId: string): ProviderMemoryBindingCapability {
+  if (providerId === "codex") {
+    return {
+      providerId,
+      transport: "env",
+      reason: "Codex SDK accepts process env at Codex client construction.",
+    };
+  }
+
+  if (providerId === "copilot") {
+    return {
+      providerId,
+      transport: "env",
+      reason: "Copilot SDK accepts process env at CopilotClient construction.",
+    };
+  }
+
+  return {
+    providerId,
+    transport: "unsupported",
+    reason: "Provider binding transport has not been verified for this provider.",
+  };
+}
+
+export function buildProviderMemoryBindingEnv(
+  projection: ProviderMemoryBindingRuntimeProjection | null | undefined,
+): Record<string, string> {
+  if (!projection || projection.transport === "unsupported") {
+    return {};
+  }
+
+  if (projection.transport === "context_file") {
+    return projection.contextFilePath
+      ? { [WITHMATE_MEMORY_BINDING_CONTEXT_FILE_ENV]: projection.contextFilePath }
+      : {};
+  }
+
+  return {
+    [WITHMATE_MEMORY_BINDING_REFERENCE_ENV]: projection.bindingReference,
+  };
+}
+
+export function buildProviderMemoryBindingSettingsKey(
+  projection: ProviderMemoryBindingRuntimeProjection | null | undefined,
+): string {
+  if (!projection) {
+    return "";
+  }
+
+  return JSON.stringify([
+    projection.transport,
+    projection.bindingId,
+    projection.contextFilePath ?? "",
+    projection.expiresAt ?? "",
+  ]);
+}
+
+export function mergeDefinedEnv(
+  baseEnv: NodeJS.ProcessEnv,
+  overlay: Record<string, string>,
+): Record<string, string> {
+  const merged: Record<string, string> = {};
+  for (const [key, value] of Object.entries(baseEnv)) {
+    if (value !== undefined) {
+      merged[key] = value;
+    }
+  }
+  return {
+    ...merged,
+    ...overlay,
+  };
+}

--- a/src-electron/provider-runtime.ts
+++ b/src-electron/provider-runtime.ts
@@ -22,6 +22,7 @@ import type {
 import type { ModelReasoningEffort, ModelCatalogProvider } from "../src/model-catalog.js";
 import type { ApprovalMode } from "../src/approval-mode.js";
 import type { CodexSandboxMode } from "../src/codex-sandbox-mode.js";
+import type { ProviderMemoryBindingRuntimeProjection } from "./provider-memory-binding.js";
 import type { SessionMemoryExtractionPrompt } from "./session-memory-extraction.js";
 
 export type ProviderPromptComposition = {
@@ -42,6 +43,7 @@ export type RunSessionTurnInput = {
   userMessage: string;
   appSettings: AppSettings;
   attachments: ComposerAttachment[];
+  memoryBinding?: ProviderMemoryBindingRuntimeProjection | null;
   signal?: AbortSignal;
   onApprovalRequest?: RunSessionTurnApprovalRequestHandler;
   onElicitationRequest?: RunSessionTurnElicitationRequestHandler;

--- a/src-electron/provider-support.ts
+++ b/src-electron/provider-support.ts
@@ -11,6 +11,10 @@ import type {
   ProviderCodingAdapter,
   ProviderTurnAdapter,
 } from "./provider-runtime.js";
+import {
+  getProviderMemoryBindingCapability,
+  type ProviderMemoryBindingTransport,
+} from "./provider-memory-binding.js";
 
 type ResolveProviderCatalogArgs = {
   providerId: string | null | undefined;
@@ -36,6 +40,7 @@ export type ProviderRuntimeCapabilities = {
   providerSupported: boolean;
   instructionSyncSupported: boolean;
   tokenUsageSupported: boolean;
+  memoryBindingTransport: ProviderMemoryBindingTransport;
 };
 
 const MATE_SUPPORTED_PROVIDER_IDS = new Set(["codex", "copilot"]);
@@ -75,10 +80,12 @@ export async function fetchProviderQuotaTelemetry(
 
 export function getProviderRuntimeCapabilities(args: { providerId: string }): ProviderRuntimeCapabilities {
   const providerSupported = MATE_SUPPORTED_PROVIDER_IDS.has(args.providerId);
+  const memoryBinding = getProviderMemoryBindingCapability(args.providerId);
   return {
     providerId: args.providerId,
     providerSupported,
     instructionSyncSupported: providerSupported,
     tokenUsageSupported: providerSupported,
+    memoryBindingTransport: providerSupported ? memoryBinding.transport : "unsupported",
   };
 }

--- a/src-electron/session-runtime-service.ts
+++ b/src-electron/session-runtime-service.ts
@@ -20,7 +20,13 @@ import { getProviderAppSettings, type AppSettings } from "../src/provider-settin
 import { isReadOnlySession, type Session } from "../src/session-state.js";
 import type { ModelCatalogProvider, ModelCatalogSnapshot } from "../src/model-catalog.js";
 import type { MateStorageState } from "../src/mate/mate-state.js";
-import { ProviderTurnError, type ProviderCodingAdapter, type RunSessionTurnResult } from "./provider-runtime.js";
+import {
+  ProviderTurnError,
+  type ProviderCodingAdapter,
+  type ProviderPromptComposition,
+  type RunSessionTurnResult,
+} from "./provider-runtime.js";
+import type { ProviderMemoryBindingRuntimeProjection } from "./provider-memory-binding.js";
 import { appendQuotaTelemetryToTransportPayload } from "./audit-log-quota.js";
 import { appendTransportPayloadFields, calculateAuditDurationMs } from "./audit-log-metadata.js";
 import { estimateLogicalPromptTokens } from "./prompt-token-estimate.js";
@@ -67,6 +73,12 @@ export type SessionRuntimeServiceDeps = {
   invalidateProviderSessionThread(providerId: string | null | undefined, sessionId: string): void;
   scheduleProviderQuotaTelemetryRefresh(providerId: string, delaysMs: number[]): void;
   clearWorkspaceFileIndex(workspacePath: string): void;
+  createProviderMemoryBinding?(input: {
+    session: Session;
+    provider: ModelCatalogProvider;
+    character: CharacterProfile | null;
+  }): Awaitable<ProviderMemoryBindingRuntimeProjection | null>;
+  revokeProviderMemoryBinding?(binding: ProviderMemoryBindingRuntimeProjection): Awaitable<void>;
   broadcastLiveSessionRun(sessionId: string): void;
   resolvePendingApprovalRequest(sessionId: string, decision: LiveApprovalDecision): void;
   resolvePendingElicitationRequest(sessionId: string, response: LiveElicitationResponse): void;
@@ -460,43 +472,96 @@ export class SessionRuntimeService {
     const providerAdapter = this.deps.getProviderCodingAdapter(provider.id);
     const sessionMemory = this.deps.getSessionMemory(session);
     const projectMemoryEntries = this.deps.resolveProjectMemoryEntriesForPrompt(session, nextMessage, sessionMemory);
-    const promptForAudit = providerAdapter.composePrompt({
-      session: providerSession,
-      sessionMemory,
-      projectMemoryEntries,
-      providerCatalog: provider,
-      userMessage: nextMessage,
-      appSettings,
-      attachments: composerPreview.attachments,
-    });
-
+    const sessionCharacter = await this.deps.resolveSessionCharacter?.(session) ?? null;
+    const memoryBinding = await Promise.resolve(this.deps.createProviderMemoryBinding?.({
+      session,
+      provider,
+      character: sessionCharacter,
+    }) ?? null);
     const currentTimestampLabel = this.deps.currentTimestampLabel ?? defaultCurrentTimestampLabel;
-    const runningSession: Session = {
-      ...session,
-      updatedAt: currentTimestampLabel(),
-      status: "running",
-      runState: "running",
-      messages: [...session.messages, { role: "user", text: nextMessage }],
+    let memoryBindingRevoked = false;
+    const revokeMemoryBinding = async () => {
+      if (!memoryBinding || memoryBinding.transport === "unsupported" || memoryBindingRevoked) {
+        return;
+      }
+      memoryBindingRevoked = true;
+      await Promise.resolve()
+        .then(() => this.deps.revokeProviderMemoryBinding?.(memoryBinding))
+        .catch((error) => {
+          console.warn("Provider memory binding revoke failed", error);
+        });
     };
 
-    await this.deps.upsertSession(runningSession);
-    this.inFlightSessionRuns.add(sessionId);
-    const runAbortController = new AbortController();
-    this.sessionRunControllers.set(sessionId, runAbortController);
-    const initialLiveState: LiveSessionRunState = {
-      ...buildEmptyLiveSessionRunState(sessionId, runningSession.threadId),
-      backgroundTasks: this.deps.getLiveSessionRun(sessionId)?.backgroundTasks ?? [],
-      reasoningText: "",
-    };
-    this.deps.setLiveSessionRun(sessionId, initialLiveState);
+    let promptForAudit: ProviderPromptComposition;
+    let runningSession: Session;
+    let runAbortController: AbortController;
+    let initialLiveState: LiveSessionRunState;
+    let runningAuditEntry: CreateAuditLogInput;
+    let runningAuditLog: AuditLogEntry;
+    let setupLiveRun = false;
+    let setupRunningSessionSaved = false;
+    try {
+      promptForAudit = providerAdapter.composePrompt({
+        session: providerSession,
+        sessionMemory,
+        projectMemoryEntries,
+        character: sessionCharacter ?? undefined,
+        providerCatalog: provider,
+        userMessage: nextMessage,
+        appSettings,
+        attachments: composerPreview.attachments,
+        memoryBinding,
+      });
 
-    let runningAuditEntry: CreateAuditLogInput = buildRunningAuditEntry({
-      sessionId,
-      createdAt: new Date().toISOString(),
-      session: runningSession,
-      logicalPrompt: promptForAudit.logicalPrompt,
-    });
-    const runningAuditLog = await this.deps.createAuditLog(runningAuditEntry);
+      runningSession = {
+        ...session,
+        updatedAt: currentTimestampLabel(),
+        status: "running",
+        runState: "running",
+        messages: [...session.messages, { role: "user", text: nextMessage }],
+      };
+
+      await this.deps.upsertSession(runningSession);
+      setupRunningSessionSaved = true;
+      this.inFlightSessionRuns.add(sessionId);
+      runAbortController = new AbortController();
+      this.sessionRunControllers.set(sessionId, runAbortController);
+      initialLiveState = {
+        ...buildEmptyLiveSessionRunState(sessionId, runningSession.threadId),
+        backgroundTasks: this.deps.getLiveSessionRun(sessionId)?.backgroundTasks ?? [],
+        reasoningText: "",
+      };
+      this.deps.setLiveSessionRun(sessionId, initialLiveState);
+      setupLiveRun = true;
+
+      runningAuditEntry = buildRunningAuditEntry({
+        sessionId,
+        createdAt: new Date().toISOString(),
+        session: runningSession,
+        logicalPrompt: promptForAudit.logicalPrompt,
+      });
+      runningAuditLog = await this.deps.createAuditLog(runningAuditEntry);
+    } catch (error) {
+      await revokeMemoryBinding();
+      this.deps.resolvePendingApprovalRequest(sessionId, "deny");
+      this.deps.resolvePendingElicitationRequest(sessionId, { action: "cancel" });
+      this.inFlightSessionRuns.delete(sessionId);
+      this.sessionRunControllers.delete(sessionId);
+      if (setupLiveRun) {
+        this.deps.setLiveSessionRun(sessionId, null);
+      }
+      if (setupRunningSessionSaved) {
+        await Promise.resolve(this.deps.upsertSession({
+          ...runningSession!,
+          updatedAt: currentTimestampLabel(),
+          status: "idle",
+          runState: "error",
+        })).catch((cleanupError) => {
+          console.warn("Session setup failure cleanup failed", cleanupError);
+        });
+      }
+      throw error;
+    }
     let runningAuditProgressSignature = buildRunningAuditProgressSignature(runningAuditEntry);
     let terminalAuditSettled = false;
     let liveProgressGeneration = 0;
@@ -577,6 +642,7 @@ export class SessionRuntimeService {
         userMessage: nextMessage,
         appSettings,
         attachments: composerPreview.attachments,
+        memoryBinding,
         signal: runAbortController.signal,
         onApprovalRequest: (approvalRequest) => {
           const decision = this.deps.waitForApprovalDecision(sessionId, approvalRequest, runAbortController.signal);
@@ -830,6 +896,7 @@ export class SessionRuntimeService {
       activeRunningSession = storedFailedSession;
       return storedFailedSession;
     } finally {
+      await revokeMemoryBinding();
       if (runningSession.provider === "copilot") {
         this.deps.scheduleProviderQuotaTelemetryRefresh(runningSession.provider, [0, 3000, 10000]);
       }

--- a/src-electron/session-runtime-service.ts
+++ b/src-electron/session-runtime-service.ts
@@ -559,6 +559,8 @@ export class SessionRuntimeService {
         })).catch((cleanupError) => {
           console.warn("Session setup failure cleanup failed", cleanupError);
         });
+        this.deps.clearWorkspaceFileIndex(session.workspacePath);
+        this.deps.broadcastLiveSessionRun(sessionId);
       }
       throw error;
     }


### PR DESCRIPTION
## 概要
- V6 Provider Binding Spikeとして、Codex / Copilot provider runtimeへ短命な Memory binding reference を env transport で注入
- binding付き provider client / thread / session を turn-local にし、既存 cache の stale 再利用も防止
- SessionRuntimeService で binding lifecycle hookを追加し、通常完了・revoke失敗・setup失敗時のcleanupを検証
- Phase 5 の設計書、capability matrix、provider adapter docs、plan を現状に同期

## 検証
- `node --test --import tsx scripts/tests/session-runtime-service.test.ts scripts/tests/provider-memory-binding.test.ts scripts/tests/provider-support.test.ts scripts/tests/copilot-adapter.test.ts scripts/tests/codex-adapter.test.ts` pass: 122 tests / 0 fail
- `npm run typecheck` pass
- `npm test` pass: 1646 tests / 1645 pass / 1 skipped / 0 fail
- `npm run build` pass
- `git diff --check` pass（CRLF warningのみ）

## レビュー
- 通常 reviewer（fastではない）でレビュー済み
- 指摘修正後、最終 judgment: approve / blocking findingなし
