### PR TITLE
docs: Memory Skill の表示方針を自然化

### DIFF
--- a/resources/skills/withmate-memory/SKILL.md
+++ b/resources/skills/withmate-memory/SKILL.md
@@ -44,7 +44,7 @@ Treat routine Memory search/read as background recall. Do not announce MemorySki
 
 Use retrieved Memory naturally, and mention it only when it materially affects the answer, conflicts with current context, needs traceability, or the user asks what context was used.
 
-When creating or updating Memory, mention the durable change only when the user asked for it, privacy or traceability matters, or the final response would otherwise hide a meaningful durable side effect.
+When creating or correcting/superseding Memory entries, mention the durable change only when the user asked for it, privacy or traceability matters, or the final response would otherwise hide a meaningful durable side effect.
 
 Forget and correction operations should be explicit when they affect future behavior, unless the user requested silent cleanup.
 

--- a/resources/skills/withmate-memory/SKILL.md
+++ b/resources/skills/withmate-memory/SKILL.md
@@ -38,6 +38,20 @@ Do not use Memory for trivial local edits where the current files and user messa
 5. Forget entries when the user requests removal, correction, privacy cleanup, or no-longer-use semantics.
 6. If Memory is unavailable, continue the task unless Memory access itself is the requested task.
 
+## User-Facing Memory Behavior
+
+Treat routine Memory search/read as background recall. Do not announce MemorySkill or CLI usage to the user just because a routine search/read happened.
+
+Use retrieved Memory naturally, and mention it only when it materially affects the answer, conflicts with current context, needs traceability, or the user asks what context was used.
+
+When creating or updating Memory, mention the durable change only when the user asked for it, privacy or traceability matters, or the final response would otherwise hide a meaningful durable side effect.
+
+Forget and correction operations should be explicit when they affect future behavior, unless the user requested silent cleanup.
+
+Do not hide Memory failures, invent retrieved context, or treat Memory as a replacement for repository source-of-truth files.
+
+Prefer natural wording such as "Based on the previous decision..." or "For next time, I recorded the reusable point." Avoid routine tool narration such as "I will use the withmate-memory Skill" or "I searched MemorySkill."
+
 ## Append Safety
 
 Before append, check:

--- a/scripts/tests/managed-memory-skill-service.test.ts
+++ b/scripts/tests/managed-memory-skill-service.test.ts
@@ -20,6 +20,18 @@ import {
 
 const execFileAsync = promisify(execFile);
 
+describe("withmate-memory bundled skill document", () => {
+  it("routine Memory search/read を background recall として案内する", async () => {
+    const skill = await readFile(path.resolve("resources", "skills", WITHMATE_MEMORY_SKILL_NAME, "SKILL.md"), "utf8");
+
+    assert.match(skill, /## User-Facing Memory Behavior/);
+    assert.match(skill, /Treat routine Memory search\/read as background recall/);
+    assert.match(skill, /Do not announce MemorySkill or CLI usage/);
+    assert.match(skill, /meaningful durable side effect/);
+    assert.match(skill, /Do not hide Memory failures/);
+  });
+});
+
 async function createBundle(): Promise<string> {
   const bundlePath = await mkdtemp(path.join(tmpdir(), "withmate-memory-skill-bundle-"));
   await writeFile(

--- a/scripts/tests/managed-memory-skill-service.test.ts
+++ b/scripts/tests/managed-memory-skill-service.test.ts
@@ -27,8 +27,10 @@ describe("withmate-memory bundled skill document", () => {
     assert.match(skill, /## User-Facing Memory Behavior/);
     assert.match(skill, /Treat routine Memory search\/read as background recall/);
     assert.match(skill, /Do not announce MemorySkill or CLI usage/);
+    assert.match(skill, /creating or correcting\/superseding Memory entries/);
     assert.match(skill, /meaningful durable side effect/);
     assert.match(skill, /Do not hide Memory failures/);
+    assert.doesNotMatch(skill, /updating Memory/);
   });
 });
 


### PR DESCRIPTION
## Summary
- bundled `withmate-memory` Skill に User-Facing Memory Behavior を追加
- routine search/read は background recall として扱い、通常は MemorySkill / CLI 利用をユーザーへ宣言しない方針を明記
- durable create/update/forget の副作用は、必要な場合に見えるようにする方針を明記
- bundled Skill の重要文言を回帰テストで固定

## Validation
- `npm exec -- tsx --test scripts/tests/managed-memory-skill-service.test.ts`
- `npm run typecheck`
- `git diff --check`
