### PR TITLE
Fix AuditLog modal refresh and live preview handling

### DIFF
--- a/scripts/tests/audit-log-refresh.test.ts
+++ b/scripts/tests/audit-log-refresh.test.ts
@@ -350,6 +350,25 @@ describe("buildDisplayedAuditLogs", () => {
     assert.deepEqual(result, persistedLogs);
   });
 
+  it("live run の sessionId が selected session と違う時は persisted をそのまま返す", () => {
+    const runningSession = {
+      ...selectedSession,
+      runState: "running" as const,
+    };
+    const persistedLogs = [makeAuditLog({ id: 10, sessionId: selectedSession.id, phase: "completed" })];
+
+    const result = buildDisplayedAuditLogs({
+      selectedSession: runningSession,
+      persistedEntries: persistedLogs,
+      liveRun: makeLiveRun({
+        sessionId: "other-session",
+        assistantText: "別 session の progress",
+      }),
+    });
+
+    assert.deepEqual(result, persistedLogs);
+  });
+
   it("session.runState が running で、先頭が terminal persisted の時は synthetic running row を先頭へ挿入する (新 run 対応)", () => {
     const runningSession = {
       ...selectedSession,
@@ -373,6 +392,7 @@ describe("buildDisplayedAuditLogs", () => {
     assert.equal(result[0]?.phase, "running");
     assert.equal(result[0]?.assistantText, "新しい run の progress");
     assert.equal(result[0]?.threadId, "thread-new-run");
+    assert.equal(result[0]?.detailAvailable, false);
     assert.equal(result[1]?.id, 10);
     assert.equal(result[1]?.phase, "completed");
   });

--- a/scripts/tests/session-audit-log-modal.test.ts
+++ b/scripts/tests/session-audit-log-modal.test.ts
@@ -6,7 +6,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { SessionAuditLogModal, shouldLoadAuditLogDetailForFold } from "../../src/session-components.js";
 import type { AuditLogSummary } from "../../src/runtime-state.js";
 
-function createAuditLogSummary(id: number): AuditLogSummary {
+function createAuditLogSummary(id: number, overrides?: Partial<AuditLogSummary>): AuditLogSummary {
   return {
     id,
     sessionId: "session-1",
@@ -22,6 +22,7 @@ function createAuditLogSummary(id: number): AuditLogSummary {
     usage: { inputTokens: id, cachedInputTokens: 0, outputTokens: id + 1 },
     errorMessage: "",
     detailAvailable: true,
+    ...overrides,
   };
 }
 
@@ -124,5 +125,38 @@ describe("SessionAuditLogModal", () => {
       html.indexOf("DONE") < html.indexOf("Main Session"),
       "source tag は phase label の後に描画する",
     );
+  });
+
+  it("detail unavailable entry は live preview として描画し、保存済み detail fold を出さない", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(SessionAuditLogModal, {
+        open: true,
+        entries: [
+          createAuditLogSummary(1, {
+            id: -1,
+            phase: "running",
+            assistantTextPreview: "streaming response",
+            operations: [{ type: "command_execution", summary: "npm test", details: "running" }],
+            detailAvailable: false,
+          }),
+        ],
+        details: {},
+        operationDetails: {},
+        hasMore: false,
+        loadingMore: false,
+        total: 1,
+        errorMessage: null,
+        onLoadMore() {},
+        onLoadDetail() {},
+        onLoadOperationDetail() {},
+        onClose() {},
+      }),
+    );
+
+    assert.match(html, /Live preview only/);
+    assert.match(html, /streaming response/);
+    assert.match(html, /npm test/);
+    assert.doesNotMatch(html, /Logical Prompt/);
+    assert.doesNotMatch(html, /Raw Items/);
   });
 });

--- a/scripts/tests/session-audit-log-state.test.tsx
+++ b/scripts/tests/session-audit-log-state.test.tsx
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { JSDOM } from "jsdom";
+import React, { act, useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import { buildNewSession } from "../../src/app-state.js";
+import { useSessionAuditLogs } from "../../src/session-audit-log-state.js";
+import type { AuditLogSummary } from "../../src/runtime-state.js";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function createAuditLogSummary(id: number): AuditLogSummary {
+  return {
+    id,
+    sessionId: "session-1",
+    createdAt: `2026-04-29T00:${String(id).padStart(2, "0")}:00.000Z`,
+    phase: "completed",
+    provider: "codex",
+    model: "gpt-5.4-mini",
+    reasoningEffort: "medium",
+    approvalMode: "never",
+    threadId: `thread-${id}`,
+    assistantTextPreview: `preview ${id}`,
+    operations: [],
+    usage: null,
+    errorMessage: "",
+    detailAvailable: true,
+  };
+}
+
+describe("useSessionAuditLogs", () => {
+  it("AuditLog modal open 時に summary を再取得する", async () => {
+    const dom = new JSDOM("<!doctype html><html><body><div id=\"root\"></div></body></html>", {
+      pretendToBeVisual: true,
+    });
+    const previousWindow = globalThis.window;
+    const previousDocument = globalThis.document;
+    const previousHTMLElement = globalThis.HTMLElement;
+    const previousNode = globalThis.Node;
+    const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+    const previousCancelAnimationFrame = globalThis.cancelAnimationFrame;
+
+    Object.defineProperty(globalThis, "window", { configurable: true, value: dom.window });
+    Object.defineProperty(globalThis, "document", { configurable: true, value: dom.window.document });
+    Object.defineProperty(globalThis, "HTMLElement", { configurable: true, value: dom.window.HTMLElement });
+    Object.defineProperty(globalThis, "Node", { configurable: true, value: dom.window.Node });
+    Object.defineProperty(globalThis, "requestAnimationFrame", {
+      configurable: true,
+      value: dom.window.requestAnimationFrame.bind(dom.window),
+    });
+    Object.defineProperty(globalThis, "cancelAnimationFrame", {
+      configurable: true,
+      value: dom.window.cancelAnimationFrame.bind(dom.window),
+    });
+
+    const session = {
+      ...buildNewSession({
+        taskTitle: "AuditLog",
+        workspaceLabel: "repo",
+        workspacePath: "/repo",
+        branch: "main",
+        characterId: "character-1",
+        character: "WithMate",
+        characterIconPath: "",
+        characterThemeColors: {
+          main: "#000000",
+          sub: "#ffffff",
+        },
+        approvalMode: "untrusted",
+      }),
+      id: "session-1",
+    };
+
+    const calls: Array<{ sessionId: string; cursor: number; limit: number }> = [];
+    const auditLogApi = {
+      async listSessionAuditLogSummaryPage(sessionId: string, page: { cursor: number; limit: number }) {
+        calls.push({ sessionId, cursor: page.cursor, limit: page.limit });
+        return {
+          entries: [createAuditLogSummary(calls.length)],
+          nextCursor: null,
+          hasMore: false,
+          total: 1,
+        };
+      },
+      async getSessionAuditLogDetailSection() {
+        return null;
+      },
+      async getSessionAuditLogOperationDetail() {
+        return null;
+      },
+    };
+    let openAuditLogs: (() => void) | null = null;
+    let root: Root | null = null;
+
+    function Harness() {
+      const auditLogs = useSessionAuditLogs({
+        withmateApi: null,
+        selectedSession: session,
+        liveRun: null,
+        auditLogApi,
+      });
+
+      useEffect(() => {
+        openAuditLogs = () => auditLogs.setAuditLogsOpen(true);
+      }, [auditLogs]);
+
+      return React.createElement("div");
+    }
+
+    try {
+      await act(async () => {
+        root = createRoot(dom.window.document.getElementById("root") as HTMLElement);
+        root.render(React.createElement(Harness));
+      });
+
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0]?.sessionId, "session-1");
+
+      await act(async () => {
+        openAuditLogs?.();
+      });
+
+      assert.equal(calls.length, 2);
+      assert.deepEqual(calls.map((call) => call.cursor), [0, 0]);
+    } finally {
+      await act(async () => root?.unmount());
+      Object.defineProperty(globalThis, "window", { configurable: true, value: previousWindow });
+      Object.defineProperty(globalThis, "document", { configurable: true, value: previousDocument });
+      Object.defineProperty(globalThis, "HTMLElement", { configurable: true, value: previousHTMLElement });
+      Object.defineProperty(globalThis, "Node", { configurable: true, value: previousNode });
+      Object.defineProperty(globalThis, "requestAnimationFrame", {
+        configurable: true,
+        value: previousRequestAnimationFrame,
+      });
+      Object.defineProperty(globalThis, "cancelAnimationFrame", {
+        configurable: true,
+        value: previousCancelAnimationFrame,
+      });
+      dom.window.close();
+    }
+  });
+});

--- a/scripts/tests/session-audit-log-state.test.tsx
+++ b/scripts/tests/session-audit-log-state.test.tsx
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { JSDOM } from "jsdom";
-import React, { act, useEffect } from "react";
+import React, { act, useEffect, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
 
 import { buildNewSession } from "../../src/app-state.js";
@@ -91,18 +91,21 @@ describe("useSessionAuditLogs", () => {
       },
     };
     let openAuditLogs: (() => void) | null = null;
+    let replaceSessionWithSameId: (() => void) | null = null;
     let root: Root | null = null;
 
     function Harness() {
+      const [currentSession, setCurrentSession] = useState(session);
       const auditLogs = useSessionAuditLogs({
         withmateApi: null,
-        selectedSession: session,
+        selectedSession: currentSession,
         liveRun: null,
         auditLogApi,
       });
 
       useEffect(() => {
         openAuditLogs = () => auditLogs.setAuditLogsOpen(true);
+        replaceSessionWithSameId = () => setCurrentSession((current) => ({ ...current }));
       }, [auditLogs]);
 
       return React.createElement("div");
@@ -123,6 +126,12 @@ describe("useSessionAuditLogs", () => {
 
       assert.equal(calls.length, 2);
       assert.deepEqual(calls.map((call) => call.cursor), [0, 0]);
+
+      await act(async () => {
+        replaceSessionWithSameId?.();
+      });
+
+      assert.equal(calls.length, 2);
     } finally {
       await act(async () => root?.unmount());
       Object.defineProperty(globalThis, "window", { configurable: true, value: previousWindow });

--- a/src/audit-log-refresh.ts
+++ b/src/audit-log-refresh.ts
@@ -136,7 +136,7 @@ export function buildDisplayedAuditLogs(input: BuildDisplayedAuditLogsInput): Au
     return input.persistedEntries.map(suppressIncompleteRunningDetail);
   }
 
-  if (input.selectedSession?.runState !== "running") {
+  if (input.selectedSession?.runState !== "running" || liveRun.sessionId !== input.selectedSession.id) {
     return input.persistedEntries.map(suppressIncompleteRunningDetail);
   }
 

--- a/src/session-audit-log-state.ts
+++ b/src/session-audit-log-state.ts
@@ -196,7 +196,7 @@ export function useSessionAuditLogs({
   const refreshAuditLogSummary = useCallback((reason: "signature" | "modal-open") => {
     let active = true;
 
-    if (!enabled || !auditLogApi || !selectedSession) {
+    if (!enabled || !auditLogApi || !selectedSessionId) {
       setAuditLogsState(createEmptyAuditLogsState(null));
       setAuditLogDetails({});
       setAuditLogOperationDetails({});
@@ -206,7 +206,7 @@ export function useSessionAuditLogs({
       };
     }
 
-    const ownerSessionId = selectedSession.id;
+    const ownerSessionId = selectedSessionId;
     setAuditLogsState((current) =>
       current.ownerSessionId === ownerSessionId
         ? { ...current, loading: true, errorMessage: null }
@@ -282,7 +282,7 @@ export function useSessionAuditLogs({
     return () => {
       active = false;
     };
-  }, [auditLogApi, enabled, selectedSession, withmateApi]);
+  }, [auditLogApi, enabled, selectedSessionId, withmateApi]);
 
   useEffect(() => {
     return refreshAuditLogSummary("signature");

--- a/src/session-audit-log-state.ts
+++ b/src/session-audit-log-state.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type {
   AuditLogDetailFragment,
@@ -193,7 +193,7 @@ export function useSessionAuditLogs({
     [selectedSession],
   );
 
-  useEffect(() => {
+  const refreshAuditLogSummary = useCallback((reason: "signature" | "modal-open") => {
     let active = true;
 
     if (!enabled || !auditLogApi || !selectedSession) {
@@ -206,24 +206,35 @@ export function useSessionAuditLogs({
       };
     }
 
+    const ownerSessionId = selectedSession.id;
     setAuditLogsState((current) =>
-      current.ownerSessionId === selectedSession.id
+      current.ownerSessionId === ownerSessionId
         ? { ...current, loading: true, errorMessage: null }
-        : { ...createEmptyAuditLogsState(selectedSession.id), loading: true },
+        : { ...createEmptyAuditLogsState(ownerSessionId), loading: true },
     );
-    if (auditLogDetailOwnerRef.current !== selectedSession.id) {
+    if (auditLogDetailOwnerRef.current !== ownerSessionId) {
       setAuditLogDetails({});
       setAuditLogOperationDetails({});
-      auditLogDetailOwnerRef.current = selectedSession.id;
+      auditLogDetailOwnerRef.current = ownerSessionId;
     }
-    void auditLogApi.listSessionAuditLogSummaryPage(selectedSession.id, {
+
+    reportAuditLogDetailLog(withmateApi, {
+      kind: "audit-log.summary.load-started",
+      message: "Audit log summary load started",
+      data: {
+        reason,
+        selectedSessionId: ownerSessionId,
+      },
+    });
+
+    void auditLogApi.listSessionAuditLogSummaryPage(ownerSessionId, {
       cursor: 0,
       limit: AUDIT_LOG_PAGE_LIMIT,
     }).then(
       (page) => {
         if (active) {
           setAuditLogsState({
-            ownerSessionId: selectedSession.id,
+            ownerSessionId,
             entries: page.entries,
             nextCursor: page.nextCursor,
             hasMore: page.hasMore,
@@ -231,16 +242,39 @@ export function useSessionAuditLogs({
             loading: false,
             errorMessage: null,
           });
+          reportAuditLogDetailLog(withmateApi, {
+            kind: "audit-log.summary.ipc-completed",
+            message: "Audit log summary IPC completed",
+            data: {
+              reason,
+              selectedSessionId: ownerSessionId,
+              returnedEntryIds: page.entries.map((entry) => entry.id),
+              total: page.total,
+              hasMore: page.hasMore,
+            },
+          });
         }
       },
       (error: unknown) => {
         if (active) {
           setAuditLogsState((current) => ({
             ...current,
-            ownerSessionId: selectedSession.id,
+            ownerSessionId,
             loading: false,
             errorMessage: error instanceof Error ? error.message : "audit log summary の取得に失敗したよ。",
           }));
+          reportAuditLogDetailLog(withmateApi, {
+            level: "error",
+            kind: "audit-log.summary.ipc-failed",
+            message: "Audit log summary IPC failed",
+            data: {
+              reason,
+              selectedSessionId: ownerSessionId,
+            },
+            error: error instanceof Error
+              ? { name: error.name, message: error.message, stack: error.stack }
+              : { message: "audit log summary IPC failed" },
+          });
         }
       },
     );
@@ -248,7 +282,19 @@ export function useSessionAuditLogs({
     return () => {
       active = false;
     };
-  }, [auditLogApi, enabled, refreshSignature, selectedSessionId]);
+  }, [auditLogApi, enabled, selectedSession, withmateApi]);
+
+  useEffect(() => {
+    return refreshAuditLogSummary("signature");
+  }, [refreshAuditLogSummary, refreshSignature, selectedSessionId]);
+
+  useEffect(() => {
+    if (!auditLogsOpen) {
+      return;
+    }
+
+    return refreshAuditLogSummary("modal-open");
+  }, [auditLogsOpen, refreshAuditLogSummary]);
 
   useEffect(() => {
     if (!auditLogsOpen) {

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -1048,9 +1048,11 @@ export function SessionAuditLogModal({
               const logicalSystemOpen = Boolean(openAuditLogFolds[auditLogLogicalPromptFieldFoldKey(entry, "system")]);
               const logicalInputOpen = Boolean(openAuditLogFolds[auditLogLogicalPromptFieldFoldKey(entry, "input")]);
               const logicalComposedOpen = Boolean(openAuditLogFolds[auditLogLogicalPromptFieldFoldKey(entry, "composed")]);
-              const displayedOperations = operationsOpen
-                ? operations.slice(0, AUDIT_LOG_OPERATION_RENDER_LIMIT)
-                : [];
+              const displayedOperations = entry.detailAvailable
+                ? operationsOpen
+                  ? operations.slice(0, AUDIT_LOG_OPERATION_RENDER_LIMIT)
+                  : []
+                : operations.slice(0, AUDIT_LOG_OPERATION_RENDER_LIMIT);
               const hiddenOperationCount = Math.max(0, operations.length - displayedOperations.length);
 
               return (
@@ -1078,6 +1080,43 @@ export function SessionAuditLogModal({
                   <span>{displayApprovalValue(entry.approvalMode)}</span>
                 </div>
 
+                {!entry.detailAvailable ? (
+                  <section className="audit-log-section audit-log-live-preview" aria-label="Live preview">
+                    <p className="audit-log-empty">
+                      Live preview only. Persisted audit log detail is not available yet.
+                    </p>
+                    {assistantText ? (
+                      <pre>{previewAuditLogText(assistantText)}</pre>
+                    ) : null}
+                    {operations.length > 0 ? (
+                      <ul className="audit-log-operations">
+                        {displayedOperations.map((operation, index) => (
+                          <li key={`${entry.id}-${operation.type}-${index}`}>
+                            <div className="audit-log-operation-head">
+                              <span>{operation.type}</span>
+                              <strong>{operation.summary}</strong>
+                            </div>
+                            {operation.details ? <pre>{previewAuditLogText(operation.details)}</pre> : null}
+                          </li>
+                        ))}
+                        {hiddenOperationCount > 0 ? (
+                          <li className="audit-log-operation-more">
+                            {hiddenOperationCount} more operations hidden for performance
+                          </li>
+                        ) : null}
+                      </ul>
+                    ) : null}
+                    {usage ? (
+                      <div className="audit-log-meta">
+                        <span>input {usage.inputTokens}</span>
+                        <span>cached {usage.cachedInputTokens}</span>
+                        <span>output {usage.outputTokens}</span>
+                      </div>
+                    ) : null}
+                    {errorMessage ? <pre>{previewAuditLogText(errorMessage)}</pre> : null}
+                  </section>
+                ) : (
+                  <>
                 <details
                   className="audit-log-fold"
                   open={logicalOpen}
@@ -1308,6 +1347,8 @@ export function SessionAuditLogModal({
                     <pre>{previewAuditLogText(detail?.rawItemsJson ?? (sectionLoading("raw") ? "loading..." : sectionError("raw") ?? "[]"))}</pre>
                   ) : null}
                 </details>
+                  </>
+                )}
                 </article>
               );
                 })}


### PR DESCRIPTION
## Summary

- Refresh Session AuditLog summaries when the AuditLog modal opens so persisted rows can recover after an early empty fetch.
- Ignore live run state whose `sessionId` does not match the selected session.
- Render detail-unavailable synthetic running rows as live preview only, without persisted detail folds.
- Add regression coverage for displayed AuditLog merging, modal rendering, and modal-open summary refresh.

## Validation

- `npm exec -- tsx --test scripts/tests/audit-log-refresh.test.ts scripts/tests/session-audit-log-modal.test.ts scripts/tests/session-audit-log-state.test.tsx`
- `npm run typecheck`
- `npm test`