### PR TITLE
[codex] メッセージ Markdown の初回描画を軽量化

### DIFF
--- a/scripts/tests/message-rich-text.test.ts
+++ b/scripts/tests/message-rich-text.test.ts
@@ -1,9 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { JSDOM } from "jsdom";
 import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { handleMarkdownLinkClick, MessageRichText } from "../../src/MessageRichText.js";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 function clickMarkdownLink(target: string) {
   const opened: string[] = [];
@@ -24,6 +29,43 @@ function clickMarkdownLink(target: string) {
   );
 
   return { defaultPrevented, opened };
+}
+
+function installDomGlobals(dom: JSDOM): () => void {
+  const previousWindow = globalThis.window;
+  const previousDocument = globalThis.document;
+  const previousNavigator = globalThis.navigator;
+  const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+  const previousCancelAnimationFrame = globalThis.cancelAnimationFrame;
+  const previousHTMLElement = globalThis.HTMLElement;
+
+  Object.defineProperty(globalThis, "window", { configurable: true, value: dom.window });
+  Object.defineProperty(globalThis, "document", { configurable: true, value: dom.window.document });
+  Object.defineProperty(globalThis, "navigator", { configurable: true, value: dom.window.navigator });
+  Object.defineProperty(globalThis, "requestAnimationFrame", {
+    configurable: true,
+    value: dom.window.requestAnimationFrame.bind(dom.window),
+  });
+  Object.defineProperty(globalThis, "cancelAnimationFrame", {
+    configurable: true,
+    value: dom.window.cancelAnimationFrame.bind(dom.window),
+  });
+  Object.defineProperty(globalThis, "HTMLElement", { configurable: true, value: dom.window.HTMLElement });
+
+  return () => {
+    Object.defineProperty(globalThis, "window", { configurable: true, value: previousWindow });
+    Object.defineProperty(globalThis, "document", { configurable: true, value: previousDocument });
+    Object.defineProperty(globalThis, "navigator", { configurable: true, value: previousNavigator });
+    Object.defineProperty(globalThis, "requestAnimationFrame", { configurable: true, value: previousRequestAnimationFrame });
+    Object.defineProperty(globalThis, "cancelAnimationFrame", { configurable: true, value: previousCancelAnimationFrame });
+    Object.defineProperty(globalThis, "HTMLElement", { configurable: true, value: previousHTMLElement });
+  };
+}
+
+function waitForAnimationFrame(window: Window): Promise<void> {
+  return new Promise((resolve) => {
+    window.requestAnimationFrame(() => resolve());
+  });
 }
 
 test("MessageRichText は **bold** を strong として render する", () => {
@@ -150,6 +192,43 @@ test("MessageRichText は GFM table を table 要素として render する", ()
   assert.match(html, /<th class="message-table-heading">置き場<\/th>/);
   assert.match(html, /<td class="message-table-cell"><code class="message-inline-code">history<\/code><\/td>/);
   assert.doesNotMatch(html, /\| --- \| --- \|/);
+});
+
+test("MessageRichText は browser 初回 render を light markdown にして後から full markdown に差し替える", async () => {
+  const dom = new JSDOM("<!doctype html><div id=\"root\"></div>", {
+    pretendToBeVisual: true,
+    url: "http://localhost/",
+  });
+  const restoreGlobals = installDomGlobals(dom);
+  const container = dom.window.document.getElementById("root");
+  let root: Root | null = null;
+
+  try {
+    assert.ok(container);
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(React.createElement(MessageRichText, {
+        text: ["| A | B |", "| --- | --- |", "| 1 | 2 |"].join("\n"),
+      }));
+    });
+
+    assert.equal(container.querySelector("[data-markdown-render-mode]")?.getAttribute("data-markdown-render-mode"), "light");
+    assert.equal(container.querySelector("table"), null);
+
+    await act(async () => {
+      await waitForAnimationFrame(dom.window);
+      await waitForAnimationFrame(dom.window);
+    });
+
+    assert.equal(container.querySelector("[data-markdown-render-mode]")?.getAttribute("data-markdown-render-mode"), "full");
+    assert.notEqual(container.querySelector("table.message-table"), null);
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    restoreGlobals();
+    dom.window.close();
+  }
 });
 
 test("MessageRichText は GFM 拡張記法を render する", () => {

--- a/src/MessageRichText.tsx
+++ b/src/MessageRichText.tsx
@@ -3,6 +3,7 @@ import ReactMarkdown, { defaultUrlTransform, type Components, type UrlTransform 
 import rehypeKatex from "rehype-katex";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
+import type { PluggableList } from "unified";
 
 import { getWithMateApi } from "./renderer-withmate-api.js";
 
@@ -11,6 +12,8 @@ type MessageRichTextProps = {
   className?: string;
   onOpenPath?: (target: string) => void;
 };
+
+type MarkdownRenderMode = "light" | "full";
 
 type MermaidRenderState =
   | { status: "pending" }
@@ -295,9 +298,63 @@ const markdownComponents: Components = {
   img: () => null,
 };
 
-function createMarkdownComponents(onOpenPath?: (target: string) => void): Components {
+function shouldDeferRichMarkdownRender(): boolean {
+  return typeof window !== "undefined";
+}
+
+function scheduleFullMarkdownRender(callback: () => void): () => void {
+  if (typeof window === "undefined") {
+    return () => undefined;
+  }
+
+  const browserWindow = window as Window & {
+    requestIdleCallback?: (callback: IdleRequestCallback, options?: IdleRequestOptions) => number;
+    cancelIdleCallback?: (handle: number) => void;
+  };
+  let canceled = false;
+  let frameId: number | null = null;
+  let idleId: number | null = null;
+  const run = () => {
+    if (!canceled) {
+      callback();
+    }
+  };
+
+  if (typeof browserWindow.requestIdleCallback === "function") {
+    idleId = browserWindow.requestIdleCallback(run, { timeout: 500 });
+  } else {
+    frameId = browserWindow.requestAnimationFrame(() => {
+      frameId = browserWindow.requestAnimationFrame(run);
+    });
+  }
+
+  return () => {
+    canceled = true;
+    if (idleId !== null && typeof browserWindow.cancelIdleCallback === "function") {
+      browserWindow.cancelIdleCallback(idleId);
+    }
+    if (frameId !== null) {
+      browserWindow.cancelAnimationFrame(frameId);
+    }
+  };
+}
+
+function createMarkdownComponents(
+  onOpenPath?: (target: string) => void,
+  options?: { enableMermaid?: boolean },
+): Components {
+  const enableMermaid = options?.enableMermaid ?? true;
   return {
     ...markdownComponents,
+    ...(enableMermaid
+      ? {}
+      : {
+          pre: ({ children, node, ...props }) => (
+            <pre {...props} className={mergeClassName("message-code-block", props.className)}>
+              {children}
+            </pre>
+          ),
+        }),
     a: ({ children, href, node, ...props }) => {
       const target = href?.trim() ?? "";
       const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
@@ -317,16 +374,49 @@ export function MessageRichText({ text, className = "message-body", onOpenPath }
   const reactId = useId();
   const footnotePrefix = useMemo(() => `message-footnote-${reactId.replace(/[^a-zA-Z0-9_-]/g, "")}-`, [reactId]);
   const footnoteLabelId = `${footnotePrefix}footnote-label`;
-  const components = useMemo(() => createMarkdownComponents(onOpenPath), [onOpenPath]);
-  const rehypePlugins = useMemo(() => [rehypeKatex, createFootnoteLabelIdPlugin(footnoteLabelId)], [footnoteLabelId]);
+  const shouldDefer = shouldDeferRichMarkdownRender();
+  const [renderState, setRenderState] = useState<{ text: string; mode: MarkdownRenderMode }>(() => ({
+    text,
+    mode: shouldDefer ? "light" : "full",
+  }));
+  const renderMode = renderState.text === text ? renderState.mode : shouldDefer ? "light" : "full";
+  const isFullRender = renderMode === "full";
+  const components = useMemo(
+    () => createMarkdownComponents(onOpenPath, { enableMermaid: isFullRender }),
+    [isFullRender, onOpenPath],
+  );
+  const rehypePlugins = useMemo<PluggableList>(
+    () => (isFullRender ? [rehypeKatex, createFootnoteLabelIdPlugin(footnoteLabelId)] : []),
+    [footnoteLabelId, isFullRender],
+  );
+  const remarkPlugins = useMemo<PluggableList>(
+    () => (isFullRender ? [remarkGfm, [remarkMath, { singleDollarTextMath: false }]] : []),
+    [isFullRender],
+  );
+
+  useEffect(() => {
+    if (!shouldDefer) {
+      setRenderState({ text, mode: "full" });
+      return;
+    }
+
+    setRenderState({ text, mode: "light" });
+    return scheduleFullMarkdownRender(() => {
+      setRenderState((current) => (
+        current.text === text
+          ? { text, mode: "full" }
+          : current
+      ));
+    });
+  }, [shouldDefer, text]);
 
   return (
-    <div className={`${className} rich-text`.trim()}>
+    <div className={`${className} rich-text`.trim()} data-markdown-render-mode={renderMode}>
       <ReactMarkdown
         components={components}
         rehypePlugins={rehypePlugins}
         urlTransform={markdownUrlTransform}
-        remarkPlugins={[remarkGfm, [remarkMath, { singleDollarTextMath: false }]]}
+        remarkPlugins={remarkPlugins}
         remarkRehypeOptions={{ clobberPrefix: footnotePrefix }}
       >
         {text}


### PR DESCRIPTION
## 概要
- MessageRichText のブラウザ初回描画を light Markdown render に変更
- idle / fallback frame 後に GFM、math、KaTeX、footnote、Mermaid 対応を含む full render へ差し替え
- browser mount test で light から full への切り替えを固定

## 背景
Codex の長い assistant message が最終 item でまとまって届く場合、全文 Markdown の parse / render が初回描画に乗り、Session UI が固まるように見えることがあったため。

## 検証
- `node --test --import tsx scripts/tests/message-rich-text.test.ts`
- `node --test --import tsx scripts/tests/session-message-column.test.ts`
- `npm run typecheck`
