### PR TITLE
feat(memory): 外部CLIからProject Memoryを利用可能にする

### DIFF
--- a/docs/design/v6-memory-foundation.md
+++ b/docs/design/v6-memory-foundation.md
@@ -637,8 +637,10 @@ character target:
 - `--character <character-id>`
 - `--character current`
 
+character targetはWithMate-launched session binding内に限定する。
 `--character current`はruntime bindingがある場合だけ使える。
-WithMate外CLIではCharacterを暗黙解決せず、必要な場合はCharacter IDを明示する。
+WithMate外CLI / `local_user` principalは現時点ではproject owner + project scopeのMemoryだけを扱い、明示Character IDを指定したCharacter Memory利用も許可しない。
+外部CLIからの明示Character ID対応は、別途principal / 認可設計を定義してから扱う。
 project targetはcurrent working directoryから暗黙推定しない。
 `--project .`はcurrent directoryを使う明示指定として許可する。
 

--- a/docs/design/v6-memory-foundation.md
+++ b/docs/design/v6-memory-foundation.md
@@ -402,6 +402,7 @@ type MemoryGetEntryResponse = {
 
 - ID指定でfull bodyを取得する。
 - binding permissionとowner / scope accessを再検証する。
+- binding referenceがない`local_user` requestでは明示project targetを必須とし、entryのowner / scopeがtargetと一致する場合だけ返す。
 - search hitのpreviewが現在の回答、実装、判断に影響しそうな場合に使う。
 - 正確な文言、理由、制約、過去の決定が重要な場合はpreviewだけで断定しない。
 - search hitを全件機械的に取得しない。必要な最小件数を、関係ありそうなpreviewから順に取得する。
@@ -539,6 +540,10 @@ value.normalize("NFC").toLowerCase()
 CLIはuser-facing entrypointであり、app外の人間やagentが自由に呼べる薄いclientとする。
 CLIはDBを直接触らず、起動中のWithMateが提供するruntime Memory APIへ接続する。
 WithMateが起動していない場合、CLIはすべてのMemory操作を拒否し、machine-readable errorを返す。
+WithMate起動中は、WithMate外のCodex / shell / CLIからもproject owner + project scopeのMemoryを明示targetで検索、取得、tag一覧、append、forgetできる。
+session bindingはCLI利用全体の認可ではなく、current Characterやcurrent WithMate session contextを解決するための追加contextである。
+binding referenceがない外部CLI requestは、runtime secretとnonce challengeを通過した同一OS userの`local_user` principalとして扱う。
+`local_user` principalは`project` owner + `project` scopeだけを扱い、`character: current`、WithMate session context、session-bound project inferenceは使えない。
 `--self` flagは採用しない。
 current CLIは`WITHMATE_MEMORY_API_URL`またはruntime discovery fileからlocalhost APIを発見する。
 discovery fileは`withmate-memory-discovery-v1` documentとして`baseUrl`、`apiSecret`、`runtimeInstanceId`、`publishedAt`を公開し、CLIはloopback HTTP URL以外を拒否する。

--- a/docs/design/v6-memory-foundation.md
+++ b/docs/design/v6-memory-foundation.md
@@ -544,6 +544,7 @@ WithMate起動中は、WithMate外のCodex / shell / CLIからもproject owner +
 session bindingはCLI利用全体の認可ではなく、current Characterやcurrent WithMate session contextを解決するための追加contextである。
 binding referenceがない外部CLI requestは、runtime secretとnonce challengeを通過した同一OS userの`local_user` principalとして扱う。
 `local_user` principalは`project` owner + `project` scopeだけを扱い、`character: current`、WithMate session context、session-bound project inferenceは使えない。
+runtime binding由来のappend / forgetでも、対応するV6 `sessions_v6` rowがまだ存在しない段階ではMemory entryの`source.sessionId`は`null`として保存する。
 `--self` flagは採用しない。
 current CLIは`WITHMATE_MEMORY_API_URL`またはruntime discovery fileからlocalhost APIを発見する。
 discovery fileは`withmate-memory-discovery-v1` documentとして`baseUrl`、`apiSecret`、`runtimeInstanceId`、`publishedAt`を公開し、CLIはloopback HTTP URL以外を拒否する。

--- a/resources/skills/withmate-memory/SKILL.md
+++ b/resources/skills/withmate-memory/SKILL.md
@@ -37,7 +37,7 @@ Read `reference/cli.md` for JSON shapes and error handling.
 
 ## Target Selection
 
-- Use a project target with `{ "project": { "type": "path", "path": "." } }` when the current directory is the intended project, including from outside WithMate-launched sessions.
+- Use a project target with `{ "project": { "type": "path", "path": "." } }` when the current directory is the intended project, including from outside WithMate-launched sessions. The helper resolves relative project paths against its own cwd before sending the request.
 - Use `{ "character": { "type": "current" } }` only inside a WithMate-launched session where current character context is available.
 - Do not infer project or character targets silently when a command requires an explicit target.
 

--- a/resources/skills/withmate-memory/SKILL.md
+++ b/resources/skills/withmate-memory/SKILL.md
@@ -38,11 +38,12 @@ Read `reference/cli.md` for JSON shapes and error handling.
 ## Target Selection
 
 - Use a project target with `{ "project": { "type": "path", "path": "." } }` when the current directory is the intended project, including from outside WithMate-launched sessions. The helper resolves relative project paths against its own cwd before sending the request.
-- Use `{ "character": { "type": "current" } }` only inside a WithMate-launched session where current character context is available.
+- Use character targets only inside a WithMate-launched session where session binding context is available.
+- External Codex or shell sessions can use project memory only; explicit character IDs are not supported for `local_user` principals yet.
 - Do not infer project or character targets silently when a command requires an explicit target.
 
 ## Error Handling
 
 - If WithMate is not running or Memory is unavailable, continue the task and mention that Memory could not be used.
-- If current character context is unavailable, retry with an explicit character or project target when appropriate.
+- If current character context is unavailable, use an explicit project target when the task can be answered from project memory; otherwise continue without Character Memory.
 - Do not expose internal runtime identifiers, secrets, headers, or local discovery details in user-facing output.

--- a/resources/skills/withmate-memory/SKILL.md
+++ b/resources/skills/withmate-memory/SKILL.md
@@ -10,6 +10,7 @@ Use this skill when a task may depend on durable WithMate Memory or when the use
 ## Principles
 
 - Use the bundled helper script instead of reading WithMate database files directly.
+- Project Memory is available from external Codex or shell sessions while WithMate is running; use explicit project targets.
 - Search before relying on remembered project or character decisions.
 - Use `get-entry` only for search hits whose exact body matters.
 - Append only durable decisions, constraints, conventions, preferences, or context that will matter in future sessions.
@@ -24,8 +25,8 @@ Run the helper from this skill directory:
 node bin/withmate-memory.mjs status
 node bin/withmate-memory.mjs context
 node bin/withmate-memory.mjs search --json '{"schemaVersion":"withmate-memory-v1","targets":[{"owner":"project","project":{"type":"path","path":"."},"scope":"project"}],"query":"release workflow"}'
-node bin/withmate-memory.mjs get-entry --json '{"schemaVersion":"withmate-memory-v1","entryId":"<entry-id>"}'
-node bin/withmate-memory.mjs list-tags --json '{"schemaVersion":"withmate-memory-v1","target":{"owner":"project","project":{"type":"path","path":"."},"scope":"project"}}'
+node bin/withmate-memory.mjs get-entry --json '{"schemaVersion":"withmate-memory-v1","entryId":"<entry-id>","target":{"owner":"project","project":{"type":"path","path":"."},"scope":"project"}}'
+node bin/withmate-memory.mjs list-tags --json '{"schemaVersion":"withmate-memory-v1","targets":[{"owner":"project","project":{"type":"path","path":"."},"scope":"project"}]}'
 node bin/withmate-memory.mjs append --file memory-entry.json
 node bin/withmate-memory.mjs forget --file forget-request.json
 ```
@@ -36,7 +37,7 @@ Read `reference/cli.md` for JSON shapes and error handling.
 
 ## Target Selection
 
-- Use a project target with `{ "project": { "type": "path", "path": "." } }` when the current directory is the intended project.
+- Use a project target with `{ "project": { "type": "path", "path": "." } }` when the current directory is the intended project, including from outside WithMate-launched sessions.
 - Use `{ "character": { "type": "current" } }` only inside a WithMate-launched session where current character context is available.
 - Do not infer project or character targets silently when a command requires an explicit target.
 

--- a/resources/skills/withmate-memory/bin/withmate-memory.mjs
+++ b/resources/skills/withmate-memory/bin/withmate-memory.mjs
@@ -155,6 +155,25 @@ async function parseArgs(argv) {
   return { route, body, apiUrl, discoveryFilePath };
 }
 
+function normalizeProjectPathTargets(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeProjectPathTargets(item));
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  const normalized = {};
+  for (const [key, item] of Object.entries(value)) {
+    normalized[key] = normalizeProjectPathTargets(item);
+  }
+
+  if (value.type === "path" && typeof value.path === "string") {
+    normalized.path = path.resolve(value.path);
+  }
+  return normalized;
+}
+
 function requireOptionValue(args, index, option) {
   const value = args[index];
   if (!value || value.startsWith("--")) {
@@ -233,7 +252,7 @@ async function main() {
       const response = await fetch(`${connection.baseUrl}${request.route.path}`, {
         method: request.route.method,
         headers,
-        body: request.route.method === "POST" ? JSON.stringify(request.body) : undefined,
+        body: request.route.method === "POST" ? JSON.stringify(normalizeProjectPathTargets(request.body)) : undefined,
         redirect: "error",
         signal: abortController.signal,
       });

--- a/resources/skills/withmate-memory/reference/cli.md
+++ b/resources/skills/withmate-memory/reference/cli.md
@@ -1,6 +1,7 @@
 # WithMate Memory Helper Reference
 
 The bundled helper is a thin client for the running WithMate V6 Memory API. It does not read or write database files directly.
+Project-scoped Memory can be used from external Codex or shell sessions while WithMate is running. Current character and current session context require a WithMate-launched session binding.
 
 Run it from this skill directory:
 
@@ -55,7 +56,7 @@ Search returns active entry previews only. Use `get-entry` when the exact body m
 ### get-entry
 
 ```bash
-node bin/withmate-memory.mjs get-entry --json '{"schemaVersion":"withmate-memory-v1","entryId":"<entry-id>"}'
+node bin/withmate-memory.mjs get-entry --json '{"schemaVersion":"withmate-memory-v1","entryId":"<entry-id>","target":{"owner":"project","project":{"type":"path","path":"."},"scope":"project"}}'
 ```
 
 Request shape:
@@ -63,14 +64,17 @@ Request shape:
 ```json
 {
   "schemaVersion": "withmate-memory-v1",
-  "entryId": "<entry-id>"
+  "entryId": "<entry-id>",
+  "target": { "owner": "project", "project": { "type": "path", "path": "." }, "scope": "project" }
 }
 ```
+
+External Codex or shell sessions must include `target`. WithMate-launched sessions with a binding may omit it.
 
 ### list-tags
 
 ```bash
-node bin/withmate-memory.mjs list-tags --json '{"schemaVersion":"withmate-memory-v1","target":{"owner":"project","project":{"type":"path","path":"."},"scope":"project"}}'
+node bin/withmate-memory.mjs list-tags --json '{"schemaVersion":"withmate-memory-v1","targets":[{"owner":"project","project":{"type":"path","path":"."},"scope":"project"}]}'
 ```
 
 Request shape:
@@ -78,7 +82,9 @@ Request shape:
 ```json
 {
   "schemaVersion": "withmate-memory-v1",
-  "target": { "owner": "project", "project": { "type": "path", "path": "." }, "scope": "project" }
+  "targets": [
+    { "owner": "project", "project": { "type": "path", "path": "." }, "scope": "project" }
+  ]
 }
 ```
 
@@ -134,6 +140,9 @@ Input shape:
 ## Notes
 
 - Search results exclude forgotten and superseded entries.
+- Project targets with `{ "type": "path", "path": "." }` are valid from external Codex sessions.
+- External `get-entry` requests require an explicit project target.
+- `{ "character": { "type": "current" } }` and `context` require a WithMate-launched session binding.
 - Append is idempotent when an idempotency key is supplied.
 - Forget hides entries from normal search and skill results.
 - Memory failures should not fail unrelated coding work.

--- a/resources/skills/withmate-memory/reference/cli.md
+++ b/resources/skills/withmate-memory/reference/cli.md
@@ -141,6 +141,7 @@ Input shape:
 
 - Search results exclude forgotten and superseded entries.
 - Project targets with `{ "type": "path", "path": "." }` are valid from external Codex sessions.
+- Relative project paths are resolved by the helper against the CLI process cwd before being sent to WithMate.
 - External `get-entry` requests require an explicit project target.
 - `{ "character": { "type": "current" } }` and `context` require a WithMate-launched session binding.
 - Append is idempotent when an idempotency key is supplied.

--- a/resources/skills/withmate-memory/reference/cli.md
+++ b/resources/skills/withmate-memory/reference/cli.md
@@ -143,7 +143,8 @@ Input shape:
 - Project targets with `{ "type": "path", "path": "." }` are valid from external Codex sessions.
 - Relative project paths are resolved by the helper against the CLI process cwd before being sent to WithMate.
 - External `get-entry` requests require an explicit project target.
-- `{ "character": { "type": "current" } }` and `context` require a WithMate-launched session binding.
+- Character targets and `context` require a WithMate-launched session binding.
+- External Codex or shell sessions currently support project memory only; explicit Character ID access needs a separate principal and authorization design.
 - Append is idempotent when an idempotency key is supplied.
 - Forget hides entries from normal search and skill results.
 - Memory failures should not fail unrelated coding work.

--- a/scripts/tests/memory-v6-contract.test.ts
+++ b/scripts/tests/memory-v6-contract.test.ts
@@ -126,9 +126,11 @@ describe("memory-v6 contract validation", () => {
     const getEntry = validateMemoryGetEntryRequest({
       schemaVersion: MEMORY_V6_SCHEMA_VERSION,
       entryId: " entry-a ",
+      target: projectTarget,
     });
     assert.equal(getEntry.ok, true);
     assert.equal(getEntry.value.entryId, "entry-a");
+    assert.deepEqual(getEntry.value.target, projectTarget);
 
     const listTags = validateMemoryListTagsRequest({
       schemaVersion: MEMORY_V6_SCHEMA_VERSION,

--- a/scripts/tests/memory-v6-http-server.test.ts
+++ b/scripts/tests/memory-v6-http-server.test.ts
@@ -9,7 +9,7 @@ import { describe, it } from "node:test";
 import { MEMORY_V6_SCHEMA_VERSION, type MemoryPermission } from "../../src/memory-v6/memory-contract.js";
 import { createOrVerifyV6FreshDatabase } from "../../src-electron/app-database-v6-bootstrap.js";
 import { createMemoryV6HttpServer, isLoopbackListenHost, isLoopbackRemoteAddress, type MemoryV6HttpServer } from "../../src-electron/memory-v6-http-server.js";
-import type { MemoryV6Principal } from "../../src-electron/memory-v6-permission.js";
+import type { MemoryV6Principal, MemoryV6SessionBindingPrincipal } from "../../src-electron/memory-v6-permission.js";
 import { MemoryV6Service } from "../../src-electron/memory-v6-service.js";
 import { MemoryV6Storage } from "../../src-electron/memory-v6-storage.js";
 import { WITHMATE_MEMORY_BINDING_REFERENCE_HEADER } from "../../src-electron/provider-memory-binding.js";
@@ -25,8 +25,9 @@ const allPermissions: MemoryPermission[] = [
 const TEST_API_SECRET = "test-secret";
 const TEST_RUNTIME_INSTANCE_ID = "test-runtime";
 
-function principal(overrides: Partial<MemoryV6Principal> = {}): MemoryV6Principal {
+function principal(overrides: Partial<MemoryV6SessionBindingPrincipal> = {}): MemoryV6SessionBindingPrincipal {
   return {
+    type: "session_binding",
     bindingIdHash: "binding-hash-a",
     sessionId: "session-a",
     providerId: "codex",
@@ -216,7 +217,13 @@ describe("MemoryV6HttpServer", () => {
         },
       });
 
-      const context = await postJson(baseUrl, "/v1/context", { schemaVersion: MEMORY_V6_SCHEMA_VERSION });
+      const context = await postJsonWithSecret(
+        baseUrl,
+        "/v1/context",
+        { schemaVersion: MEMORY_V6_SCHEMA_VERSION },
+        TEST_API_SECRET,
+        { [WITHMATE_MEMORY_BINDING_REFERENCE_HEADER]: "binding-ref-a" },
+      );
       assert.equal(context.status, 200);
       assert.deepEqual(context.json, {
         schemaVersion: MEMORY_V6_SCHEMA_VERSION,
@@ -284,7 +291,13 @@ describe("MemoryV6HttpServer", () => {
 
   it("context requestのschemaVersion不一致を422で返す", async () => {
     await withMemoryApi(async ({ baseUrl }) => {
-      const context = await postJson(baseUrl, "/v1/context", {});
+      const context = await postJsonWithSecret(
+        baseUrl,
+        "/v1/context",
+        {},
+        TEST_API_SECRET,
+        { [WITHMATE_MEMORY_BINDING_REFERENCE_HEADER]: "binding-ref-a" },
+      );
 
       assert.equal(context.status, 422);
       assert.equal(context.json.error.code, "MEMORY_INVALID_SCHEMA_VERSION");
@@ -311,6 +324,7 @@ describe("MemoryV6HttpServer", () => {
       const detail = await postJson(baseUrl, "/v1/get_entry", {
         schemaVersion: MEMORY_V6_SCHEMA_VERSION,
         entryId: append.json.entry.id,
+        target: { owner: "project", scope: "project", project: { type: "id", id: "project-a" } },
       });
       assert.equal(detail.status, 200);
       assert.equal(detail.json.entry.body, "Memory localhost APIはservice境界を薄く包む。");
@@ -334,15 +348,19 @@ describe("MemoryV6HttpServer", () => {
     });
   });
 
-  it("bindingなしのservice errorをHTTP statusへ写像する", async () => {
+  it("bindingなしでもvalid secretがあればlocal_userとしてproject targetを使える", async () => {
     await withMemoryApi(async ({ baseUrl }) => {
       const response = await postJson(baseUrl, "/v1/search", {
         schemaVersion: MEMORY_V6_SCHEMA_VERSION,
         targets: [{ owner: "project", scope: "project", project: { type: "id", id: "project-a" } }],
         query: "memory",
       });
-      assert.equal(response.status, 401);
-      assert.equal(response.json.error.code, "MEMORY_BINDING_REQUIRED");
+      assert.equal(response.status, 200);
+      assert.deepEqual(response.json.items, []);
+
+      const context = await postJson(baseUrl, "/v1/context", { schemaVersion: MEMORY_V6_SCHEMA_VERSION });
+      assert.equal(context.status, 401);
+      assert.equal(context.json.error.code, "MEMORY_BINDING_REQUIRED");
     }, null);
   });
 
@@ -445,7 +463,13 @@ describe("MemoryV6HttpServer", () => {
     let resolverCalls = 0;
 
     await withMemoryApi(async ({ baseUrl }) => {
-      const firstRequest = postJson(baseUrl, "/v1/context", { schemaVersion: MEMORY_V6_SCHEMA_VERSION });
+      const firstRequest = postJsonWithSecret(
+        baseUrl,
+        "/v1/context",
+        { schemaVersion: MEMORY_V6_SCHEMA_VERSION },
+        TEST_API_SECRET,
+        { [WITHMATE_MEMORY_BINDING_REFERENCE_HEADER]: "binding-ref-a" },
+      );
       await new Promise<void>((resolve) => setTimeout(resolve, 20));
 
       const rejected = await postJson(baseUrl, "/v1/search", {

--- a/scripts/tests/memory-v6-http-server.test.ts
+++ b/scripts/tests/memory-v6-http-server.test.ts
@@ -364,6 +364,36 @@ describe("MemoryV6HttpServer", () => {
     }, null);
   });
 
+  it("stale binding header付きでも明示project targetはlocal_userとして使える", async () => {
+    await withMemoryApi(async ({ baseUrl }) => {
+      const append = await postJsonWithSecret(
+        baseUrl,
+        "/v1/append",
+        appendRequest({ idempotencyKey: "stale-binding-local-user" }),
+        TEST_API_SECRET,
+        { [WITHMATE_MEMORY_BINDING_REFERENCE_HEADER]: "stale-binding-ref" },
+      );
+      assert.equal(append.status, 200);
+      assert.equal(append.json.entry.owner.id, "project-a");
+
+      const currentCharacter = await postJsonWithSecret(
+        baseUrl,
+        "/v1/search",
+        {
+          schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+          targets: [{ owner: "character", scope: "character", character: { type: "current" } }],
+          query: "memory",
+        },
+        TEST_API_SECRET,
+        { [WITHMATE_MEMORY_BINDING_REFERENCE_HEADER]: "stale-binding-ref" },
+      );
+      assert.equal(currentCharacter.status, 401);
+      assert.equal(currentCharacter.json.error.code, "MEMORY_BINDING_REQUIRED");
+    }, null, {
+      resolvePrincipal: () => null,
+    });
+  });
+
   it("invalid route / method / JSON / body sizeをtransport errorで返す", async () => {
     await withMemoryApi(async ({ baseUrl }) => {
       const missing = await fetch(`${baseUrl}/v1/missing`, {

--- a/scripts/tests/memory-v6-runtime.test.ts
+++ b/scripts/tests/memory-v6-runtime.test.ts
@@ -301,6 +301,22 @@ describe("Memory V6 runtime API", () => {
         assert.equal(searchJson.items.length, 1);
         assert.equal(searchJson.items[0].id, appendJson.entry.id);
 
+        const detail = await fetch(`${runtime.baseUrl}/v1/get_entry`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-WithMate-Memory-Api-Secret": discovery.apiSecret,
+            [WITHMATE_MEMORY_BINDING_REFERENCE_HEADER]: binding.bindingReference,
+          },
+          body: JSON.stringify({
+            schemaVersion: "withmate-memory-v1",
+            entryId: appendJson.entry.id,
+          }),
+        });
+        assert.equal(detail.status, 200);
+        const detailJson = await detail.json();
+        assert.equal(detailJson.entry.source.sessionId, null);
+
         assert.deepEqual({
           schemaVersion: "withmate-memory-v1",
           session: { id: bindingRegistry.resolvePrincipal(binding.bindingReference)?.sessionId },

--- a/scripts/tests/memory-v6-runtime.test.ts
+++ b/scripts/tests/memory-v6-runtime.test.ts
@@ -239,11 +239,73 @@ describe("Memory V6 runtime API", () => {
           body: JSON.stringify({ schemaVersion: "withmate-memory-v1" }),
         });
         assert.equal(context.status, 200);
-        assert.deepEqual(await context.json(), {
+        const contextJson = await context.json();
+        assert.equal(contextJson.schemaVersion, "withmate-memory-v1");
+        assert.deepEqual(contextJson.session, { id: bindingRegistry.resolvePrincipal(binding.bindingReference)?.sessionId });
+        assert.deepEqual(contextJson.character, { id: "character-a", name: "Character A" });
+        assert.equal(contextJson.sessionProject.displayName, "Workspace A");
+        assert.match(contextJson.sessionProject.id, /^project-/);
+        assert.deepEqual(contextJson.permissions, [
+          "memory.resolve_context",
+          "memory.search",
+          "memory.get_entry",
+          "memory.list_tags",
+          "memory.append",
+          "memory.forget",
+        ]);
+
+        const append = await fetch(`${runtime.baseUrl}/v1/append`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-WithMate-Memory-Api-Secret": discovery.apiSecret,
+            [WITHMATE_MEMORY_BINDING_REFERENCE_HEADER]: binding.bindingReference,
+          },
+          body: JSON.stringify({
+            schemaVersion: "withmate-memory-v1",
+            target: {
+              owner: "project",
+              scope: "project",
+              project: { type: "id", id: contextJson.sessionProject.id },
+            },
+            kind: "note",
+            title: "Runtime binding project id",
+            body: "context.sessionProject.id can be reused as a project target.",
+            preview: "sessionProject.id is reusable.",
+            tags: [{ type: "topic", value: "runtime" }],
+          }),
+        });
+        assert.equal(append.status, 200);
+        const appendJson = await append.json();
+        assert.equal(appendJson.entry.owner.id, contextJson.sessionProject.id);
+
+        const search = await fetch(`${runtime.baseUrl}/v1/search`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-WithMate-Memory-Api-Secret": discovery.apiSecret,
+            [WITHMATE_MEMORY_BINDING_REFERENCE_HEADER]: binding.bindingReference,
+          },
+          body: JSON.stringify({
+            schemaVersion: "withmate-memory-v1",
+            targets: [{
+              owner: "project",
+              scope: "project",
+              project: { type: "id", id: contextJson.sessionProject.id },
+            }],
+            query: "reusable",
+          }),
+        });
+        assert.equal(search.status, 200);
+        const searchJson = await search.json();
+        assert.equal(searchJson.items.length, 1);
+        assert.equal(searchJson.items[0].id, appendJson.entry.id);
+
+        assert.deepEqual({
           schemaVersion: "withmate-memory-v1",
           session: { id: bindingRegistry.resolvePrincipal(binding.bindingReference)?.sessionId },
           character: { id: "character-a", name: "Character A" },
-          sessionProject: { id: "C:/workspace/a", displayName: "Workspace A" },
+          sessionProject: contextJson.sessionProject,
           permissions: [
             "memory.resolve_context",
             "memory.search",
@@ -252,7 +314,7 @@ describe("Memory V6 runtime API", () => {
             "memory.append",
             "memory.forget",
           ],
-        });
+        }, contextJson);
 
         bindingRegistry.revokeBinding(binding);
         const revokedContext = await fetch(`${runtime.baseUrl}/v1/context`, {

--- a/scripts/tests/memory-v6-service.test.ts
+++ b/scripts/tests/memory-v6-service.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -8,7 +8,11 @@ import { describe, it } from "node:test";
 import { MEMORY_V6_SCHEMA_VERSION, type MemoryPermission, type NormalizedMemoryTag } from "../../src/memory-v6/memory-contract.js";
 import { createOrVerifyV6FreshDatabase } from "../../src-electron/app-database-v6-bootstrap.js";
 import { MemoryV6Service } from "../../src-electron/memory-v6-service.js";
-import type { MemoryV6Principal } from "../../src-electron/memory-v6-permission.js";
+import {
+  createLocalUserMemoryPrincipal,
+  type MemoryV6SessionBindingPrincipal,
+} from "../../src-electron/memory-v6-permission.js";
+import { createMemoryV6ProjectResolver } from "../../src-electron/memory-v6-project-resolver.js";
 import type { MemoryV6ResolvedTarget } from "../../src-electron/memory-v6-schema.js";
 import { MemoryV6Storage } from "../../src-electron/memory-v6-storage.js";
 
@@ -40,8 +44,9 @@ function tag(type: string, value: string): NormalizedMemoryTag {
   };
 }
 
-function principal(overrides: Partial<MemoryV6Principal> = {}): MemoryV6Principal {
+function principal(overrides: Partial<MemoryV6SessionBindingPrincipal> = {}): MemoryV6SessionBindingPrincipal {
   return {
+    type: "session_binding",
     bindingIdHash: "binding-hash-a",
     sessionId: "session-a",
     providerId: "codex",
@@ -291,6 +296,189 @@ describe("MemoryV6Service", () => {
       assert.deepEqual(retry.results, [{ entryId: "mem-created-after-not-found", status: "not_found" }]);
       assert.equal(storage.getEntry("mem-created-after-not-found")?.state, "active");
     });
+  });
+
+  it("local_user は明示project targetで外部CLI相当の操作ができる", async () => {
+    await withService(({ service }) => {
+      const localUser = createLocalUserMemoryPrincipal();
+      const append = service.append(localUser, appendRequest({
+        idempotencyKey: "local-user-append",
+        sourceMessageId: "external-message-1",
+      }));
+      assert.equal("error" in append, false);
+      assert.equal(append.entry.owner.type, "project");
+      assert.equal(append.entry.owner.id, "project-a");
+      assert.equal(append.entry.state, "active");
+
+      const search = service.search(localUser, {
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        targets: [{ owner: "project", scope: "project", project: { type: "path", path: "C:/workspace/project-a" } }],
+        query: "payload",
+      });
+      assert.equal("error" in search, false);
+      assert.equal(search.items.length, 1);
+      assert.equal(search.items[0]?.id, append.entry.id);
+
+      const tags = service.listTags(localUser, {
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        targets: [{ owner: "project", scope: "project", project: { type: "id", id: "project-a" } }],
+      });
+      assert.equal("error" in tags, false);
+      assert.deepEqual(tags.tags, [{ type: "topic", value: "memory" }]);
+
+      const detail = service.getEntry(localUser, {
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        entryId: append.entry.id,
+        target: { owner: "project", scope: "project", project: { type: "id", id: "project-a" } },
+      });
+      assert.equal("error" in detail, false);
+      assert.equal(detail.entry.source.sessionId, null);
+      assert.equal(detail.entry.source.providerId, "local-user");
+
+      const missingTarget = service.getEntry(localUser, {
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        entryId: append.entry.id,
+      });
+      assert.equal("error" in missingTarget, true);
+      assert.equal(missingTarget.error.code, "MEMORY_TARGET_REQUIRED");
+
+      const missingTargetForMissingEntry = service.getEntry(localUser, {
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        entryId: "missing-entry",
+      });
+      assert.equal("error" in missingTargetForMissingEntry, true);
+      assert.equal(missingTargetForMissingEntry.error.code, "MEMORY_TARGET_REQUIRED");
+
+      const forbiddenTarget = {
+        owner: "character" as const,
+        scope: "character" as const,
+        character: { type: "id" as const, id: "character-a" },
+      };
+      const forbiddenExisting = service.getEntry(localUser, {
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        entryId: append.entry.id,
+        target: forbiddenTarget,
+      });
+      const forbiddenMissing = service.getEntry(localUser, {
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        entryId: "missing-entry",
+        target: forbiddenTarget,
+      });
+      assert.equal("error" in forbiddenExisting, true);
+      assert.equal("error" in forbiddenMissing, true);
+      assert.equal(forbiddenExisting.error.code, "MEMORY_FORBIDDEN");
+      assert.equal(forbiddenMissing.error.code, "MEMORY_FORBIDDEN");
+
+      const forget = service.forget(localUser, {
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        target: { owner: "project", scope: "project", project: { type: "id", id: "project-a" } },
+        entryIds: [append.entry.id],
+        reason: "user_request",
+      });
+      assert.equal("error" in forget, false);
+      assert.deepEqual(forget.results, [{ entryId: append.entry.id, status: "forgotten" }]);
+    });
+  });
+
+  it("local_user のget-entryは明示project target外のentryを返さない", async () => {
+    await withService(({ service, storage }) => {
+      const localUser = createLocalUserMemoryPrincipal();
+      storage.appendEntry({
+        id: "mem-local-other-project",
+        target: {
+          owner: { type: "project", id: "project-b" },
+          scope: { type: "project", id: "project-b" },
+        },
+        kind: "note",
+        title: "別project",
+        body: "別projectのbody",
+        preview: "別project",
+        tags: [tag("topic", "secret")],
+        source: {
+          type: "agent",
+          sessionId: null,
+          messageId: null,
+          providerId: "codex",
+        },
+      });
+
+      const detail = service.getEntry(localUser, {
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        entryId: "mem-local-other-project",
+        target: { owner: "project", scope: "project", project: { type: "id", id: "project-a" } },
+      });
+      assert.equal("error" in detail, true);
+      assert.equal(detail.error.code, "MEMORY_ENTRY_NOT_FOUND");
+    });
+  });
+
+  it("local_user はcurrent character / character target / contextを使えない", async () => {
+    await withService(({ service }) => {
+      const localUser = createLocalUserMemoryPrincipal();
+
+      const context = service.resolveContext(localUser, { schemaVersion: MEMORY_V6_SCHEMA_VERSION });
+      assert.equal("error" in context, true);
+      assert.equal(context.error.code, "MEMORY_BINDING_REQUIRED");
+
+      const currentCharacter = service.search(localUser, {
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        targets: [{ owner: "character", scope: "character", character: { type: "current" } }],
+        query: "memory",
+      });
+      assert.equal("error" in currentCharacter, true);
+      assert.equal(currentCharacter.error.code, "MEMORY_BINDING_REQUIRED");
+
+      const explicitCharacter = service.search(localUser, {
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        targets: [{ owner: "character", scope: "character", character: { type: "id", id: "character-a" } }],
+        query: "memory",
+      });
+      assert.equal("error" in explicitCharacter, true);
+      assert.equal(explicitCharacter.error.code, "MEMORY_FORBIDDEN");
+    });
+  });
+
+  it("runtime project resolver はproject.pathからV6 project scopeを作成して解決する", async () => {
+    const tempDirectory = await mkdtemp(join(tmpdir(), "withmate-memory-v6-project-resolver-"));
+    const workspacePath = join(tempDirectory, "repo");
+    await mkdir(join(workspacePath, ".git"), { recursive: true });
+    const { dbPath } = await createOrVerifyV6FreshDatabase(tempDirectory);
+    const storage = new MemoryV6Storage(dbPath);
+    const service = new MemoryV6Service({
+      storage,
+      ...createMemoryV6ProjectResolver(dbPath),
+    });
+    try {
+      const localUser = createLocalUserMemoryPrincipal();
+      const append = service.append(localUser, appendRequest({
+        target: {
+          owner: "project",
+          scope: "project",
+          project: { type: "path", path: workspacePath },
+        },
+      }));
+      assert.equal("error" in append, false);
+      assert.equal(append.entry.owner.type, "project");
+
+      const search = service.search(localUser, {
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        targets: [{ owner: "project", scope: "project", project: { type: "path", path: workspacePath } }],
+        query: "agent payload",
+      });
+      assert.equal("error" in search, false);
+      assert.equal(search.items.length, 1);
+      assert.equal(search.items[0]?.id, append.entry.id);
+
+      const resolver = createMemoryV6ProjectResolver(dbPath);
+      const first = resolver.resolveProjectByPath(workspacePath);
+      const second = resolver.resolveProjectByPath(workspacePath);
+      assert.ok(first);
+      assert.ok(second);
+      assert.equal(second.id, first.id);
+    } finally {
+      storage.close();
+      await rm(tempDirectory, { recursive: true, force: true });
+    }
   });
 
   it("resolverが明示的にnot-foundを返すproject / character targetは拒否する", async () => {

--- a/scripts/tests/withmate-memory-cli.test.ts
+++ b/scripts/tests/withmate-memory-cli.test.ts
@@ -365,6 +365,38 @@ describe("withmate-memory CLI", () => {
     assert.deepEqual(stdout.json(), { schemaVersion: MEMORY_V6_SCHEMA_VERSION, items: [] });
   });
 
+  it("project.pathの相対pathはCLI起動cwd基準の絶対pathへ正規化して送る", async () => {
+    const stdout = createOutputCapture();
+    const tempDirectory = await mkdtemp(join(tmpdir(), "withmate-memory-cli-cwd-"));
+    const previousCwd = process.cwd();
+    let capturedBody: any = null;
+    try {
+      process.chdir(tempDirectory);
+      const exitCode = await runWithMateMemoryCli(["search", "--json", JSON.stringify({
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        targets: [{ owner: "project", scope: "project", project: { type: "path", path: "." } }],
+        query: "cli",
+      })], {
+        env: TEST_RUNTIME_ENV,
+        stdout: stdout.stream,
+        fetch: async (url, init) => {
+          if (isStatusChallengeRequest(String(url))) {
+            return createStatusChallengeResponse(String(url));
+          }
+          assert.equal(String(url), "http://127.0.0.1:7777/v1/search");
+          capturedBody = JSON.parse(String(init?.body));
+          return new Response(JSON.stringify({ schemaVersion: MEMORY_V6_SCHEMA_VERSION, items: [] }), { status: 200 });
+        },
+      });
+
+      assert.equal(exitCode, WITHMATE_MEMORY_CLI_EXIT_CODES.ok);
+      assert.equal(capturedBody.targets[0].project.path, tempDirectory);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(tempDirectory, { recursive: true, force: true });
+    }
+  });
+
   it("contextはschemaVersionつきJSON bodyをPOSTで送る", async () => {
     const stdout = createOutputCapture();
     let capturedBody: unknown = null;

--- a/scripts/withmate-memory.ts
+++ b/scripts/withmate-memory.ts
@@ -258,10 +258,30 @@ export async function parseWithMateMemoryCliArgs(
 
   return {
     command,
-    body,
+    body: normalizeProjectPathTargets(body),
     ...(apiUrl ? { apiUrl } : {}),
     ...(discoveryFilePath ? { discoveryFilePath } : {}),
   };
+}
+
+function normalizeProjectPathTargets(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeProjectPathTargets(item));
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  const record = value as Record<string, unknown>;
+  const normalized: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(record)) {
+    normalized[key] = normalizeProjectPathTargets(item);
+  }
+
+  if (record.type === "path" && typeof record.path === "string") {
+    normalized.path = path.resolve(record.path);
+  }
+  return normalized;
 }
 
 function requireOptionValue(args: readonly string[], index: number, option: string): string {

--- a/src-electron/memory-binding-registry.ts
+++ b/src-electron/memory-binding-registry.ts
@@ -8,6 +8,7 @@ import {
   getProviderMemoryBindingCapability,
   type ProviderMemoryBindingRuntimeProjection,
 } from "./provider-memory-binding.js";
+import type { MemoryV6ProjectContext } from "./memory-v6-context-resolver.js";
 import type { MemoryV6Principal } from "./memory-v6-permission.js";
 
 const DEFAULT_MEMORY_PERMISSIONS: readonly MemoryPermission[] = [
@@ -45,9 +46,19 @@ export type CreateMemoryBindingInput = {
   expiresAt?: string | null;
 };
 
+export type MemoryBindingProjectResolver = {
+  resolveProjectByPath?(projectPath: string): MemoryV6ProjectContext | null;
+};
+
 export class MemoryBindingRegistry {
   private readonly recordsByBindingId = new Map<string, MemoryBindingRecord>();
   private readonly bindingIdsByReferenceHash = new Map<string, string>();
+
+  constructor(private projectResolver: MemoryBindingProjectResolver = {}) {}
+
+  setProjectResolver(projectResolver: MemoryBindingProjectResolver): void {
+    this.projectResolver = projectResolver;
+  }
 
   createBinding(input: CreateMemoryBindingInput): ProviderMemoryBindingRuntimeProjection | null {
     this.revokeSessionBindings(input.session.id);
@@ -65,10 +76,14 @@ export class MemoryBindingRegistry {
     const bindingReference = randomBytes(32).toString("base64url");
     const bindingReferenceHash = hashBindingReference(bindingReference);
     const createdAt = (input.now ?? new Date()).toISOString();
-    const sessionProject = input.session.workspacePath.trim()
+    const workspacePath = input.session.workspacePath.trim();
+    const resolvedProject = workspacePath
+      ? this.projectResolver.resolveProjectByPath?.(workspacePath) ?? null
+      : null;
+    const sessionProject = workspacePath
       ? {
-          id: input.session.workspacePath,
-          displayName: input.session.workspaceLabel.trim() || input.session.workspacePath,
+          id: resolvedProject?.id ?? workspacePath,
+          displayName: input.session.workspaceLabel.trim() || resolvedProject?.displayName || workspacePath,
         }
       : null;
     const character = input.character
@@ -158,6 +173,7 @@ export class MemoryBindingRegistry {
     }
 
     return {
+      type: "session_binding",
       bindingIdHash: record.bindingReferenceHash,
       sessionId: record.sessionId,
       providerId: record.providerId,

--- a/src-electron/memory-v6-context-resolver.ts
+++ b/src-electron/memory-v6-context-resolver.ts
@@ -7,6 +7,7 @@ import type {
 import type { MemoryV6ResolvedTarget } from "./memory-v6-schema.js";
 import {
   canAccessMemoryTarget,
+  isSessionBindingPrincipal,
   memoryBindingRequiredError,
   memoryForbiddenError,
   type MemoryV6Principal,
@@ -56,7 +57,9 @@ function resolveCharacter(
   field: string,
 ): { id: string; name: string } | MemoryError {
   if (ref.type === "current") {
-    return principal.character ?? memoryBindingRequiredError("current character requires a WithMate runtime binding.");
+    return isSessionBindingPrincipal(principal) && principal.character
+      ? principal.character
+      : memoryBindingRequiredError("current character requires a WithMate runtime binding.");
   }
   if (deps.resolveCharacterById) {
     return deps.resolveCharacterById(ref.id) ?? targetNotFoundError(field);

--- a/src-electron/memory-v6-http-server.ts
+++ b/src-electron/memory-v6-http-server.ts
@@ -282,7 +282,7 @@ export function createMemoryV6HttpServer(options: MemoryV6HttpServerOptions): Me
 
       const bindingReference = readBindingReference(request);
       const principal = bindingReference
-        ? await options.resolvePrincipal({ request, bindingReference })
+        ? await options.resolvePrincipal({ request, bindingReference }) ?? createLocalUserMemoryPrincipal()
         : createLocalUserMemoryPrincipal();
       const body = await readJsonBody(request, maxBodyBytes);
       const result = routeServiceRequest(options.service, principal, route, body);

--- a/src-electron/memory-v6-http-server.ts
+++ b/src-electron/memory-v6-http-server.ts
@@ -5,6 +5,7 @@ import type { AddressInfo } from "node:net";
 import { createMemoryErrorResponse, type MemoryErrorResponse } from "../src/memory-v6/memory-response-contract.js";
 import type { MemoryV6Service } from "./memory-v6-service.js";
 import type { MemoryV6Principal } from "./memory-v6-permission.js";
+import { createLocalUserMemoryPrincipal } from "./memory-v6-permission.js";
 import { WITHMATE_MEMORY_BINDING_REFERENCE_HEADER } from "./provider-memory-binding.js";
 
 export type MemoryV6HttpServerOptions = {
@@ -279,10 +280,10 @@ export function createMemoryV6HttpServer(options: MemoryV6HttpServerOptions): Me
         return;
       }
 
-      const principal = await options.resolvePrincipal({
-        request,
-        bindingReference: readBindingReference(request),
-      });
+      const bindingReference = readBindingReference(request);
+      const principal = bindingReference
+        ? await options.resolvePrincipal({ request, bindingReference })
+        : createLocalUserMemoryPrincipal();
       const body = await readJsonBody(request, maxBodyBytes);
       const result = routeServiceRequest(options.service, principal, route, body);
       writeJson(response, statusForMemoryResponse(result), result);

--- a/src-electron/memory-v6-permission.ts
+++ b/src-electron/memory-v6-permission.ts
@@ -1,7 +1,8 @@
 import type { MemoryError, MemoryPermission } from "../src/memory-v6/memory-contract.js";
 import type { MemoryV6ResolvedTarget } from "./memory-v6-schema.js";
 
-export type MemoryV6Principal = {
+export type MemoryV6SessionBindingPrincipal = {
+  type: "session_binding";
   bindingIdHash: string;
   sessionId: string;
   providerId: string;
@@ -11,6 +12,38 @@ export type MemoryV6Principal = {
   accessibleCharacterIds?: readonly string[];
   accessibleProjectIds?: readonly string[];
 };
+
+export type MemoryV6LocalUserPrincipal = {
+  type: "local_user";
+  bindingIdHash: "local-user";
+  providerId: "local-user";
+  permissions: readonly MemoryPermission[];
+};
+
+export type MemoryV6Principal = MemoryV6SessionBindingPrincipal | MemoryV6LocalUserPrincipal;
+
+export const LOCAL_USER_MEMORY_PERMISSIONS: readonly MemoryPermission[] = [
+  "memory.search",
+  "memory.get_entry",
+  "memory.list_tags",
+  "memory.append",
+  "memory.forget",
+];
+
+export function createLocalUserMemoryPrincipal(): MemoryV6LocalUserPrincipal {
+  return {
+    type: "local_user",
+    bindingIdHash: "local-user",
+    providerId: "local-user",
+    permissions: LOCAL_USER_MEMORY_PERMISSIONS,
+  };
+}
+
+export function isSessionBindingPrincipal(
+  principal: MemoryV6Principal,
+): principal is MemoryV6SessionBindingPrincipal {
+  return principal.type === "session_binding";
+}
 
 export function memoryBindingRequiredError(message = "WithMate runtime binding is required."): MemoryError {
   return {
@@ -44,6 +77,10 @@ export function requireMemoryPermission(principal: MemoryV6Principal | null, per
 }
 
 export function canAccessMemoryTarget(principal: MemoryV6Principal, target: MemoryV6ResolvedTarget): boolean {
+  if (principal.type === "local_user") {
+    return target.owner.type === "project" && target.scope.type === "project";
+  }
+
   if (target.owner.type === "user" || target.scope.type === "session" || target.scope.type === "global") {
     return false;
   }

--- a/src-electron/memory-v6-project-resolver.ts
+++ b/src-electron/memory-v6-project-resolver.ts
@@ -1,0 +1,121 @@
+import { randomUUID } from "node:crypto";
+import type { DatabaseSync } from "node:sqlite";
+
+import { resolveProjectScope } from "./project-scope.js";
+import { openAppDatabase } from "./sqlite-connection.js";
+import type { MemoryV6ProjectContext, MemoryV6TargetResolverDeps } from "./memory-v6-context-resolver.js";
+
+type ProjectScopeRow = {
+  id: string;
+  project_type: string;
+  project_key: string;
+  workspace_path: string;
+  display_name: string;
+};
+
+export function createMemoryV6ProjectResolver(dbPath: string): Pick<
+  MemoryV6TargetResolverDeps,
+  "resolveProjectById" | "resolveProjectByPath" | "resolveProjectByAlias"
+> & { resolveSessionById(id: string): boolean } {
+  return {
+    resolveProjectById: (id) => withDatabase(dbPath, (db) => {
+      const row = db.prepare(`
+        SELECT id, display_name
+        FROM project_scopes_v6
+        WHERE id = ?
+      `).get(id) as { id: string; display_name: string } | undefined;
+      return row ? { id: row.id, displayName: row.display_name } : null;
+    }),
+    resolveProjectByPath: (projectPath) => withDatabase(dbPath, (db) => {
+      const resolved = resolveProjectScope(projectPath);
+      const now = new Date().toISOString();
+      const existing = db.prepare(`
+        SELECT id
+        FROM project_scopes_v6
+        WHERE project_type = ?
+          AND project_key = ?
+      `).get(resolved.projectType, resolved.projectKey) as { id: string } | undefined;
+      const projectId = existing?.id ?? `project-${randomUUID()}`;
+
+      db.prepare(`
+        INSERT INTO project_scopes_v6 (
+          id,
+          project_type,
+          project_key,
+          workspace_path,
+          git_root,
+          git_remote_url,
+          display_name,
+          created_at,
+          updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(project_type, project_key) DO UPDATE SET
+          workspace_path = excluded.workspace_path,
+          git_root = excluded.git_root,
+          git_remote_url = excluded.git_remote_url,
+          display_name = excluded.display_name,
+          updated_at = excluded.updated_at
+      `).run(
+        projectId,
+        resolved.projectType,
+        resolved.projectKey,
+        resolved.workspacePath,
+        resolved.gitRoot ?? "",
+        resolved.gitRemoteUrl ?? "",
+        resolved.displayName,
+        now,
+        now,
+      );
+
+      const row = db.prepare(`
+        SELECT id, display_name
+        FROM project_scopes_v6
+        WHERE project_type = ?
+          AND project_key = ?
+      `).get(resolved.projectType, resolved.projectKey) as { id: string; display_name: string } | undefined;
+      return row
+        ? { id: row.id, displayName: row.display_name }
+        : { id: projectId, displayName: resolved.displayName };
+    }),
+    resolveProjectByAlias: (alias) => withDatabase(dbPath, (db) => {
+      const row = db.prepare(`
+        SELECT id, display_name
+        FROM project_scopes_v6
+        WHERE id = ?
+           OR project_key = ?
+           OR display_name = ?
+           OR workspace_path = ?
+        ORDER BY updated_at DESC
+        LIMIT 1
+      `).get(alias, alias, alias, alias) as { id: string; display_name: string } | undefined;
+      return row ? { id: row.id, displayName: row.display_name } : null;
+    }),
+    resolveSessionById: (id) => withDatabase(dbPath, (db) => {
+      const row = db.prepare(`
+        SELECT id
+        FROM sessions_v6
+        WHERE id = ?
+      `).get(id) as { id: string } | undefined;
+      return Boolean(row);
+    }),
+  };
+}
+
+export function listMemoryV6ProjectScopes(dbPath: string): ProjectScopeRow[] {
+  return withDatabase(dbPath, (db) =>
+    db.prepare(`
+      SELECT id, project_type, project_key, workspace_path, display_name
+      FROM project_scopes_v6
+      ORDER BY updated_at DESC, id ASC
+    `).all() as ProjectScopeRow[]
+  );
+}
+
+function withDatabase<T>(dbPath: string, runner: (db: DatabaseSync) => T): T {
+  const db = openAppDatabase(dbPath);
+  try {
+    return runner(db);
+  } finally {
+    db.close();
+  }
+}

--- a/src-electron/memory-v6-runtime.ts
+++ b/src-electron/memory-v6-runtime.ts
@@ -16,6 +16,7 @@ import {
   createMemoryV6HttpServer,
   type MemoryV6HttpServer,
 } from "./memory-v6-http-server.js";
+import { createMemoryV6ProjectResolver } from "./memory-v6-project-resolver.js";
 import type { MemoryBindingRegistry } from "./memory-binding-registry.js";
 import { MemoryV6Service } from "./memory-v6-service.js";
 import { MemoryV6Storage } from "./memory-v6-storage.js";
@@ -244,7 +245,12 @@ export async function startMemoryV6RuntimeApi(
 
     const bootstrap = await createOrVerifyV6FreshDatabase(options.userDataPath);
     storage = new MemoryV6Storage(bootstrap.dbPath);
-    const service = new MemoryV6Service({ storage });
+    const projectResolver = createMemoryV6ProjectResolver(bootstrap.dbPath);
+    options.bindingRegistry?.setProjectResolver(projectResolver);
+    const service = new MemoryV6Service({
+      storage,
+      ...projectResolver,
+    });
     const apiSecret = createRuntimeApiSecret();
     const runtimeInstanceId = randomUUID();
     server = createMemoryV6HttpServer({

--- a/src-electron/memory-v6-service.ts
+++ b/src-electron/memory-v6-service.ts
@@ -27,6 +27,7 @@ import type { MemoryEntryDetail } from "../src/memory-v6/memory-state.js";
 import { resolveMemoryV6Target, targetMatchesPrincipal, type MemoryV6TargetResolverDeps } from "./memory-v6-context-resolver.js";
 import type { MemoryV6ResolvedTarget } from "./memory-v6-schema.js";
 import {
+  isSessionBindingPrincipal,
   requireMemoryPermission,
   type MemoryV6Principal,
 } from "./memory-v6-permission.js";
@@ -38,6 +39,7 @@ import {
 
 export type MemoryV6ServiceDeps = MemoryV6TargetResolverDeps & {
   storage: MemoryV6Storage;
+  resolveSessionById?(id: string): boolean;
 };
 
 type MemoryV6ServiceResult<T> = T | MemoryErrorResponse;
@@ -49,8 +51,33 @@ function entryTarget(entry: MemoryEntryDetail): MemoryV6ResolvedTarget {
   };
 }
 
+function sameTarget(left: MemoryV6ResolvedTarget, right: MemoryV6ResolvedTarget): boolean {
+  return left.owner.type === right.owner.type
+    && left.owner.id === right.owner.id
+    && left.scope.type === right.scope.type
+    && left.scope.id === right.scope.id;
+}
+
 function toMemoryErrorResponse(error: MemoryError): MemoryErrorResponse {
   return createMemoryErrorResponse(error);
+}
+
+function bindingIdHashForPrincipal(principal: MemoryV6Principal): string {
+  return principal.bindingIdHash;
+}
+
+function sessionIdForPrincipal(principal: MemoryV6Principal, deps: MemoryV6ServiceDeps): string | null {
+  if (!isSessionBindingPrincipal(principal)) {
+    return null;
+  }
+  if (deps.resolveSessionById && !deps.resolveSessionById(principal.sessionId)) {
+    return null;
+  }
+  return principal.sessionId;
+}
+
+function providerIdForPrincipal(principal: MemoryV6Principal): string | null {
+  return principal.providerId;
 }
 
 function storageErrorResponse(error: unknown): MemoryErrorResponse {
@@ -73,6 +100,12 @@ export class MemoryV6Service {
   constructor(private readonly deps: MemoryV6ServiceDeps) {}
 
   resolveContext(principal: MemoryV6Principal | null, request: unknown): MemoryV6ServiceResult<MemoryResolveContextResponse> {
+    if (principal && !isSessionBindingPrincipal(principal)) {
+      return toMemoryErrorResponse({
+        code: "MEMORY_BINDING_REQUIRED",
+        message: "WithMate runtime binding is required.",
+      });
+    }
     const permissionError = requireMemoryPermission(principal, "memory.resolve_context");
     if (permissionError || !principal) {
       return toMemoryErrorResponse(permissionError ?? {
@@ -139,8 +172,31 @@ export class MemoryV6Service {
       return toMemoryErrorResponse(validated.error);
     }
 
+    let requestedTarget: MemoryV6ResolvedTarget | null = null;
+    if (!isSessionBindingPrincipal(principal)) {
+      if (!validated.value.target) {
+        return toMemoryErrorResponse({
+          code: "MEMORY_TARGET_REQUIRED",
+          message: "Project target is required for external get-entry.",
+          field: "target",
+        });
+      }
+      const resolved = resolveMemoryV6Target(validated.value.target, principal, this.deps);
+      if (!resolved.ok) {
+        return toMemoryErrorResponse(resolved.error);
+      }
+      requestedTarget = resolved.target;
+    }
+
     const entry = this.deps.storage.getEntry(validated.value.entryId);
-    if (!entry || entry.state !== "active" || !targetMatchesPrincipal(principal, entryTarget(entry))) {
+    if (!entry || entry.state !== "active") {
+      return createMemoryGetEntryResponse(null);
+    }
+    const target = entryTarget(entry);
+    if (requestedTarget && !sameTarget(requestedTarget, target)) {
+      return createMemoryGetEntryResponse(null);
+    }
+    if (!targetMatchesPrincipal(principal, target)) {
       return createMemoryGetEntryResponse(null);
     }
     return createMemoryGetEntryResponse(entry);
@@ -198,12 +254,12 @@ export class MemoryV6Service {
         tags: validated.value.tags,
         supersedes: validated.value.supersedes,
         idempotencyKey: validated.value.idempotencyKey,
-        bindingIdHash: principal.bindingIdHash,
+        bindingIdHash: bindingIdHashForPrincipal(principal),
         source: {
           type: "agent",
-          sessionId: principal.sessionId,
+          sessionId: sessionIdForPrincipal(principal, this.deps),
           messageId: validated.value.sourceMessageId ?? null,
-          providerId: principal.providerId,
+          providerId: providerIdForPrincipal(principal),
           appMessageId: null,
         },
       });
@@ -236,8 +292,8 @@ export class MemoryV6Service {
         entryIds: validated.value.entryIds,
         reason: validated.value.reason,
         idempotencyKey: validated.value.idempotencyKey,
-        bindingIdHash: principal.bindingIdHash,
-        sessionId: principal.sessionId,
+        bindingIdHash: bindingIdHashForPrincipal(principal),
+        sessionId: sessionIdForPrincipal(principal, this.deps),
       });
       return createMemoryForgetResponse(results);
     } catch (error) {

--- a/src/memory-v6/memory-contract.ts
+++ b/src/memory-v6/memory-contract.ts
@@ -64,6 +64,7 @@ export type MemorySearchRequest = {
 export type MemoryGetEntryRequest = {
   schemaVersion: MemoryV6SchemaVersion;
   entryId: string;
+  target?: MemoryTargetSelector;
 };
 
 export type MemoryListTagsRequest = {

--- a/src/memory-v6/memory-validation.ts
+++ b/src/memory-v6/memory-validation.ts
@@ -37,7 +37,7 @@ const MEMORY_FORGET_REASONS = new Set<MemoryForgetReason>([
 
 const RESOLVE_CONTEXT_REQUEST_KEYS = new Set(["schemaVersion"]);
 const SEARCH_REQUEST_KEYS = new Set(["schemaVersion", "targets", "query", "kinds", "tags", "limit", "cursor"]);
-const GET_ENTRY_REQUEST_KEYS = new Set(["schemaVersion", "entryId"]);
+const GET_ENTRY_REQUEST_KEYS = new Set(["schemaVersion", "entryId", "target"]);
 const LIST_TAGS_REQUEST_KEYS = new Set(["schemaVersion", "targets"]);
 const APPEND_REQUEST_KEYS = new Set([
   "schemaVersion",
@@ -496,12 +496,19 @@ export function validateMemoryGetEntryRequest(value: unknown): MemoryValidationR
   if (!entryId.ok) {
     return entryId;
   }
+  const target = value.target === undefined
+    ? undefined
+    : normalizeMemoryTarget(value.target, "target");
+  if (target && !target.ok) {
+    return target;
+  }
 
   return {
     ok: true,
     value: {
       schemaVersion: MEMORY_V6_SCHEMA_VERSION,
       entryId: entryId.value,
+      ...(target ? { target: target.value } : {}),
     },
   };
 }


### PR DESCRIPTION
## Summary

- Memory V6 の principal を `session_binding` / `local_user` に分離
- binding reference なし + valid runtime secret の外部 CLI request を `local_user` として扱い、Project Memory の search/get-entry/list-tags/append/forget を許可
- current Character / WithMate session context は session binding 専用に維持
- `project.path` から V6 project scope を解決する runtime resolver を追加し、context の `sessionProject.id` を後続 target として再利用可能に修正
- 外部 `get-entry` は明示 project target 必須にして existence oracle を防止
- docs / bundled Memory skill reference を外部 Codex 利用前提に更新

## Review

- reviewer agent で3巡レビュー
- 1巡目、2巡目の指摘を修正
- 3巡目は `No actionable findings.`

## Validation

- `node --test --import tsx scripts/tests/memory-v6-service.test.ts scripts/tests/memory-v6-http-server.test.ts scripts/tests/memory-v6-runtime.test.ts scripts/tests/memory-v6-contract.test.ts scripts/tests/memory-binding-registry.test.ts`
- `node --test --import tsx scripts/tests/memory-v6-service.test.ts scripts/tests/memory-v6-http-server.test.ts scripts/tests/withmate-memory-cli.test.ts scripts/tests/memory-binding-registry.test.ts scripts/tests/memory-v6-runtime.test.ts scripts/tests/memory-v6-contract.test.ts scripts/tests/managed-memory-skill-service.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm test`
