### PR TITLE
docs: Memory Skill の Windows 向け CLI 例を更新

### DIFF
--- a/docs/design/v6-memory-foundation.md
+++ b/docs/design/v6-memory-foundation.md
@@ -591,6 +591,7 @@ withmate-memory search --file payload.json
 ```
 
 `--json`と`--file`はrequest bodyの入力方法であり、output format指定ではない。CLI outputは常にJSONをstdoutへ出す。
+Windows PowerShell / `.cmd` wrapper経由ではinline JSONのquoteが壊れやすいため、request bodyを渡すcommandでは`--file <path>`を推奨する。
 API errorもtransportできた場合はruntime APIのJSON responseをそのままstdoutへ出す。
 CLI request timeoutは10秒を既定とし、discovery endpointへ接続できない、または応答が戻らない場合は`WITHMATE_NOT_RUNNING`として扱う。
 CLI fetchはHTTP redirectを追従しない。初期URLがloopbackでも、POST bodyを別endpointへ転送しないためにredirectは接続失敗と同じ扱いにする。

--- a/resources/skills/withmate-memory/SKILL.md
+++ b/resources/skills/withmate-memory/SKILL.md
@@ -57,16 +57,39 @@ Run the installed command from the target project directory:
 ```bash
 withmate-memory status
 withmate-memory context
-withmate-memory search --json '{"schemaVersion":"withmate-memory-v1","targets":[{"owner":"project","project":{"type":"path","path":"."},"scope":"project"}],"query":"release workflow"}'
-withmate-memory get-entry --json '{"schemaVersion":"withmate-memory-v1","entryId":"<entry-id>","target":{"owner":"project","project":{"type":"path","path":"."},"scope":"project"}}'
-withmate-memory list-tags --json '{"schemaVersion":"withmate-memory-v1","targets":[{"owner":"project","project":{"type":"path","path":"."},"scope":"project"}]}'
+withmate-memory search --file memory-search.json
+withmate-memory get-entry --file memory-get-entry.json
+withmate-memory list-tags --file memory-list-tags.json
 withmate-memory append --file memory-entry.json
 withmate-memory forget --file forget-request.json
 ```
 
 Commands write one JSON object to stdout.
 
+For commands that require a request body, prefer `--file <path>`. Inline `--json` is supported, but it is shell-sensitive. On Windows PowerShell or `.cmd` wrappers, double quotes inside JSON can be consumed before the CLI receives the argument. If `--json` fails with invalid JSON or a CLI usage error, write the request to a temporary JSON file and retry with `--file`.
+
 If `withmate-memory` is not found and `bin/withmate-memory.mjs` exists in this skill directory, replace `withmate-memory` with `node bin/withmate-memory.mjs` in the commands above.
+
+PowerShell example:
+
+```powershell
+$request = @{
+  schemaVersion = "withmate-memory-v1"
+  targets = @(
+    @{
+      owner = "project"
+      project = @{ type = "path"; path = "." }
+      scope = "project"
+    }
+  )
+  query = "release workflow"
+} | ConvertTo-Json -Depth 10
+
+$requestPath = Join-Path $env:TEMP "withmate-memory-search.json"
+Set-Content -LiteralPath $requestPath -Value $request -Encoding utf8
+withmate-memory search --file $requestPath
+Remove-Item -LiteralPath $requestPath -Force
+```
 
 ### Request Shapes
 

--- a/resources/skills/withmate-memory/reference/cli.md
+++ b/resources/skills/withmate-memory/reference/cli.md
@@ -9,6 +9,8 @@ Run it from the target project directory after WithMate is installed:
 withmate-memory <command> [--json <json> | --file <path>]
 ```
 
+For commands that require a request body, prefer `--file <path>`. Inline `--json` is supported, but it is shell-sensitive. On Windows PowerShell or `.cmd` wrappers, double quotes inside JSON can be consumed before the CLI receives the argument. If `--json` fails with invalid JSON or a CLI usage error, write the request to a temporary JSON file and retry with `--file`.
+
 On Windows, the installer places `withmate-memory.cmd` in the WithMate install directory and creates a user-level alias at `%LOCALAPPDATA%\Microsoft\WindowsApps\withmate-memory.cmd`. It does not edit the user's `Path` registry value. A new terminal may be required after install or uninstall.
 
 When a managed skill includes `bin/withmate-memory.mjs` and no `withmate-memory` command is available on `PATH`, use `node bin/withmate-memory.mjs <command>` as a temporary fallback.
@@ -38,7 +40,7 @@ Sends:
 ### search
 
 ```bash
-withmate-memory search --json '{"schemaVersion":"withmate-memory-v1","targets":[{"owner":"project","project":{"type":"path","path":"."},"scope":"project"}],"query":"approval mode"}'
+withmate-memory search --file memory-search.json
 ```
 
 Request shape:
@@ -58,7 +60,7 @@ Search returns active entry previews only. Use `get-entry` when the exact body m
 ### get-entry
 
 ```bash
-withmate-memory get-entry --json '{"schemaVersion":"withmate-memory-v1","entryId":"<entry-id>","target":{"owner":"project","project":{"type":"path","path":"."},"scope":"project"}}'
+withmate-memory get-entry --file memory-get-entry.json
 ```
 
 Request shape:
@@ -76,7 +78,7 @@ External Codex or shell sessions must include `target`. WithMate-launched sessio
 ### list-tags
 
 ```bash
-withmate-memory list-tags --json '{"schemaVersion":"withmate-memory-v1","targets":[{"owner":"project","project":{"type":"path","path":"."},"scope":"project"}]}'
+withmate-memory list-tags --file memory-list-tags.json
 ```
 
 Request shape:


### PR DESCRIPTION
## Summary
- TASK-148: withmate-memory Skill の request body 例を `--file` 既定へ更新
- Windows PowerShell / `.cmd` wrapper で inline `--json` が壊れやすい点と、`--file` fallback を明記
- CLI 本体側の `--stdin` / `@file` / error hint 改善は TASK-149 側へ分離

## Validation
- `withmate-memory search --file <temp-json>`
- `withmate-memory list-tags --file <temp-json>`
- `rg -n -- "--file memory-search.json|--file memory-list-tags.json|PowerShell example|Inline `--json`|invalid JSON" resources/skills/withmate-memory/SKILL.md resources/skills/withmate-memory/reference/cli.md`
- `npm exec -- tsx --test scripts/tests/managed-memory-skill-service.test.ts`