### PR TITLE
feat: Memory CLI の入力経路を拡張

### DIFF
--- a/docs/design/v6-memory-foundation.md
+++ b/docs/design/v6-memory-foundation.md
@@ -582,16 +582,21 @@ current raw JSON CLI:
 ```text
 withmate-memory status
 withmate-memory context
+withmate-memory schema
+withmate-memory validate --command append --stdin
 withmate-memory search --json '<MemorySearchRequest>'
 withmate-memory get-entry --json '<MemoryGetEntryRequest>'
 withmate-memory list-tags --json '<MemoryListTagsRequest>'
 withmate-memory append --json '<MemoryAppendRequest>'
 withmate-memory forget --json '<MemoryForgetRequest>'
 withmate-memory search --file payload.json
+withmate-memory search @payload.json
+withmate-memory search --project ../repo-a --query "approval modeの方針"
 ```
 
-`--json`と`--file`はrequest bodyの入力方法であり、output format指定ではない。CLI outputは常にJSONをstdoutへ出す。
-Windows PowerShell / `.cmd` wrapper経由ではinline JSONのquoteが壊れやすいため、request bodyを渡すcommandでは`--file <path>`を推奨する。
+`--json`、`--file`、`@file`、`--stdin`はrequest bodyの入力方法であり、output format指定ではない。CLI outputは常にJSONをstdoutへ出す。
+Windows PowerShell / `.cmd` wrapper経由ではinline JSONのquoteが壊れやすいため、request bodyを渡すcommandでは`--stdin`または`--file <path>`を推奨する。
+`schema`と`validate`はruntime APIへ接続せずにCLI process内で完結する。`validate`はMemory entryを作成、更新、forgetしない。
 API errorもtransportできた場合はruntime APIのJSON responseをそのままstdoutへ出す。
 CLI request timeoutは10秒を既定とし、discovery endpointへ接続できない、または応答が戻らない場合は`WITHMATE_NOT_RUNNING`として扱う。
 CLI fetchはHTTP redirectを追従しない。初期URLがloopbackでも、POST bodyを別endpointへ転送しないためにredirectは接続失敗と同じ扱いにする。
@@ -605,17 +610,16 @@ stable exit codeは次とする。
 | `3` | runtime APIがnon-2xx JSON responseを返した |
 | `4` | transport failure |
 
-future helper flags:
+current convenience flags:
 
 ```text
-withmate-memory search --project ../repo-a --query "approval modeの方針" --json
-withmate-memory search --project-id <project-id> --query "approval modeの方針" --json
-withmate-memory search --character current --query "呼び方の好み" --json
-withmate-memory get --id <entry-id> --json
-withmate-memory tags --project ../repo-a --json
-withmate-memory append --project ../repo-a --input <payload.json> --json
-withmate-memory forget --input <payload.json> --json
+withmate-memory search --project ../repo-a --query "approval modeの方針"
+withmate-memory search --project-id <project-id> --query "approval modeの方針"
+withmate-memory get-entry --project ../repo-a --entry-id <entry-id>
+withmate-memory list-tags --project ../repo-a
 ```
+
+create / update / supersede系の複雑なrequestをすべてCLI flagsへ展開することは目指さない。write系の構造化requestは`--stdin`または`--file`を正本とする。
 
 ### Runtime Binding
 

--- a/resources/skills/withmate-memory/SKILL.md
+++ b/resources/skills/withmate-memory/SKILL.md
@@ -57,6 +57,9 @@ Run the installed command from the target project directory:
 ```bash
 withmate-memory status
 withmate-memory context
+withmate-memory schema
+withmate-memory validate --command append --stdin
+withmate-memory search --project . --query "release workflow"
 withmate-memory search --file memory-search.json
 withmate-memory get-entry --file memory-get-entry.json
 withmate-memory list-tags --file memory-list-tags.json
@@ -66,7 +69,7 @@ withmate-memory forget --file forget-request.json
 
 Commands write one JSON object to stdout.
 
-For commands that require a request body, prefer `--file <path>`. Inline `--json` is supported, but it is shell-sensitive. On Windows PowerShell or `.cmd` wrappers, double quotes inside JSON can be consumed before the CLI receives the argument. If `--json` fails with invalid JSON or a CLI usage error, write the request to a temporary JSON file and retry with `--file`.
+For commands that require a request body, prefer `--stdin` or `--file <path>`. Inline `--json` is supported, but it is shell-sensitive. On Windows PowerShell or `.cmd` wrappers, double quotes inside JSON can be consumed before the CLI receives the argument. If `--json` fails with invalid JSON or a CLI usage error, pipe the request through `--stdin`, or write it to a temporary JSON file and retry with `--file`.
 
 If `withmate-memory` is not found and `bin/withmate-memory.mjs` exists in this skill directory, replace `withmate-memory` with `node bin/withmate-memory.mjs` in the commands above.
 
@@ -85,15 +88,20 @@ $request = @{
   query = "release workflow"
 } | ConvertTo-Json -Depth 10
 
-$requestPath = Join-Path $env:TEMP "withmate-memory-search.json"
-Set-Content -LiteralPath $requestPath -Value $request -Encoding utf8
-withmate-memory search --file $requestPath
-Remove-Item -LiteralPath $requestPath -Force
+$request | withmate-memory search --stdin
 ```
 
 ### Request Shapes
 
 `status` does not require a request body.
+
+`schema` does not require a request body and returns supported commands, request body input modes, memory entry kinds, and forget reasons.
+
+`validate` validates a request body locally without writing Memory:
+
+```bash
+withmate-memory validate --command append --stdin
+```
 
 `context` sends this default body when no JSON is supplied:
 

--- a/resources/skills/withmate-memory/bin/withmate-memory.mjs
+++ b/resources/skills/withmate-memory/bin/withmate-memory.mjs
@@ -10,6 +10,18 @@ const discoveryFileName = "memory-v6-api.json";
 const apiSecretHeader = "x-withmate-memory-api-secret";
 const bindingReferenceHeader = "x-withmate-memory-binding-reference";
 const bindingReferenceEnv = "WITHMATE_MEMORY_BINDING_REFERENCE";
+const entryKinds = [
+  "decision",
+  "constraint",
+  "convention",
+  "context",
+  "deferred",
+  "preference",
+  "relationship",
+  "boundary",
+  "note",
+];
+const forgetReasons = ["user_request", "incorrect", "outdated", "privacy", "other"];
 
 const exitCodes = {
   ok: 0,
@@ -20,17 +32,21 @@ const exitCodes = {
 };
 
 const commands = new Map([
-  ["status", { method: "GET", path: "/v1/status", defaultBody: {} }],
-  ["context", { method: "POST", path: "/v1/context", defaultBody: { schemaVersion } }],
-  ["resolve-context", { method: "POST", path: "/v1/context", defaultBody: { schemaVersion } }],
-  ["search", { method: "POST", path: "/v1/search", defaultBody: {} }],
-  ["get-entry", { method: "POST", path: "/v1/get_entry", defaultBody: {} }],
-  ["get_entry", { method: "POST", path: "/v1/get_entry", defaultBody: {} }],
-  ["list-tags", { method: "POST", path: "/v1/list_tags", defaultBody: {} }],
-  ["list_tags", { method: "POST", path: "/v1/list_tags", defaultBody: {} }],
-  ["append", { method: "POST", path: "/v1/append", defaultBody: {} }],
-  ["forget", { method: "POST", path: "/v1/forget", defaultBody: {} }],
+  ["status", { name: "status", method: "GET", path: "/v1/status", defaultBody: {} }],
+  ["context", { name: "context", method: "POST", path: "/v1/context", defaultBody: { schemaVersion } }],
+  ["resolve-context", { name: "context", method: "POST", path: "/v1/context", defaultBody: { schemaVersion } }],
+  ["search", { name: "search", method: "POST", path: "/v1/search", defaultBody: {} }],
+  ["get-entry", { name: "get_entry", method: "POST", path: "/v1/get_entry", defaultBody: {} }],
+  ["get_entry", { name: "get_entry", method: "POST", path: "/v1/get_entry", defaultBody: {} }],
+  ["list-tags", { name: "list_tags", method: "POST", path: "/v1/list_tags", defaultBody: {} }],
+  ["list_tags", { name: "list_tags", method: "POST", path: "/v1/list_tags", defaultBody: {} }],
+  ["append", { name: "append", method: "POST", path: "/v1/append", defaultBody: {} }],
+  ["forget", { name: "forget", method: "POST", path: "/v1/forget", defaultBody: {} }],
+  ["schema", { name: "schema", local: true, defaultBody: {} }],
+  ["capabilities", { name: "schema", local: true, defaultBody: {} }],
+  ["validate", { name: "validate", local: true, defaultBody: {} }],
 ]);
+const validatableCommands = new Set(["context", "search", "get_entry", "list_tags", "append", "forget"]);
 
 function memoryError(code, message) {
   return { schemaVersion, error: { code, message } };
@@ -119,40 +135,147 @@ async function parseArgs(argv) {
   const [rawCommand, ...rest] = argv;
   const route = rawCommand ? commands.get(rawCommand) : undefined;
   if (!route) {
-    throw usage("Usage: withmate-memory <status|context|search|get-entry|list-tags|append|forget> [--json <json> | --file <path>] [--api-url <url>] [--discovery-file <path>]");
+    throw usage("Usage: withmate-memory <status|context|search|get-entry|list-tags|append|forget|schema|validate> [--json <json> | --file <path> | --stdin] [--api-url <url>] [--discovery-file <path>]");
   }
 
   let jsonInput = null;
   let filePath = null;
+  let stdinRequested = false;
   let apiUrl;
   let discoveryFilePath;
+  let validateCommand;
+  let projectPath;
+  let projectId;
+  let query;
+  let entryId;
+  let limit;
   for (let index = 0; index < rest.length; index += 1) {
     const arg = rest[index];
     if (arg === "--json") {
       jsonInput = requireOptionValue(rest, ++index, arg);
     } else if (arg === "--file") {
       filePath = requireOptionValue(rest, ++index, arg);
+    } else if (arg === "--stdin") {
+      stdinRequested = true;
+    } else if (arg.startsWith("@") && arg.length > 1) {
+      filePath = arg.slice(1);
     } else if (arg === "--api-url") {
       apiUrl = requireOptionValue(rest, ++index, arg);
     } else if (arg === "--discovery-file") {
       discoveryFilePath = requireOptionValue(rest, ++index, arg);
+    } else if (arg === "--command") {
+      validateCommand = normalizeValidatableCommand(requireOptionValue(rest, ++index, arg));
+      if (!validateCommand) {
+        throw usage(`--command must be one of: ${Array.from(validatableCommands).join(", ")}.`);
+      }
+    } else if (arg === "--project") {
+      projectPath = requireOptionValue(rest, ++index, arg);
+    } else if (arg === "--project-id") {
+      projectId = requireOptionValue(rest, ++index, arg);
+    } else if (arg === "--query") {
+      query = requireOptionValue(rest, ++index, arg);
+    } else if (arg === "--entry-id") {
+      entryId = requireOptionValue(rest, ++index, arg);
+    } else if (arg === "--limit") {
+      limit = parseLimit(requireOptionValue(rest, ++index, arg));
     } else {
       throw usage(`Unknown option: ${arg}`);
     }
   }
-  if (jsonInput !== null && filePath !== null) {
-    throw usage("--json and --file cannot be used together.");
+  const bodyInputCount = [jsonInput !== null, filePath !== null, stdinRequested].filter(Boolean).length;
+  if (bodyInputCount > 1) {
+    throw usage("--json, --file, @file, and --stdin cannot be used together.");
+  }
+  if (projectPath && projectId) {
+    throw usage("--project and --project-id cannot be used together.");
+  }
+  if (route.name === "validate" && !validateCommand) {
+    throw usage("validate requires --command <context|search|get-entry|list-tags|append|forget>.");
   }
 
   let body = route.defaultBody;
-  if (route.method === "POST") {
+  if (route.method === "POST" || route.name === "validate") {
     if (jsonInput !== null) {
       body = parseJson(jsonInput);
     } else if (filePath !== null) {
       body = parseJson(await readFile(filePath, "utf8"));
+    } else if (stdinRequested) {
+      body = parseJson(await readStdin(process.stdin));
+    } else if (hasShorthandOptions({ projectPath, projectId, query, entryId, limit })) {
+      body = buildShorthandBody(route.name, { projectPath, projectId, query, entryId, limit });
     }
   }
-  return { route, body, apiUrl, discoveryFilePath };
+  return { route, body, apiUrl, discoveryFilePath, validateCommand };
+}
+
+function normalizeValidatableCommand(value) {
+  const command = commands.get(value)?.name;
+  return validatableCommands.has(command) ? command : undefined;
+}
+
+function parseLimit(value) {
+  const limit = Number(value);
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw usage("--limit must be a positive integer.");
+  }
+  return limit;
+}
+
+function hasShorthandOptions(options) {
+  return Boolean(options.projectPath || options.projectId || options.query || options.entryId || options.limit !== undefined);
+}
+
+function buildProjectTarget(options) {
+  if (options.projectId) {
+    return { owner: "project", scope: "project", project: { type: "id", id: options.projectId } };
+  }
+  if (options.projectPath) {
+    return { owner: "project", scope: "project", project: { type: "path", path: options.projectPath } };
+  }
+  return null;
+}
+
+function buildShorthandBody(command, options) {
+  const target = buildProjectTarget(options);
+  if (command === "search") {
+    if (!target) {
+      throw usage("search shorthand requires --project <path> or --project-id <id>.");
+    }
+    if (!options.query) {
+      throw usage("search shorthand requires --query <text>.");
+    }
+    return {
+      schemaVersion,
+      targets: [target],
+      query: options.query,
+      ...(options.limit !== undefined ? { limit: options.limit } : {}),
+    };
+  }
+  if (command === "list_tags") {
+    if (!target) {
+      throw usage("list-tags shorthand requires --project <path> or --project-id <id>.");
+    }
+    return { schemaVersion, targets: [target] };
+  }
+  if (command === "get_entry") {
+    if (!options.entryId) {
+      throw usage("get-entry shorthand requires --entry-id <id>.");
+    }
+    return {
+      schemaVersion,
+      entryId: options.entryId,
+      ...(target ? { target } : {}),
+    };
+  }
+  throw usage(`${command} does not support shorthand options. Use --json, --file, @file, or --stdin.`);
+}
+
+async function readStdin(stdin) {
+  const chunks = [];
+  for await (const chunk of stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
 }
 
 function normalizeProjectPathTargets(value) {
@@ -190,8 +313,87 @@ function parseJson(raw) {
   try {
     return JSON.parse(trimmed);
   } catch {
-    throw usage("Request JSON must be valid JSON.");
+    throw usage("Request JSON must be valid JSON. If shell quoting changed the JSON, retry with --file <path> or --stdin.");
   }
+}
+
+function buildSchemaResponse() {
+  return {
+    schemaVersion,
+    entryKinds,
+    forgetReasons,
+    commands: ["status", "context", "search", "get-entry", "list-tags", "append", "forget", "schema", "validate"],
+    requestBodyInputs: ["--json", "--file", "@file", "--stdin"],
+  };
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validateRequest(command, body) {
+  if (!isRecord(body)) {
+    return { ok: false, error: { code: "MEMORY_INVALID_REQUEST", message: "Request must be an object." } };
+  }
+  if (body.schemaVersion !== schemaVersion) {
+    return { ok: false, error: { code: "MEMORY_INVALID_SCHEMA_VERSION", message: "Unsupported memory schemaVersion.", field: "schemaVersion" } };
+  }
+  if (command === "context") {
+    return { ok: true, value: { schemaVersion } };
+  }
+  if (command === "search") {
+    if (!Array.isArray(body.targets) || body.targets.length === 0) {
+      return { ok: false, error: { code: "MEMORY_TARGET_REQUIRED", message: "At least one memory target is required.", field: "targets" } };
+    }
+    if (typeof body.query !== "string" || body.query.trim().length === 0) {
+      return { ok: false, error: { code: "MEMORY_INVALID_FIELD", message: "query must not be empty.", field: "query" } };
+    }
+    return { ok: true, value: { ...body, query: body.query.trim() } };
+  }
+  if (command === "get_entry") {
+    if (typeof body.entryId !== "string" || body.entryId.trim().length === 0) {
+      return { ok: false, error: { code: "MEMORY_INVALID_FIELD", message: "entryId must not be empty.", field: "entryId" } };
+    }
+    return { ok: true, value: { ...body, entryId: body.entryId.trim() } };
+  }
+  if (command === "list_tags") {
+    if (!Array.isArray(body.targets) || body.targets.length === 0) {
+      return { ok: false, error: { code: "MEMORY_TARGET_REQUIRED", message: "At least one memory target is required.", field: "targets" } };
+    }
+    return { ok: true, value: body };
+  }
+  if (command === "append") {
+    if (!entryKinds.includes(body.kind)) {
+      return { ok: false, error: { code: "MEMORY_INVALID_FIELD", message: "kind must be a valid memory kind.", field: "kind" } };
+    }
+    for (const field of ["target", "title", "body", "preview", "tags"]) {
+      if (body[field] === undefined) {
+        return { ok: false, error: { code: "MEMORY_INVALID_FIELD", message: `${field} is required.`, field } };
+      }
+    }
+    if (!Array.isArray(body.tags)) {
+      return { ok: false, error: { code: "MEMORY_INVALID_FIELD", message: "tags must be an array.", field: "tags" } };
+    }
+    return { ok: true, value: body };
+  }
+  if (!Array.isArray(body.entryIds) || body.entryIds.length === 0) {
+    return { ok: false, error: { code: "MEMORY_INVALID_FIELD", message: "entryIds must not be empty.", field: "entryIds" } };
+  }
+  if (body.reason !== undefined && !forgetReasons.includes(body.reason)) {
+    return { ok: false, error: { code: "MEMORY_INVALID_FIELD", message: "reason must be a valid forget reason.", field: "reason" } };
+  }
+  return { ok: true, value: body };
+}
+
+function buildValidateResponse(command, body) {
+  const result = validateRequest(command, body);
+  if (!result.ok) {
+    return { exitCode: exitCodes.apiError, response: { schemaVersion, error: result.error } };
+  }
+  return {
+    exitCode: exitCodes.ok,
+    response: { schemaVersion, valid: true, command, value: result.value },
+  };
 }
 
 async function readJsonResponse(response) {
@@ -229,6 +431,16 @@ async function verifyRuntime(connection, signal) {
 async function main() {
   try {
     const request = await parseArgs(process.argv.slice(2));
+    if (request.route.name === "schema") {
+      console.log(JSON.stringify(buildSchemaResponse()));
+      return exitCodes.ok;
+    }
+    if (request.route.name === "validate") {
+      const result = buildValidateResponse(request.validateCommand, normalizeProjectPathTargets(request.body));
+      console.log(JSON.stringify(result.response));
+      return result.exitCode;
+    }
+
     const connection = await readDiscovery(request);
     if (!connection) {
       console.log(JSON.stringify(notRunning()));

--- a/resources/skills/withmate-memory/bin/withmate-memory.mjs
+++ b/resources/skills/withmate-memory/bin/withmate-memory.mjs
@@ -135,7 +135,7 @@ async function parseArgs(argv) {
   const [rawCommand, ...rest] = argv;
   const route = rawCommand ? commands.get(rawCommand) : undefined;
   if (!route) {
-    throw usage("Usage: withmate-memory <status|context|search|get-entry|list-tags|append|forget|schema|validate> [--json <json> | --file <path> | --stdin] [--api-url <url>] [--discovery-file <path>]");
+    throw usage("Usage: withmate-memory <status|context|search|get-entry|list-tags|append|forget|schema|validate> [--json <json> | --file <path> | @file | --stdin] [--command <command>] [--project <path> | --project-id <id>] [--query <text>] [--entry-id <id>] [--limit <n>] [--api-url <url>] [--discovery-file <path>]");
   }
 
   let jsonInput = null;
@@ -327,62 +327,549 @@ function buildSchemaResponse() {
   };
 }
 
+const entryKindSet = new Set(entryKinds);
+const forgetReasonSet = new Set(forgetReasons);
+const resolveContextRequestKeys = new Set(["schemaVersion"]);
+const searchRequestKeys = new Set(["schemaVersion", "targets", "query", "kinds", "tags", "limit", "cursor"]);
+const getEntryRequestKeys = new Set(["schemaVersion", "entryId", "target"]);
+const listTagsRequestKeys = new Set(["schemaVersion", "targets"]);
+const appendRequestKeys = new Set([
+  "schemaVersion",
+  "target",
+  "kind",
+  "title",
+  "body",
+  "preview",
+  "tags",
+  "supersedes",
+  "sourceMessageId",
+  "idempotencyKey",
+]);
+const forgetRequestKeys = new Set(["schemaVersion", "target", "entryIds", "reason", "sourceMessageId", "idempotencyKey"]);
+const projectTargetIdKeys = new Set(["type", "id"]);
+const projectTargetPathKeys = new Set(["type", "path"]);
+const projectTargetAliasKeys = new Set(["type", "alias"]);
+const characterTargetIdKeys = new Set(["type", "id"]);
+const characterTargetCurrentKeys = new Set(["type"]);
+const memoryTagKeys = new Set(["type", "value"]);
+const projectProjectTargetKeys = new Set(["owner", "scope", "project"]);
+const characterCharacterTargetKeys = new Set(["owner", "scope", "character"]);
+const characterProjectTargetKeys = new Set(["owner", "scope", "character", "project"]);
+
+const maxSearchQueryLength = 500;
+const maxTitleLength = 160;
+const maxPreviewLength = 280;
+const maxBodyLength = 8_000;
+const maxTagTypeLength = 48;
+const maxTagValueLength = 96;
+const maxIdLength = 200;
+const maxCursorLength = 500;
+const maxLimit = 50;
+const maxTags = 20;
+const maxSupersedes = 20;
+const maxForgetEntryIds = 50;
+const maxTargets = 5;
+
 function isRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function validationError(code, message, field) {
+  return { ok: false, error: field ? { code, message, field } : { code, message } };
+}
+
+function rejectUnknownKeys(value, allowedKeys, field) {
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) {
+      return validationError("MEMORY_UNKNOWN_FIELD", `Unknown field: ${field}.${key}`, `${field}.${key}`);
+    }
+  }
+  return { ok: true, value: undefined };
+}
+
+function hasUnpairedSurrogate(value) {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return true;
+      }
+      index += 1;
+      continue;
+    }
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function normalizeText(value, field, options) {
+  if (typeof value !== "string") {
+    if (options.required === false && value === undefined) {
+      return { ok: true, value: "" };
+    }
+    return validationError("MEMORY_INVALID_FIELD", `${field} must be a string.`, field);
+  }
+  if (value.includes("\0")) {
+    return validationError("MEMORY_INVALID_FIELD", `${field} must not contain null bytes.`, field);
+  }
+  if (hasUnpairedSurrogate(value)) {
+    return validationError("MEMORY_INVALID_FIELD", `${field} must be well-formed Unicode.`, field);
+  }
+  const normalized = value.trim();
+  if (options.required !== false && normalized.length === 0) {
+    return validationError("MEMORY_INVALID_FIELD", `${field} must not be empty.`, field);
+  }
+  if (normalized.length > options.maxLength) {
+    return validationError("MEMORY_FIELD_TOO_LARGE", `${field} is too long.`, field);
+  }
+  return { ok: true, value: normalized };
+}
+
+function normalizeOptionalText(value, field, maxLength = maxIdLength) {
+  if (value === undefined) {
+    return { ok: true, value: undefined };
+  }
+  return normalizeText(value, field, { maxLength });
+}
+
+function validateSchemaVersion(value) {
+  if (value.schemaVersion !== schemaVersion) {
+    return validationError("MEMORY_INVALID_SCHEMA_VERSION", "Unsupported memory schemaVersion.", "schemaVersion");
+  }
+  return { ok: true, value: undefined };
+}
+
+function normalizeStringArray(value, field, options) {
+  if (value === undefined) {
+    return { ok: true, value: undefined };
+  }
+  if (!Array.isArray(value)) {
+    return validationError("MEMORY_INVALID_FIELD", `${field} must be an array.`, field);
+  }
+  if (value.length > options.maxItems) {
+    return validationError("MEMORY_FIELD_TOO_LARGE", `${field} has too many items.`, field);
+  }
+  const normalized = [];
+  const seen = new Set();
+  for (let index = 0; index < value.length; index += 1) {
+    const item = normalizeText(value[index], `${field}[${index}]`, { maxLength: options.maxLength });
+    if (!item.ok) {
+      return item;
+    }
+    if (seen.has(item.value)) {
+      continue;
+    }
+    seen.add(item.value);
+    normalized.push(item.value);
+  }
+  return { ok: true, value: normalized };
+}
+
+function validateMemoryKind(value, field) {
+  if (typeof value !== "string" || !entryKindSet.has(value)) {
+    return validationError("MEMORY_INVALID_FIELD", `${field} must be a valid memory kind.`, field);
+  }
+  return { ok: true, value };
+}
+
+function normalizeProjectTarget(value, field) {
+  if (!isRecord(value)) {
+    return validationError("MEMORY_INVALID_FIELD", `${field} must be an object.`, field);
+  }
+  if (value.type === "id") {
+    const unknownKeys = rejectUnknownKeys(value, projectTargetIdKeys, field);
+    if (!unknownKeys.ok) {
+      return unknownKeys;
+    }
+    const id = normalizeText(value.id, `${field}.id`, { maxLength: maxIdLength });
+    return id.ok ? { ok: true, value: { type: "id", id: id.value } } : id;
+  }
+  if (value.type === "path") {
+    const unknownKeys = rejectUnknownKeys(value, projectTargetPathKeys, field);
+    if (!unknownKeys.ok) {
+      return unknownKeys;
+    }
+    const projectPath = normalizeText(value.path, `${field}.path`, { maxLength: 1_000 });
+    return projectPath.ok ? { ok: true, value: { type: "path", path: projectPath.value } } : projectPath;
+  }
+  if (value.type === "alias") {
+    const unknownKeys = rejectUnknownKeys(value, projectTargetAliasKeys, field);
+    if (!unknownKeys.ok) {
+      return unknownKeys;
+    }
+    const alias = normalizeText(value.alias, `${field}.alias`, { maxLength: maxIdLength });
+    return alias.ok ? { ok: true, value: { type: "alias", alias: alias.value } } : alias;
+  }
+  return validationError("MEMORY_INVALID_FIELD", `${field}.type must be id, path, or alias.`, `${field}.type`);
+}
+
+function normalizeCharacterTarget(value, field) {
+  if (!isRecord(value)) {
+    return validationError("MEMORY_INVALID_FIELD", `${field} must be an object.`, field);
+  }
+  if (value.type === "current") {
+    const unknownKeys = rejectUnknownKeys(value, characterTargetCurrentKeys, field);
+    if (!unknownKeys.ok) {
+      return unknownKeys;
+    }
+    return { ok: true, value: { type: "current" } };
+  }
+  if (value.type === "id") {
+    const unknownKeys = rejectUnknownKeys(value, characterTargetIdKeys, field);
+    if (!unknownKeys.ok) {
+      return unknownKeys;
+    }
+    const id = normalizeText(value.id, `${field}.id`, { maxLength: maxIdLength });
+    return id.ok ? { ok: true, value: { type: "id", id: id.value } } : id;
+  }
+  return validationError("MEMORY_INVALID_FIELD", `${field}.type must be id or current.`, `${field}.type`);
+}
+
+function normalizeMemoryTarget(value, field) {
+  if (!isRecord(value)) {
+    return validationError("MEMORY_INVALID_FIELD", `${field} must be an object.`, field);
+  }
+  if (value.owner === "project" && value.scope === "project") {
+    const unknownKeys = rejectUnknownKeys(value, projectProjectTargetKeys, field);
+    if (!unknownKeys.ok) {
+      return unknownKeys;
+    }
+    const project = normalizeProjectTarget(value.project, `${field}.project`);
+    return project.ok ? { ok: true, value: { owner: "project", scope: "project", project: project.value } } : project;
+  }
+  if (value.owner === "character" && value.scope === "character") {
+    const unknownKeys = rejectUnknownKeys(value, characterCharacterTargetKeys, field);
+    if (!unknownKeys.ok) {
+      return unknownKeys;
+    }
+    const character = normalizeCharacterTarget(value.character, `${field}.character`);
+    return character.ok ? { ok: true, value: { owner: "character", scope: "character", character: character.value } } : character;
+  }
+  if (value.owner === "character" && value.scope === "project") {
+    const unknownKeys = rejectUnknownKeys(value, characterProjectTargetKeys, field);
+    if (!unknownKeys.ok) {
+      return unknownKeys;
+    }
+    const character = normalizeCharacterTarget(value.character, `${field}.character`);
+    if (!character.ok) {
+      return character;
+    }
+    const project = normalizeProjectTarget(value.project, `${field}.project`);
+    return project.ok
+      ? { ok: true, value: { owner: "character", scope: "project", character: character.value, project: project.value } }
+      : project;
+  }
+  return validationError("MEMORY_INVALID_TARGET", "Unsupported memory owner / scope combination.", field);
+}
+
+function normalizeTargets(value) {
+  if (!Array.isArray(value) || value.length === 0) {
+    return validationError("MEMORY_TARGET_REQUIRED", "At least one memory target is required.", "targets");
+  }
+  if (value.length > maxTargets) {
+    return validationError("MEMORY_FIELD_TOO_LARGE", `targets supports at most ${maxTargets} items.`, "targets");
+  }
+  const normalized = [];
+  const seen = new Set();
+  for (let index = 0; index < value.length; index += 1) {
+    const target = normalizeMemoryTarget(value[index], `targets[${index}]`);
+    if (!target.ok) {
+      return target;
+    }
+    const key = JSON.stringify(target.value);
+    if (seen.has(key)) {
+      return validationError("MEMORY_DUPLICATE_TARGET", "targets must not contain duplicates.", `targets[${index}]`);
+    }
+    seen.add(key);
+    normalized.push(target.value);
+  }
+  return { ok: true, value: normalized };
+}
+
+function normalizeTags(value, field = "tags", options = {}) {
+  if (value === undefined) {
+    if (options.required) {
+      return validationError("MEMORY_INVALID_FIELD", `${field} is required.`, field);
+    }
+    return { ok: true, value: [] };
+  }
+  if (!Array.isArray(value)) {
+    return validationError("MEMORY_INVALID_FIELD", `${field} must be an array.`, field);
+  }
+  if (value.length > maxTags) {
+    return validationError("MEMORY_FIELD_TOO_LARGE", `${field} has too many items.`, field);
+  }
+  const normalized = [];
+  const seen = new Set();
+  for (let index = 0; index < value.length; index += 1) {
+    const tag = value[index];
+    if (!isRecord(tag)) {
+      return validationError("MEMORY_INVALID_FIELD", `${field}[${index}] must be an object.`, `${field}[${index}]`);
+    }
+    const unknownKeys = rejectUnknownKeys(tag, memoryTagKeys, `${field}[${index}]`);
+    if (!unknownKeys.ok) {
+      return unknownKeys;
+    }
+    const type = normalizeText(tag.type, `${field}[${index}].type`, { maxLength: maxTagTypeLength });
+    if (!type.ok) {
+      return type;
+    }
+    const tagValue = normalizeText(tag.value, `${field}[${index}].value`, { maxLength: maxTagValueLength });
+    if (!tagValue.ok) {
+      return tagValue;
+    }
+    const canonicalType = type.value.normalize("NFC").toLowerCase();
+    const canonicalValue = tagValue.value.normalize("NFC").toLowerCase();
+    const key = `${canonicalType}\0${canonicalValue}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    normalized.push({ type: type.value, value: tagValue.value, canonicalType, canonicalValue });
+  }
+  return { ok: true, value: normalized };
+}
+
+function normalizeKinds(value) {
+  if (value === undefined) {
+    return { ok: true, value: undefined };
+  }
+  if (!Array.isArray(value)) {
+    return validationError("MEMORY_INVALID_FIELD", "kinds must be an array.", "kinds");
+  }
+  if (value.length > entryKinds.length) {
+    return validationError("MEMORY_FIELD_TOO_LARGE", "kinds has too many items.", "kinds");
+  }
+  const normalized = [];
+  const seen = new Set();
+  for (let index = 0; index < value.length; index += 1) {
+    const kind = validateMemoryKind(value[index], `kinds[${index}]`);
+    if (!kind.ok) {
+      return kind;
+    }
+    if (seen.has(kind.value)) {
+      continue;
+    }
+    seen.add(kind.value);
+    normalized.push(kind.value);
+  }
+  return { ok: true, value: normalized.length > 0 ? normalized : undefined };
+}
+
 function validateRequest(command, body) {
   if (!isRecord(body)) {
-    return { ok: false, error: { code: "MEMORY_INVALID_REQUEST", message: "Request must be an object." } };
-  }
-  if (body.schemaVersion !== schemaVersion) {
-    return { ok: false, error: { code: "MEMORY_INVALID_SCHEMA_VERSION", message: "Unsupported memory schemaVersion.", field: "schemaVersion" } };
+    const label = command === "get_entry" ? "Get entry"
+      : command === "list_tags" ? "List tags"
+        : command === "context" ? "Resolve context"
+          : command[0].toUpperCase() + command.slice(1);
+    return validationError("MEMORY_INVALID_REQUEST", `${label} request must be an object.`);
   }
   if (command === "context") {
+    const unknownKeys = rejectUnknownKeys(body, resolveContextRequestKeys, "request");
+    if (!unknownKeys.ok) {
+      return unknownKeys;
+    }
+    const schema = validateSchemaVersion(body);
+    if (!schema.ok) {
+      return schema;
+    }
     return { ok: true, value: { schemaVersion } };
   }
   if (command === "search") {
-    if (!Array.isArray(body.targets) || body.targets.length === 0) {
-      return { ok: false, error: { code: "MEMORY_TARGET_REQUIRED", message: "At least one memory target is required.", field: "targets" } };
+    const unknownKeys = rejectUnknownKeys(body, searchRequestKeys, "request");
+    if (!unknownKeys.ok) {
+      return unknownKeys;
     }
-    if (typeof body.query !== "string" || body.query.trim().length === 0) {
-      return { ok: false, error: { code: "MEMORY_INVALID_FIELD", message: "query must not be empty.", field: "query" } };
+    const schema = validateSchemaVersion(body);
+    if (!schema.ok) {
+      return schema;
     }
-    return { ok: true, value: { ...body, query: body.query.trim() } };
+    const targets = normalizeTargets(body.targets);
+    if (!targets.ok) {
+      return targets;
+    }
+    const query = normalizeText(body.query, "query", { maxLength: maxSearchQueryLength });
+    if (!query.ok) {
+      return query;
+    }
+    const kinds = normalizeKinds(body.kinds);
+    if (!kinds.ok) {
+      return kinds;
+    }
+    const tags = normalizeTags(body.tags);
+    if (!tags.ok) {
+      return tags;
+    }
+    const cursor = normalizeOptionalText(body.cursor, "cursor", maxCursorLength);
+    if (!cursor.ok) {
+      return cursor;
+    }
+    let limit;
+    if (body.limit !== undefined) {
+      if (typeof body.limit !== "number" || !Number.isInteger(body.limit) || body.limit < 1 || body.limit > maxLimit) {
+        return validationError("MEMORY_INVALID_FIELD", `limit must be an integer from 1 to ${maxLimit}.`, "limit");
+      }
+      limit = body.limit;
+    }
+    return {
+      ok: true,
+      value: {
+        schemaVersion,
+        targets: targets.value,
+        query: query.value,
+        ...(kinds.value ? { kinds: kinds.value } : {}),
+        ...(tags.value.length > 0 ? { tags: tags.value } : {}),
+        ...(limit !== undefined ? { limit } : {}),
+        ...(cursor.value !== undefined ? { cursor: cursor.value } : {}),
+      },
+    };
   }
   if (command === "get_entry") {
-    if (typeof body.entryId !== "string" || body.entryId.trim().length === 0) {
-      return { ok: false, error: { code: "MEMORY_INVALID_FIELD", message: "entryId must not be empty.", field: "entryId" } };
+    const unknownKeys = rejectUnknownKeys(body, getEntryRequestKeys, "request");
+    if (!unknownKeys.ok) {
+      return unknownKeys;
     }
-    return { ok: true, value: { ...body, entryId: body.entryId.trim() } };
+    const schema = validateSchemaVersion(body);
+    if (!schema.ok) {
+      return schema;
+    }
+    const entryId = normalizeText(body.entryId, "entryId", { maxLength: maxIdLength });
+    if (!entryId.ok) {
+      return entryId;
+    }
+    const target = body.target === undefined ? undefined : normalizeMemoryTarget(body.target, "target");
+    if (target && !target.ok) {
+      return target;
+    }
+    return {
+      ok: true,
+      value: {
+        schemaVersion,
+        entryId: entryId.value,
+        ...(target ? { target: target.value } : {}),
+      },
+    };
   }
   if (command === "list_tags") {
-    if (!Array.isArray(body.targets) || body.targets.length === 0) {
-      return { ok: false, error: { code: "MEMORY_TARGET_REQUIRED", message: "At least one memory target is required.", field: "targets" } };
+    const unknownKeys = rejectUnknownKeys(body, listTagsRequestKeys, "request");
+    if (!unknownKeys.ok) {
+      return unknownKeys;
     }
-    return { ok: true, value: body };
+    const schema = validateSchemaVersion(body);
+    if (!schema.ok) {
+      return schema;
+    }
+    const targets = normalizeTargets(body.targets);
+    if (!targets.ok) {
+      return targets;
+    }
+    return { ok: true, value: { schemaVersion, targets: targets.value } };
   }
   if (command === "append") {
-    if (!entryKinds.includes(body.kind)) {
-      return { ok: false, error: { code: "MEMORY_INVALID_FIELD", message: "kind must be a valid memory kind.", field: "kind" } };
+    const unknownKeys = rejectUnknownKeys(body, appendRequestKeys, "request");
+    if (!unknownKeys.ok) {
+      return unknownKeys;
     }
-    for (const field of ["target", "title", "body", "preview", "tags"]) {
-      if (body[field] === undefined) {
-        return { ok: false, error: { code: "MEMORY_INVALID_FIELD", message: `${field} is required.`, field } };
-      }
+    const schema = validateSchemaVersion(body);
+    if (!schema.ok) {
+      return schema;
     }
-    if (!Array.isArray(body.tags)) {
-      return { ok: false, error: { code: "MEMORY_INVALID_FIELD", message: "tags must be an array.", field: "tags" } };
+    const target = normalizeMemoryTarget(body.target, "target");
+    if (!target.ok) {
+      return target;
     }
-    return { ok: true, value: body };
+    const kind = validateMemoryKind(body.kind, "kind");
+    if (!kind.ok) {
+      return kind;
+    }
+    const title = normalizeText(body.title, "title", { maxLength: maxTitleLength });
+    if (!title.ok) {
+      return title;
+    }
+    const requestBody = normalizeText(body.body, "body", { maxLength: maxBodyLength });
+    if (!requestBody.ok) {
+      return requestBody;
+    }
+    const preview = normalizeText(body.preview, "preview", { maxLength: maxPreviewLength });
+    if (!preview.ok) {
+      return preview;
+    }
+    const tags = normalizeTags(body.tags, "tags", { required: true });
+    if (!tags.ok) {
+      return tags;
+    }
+    const supersedes = normalizeStringArray(body.supersedes, "supersedes", { maxItems: maxSupersedes, maxLength: maxIdLength });
+    if (!supersedes.ok) {
+      return supersedes;
+    }
+    const sourceMessageId = normalizeOptionalText(body.sourceMessageId, "sourceMessageId");
+    if (!sourceMessageId.ok) {
+      return sourceMessageId;
+    }
+    const idempotencyKey = normalizeOptionalText(body.idempotencyKey, "idempotencyKey");
+    if (!idempotencyKey.ok) {
+      return idempotencyKey;
+    }
+    return {
+      ok: true,
+      value: {
+        schemaVersion,
+        target: target.value,
+        kind: kind.value,
+        title: title.value,
+        body: requestBody.value,
+        preview: preview.value,
+        tags: tags.value,
+        ...(supersedes.value && supersedes.value.length > 0 ? { supersedes: supersedes.value } : {}),
+        ...(sourceMessageId.value !== undefined ? { sourceMessageId: sourceMessageId.value } : {}),
+        ...(idempotencyKey.value !== undefined ? { idempotencyKey: idempotencyKey.value } : {}),
+      },
+    };
   }
-  if (!Array.isArray(body.entryIds) || body.entryIds.length === 0) {
-    return { ok: false, error: { code: "MEMORY_INVALID_FIELD", message: "entryIds must not be empty.", field: "entryIds" } };
+  const unknownKeys = rejectUnknownKeys(body, forgetRequestKeys, "request");
+  if (!unknownKeys.ok) {
+    return unknownKeys;
   }
-  if (body.reason !== undefined && !forgetReasons.includes(body.reason)) {
-    return { ok: false, error: { code: "MEMORY_INVALID_FIELD", message: "reason must be a valid forget reason.", field: "reason" } };
+  const schema = validateSchemaVersion(body);
+  if (!schema.ok) {
+    return schema;
   }
-  return { ok: true, value: body };
+  const target = normalizeMemoryTarget(body.target, "target");
+  if (!target.ok) {
+    return target;
+  }
+  const entryIds = normalizeStringArray(body.entryIds, "entryIds", { maxItems: maxForgetEntryIds, maxLength: maxIdLength });
+  if (!entryIds.ok) {
+    return entryIds;
+  }
+  if (!entryIds.value || entryIds.value.length === 0) {
+    return validationError("MEMORY_INVALID_FIELD", "entryIds must not be empty.", "entryIds");
+  }
+  if (body.reason !== undefined && (typeof body.reason !== "string" || !forgetReasonSet.has(body.reason))) {
+    return validationError("MEMORY_INVALID_FIELD", "reason must be a valid forget reason.", "reason");
+  }
+  const sourceMessageId = normalizeOptionalText(body.sourceMessageId, "sourceMessageId");
+  if (!sourceMessageId.ok) {
+    return sourceMessageId;
+  }
+  const idempotencyKey = normalizeOptionalText(body.idempotencyKey, "idempotencyKey");
+  if (!idempotencyKey.ok) {
+    return idempotencyKey;
+  }
+  return {
+    ok: true,
+    value: {
+      schemaVersion,
+      target: target.value,
+      entryIds: entryIds.value,
+      ...(body.reason !== undefined ? { reason: body.reason } : {}),
+      ...(sourceMessageId.value !== undefined ? { sourceMessageId: sourceMessageId.value } : {}),
+      ...(idempotencyKey.value !== undefined ? { idempotencyKey: idempotencyKey.value } : {}),
+    }
+  };
 }
 
 function buildValidateResponse(command, body) {

--- a/resources/skills/withmate-memory/reference/cli.md
+++ b/resources/skills/withmate-memory/reference/cli.md
@@ -6,16 +6,32 @@ Project-scoped Memory can be used from external Codex or shell sessions while Wi
 Run it from the target project directory after WithMate is installed:
 
 ```bash
-withmate-memory <command> [--json <json> | --file <path>]
+withmate-memory <command> [--json <json> | --file <path> | --stdin]
 ```
 
-For commands that require a request body, prefer `--file <path>`. Inline `--json` is supported, but it is shell-sensitive. On Windows PowerShell or `.cmd` wrappers, double quotes inside JSON can be consumed before the CLI receives the argument. If `--json` fails with invalid JSON or a CLI usage error, write the request to a temporary JSON file and retry with `--file`.
+For commands that require a request body, prefer `--stdin` or `--file <path>`. Inline `--json` is supported, but it is shell-sensitive. On Windows PowerShell or `.cmd` wrappers, double quotes inside JSON can be consumed before the CLI receives the argument. If `--json` fails with invalid JSON or a CLI usage error, pipe the request through `--stdin`, or write it to a temporary JSON file and retry with `--file`.
 
 On Windows, the installer places `withmate-memory.cmd` in the WithMate install directory and creates a user-level alias at `%LOCALAPPDATA%\Microsoft\WindowsApps\withmate-memory.cmd`. It does not edit the user's `Path` registry value. A new terminal may be required after install or uninstall.
 
 When a managed skill includes `bin/withmate-memory.mjs` and no `withmate-memory` command is available on `PATH`, use `node bin/withmate-memory.mjs <command>` as a temporary fallback.
 
 ## Commands
+
+### schema
+
+```bash
+withmate-memory schema
+```
+
+Returns supported commands, request body input modes, memory entry kinds, and forget reasons.
+
+### validate
+
+```bash
+withmate-memory validate --command append --stdin
+```
+
+Validates a request body locally and prints either `{ "valid": true, ... }` or a memory validation error. It does not create, update, or forget Memory.
 
 ### status
 
@@ -40,6 +56,7 @@ Sends:
 ### search
 
 ```bash
+withmate-memory search --project . --query "approval mode"
 withmate-memory search --file memory-search.json
 ```
 
@@ -60,6 +77,7 @@ Search returns active entry previews only. Use `get-entry` when the exact body m
 ### get-entry
 
 ```bash
+withmate-memory get-entry --project . --entry-id <entry-id>
 withmate-memory get-entry --file memory-get-entry.json
 ```
 
@@ -78,6 +96,7 @@ External Codex or shell sessions must include `target`. WithMate-launched sessio
 ### list-tags
 
 ```bash
+withmate-memory list-tags --project .
 withmate-memory list-tags --file memory-list-tags.json
 ```
 

--- a/scripts/tests/managed-memory-skill-service.test.ts
+++ b/scripts/tests/managed-memory-skill-service.test.ts
@@ -445,17 +445,53 @@ describe("withmate-memory bundled helper", () => {
     assert.equal(JSON.parse(stdout).error.code, "WITHMATE_NOT_RUNNING");
   });
 
-  it("future helper flags ではなく raw JSON/file contract を要求する", async () => {
-    await execFileAsync(process.execPath, [helperPath, "search", "--project", "."], {
+  it("schema は helper 単体で capability を返す", async () => {
+    const { stdout } = await execFileAsync(process.execPath, [helperPath, "schema"], {
       env: process.env,
-    }).then(
-      () => assert.fail("unknown option should fail"),
-      (error: unknown) => {
-        const execError = error as { code?: number; stdout?: string };
-        assert.equal(execError.code, 1);
-        assert.equal(JSON.parse(execError.stdout ?? "{}").error.code, "WITHMATE_MEMORY_CLI_USAGE");
+    });
+
+    const schema = JSON.parse(stdout);
+    assert.deepEqual(schema.requestBodyInputs, ["--json", "--file", "@file", "--stdin"]);
+    assert(schema.entryKinds.includes("decision"));
+    assert(schema.forgetReasons.includes("user_request"));
+  });
+
+  it("validate は helper 単体で request を検証する", async () => {
+    const request = JSON.stringify({
+      schemaVersion: "withmate-memory-v1",
+      target: { owner: "project", scope: "project", project: { type: "id", id: "project-a" } },
+      kind: "investigation",
+      title: "Invalid",
+      body: "Invalid",
+      preview: "Invalid",
+      tags: [],
+    });
+    const { stdout } = await execFileAsync(process.execPath, [helperPath, "validate", "--command", "append", "--json", request], {
+      env: process.env,
+    }).catch((error: unknown) => {
+      const execError = error as { code?: number; stdout?: string };
+      assert.equal(execError.code, 3);
+      return { stdout: execError.stdout ?? "" };
+    });
+
+    const error = JSON.parse(stdout).error;
+    assert.equal(error.code, "MEMORY_INVALID_FIELD");
+    assert.equal(error.field, "kind");
+  });
+
+  it("read shorthand は helper でも request body を組み立てる", async () => {
+    const { stdout } = await execFileAsync(process.execPath, [helperPath, "search", "--project", ".", "--query", "cli"], {
+      env: {
+        ...process.env,
+        WITHMATE_MEMORY_DISCOVERY_FILE: path.join(tmpdir(), "withmate-memory-missing.json"),
       },
-    );
+    }).catch((error: unknown) => {
+      const execError = error as { code?: number; stdout?: string };
+      assert.equal(execError.code, 2);
+      return { stdout: execError.stdout ?? "" };
+    });
+
+    assert.equal(JSON.parse(stdout).error.code, "WITHMATE_NOT_RUNNING");
   });
 
   it("usage error は PATH CLI command 形式を案内する", async () => {

--- a/scripts/tests/managed-memory-skill-service.test.ts
+++ b/scripts/tests/managed-memory-skill-service.test.ts
@@ -479,6 +479,131 @@ describe("withmate-memory bundled helper", () => {
     assert.equal(error.field, "kind");
   });
 
+  it("validate は helper 側でも runtime validation と同じ失敗ケースを拒否する", async () => {
+    const invalidCases = [
+      {
+        name: "unknown append field",
+        command: "append",
+        request: {
+          schemaVersion: "withmate-memory-v1",
+          target: { owner: "project", scope: "project", project: { type: "id", id: "project-a" } },
+          kind: "decision",
+          title: "Title",
+          body: "Body",
+          preview: "Preview",
+          tags: [],
+          extra: true,
+        },
+        code: "MEMORY_UNKNOWN_FIELD",
+        field: "request.extra",
+      },
+      {
+        name: "invalid target shape",
+        command: "append",
+        request: {
+          schemaVersion: "withmate-memory-v1",
+          target: { owner: "project", scope: "project", project: { type: "id", id: "" } },
+          kind: "decision",
+          title: "Title",
+          body: "Body",
+          preview: "Preview",
+          tags: [],
+        },
+        code: "MEMORY_INVALID_FIELD",
+        field: "target.project.id",
+      },
+      {
+        name: "empty title",
+        command: "append",
+        request: {
+          schemaVersion: "withmate-memory-v1",
+          target: { owner: "project", scope: "project", project: { type: "id", id: "project-a" } },
+          kind: "decision",
+          title: " ",
+          body: "Body",
+          preview: "Preview",
+          tags: [],
+        },
+        code: "MEMORY_INVALID_FIELD",
+        field: "title",
+      },
+      {
+        name: "invalid tag object",
+        command: "append",
+        request: {
+          schemaVersion: "withmate-memory-v1",
+          target: { owner: "project", scope: "project", project: { type: "id", id: "project-a" } },
+          kind: "decision",
+          title: "Title",
+          body: "Body",
+          preview: "Preview",
+          tags: [{ type: "Topic", value: "CLI", extra: true }],
+        },
+        code: "MEMORY_UNKNOWN_FIELD",
+        field: "tags[0].extra",
+      },
+      {
+        name: "forget requires target",
+        command: "forget",
+        request: {
+          schemaVersion: "withmate-memory-v1",
+          entryIds: ["entry-a"],
+        },
+        code: "MEMORY_INVALID_FIELD",
+        field: "target",
+      },
+    ];
+
+    for (const testCase of invalidCases) {
+      const { stdout } = await execFileAsync(process.execPath, [
+        helperPath,
+        "validate",
+        "--command",
+        testCase.command,
+        "--json",
+        JSON.stringify(testCase.request),
+      ], {
+        env: process.env,
+      }).catch((error: unknown) => {
+        const execError = error as { code?: number; stdout?: string };
+        assert.equal(execError.code, 3, testCase.name);
+        return { stdout: execError.stdout ?? "" };
+      });
+
+      const response = JSON.parse(stdout);
+      assert.equal(response.error.code, testCase.code, testCase.name);
+      assert.equal(response.error.field, testCase.field, testCase.name);
+    }
+  });
+
+  it("validate は helper 側でも append request を正規化する", async () => {
+    const request = JSON.stringify({
+      schemaVersion: "withmate-memory-v1",
+      target: { owner: "project", scope: "project", project: { type: "id", id: " project-a " } },
+      kind: "decision",
+      title: " Title ",
+      body: " Body ",
+      preview: " Preview ",
+      tags: [{ type: "Topic", value: " Release " }, { type: "topic", value: "release" }],
+      supersedes: [" entry-a ", "entry-a"],
+    });
+    const { stdout } = await execFileAsync(process.execPath, [helperPath, "validate", "--command", "append", "--json", request], {
+      env: process.env,
+    });
+
+    const response = JSON.parse(stdout);
+    assert.equal(response.valid, true);
+    assert.equal(response.value.target.project.id, "project-a");
+    assert.equal(response.value.title, "Title");
+    assert.deepEqual(response.value.tags, [{
+      type: "Topic",
+      value: "Release",
+      canonicalType: "topic",
+      canonicalValue: "release",
+    }]);
+    assert.deepEqual(response.value.supersedes, ["entry-a"]);
+  });
+
   it("read shorthand は helper でも request body を組み立てる", async () => {
     const { stdout } = await execFileAsync(process.execPath, [helperPath, "search", "--project", ".", "--query", "cli"], {
       env: {

--- a/scripts/tests/withmate-memory-cli.test.ts
+++ b/scripts/tests/withmate-memory-cli.test.ts
@@ -737,4 +737,19 @@ describe("withmate-memory CLI", () => {
     assert.equal(exitCode, WITHMATE_MEMORY_CLI_EXIT_CODES.usage);
     assert.match(stdout.json().error.message, /--json requires a value/);
   });
+
+  it("unknown commandは現行CLI surfaceを含むusage errorを返す", async () => {
+    const stdout = createOutputCapture();
+    const exitCode = await runWithMateMemoryCli(["nope"], {
+      env: { WITHMATE_MEMORY_API_URL: "http://127.0.0.1:7777" },
+      stdout: stdout.stream,
+    });
+
+    const message = stdout.json().error.message;
+    assert.equal(exitCode, WITHMATE_MEMORY_CLI_EXIT_CODES.usage);
+    assert.match(message, /schema\|validate/);
+    assert.match(message, /@file/);
+    assert.match(message, /--stdin/);
+    assert.match(message, /--project/);
+  });
 });

--- a/scripts/tests/withmate-memory-cli.test.ts
+++ b/scripts/tests/withmate-memory-cli.test.ts
@@ -5,6 +5,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from "node:ht
 import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Readable } from "node:stream";
 import { describe, it } from "node:test";
 
 import { MEMORY_V6_SCHEMA_VERSION } from "../../src/memory-v6/memory-contract.js";
@@ -55,6 +56,10 @@ function createStatusChallengeResponse(url: string): Response {
       hmacSha256: createHmac("sha256", TEST_API_SECRET).update(nonce, "utf8").digest("base64url"),
     },
   }), { status: 200 });
+}
+
+function createStdin(value: string): NodeJS.ReadStream {
+  return Object.assign(Readable.from([value]), { isTTY: false }) as NodeJS.ReadStream;
 }
 
 function isStatusChallengeRequest(url: string): boolean {
@@ -363,6 +368,171 @@ describe("withmate-memory CLI", () => {
     assert.equal(exitCode, WITHMATE_MEMORY_CLI_EXIT_CODES.ok);
     assert.deepEqual(capturedBody, requestBody);
     assert.deepEqual(stdout.json(), { schemaVersion: MEMORY_V6_SCHEMA_VERSION, items: [] });
+  });
+
+  it("schemaはruntime接続なしでCLI capabilitiesを返す", async () => {
+    const stdout = createOutputCapture();
+    let fetchCalls = 0;
+    const exitCode = await runWithMateMemoryCli(["schema"], {
+      env: {},
+      stdout: stdout.stream,
+      fetch: async () => {
+        fetchCalls += 1;
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      },
+    });
+
+    assert.equal(exitCode, WITHMATE_MEMORY_CLI_EXIT_CODES.ok);
+    assert.equal(fetchCalls, 0);
+    assert.deepEqual(stdout.json().entryKinds, [
+      "decision",
+      "constraint",
+      "convention",
+      "context",
+      "deferred",
+      "preference",
+      "relationship",
+      "boundary",
+      "note",
+    ]);
+    assert.deepEqual(stdout.json().forgetReasons, ["user_request", "incorrect", "outdated", "privacy", "other"]);
+    assert.deepEqual(stdout.json().requestBodyInputs, ["--json", "--file", "@file", "--stdin"]);
+  });
+
+  it("validateはrequest bodyをruntimeへ送らずに検証する", async () => {
+    const stdout = createOutputCapture();
+    let fetchCalls = 0;
+    const requestBody = {
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      target: { owner: "project", scope: "project", project: { type: "id", id: "project-a" } },
+      kind: "decision",
+      title: "Decision",
+      body: "Body",
+      preview: "Preview",
+      tags: [{ type: "topic", value: "cli" }],
+    };
+
+    const exitCode = await runWithMateMemoryCli(["validate", "--command", "append", "--json", JSON.stringify(requestBody)], {
+      env: TEST_RUNTIME_ENV,
+      stdout: stdout.stream,
+      fetch: async () => {
+        fetchCalls += 1;
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      },
+    });
+
+    assert.equal(exitCode, WITHMATE_MEMORY_CLI_EXIT_CODES.ok);
+    assert.equal(fetchCalls, 0);
+    assert.equal(stdout.json().valid, true);
+    assert.equal(stdout.json().command, "append");
+    assert.equal(stdout.json().value.tags[0].canonicalValue, "cli");
+  });
+
+  it("validateはinvalid requestをJSON errorで返す", async () => {
+    const stdout = createOutputCapture();
+    const requestBody = {
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      target: { owner: "project", scope: "project", project: { type: "id", id: "project-a" } },
+      kind: "investigation",
+      title: "Decision",
+      body: "Body",
+      preview: "Preview",
+      tags: [],
+    };
+
+    const exitCode = await runWithMateMemoryCli(["validate", "--command", "append", "--json", JSON.stringify(requestBody)], {
+      env: TEST_RUNTIME_ENV,
+      stdout: stdout.stream,
+    });
+
+    assert.equal(exitCode, WITHMATE_MEMORY_CLI_EXIT_CODES.apiError);
+    assert.equal(stdout.json().error.code, "MEMORY_INVALID_FIELD");
+    assert.equal(stdout.json().error.field, "kind");
+  });
+
+  it("--stdinは明示的に標準入力からrequest bodyを読む", async () => {
+    const stdout = createOutputCapture();
+    const requestBody = {
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      targets: [{ owner: "project", scope: "project", project: { type: "id", id: "project-a" } }],
+      query: "cli",
+    };
+    let capturedBody: unknown = null;
+
+    const exitCode = await runWithMateMemoryCli(["search", "--stdin"], {
+      env: TEST_RUNTIME_ENV,
+      stdin: createStdin(JSON.stringify(requestBody)),
+      stdout: stdout.stream,
+      fetch: async (url, init) => {
+        if (isStatusChallengeRequest(String(url))) {
+          return createStatusChallengeResponse(String(url));
+        }
+        capturedBody = JSON.parse(String(init?.body));
+        return new Response(JSON.stringify({ schemaVersion: MEMORY_V6_SCHEMA_VERSION, items: [] }), { status: 200 });
+      },
+    });
+
+    assert.equal(exitCode, WITHMATE_MEMORY_CLI_EXIT_CODES.ok);
+    assert.deepEqual(capturedBody, requestBody);
+  });
+
+  it("@fileは--fileの短縮形としてrequest bodyを読む", async () => {
+    const tempDirectory = await mkdtemp(join(tmpdir(), "withmate-memory-cli-at-file-"));
+    const requestPath = join(tempDirectory, "search.json");
+    const stdout = createOutputCapture();
+    const requestBody = {
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      targets: [{ owner: "project", scope: "project", project: { type: "id", id: "project-a" } }],
+      query: "cli",
+    };
+    let capturedBody: unknown = null;
+    try {
+      await writeFile(requestPath, JSON.stringify(requestBody), "utf8");
+
+      const exitCode = await runWithMateMemoryCli(["search", `@${requestPath}`], {
+        env: TEST_RUNTIME_ENV,
+        stdout: stdout.stream,
+        fetch: async (url, init) => {
+          if (isStatusChallengeRequest(String(url))) {
+            return createStatusChallengeResponse(String(url));
+          }
+          capturedBody = JSON.parse(String(init?.body));
+          return new Response(JSON.stringify({ schemaVersion: MEMORY_V6_SCHEMA_VERSION, items: [] }), { status: 200 });
+        },
+      });
+
+      assert.equal(exitCode, WITHMATE_MEMORY_CLI_EXIT_CODES.ok);
+      assert.deepEqual(capturedBody, requestBody);
+    } finally {
+      await rm(tempDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("search shorthandはprojectとqueryからrequest bodyを作る", async () => {
+    const stdout = createOutputCapture();
+    const tempDirectory = await mkdtemp(join(tmpdir(), "withmate-memory-cli-shorthand-"));
+    let capturedBody: any = null;
+    try {
+      const exitCode = await runWithMateMemoryCli(["search", "--project", tempDirectory, "--query", "release workflow", "--limit", "3"], {
+        env: TEST_RUNTIME_ENV,
+        stdout: stdout.stream,
+        fetch: async (url, init) => {
+          if (isStatusChallengeRequest(String(url))) {
+            return createStatusChallengeResponse(String(url));
+          }
+          capturedBody = JSON.parse(String(init?.body));
+          return new Response(JSON.stringify({ schemaVersion: MEMORY_V6_SCHEMA_VERSION, items: [] }), { status: 200 });
+        },
+      });
+
+      assert.equal(exitCode, WITHMATE_MEMORY_CLI_EXIT_CODES.ok);
+      assert.equal(capturedBody.schemaVersion, MEMORY_V6_SCHEMA_VERSION);
+      assert.equal(capturedBody.targets[0].project.path, tempDirectory);
+      assert.equal(capturedBody.query, "release workflow");
+      assert.equal(capturedBody.limit, 3);
+    } finally {
+      await rm(tempDirectory, { recursive: true, force: true });
+    }
   });
 
   it("project.pathの相対pathはCLI起動cwd基準の絶対pathへ正規化して送る", async () => {

--- a/scripts/withmate-memory.ts
+++ b/scripts/withmate-memory.ts
@@ -261,7 +261,7 @@ export async function parseWithMateMemoryCliArgs(
   const [rawCommand, ...rest] = args;
   const command = rawCommand ? commandAliases.get(rawCommand) : undefined;
   if (!command) {
-    throw usageError("Usage: withmate-memory <status|context|search|get-entry|list-tags|append|forget> [--json <json> | --file <path>] [--api-url <url>] [--discovery-file <path>]");
+    throw usageError("Usage: withmate-memory <status|context|search|get-entry|list-tags|append|forget|schema|validate> [--json <json> | --file <path> | @file | --stdin] [--command <command>] [--project <path> | --project-id <id>] [--query <text>] [--entry-id <id>] [--limit <n>] [--api-url <url>] [--discovery-file <path>]");
   }
 
   let jsonInput: string | null = null;

--- a/scripts/withmate-memory.ts
+++ b/scripts/withmate-memory.ts
@@ -3,7 +3,12 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
-import { MEMORY_V6_SCHEMA_VERSION } from "../src/memory-v6/memory-contract.js";
+import {
+  MEMORY_ENTRY_KINDS,
+  MEMORY_FORGET_REASONS,
+  MEMORY_V6_SCHEMA_VERSION,
+  type MemoryValidationResult,
+} from "../src/memory-v6/memory-contract.js";
 import {
   normalizeWithMateMemoryApiBaseUrl,
   resolveDefaultWithMateMemoryDiscoveryFilePath,
@@ -12,6 +17,14 @@ import {
   type WithMateMemoryDiscoveryDocument,
 } from "../src/memory-v6/memory-discovery.js";
 import { createMemoryErrorResponse, type MemoryErrorResponse } from "../src/memory-v6/memory-response-contract.js";
+import {
+  validateMemoryAppendRequest,
+  validateMemoryForgetRequest,
+  validateMemoryGetEntryRequest,
+  validateMemoryListTagsRequest,
+  validateMemoryResolveContextRequest,
+  validateMemorySearchRequest,
+} from "../src/memory-v6/memory-validation.js";
 import {
   WITHMATE_MEMORY_BINDING_REFERENCE_ENV,
   WITHMATE_MEMORY_BINDING_REFERENCE_HEADER,
@@ -37,11 +50,17 @@ export type WithMateMemoryCliCommand =
   | "get_entry"
   | "list_tags"
   | "append"
-  | "forget";
+  | "forget"
+  | "schema"
+  | "validate";
+
+export type WithMateMemoryApiCommand = Exclude<WithMateMemoryCliCommand, "schema" | "validate">;
+export type WithMateMemoryValidatedCommand = Exclude<WithMateMemoryApiCommand, "status">;
 
 export type WithMateMemoryCliRequest = {
   command: WithMateMemoryCliCommand;
   body: unknown;
+  validateCommand?: WithMateMemoryValidatedCommand;
   discoveryFilePath?: string;
   apiUrl?: string;
 };
@@ -62,7 +81,7 @@ export type WithMateMemoryCliDeps = {
   requestTimeoutMs?: number;
 };
 
-const routeByCommand: Record<WithMateMemoryCliCommand, { method: "GET" | "POST"; path: string }> = {
+const routeByCommand: Record<WithMateMemoryApiCommand, { method: "GET" | "POST"; path: string }> = {
   status: { method: "GET", path: "/v1/status" },
   context: { method: "POST", path: "/v1/context" },
   search: { method: "POST", path: "/v1/search" },
@@ -86,6 +105,18 @@ const commandAliases = new Map<string, WithMateMemoryCliCommand>([
   ["list_tags", "list_tags"],
   ["append", "append"],
   ["forget", "forget"],
+  ["schema", "schema"],
+  ["capabilities", "schema"],
+  ["validate", "validate"],
+]);
+
+const validatableCommands = new Set<WithMateMemoryValidatedCommand>([
+  "context",
+  "search",
+  "get_entry",
+  "list_tags",
+  "append",
+  "forget",
 ]);
 
 function usageError(message: string): MemoryErrorResponse {
@@ -145,8 +176,20 @@ async function parseJsonInput(input: string): Promise<unknown> {
   try {
     return JSON.parse(trimmed) as unknown;
   } catch {
-    throw usageError("Request JSON must be valid JSON.");
+    throw usageError("Request JSON must be valid JSON. If shell quoting changed the JSON, retry with --file <path> or --stdin.");
   }
+}
+
+function normalizeCommandName(value: string): WithMateMemoryCliCommand | undefined {
+  return commandAliases.get(value);
+}
+
+function normalizeValidatableCommand(value: string): WithMateMemoryValidatedCommand | undefined {
+  const command = normalizeCommandName(value);
+  if (command && validatableCommands.has(command as WithMateMemoryValidatedCommand)) {
+    return command as WithMateMemoryValidatedCommand;
+  }
+  return undefined;
 }
 
 export async function discoverWithMateMemoryApi(
@@ -223,8 +266,15 @@ export async function parseWithMateMemoryCliArgs(
 
   let jsonInput: string | null = null;
   let filePath: string | null = null;
+  let stdinRequested = false;
   let apiUrl: string | undefined;
   let discoveryFilePath: string | undefined;
+  let validateCommand: WithMateMemoryValidatedCommand | undefined;
+  let projectPath: string | undefined;
+  let projectId: string | undefined;
+  let query: string | undefined;
+  let entryId: string | undefined;
+  let limit: number | undefined;
 
   for (let index = 0; index < rest.length; index += 1) {
     const arg = rest[index];
@@ -232,25 +282,61 @@ export async function parseWithMateMemoryCliArgs(
       jsonInput = requireOptionValue(rest, ++index, arg);
     } else if (arg === "--file") {
       filePath = requireOptionValue(rest, ++index, arg);
+    } else if (arg === "--stdin") {
+      stdinRequested = true;
+    } else if (arg.startsWith("@") && arg.length > 1) {
+      filePath = arg.slice(1);
     } else if (arg === "--api-url") {
       apiUrl = requireOptionValue(rest, ++index, arg);
     } else if (arg === "--discovery-file") {
       discoveryFilePath = requireOptionValue(rest, ++index, arg);
+    } else if (arg === "--command") {
+      const value = requireOptionValue(rest, ++index, arg);
+      validateCommand = normalizeValidatableCommand(value);
+      if (!validateCommand) {
+        throw usageError(`--command must be one of: ${Array.from(validatableCommands).join(", ")}.`);
+      }
+    } else if (arg === "--project") {
+      projectPath = requireOptionValue(rest, ++index, arg);
+    } else if (arg === "--project-id") {
+      projectId = requireOptionValue(rest, ++index, arg);
+    } else if (arg === "--query") {
+      query = requireOptionValue(rest, ++index, arg);
+    } else if (arg === "--entry-id") {
+      entryId = requireOptionValue(rest, ++index, arg);
+    } else if (arg === "--limit") {
+      limit = parseLimitOption(requireOptionValue(rest, ++index, arg));
     } else {
       throw usageError(`Unknown option: ${arg}`);
     }
   }
 
-  if (jsonInput !== null && filePath !== null) {
-    throw usageError("--json and --file cannot be used together.");
+  const bodyInputCount = [jsonInput !== null, filePath !== null, stdinRequested].filter(Boolean).length;
+  if (bodyInputCount > 1) {
+    throw usageError("--json, --file, @file, and --stdin cannot be used together.");
+  }
+
+  if (projectPath && projectId) {
+    throw usageError("--project and --project-id cannot be used together.");
+  }
+
+  if (command === "validate" && !validateCommand) {
+    throw usageError("validate requires --command <context|search|get-entry|list-tags|append|forget>.");
   }
 
   let body: unknown = defaultRequestBody(command);
-  if (command !== "status") {
+  if (command !== "status" && command !== "schema") {
     if (jsonInput !== null) {
       body = await parseJsonInput(jsonInput);
     } else if (filePath !== null) {
       body = await parseJsonInput(await (deps.readFile ?? readFile)(filePath, "utf8"));
+    } else if (stdinRequested) {
+      if (!deps.stdin) {
+        throw usageError("--stdin requires stdin.");
+      }
+      body = await parseJsonInput(await readStdin(deps.stdin));
+    } else if (hasShorthandOptions({ projectPath, projectId, query, entryId, limit })) {
+      body = buildShorthandBody(command, { projectPath, projectId, query, entryId, limit });
     } else if (deps.stdin && !deps.stdin.isTTY) {
       body = await parseJsonInput(await readStdin(deps.stdin));
     }
@@ -259,9 +345,86 @@ export async function parseWithMateMemoryCliArgs(
   return {
     command,
     body: normalizeProjectPathTargets(body),
+    ...(validateCommand ? { validateCommand } : {}),
     ...(apiUrl ? { apiUrl } : {}),
     ...(discoveryFilePath ? { discoveryFilePath } : {}),
   };
+}
+
+function parseLimitOption(value: string): number {
+  const limit = Number(value);
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw usageError("--limit must be a positive integer.");
+  }
+  return limit;
+}
+
+function hasShorthandOptions(options: {
+  projectPath?: string;
+  projectId?: string;
+  query?: string;
+  entryId?: string;
+  limit?: number;
+}): boolean {
+  return Boolean(options.projectPath || options.projectId || options.query || options.entryId || options.limit !== undefined);
+}
+
+function buildProjectTarget(options: { projectPath?: string; projectId?: string }): unknown | null {
+  if (options.projectId) {
+    return { owner: "project", scope: "project", project: { type: "id", id: options.projectId } };
+  }
+  if (options.projectPath) {
+    return { owner: "project", scope: "project", project: { type: "path", path: options.projectPath } };
+  }
+  return null;
+}
+
+function buildShorthandBody(
+  command: WithMateMemoryCliCommand,
+  options: { projectPath?: string; projectId?: string; query?: string; entryId?: string; limit?: number },
+): unknown {
+  if (command === "validate") {
+    throw usageError("validate shorthand options are not supported. Use --json, --file, @file, or --stdin.");
+  }
+
+  const target = buildProjectTarget(options);
+  if (command === "search") {
+    if (!target) {
+      throw usageError("search shorthand requires --project <path> or --project-id <id>.");
+    }
+    if (!options.query) {
+      throw usageError("search shorthand requires --query <text>.");
+    }
+    return {
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      targets: [target],
+      query: options.query,
+      ...(options.limit !== undefined ? { limit: options.limit } : {}),
+    };
+  }
+
+  if (command === "list_tags") {
+    if (!target) {
+      throw usageError("list-tags shorthand requires --project <path> or --project-id <id>.");
+    }
+    return {
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      targets: [target],
+    };
+  }
+
+  if (command === "get_entry") {
+    if (!options.entryId) {
+      throw usageError("get-entry shorthand requires --entry-id <id>.");
+    }
+    return {
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      entryId: options.entryId,
+      ...(target ? { target } : {}),
+    };
+  }
+
+  throw usageError(`${command} does not support shorthand options. Use --json, --file, @file, or --stdin.`);
 }
 
 function normalizeProjectPathTargets(value: unknown): unknown {
@@ -290,6 +453,70 @@ function requireOptionValue(args: readonly string[], index: number, option: stri
     throw usageError(`${option} requires a value.`);
   }
   return value;
+}
+
+function buildSchemaResponse(): unknown {
+  return {
+    schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+    entryKinds: [...MEMORY_ENTRY_KINDS],
+    forgetReasons: [...MEMORY_FORGET_REASONS],
+    commands: [
+      "status",
+      "context",
+      "search",
+      "get-entry",
+      "list-tags",
+      "append",
+      "forget",
+      "schema",
+      "validate",
+    ],
+    requestBodyInputs: ["--json", "--file", "@file", "--stdin"],
+  };
+}
+
+function validateMemoryCliRequestBody(
+  command: WithMateMemoryValidatedCommand,
+  body: unknown,
+): MemoryValidationResult<unknown> {
+  if (command === "context") {
+    return validateMemoryResolveContextRequest(body);
+  }
+  if (command === "search") {
+    return validateMemorySearchRequest(body);
+  }
+  if (command === "get_entry") {
+    return validateMemoryGetEntryRequest(body);
+  }
+  if (command === "list_tags") {
+    return validateMemoryListTagsRequest(body);
+  }
+  if (command === "append") {
+    return validateMemoryAppendRequest(body);
+  }
+  return validateMemoryForgetRequest(body);
+}
+
+function buildValidateResponse(command: WithMateMemoryValidatedCommand, body: unknown): {
+  exitCode: number;
+  response: unknown;
+} {
+  const validation = validateMemoryCliRequestBody(command, body);
+  if (!validation.ok) {
+    return {
+      exitCode: WITHMATE_MEMORY_CLI_EXIT_CODES.apiError,
+      response: createMemoryErrorResponse(validation.error),
+    };
+  }
+  return {
+    exitCode: WITHMATE_MEMORY_CLI_EXIT_CODES.ok,
+    response: {
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      valid: true,
+      command,
+      value: validation.value,
+    },
+  };
 }
 
 async function readJsonResponse(response: Response): Promise<unknown> {
@@ -354,6 +581,16 @@ export async function runWithMateMemoryCli(
 
   try {
     const request = await parseWithMateMemoryCliArgs(args, deps);
+    if (request.command === "schema") {
+      stdout.write(`${JSON.stringify(buildSchemaResponse())}\n`);
+      return WITHMATE_MEMORY_CLI_EXIT_CODES.ok;
+    }
+    if (request.command === "validate") {
+      const result = buildValidateResponse(request.validateCommand!, request.body);
+      stdout.write(`${JSON.stringify(result.response)}\n`);
+      return result.exitCode;
+    }
+
     const connection = await discoverWithMateMemoryApi({
       env: deps.env,
       apiUrl: request.apiUrl,

--- a/src/memory-v6/memory-contract.ts
+++ b/src/memory-v6/memory-contract.ts
@@ -4,16 +4,19 @@ export type MemoryV6SchemaVersion = typeof MEMORY_V6_SCHEMA_VERSION;
 
 export type MemoryEntryState = "active" | "superseded" | "forgotten";
 
-export type MemoryEntryKind =
-  | "decision"
-  | "constraint"
-  | "convention"
-  | "context"
-  | "deferred"
-  | "preference"
-  | "relationship"
-  | "boundary"
-  | "note";
+export const MEMORY_ENTRY_KINDS = [
+  "decision",
+  "constraint",
+  "convention",
+  "context",
+  "deferred",
+  "preference",
+  "relationship",
+  "boundary",
+  "note",
+] as const;
+
+export type MemoryEntryKind = typeof MEMORY_ENTRY_KINDS[number];
 
 export type MemoryPermission =
   | "memory.search"
@@ -85,7 +88,15 @@ export type MemoryAppendRequest = {
   idempotencyKey?: string;
 };
 
-export type MemoryForgetReason = "user_request" | "incorrect" | "outdated" | "privacy" | "other";
+export const MEMORY_FORGET_REASONS = [
+  "user_request",
+  "incorrect",
+  "outdated",
+  "privacy",
+  "other",
+] as const;
+
+export type MemoryForgetReason = typeof MEMORY_FORGET_REASONS[number];
 
 export type MemoryForgetRequest = {
   schemaVersion: MemoryV6SchemaVersion;

--- a/src/memory-v6/memory-validation.ts
+++ b/src/memory-v6/memory-validation.ts
@@ -1,4 +1,6 @@
 import {
+  MEMORY_ENTRY_KINDS,
+  MEMORY_FORGET_REASONS,
   MEMORY_V6_SCHEMA_VERSION,
   type CharacterTargetRef,
   type MemoryAppendRequest,
@@ -15,25 +17,8 @@ import {
   type ProjectTargetRef,
 } from "./memory-contract.js";
 
-const MEMORY_ENTRY_KINDS = new Set<MemoryEntryKind>([
-  "decision",
-  "constraint",
-  "convention",
-  "context",
-  "deferred",
-  "preference",
-  "relationship",
-  "boundary",
-  "note",
-]);
-
-const MEMORY_FORGET_REASONS = new Set<MemoryForgetReason>([
-  "user_request",
-  "incorrect",
-  "outdated",
-  "privacy",
-  "other",
-]);
+const MEMORY_ENTRY_KIND_SET = new Set<MemoryEntryKind>(MEMORY_ENTRY_KINDS);
+const MEMORY_FORGET_REASON_SET = new Set<MemoryForgetReason>(MEMORY_FORGET_REASONS);
 
 const RESOLVE_CONTEXT_REQUEST_KEYS = new Set(["schemaVersion"]);
 const SEARCH_REQUEST_KEYS = new Set(["schemaVersion", "targets", "query", "kinds", "tags", "limit", "cursor"]);
@@ -199,7 +184,7 @@ function normalizeStringArray(value: unknown, field: string, options: { maxItems
 }
 
 function validateMemoryKind(value: unknown, field: string): MemoryValidationResult<MemoryEntryKind> {
-  if (typeof value !== "string" || !MEMORY_ENTRY_KINDS.has(value as MemoryEntryKind)) {
+  if (typeof value !== "string" || !MEMORY_ENTRY_KIND_SET.has(value as MemoryEntryKind)) {
     return error("MEMORY_INVALID_FIELD", `${field} must be a valid memory kind.`, field);
   }
 
@@ -383,7 +368,7 @@ function normalizeKinds(value: unknown): MemoryValidationResult<MemoryEntryKind[
   if (!Array.isArray(value)) {
     return error("MEMORY_INVALID_FIELD", "kinds must be an array.", "kinds");
   }
-  if (value.length > MEMORY_ENTRY_KINDS.size) {
+  if (value.length > MEMORY_ENTRY_KINDS.length) {
     return error("MEMORY_FIELD_TOO_LARGE", "kinds has too many items.", "kinds");
   }
 
@@ -628,7 +613,7 @@ export function validateMemoryForgetRequest(value: unknown): MemoryValidationRes
   if (!entryIds.value || entryIds.value.length === 0) {
     return error("MEMORY_INVALID_FIELD", "entryIds must not be empty.", "entryIds");
   }
-  if (value.reason !== undefined && (typeof value.reason !== "string" || !MEMORY_FORGET_REASONS.has(value.reason as MemoryForgetReason))) {
+  if (value.reason !== undefined && (typeof value.reason !== "string" || !MEMORY_FORGET_REASON_SET.has(value.reason as MemoryForgetReason))) {
     return error("MEMORY_INVALID_FIELD", "reason must be a valid forget reason.", "reason");
   }
   const sourceMessageId = normalizeOptionalText(value.sourceMessageId, "sourceMessageId");


### PR DESCRIPTION
## Summary
- `withmate-memory schema` / `validate` を追加し、CLI単体でenum確認とrequest検証をできるようにした
- `--stdin` / `@file` / read系shorthandを追加し、PowerShellで一時ファイル必須にならない入力経路を用意した
- bundled helper、Skill docs、CLI reference、V6 Memory design docを更新した

## Scope
- Search ranking / tag matching improvements are TASK-151 側で扱う
- create/update 相当の複雑なwrite requestの全flag展開は含めず、構造化writeは `--stdin` / `--file` を使う

## Validation
- `npm run typecheck`
- `npm exec -- tsx --test scripts/tests/withmate-memory-cli.test.ts scripts/tests/managed-memory-skill-service.test.ts scripts/tests/memory-v6-contract.test.ts`
- `npm test`
- `git diff --check`
