### PR TITLE
TASK-151 Memory検索の使い勝手を改善

### DIFF
--- a/docs/design/v6-memory-foundation.md
+++ b/docs/design/v6-memory-foundation.md
@@ -386,6 +386,7 @@ Responseはpreview中心とする。
 type MemorySearchResponse = {
   schemaVersion: "withmate-memory-v1";
   items: MemorySearchHit[];
+  relatedTags?: MemoryTag[];
   nextCursor?: string;
 };
 
@@ -399,13 +400,20 @@ type MemorySearchHit = {
   tags: MemoryTag[];
   createdAt: string;
   updatedAt: string;
+  match?: {
+    fields: ("title" | "preview" | "body" | "tags")[];
+    snippet?: string;
+  };
 };
 ```
 
 - search hitにfull `body`を含めない。
+- public APIの`query`は非空文字列を必須とする。storage層は防御的に空queryでもactive entry pageを返すが、agent-facing contractでは空queryをsearch requestとして受け付けない。
 - active filterはSQL / search service側でpagination前に行う。
 - response builderはpagination済みのactive hit pageだけを受け取り、inactive entryを黙って捨てない。
-- relevance scoreはpublic contractに含めない。
+- searchはtitle / preview / body / tagsをtoken単位で照合し、`delivery-cleanup`と`delivery cleanup`のようなtag表記揺れを吸収する。
+- 0件時は近いtag候補を`relatedTags`で返してよい。
+- relevance scoreはpublic contractに含めない。match metadataはmatched fieldsと短いsnippetに限定する。
 - V4以前のautomatic relevance selection / prompt injectionは復活させない。
 - 初期searchはtarget / kind / tag / query filterを優先し、agentがpreviewを見て必要なら`get_entry`する。
 - forgotten / superseded entryは通常結果へ出さない。
@@ -592,6 +600,8 @@ withmate-memory forget --json '<MemoryForgetRequest>'
 withmate-memory search --file payload.json
 withmate-memory search @payload.json
 withmate-memory search --project ../repo-a --query "approval modeの方針"
+withmate-memory search --project ../repo-a --query "delivery cleanup" --tag delivery-cleanup
+withmate-memory search --project ../repo-a --tags topic:delivery-cleanup,topic:relaygraph
 ```
 
 `--json`、`--file`、`@file`、`--stdin`はrequest bodyの入力方法であり、output format指定ではない。CLI outputは常にJSONをstdoutへ出す。
@@ -615,6 +625,8 @@ current convenience flags:
 ```text
 withmate-memory search --project ../repo-a --query "approval modeの方針"
 withmate-memory search --project-id <project-id> --query "approval modeの方針"
+withmate-memory search --project ../repo-a --query "delivery cleanup" --tag delivery-cleanup
+withmate-memory search --project ../repo-a --tags topic:delivery-cleanup,topic:relaygraph
 withmate-memory get-entry --project ../repo-a --entry-id <entry-id>
 withmate-memory list-tags --project ../repo-a
 ```

--- a/docs/design/v6-memory-foundation.md
+++ b/docs/design/v6-memory-foundation.md
@@ -408,6 +408,7 @@ type MemorySearchHit = {
 ```
 
 - search hitにfull `body`を含めない。
+- `match.fields`はbody hitを示してよいが、`match.snippet`はtags / title / preview由来に限定し、body断片は`memory.search`権限だけでは返さない。
 - public APIの`query`は非空文字列を必須とする。storage層は防御的に空queryでもactive entry pageを返すが、agent-facing contractでは空queryをsearch requestとして受け付けない。
 - active filterはSQL / search service側でpagination前に行う。
 - response builderはpagination済みのactive hit pageだけを受け取り、inactive entryを黙って捨てない。

--- a/resources/skills/withmate-memory/SKILL.md
+++ b/resources/skills/withmate-memory/SKILL.md
@@ -139,7 +139,7 @@ withmate-memory validate --command append --stdin
 
 Search supports natural-language terms across title, preview, body, and tags. Hyphenated and spaced tag words such as `delivery-cleanup` and `delivery cleanup` are treated as related candidates. Shorthand `--tag <tag>` defaults to `topic:<tag>`, and `--tags` accepts comma-separated `<type>:<tag>` values.
 
-Search results may include `match` on each hit with matched fields and a short snippet. When no entries match, the response may include `relatedTags`.
+Search results may include `match` on each hit with matched fields and a short snippet. `match.fields` can report body matches, but snippets are limited to tags, title, and preview; use `get-entry` when the exact body matters. When no entries match, the response may include `relatedTags`.
 
 `get-entry`:
 

--- a/resources/skills/withmate-memory/SKILL.md
+++ b/resources/skills/withmate-memory/SKILL.md
@@ -74,6 +74,8 @@ withmate-memory context
 withmate-memory schema
 withmate-memory validate --command append --stdin
 withmate-memory search --project . --query "release workflow"
+withmate-memory search --project . --query "delivery cleanup" --tag delivery-cleanup
+withmate-memory search --project . --tags topic:delivery-cleanup,topic:relaygraph
 withmate-memory search --file memory-search.json
 withmate-memory get-entry --file memory-get-entry.json
 withmate-memory list-tags --file memory-list-tags.json
@@ -134,6 +136,10 @@ withmate-memory validate --command append --stdin
   "query": "approval mode"
 }
 ```
+
+Search supports natural-language terms across title, preview, body, and tags. Hyphenated and spaced tag words such as `delivery-cleanup` and `delivery cleanup` are treated as related candidates. Shorthand `--tag <tag>` defaults to `topic:<tag>`, and `--tags` accepts comma-separated `<type>:<tag>` values.
+
+Search results may include `match` on each hit with matched fields and a short snippet. When no entries match, the response may include `relatedTags`.
 
 `get-entry`:
 

--- a/resources/skills/withmate-memory/bin/withmate-memory.mjs
+++ b/resources/skills/withmate-memory/bin/withmate-memory.mjs
@@ -135,7 +135,7 @@ async function parseArgs(argv) {
   const [rawCommand, ...rest] = argv;
   const route = rawCommand ? commands.get(rawCommand) : undefined;
   if (!route) {
-    throw usage("Usage: withmate-memory <status|context|search|get-entry|list-tags|append|forget|schema|validate> [--json <json> | --file <path> | @file | --stdin] [--command <command>] [--project <path> | --project-id <id>] [--query <text>] [--entry-id <id>] [--limit <n>] [--api-url <url>] [--discovery-file <path>]");
+    throw usage("Usage: withmate-memory <status|context|search|get-entry|list-tags|append|forget|schema|validate> [--json <json> | --file <path> | @file | --stdin] [--command <command>] [--project <path> | --project-id <id>] [--query <text>] [--tag <tag> | --tags <tags>] [--entry-id <id>] [--limit <n>] [--api-url <url>] [--discovery-file <path>]");
   }
 
   let jsonInput = null;
@@ -147,6 +147,7 @@ async function parseArgs(argv) {
   let projectPath;
   let projectId;
   let query;
+  const tagOptions = [];
   let entryId;
   let limit;
   for (let index = 0; index < rest.length; index += 1) {
@@ -174,6 +175,10 @@ async function parseArgs(argv) {
       projectId = requireOptionValue(rest, ++index, arg);
     } else if (arg === "--query") {
       query = requireOptionValue(rest, ++index, arg);
+    } else if (arg === "--tag") {
+      tagOptions.push(requireOptionValue(rest, ++index, arg));
+    } else if (arg === "--tags") {
+      tagOptions.push(...parseTagsOption(requireOptionValue(rest, ++index, arg)));
     } else if (arg === "--entry-id") {
       entryId = requireOptionValue(rest, ++index, arg);
     } else if (arg === "--limit") {
@@ -201,8 +206,8 @@ async function parseArgs(argv) {
       body = parseJson(await readFile(filePath, "utf8"));
     } else if (stdinRequested) {
       body = parseJson(await readStdin(process.stdin));
-    } else if (hasShorthandOptions({ projectPath, projectId, query, entryId, limit })) {
-      body = buildShorthandBody(route.name, { projectPath, projectId, query, entryId, limit });
+    } else if (hasShorthandOptions({ projectPath, projectId, query, tags: tagOptions, entryId, limit })) {
+      body = buildShorthandBody(route.name, { projectPath, projectId, query, tags: tagOptions, entryId, limit });
     }
   }
   return { route, body, apiUrl, discoveryFilePath, validateCommand };
@@ -221,8 +226,39 @@ function parseLimit(value) {
   return limit;
 }
 
+function parseTagsOption(value) {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function normalizeCliTagOptions(values) {
+  const tags = [];
+  const seen = new Set();
+  for (const rawValue of values) {
+    const trimmed = rawValue.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const separatorIndex = trimmed.indexOf(":");
+    const type = separatorIndex > 0 ? trimmed.slice(0, separatorIndex).trim() : "topic";
+    const value = separatorIndex > 0 ? trimmed.slice(separatorIndex + 1).trim() : trimmed;
+    if (!type || !value) {
+      throw usage("--tag and --tags values must be <tag> or <type>:<tag>.");
+    }
+    const key = `${type.normalize("NFC").toLowerCase()}\0${value.normalize("NFC").toLowerCase()}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    tags.push({ type, value });
+  }
+  return tags;
+}
+
 function hasShorthandOptions(options) {
-  return Boolean(options.projectPath || options.projectId || options.query || options.entryId || options.limit !== undefined);
+  return Boolean(options.projectPath || options.projectId || options.query || (options.tags && options.tags.length > 0) || options.entryId || options.limit !== undefined);
 }
 
 function buildProjectTarget(options) {
@@ -241,13 +277,16 @@ function buildShorthandBody(command, options) {
     if (!target) {
       throw usage("search shorthand requires --project <path> or --project-id <id>.");
     }
-    if (!options.query) {
-      throw usage("search shorthand requires --query <text>.");
+    const tags = normalizeCliTagOptions(options.tags || []);
+    const query = options.query || tags.map((tag) => tag.value).join(" ");
+    if (!query) {
+      throw usage("search shorthand requires --query <text> or --tag <tag>.");
     }
     return {
       schemaVersion,
       targets: [target],
-      query: options.query,
+      query,
+      ...(tags.length > 0 ? { tags } : {}),
       ...(options.limit !== undefined ? { limit: options.limit } : {}),
     };
   }

--- a/resources/skills/withmate-memory/reference/cli.md
+++ b/resources/skills/withmate-memory/reference/cli.md
@@ -57,6 +57,8 @@ Sends:
 
 ```bash
 withmate-memory search --project . --query "approval mode"
+withmate-memory search --project . --query "delivery cleanup" --tag delivery-cleanup
+withmate-memory search --project . --tags topic:delivery-cleanup,topic:relaygraph
 withmate-memory search --file memory-search.json
 ```
 
@@ -73,6 +75,7 @@ Request shape:
 ```
 
 Search returns active entry previews only. Use `get-entry` when the exact body matters.
+Search uses natural-language terms across title, preview, body, and tags. Hyphenated and spaced tag words such as `delivery-cleanup` and `delivery cleanup` are treated as related candidates. Shorthand `--tag <tag>` defaults to `topic:<tag>`, and `--tags` accepts comma-separated `<type>:<tag>` values. Search results may include matched fields and a short snippet; 0-result responses may include related tag candidates.
 
 ### get-entry
 

--- a/resources/skills/withmate-memory/reference/cli.md
+++ b/resources/skills/withmate-memory/reference/cli.md
@@ -75,7 +75,7 @@ Request shape:
 ```
 
 Search returns active entry previews only. Use `get-entry` when the exact body matters.
-Search uses natural-language terms across title, preview, body, and tags. Hyphenated and spaced tag words such as `delivery-cleanup` and `delivery cleanup` are treated as related candidates. Shorthand `--tag <tag>` defaults to `topic:<tag>`, and `--tags` accepts comma-separated `<type>:<tag>` values. Search results may include matched fields and a short snippet; 0-result responses may include related tag candidates.
+Search uses natural-language terms across title, preview, body, and tags. Hyphenated and spaced tag words such as `delivery-cleanup` and `delivery cleanup` are treated as related candidates. Shorthand `--tag <tag>` defaults to `topic:<tag>`, and `--tags` accepts comma-separated `<type>:<tag>` values. Search results may include matched fields and a short snippet; body matches may be reported in `match.fields`, but snippets are limited to tags, title, and preview. 0-result responses may include related tag candidates.
 
 ### get-entry
 

--- a/scripts/tests/memory-v6-service.test.ts
+++ b/scripts/tests/memory-v6-service.test.ts
@@ -223,6 +223,31 @@ describe("MemoryV6Service", () => {
     });
   });
 
+  it("search はbody matchを示してもbody由来snippetを返さない", async () => {
+    await withService(({ service }) => {
+      service.append(principal(), appendRequest({
+        title: "権限境界",
+        body: "search権限だけでは直接読ませない秘密の本文断片",
+        preview: "検索結果の要約",
+        tags: [{ type: "topic", value: "permission" }],
+      }));
+
+      const search = service.search(principal(), {
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        targets: [{ owner: "project", scope: "project", project: { type: "alias", alias: "main" } }],
+        query: "秘密の本文断片",
+      });
+
+      assert.equal("error" in search, false);
+      if ("error" in search) {
+        return;
+      }
+      assert.equal(search.items.length, 1);
+      assert.deepEqual(search.items[0]?.match?.fields, ["body"]);
+      assert.equal(search.items[0]?.match?.snippet, undefined);
+    });
+  });
+
   it("permission不足とtarget access違反をstorageへ渡す前に拒否する", async () => {
     await withService(({ service }) => {
       const unauthorized = service.search(principal({ permissions: ["memory.resolve_context"] }), {

--- a/scripts/tests/memory-v6-service.test.ts
+++ b/scripts/tests/memory-v6-service.test.ts
@@ -189,6 +189,40 @@ describe("MemoryV6Service", () => {
     });
   });
 
+  it("search はmatch情報と0件時のrelatedTagsをresponse contractで返す", async () => {
+    await withService(({ service }) => {
+      service.append(principal(), appendRequest({
+        title: "納品cleanup branch strategy",
+        body: "KMT prefix removal は納品用ブランチで進め、RelayGraph は削除可とする。",
+        preview: "納品cleanupのブランチ方針。",
+        tags: [
+          { type: "topic", value: "delivery-cleanup" },
+          { type: "topic", value: "relaygraph" },
+        ],
+      }));
+
+      const search = service.search(principal(), {
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        targets: [{ owner: "project", scope: "project", project: { type: "alias", alias: "main" } }],
+        query: "delivery cleanup branch relaygraph",
+      });
+      assert.equal("error" in search, false);
+      assert.equal(search.items.length, 1);
+      assert.ok(search.items[0]?.match?.fields.includes("tags"));
+      assert.match(search.items[0]?.match?.snippet ?? "", /delivery-cleanup|relaygraph/);
+
+      const noEntry = service.search(principal(), {
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        targets: [{ owner: "project", scope: "project", project: { type: "alias", alias: "main" } }],
+        query: "delivery cleanup",
+        kinds: ["preference"],
+      });
+      assert.equal("error" in noEntry, false);
+      assert.deepEqual(noEntry.items, []);
+      assert.deepEqual(noEntry.relatedTags, [{ type: "topic", value: "delivery-cleanup" }]);
+    });
+  });
+
   it("permission不足とtarget access違反をstorageへ渡す前に拒否する", async () => {
     await withService(({ service }) => {
       const unauthorized = service.search(principal({ permissions: ["memory.resolve_context"] }), {

--- a/scripts/tests/memory-v6-storage.test.ts
+++ b/scripts/tests/memory-v6-storage.test.ts
@@ -160,6 +160,78 @@ describe("MemoryV6Storage", () => {
     });
   });
 
+  it("search は自然文queryをtoken化し、タグ表記揺れとmatch情報と0件時候補を返す", async () => {
+    await withStorage(({ storage }) => {
+      storage.appendEntry(baseAppend({
+        id: "mem-delivery-cleanup",
+        title: "納品cleanup branch strategy",
+        body: "KMT prefix removal は納品用ブランチで進め、RelayGraph は削除可とする。",
+        preview: "納品cleanupのブランチ方針。",
+        tags: [
+          tag("topic", "delivery-cleanup"),
+          tag("topic", "branch-strategy"),
+          tag("topic", "relaygraph"),
+        ],
+      }));
+      storage.appendEntry(baseAppend({
+        id: "mem-unrelated",
+        title: "UI方針",
+        body: "Memory UIは既存のlayoutに揃える。",
+        preview: "UI方針",
+        tags: [tag("topic", "ui")],
+      }));
+
+      const naturalQuery = storage.searchEntries({
+        targets: [projectTarget],
+        query: "delivery cleanup branch relaygraph",
+      });
+      assert.equal(naturalQuery.items[0]?.id, "mem-delivery-cleanup");
+      assert.deepEqual(naturalQuery.items[0]?.match?.fields.includes("tags"), true);
+      assert.match(naturalQuery.items[0]?.match?.snippet ?? "", /delivery-cleanup|relaygraph/);
+
+      const hyphenated = storage.searchEntries({ targets: [projectTarget], query: "delivery-cleanup" });
+      const spaced = storage.searchEntries({ targets: [projectTarget], query: "delivery cleanup" });
+      assert.equal(hyphenated.items[0]?.id, "mem-delivery-cleanup");
+      assert.equal(spaced.items[0]?.id, "mem-delivery-cleanup");
+
+      const noEntry = storage.searchEntries({
+        targets: [projectTarget],
+        query: "delivery cleanup",
+        kinds: ["preference"],
+      });
+      assert.deepEqual(noEntry.items, []);
+      assert.deepEqual(noEntry.relatedTags?.map((item) => item.value), ["delivery-cleanup"]);
+    });
+  });
+
+  it("search storage は空queryでも防御的にactive entryをupdated_at順に返す", async () => {
+    await withStorage(({ storage }) => {
+      storage.appendEntry(baseAppend({
+        id: "mem-empty-query-old",
+        title: "Old",
+        body: "old body",
+        preview: "old",
+        now: "2026-06-24T00:00:00.000Z",
+      }));
+      storage.appendEntry(baseAppend({
+        id: "mem-empty-query-new",
+        title: "New",
+        body: "new body",
+        preview: "new",
+        now: "2026-06-24T00:01:00.000Z",
+      }));
+
+      const first = storage.searchEntries({ targets: [projectTarget], query: "", limit: 1 });
+      assert.deepEqual(first.items.map((item) => item.id), ["mem-empty-query-new"]);
+      assert.equal(first.items[0]?.match, undefined);
+      assert.ok(first.nextCursor);
+
+      const second = storage.searchEntries({ targets: [projectTarget], query: "", limit: 1, cursor: first.nextCursor });
+      assert.deepEqual(second.items.map((item) => item.id), ["mem-empty-query-old"]);
+      assert.equal(second.relatedTags, undefined);
+    });
+  });
+
   it("review search / get / forget はactive entryの閲覧とforgetに限定する", async () => {
     await withStorage(({ storage }) => {
       storage.appendEntry(baseAppend({
@@ -436,6 +508,52 @@ describe("MemoryV6Storage", () => {
 
       const second = storage.searchEntries({ targets: [projectTarget], query: "shared", limit: 1, cursor: first.nextCursor });
       assert.deepEqual(second.items.map((item) => item.id), ["mem-a"]);
+      assert.equal(second.nextCursor, undefined);
+    });
+  });
+
+  it("search pagination はmatch scoreに関係なくupdated_at cursor順で漏れなく進める", async () => {
+    await withStorage(({ storage }) => {
+      storage.appendEntry(baseAppend({
+        id: "mem-low-score-old",
+        title: "Delivery",
+        body: "Delivery only",
+        preview: "Delivery",
+        tags: [tag("topic", "delivery")],
+        now: "2026-06-24T00:00:00.000Z",
+      }));
+      storage.appendEntry(baseAppend({
+        id: "mem-high-score-middle",
+        title: "Delivery cleanup branch relaygraph",
+        body: "delivery cleanup branch relaygraph",
+        preview: "delivery cleanup branch relaygraph",
+        tags: [tag("topic", "delivery-cleanup"), tag("topic", "relaygraph")],
+        now: "2026-06-24T00:01:00.000Z",
+      }));
+      storage.appendEntry(baseAppend({
+        id: "mem-low-score-new",
+        title: "Delivery",
+        body: "Delivery only",
+        preview: "Delivery",
+        tags: [tag("topic", "delivery")],
+        now: "2026-06-24T00:02:00.000Z",
+      }));
+
+      const first = storage.searchEntries({
+        targets: [projectTarget],
+        query: "delivery cleanup branch relaygraph",
+        limit: 1,
+      });
+      assert.deepEqual(first.items.map((item) => item.id), ["mem-low-score-new"]);
+      assert.ok(first.nextCursor);
+
+      const second = storage.searchEntries({
+        targets: [projectTarget],
+        query: "delivery cleanup branch relaygraph",
+        limit: 2,
+        cursor: first.nextCursor,
+      });
+      assert.deepEqual(second.items.map((item) => item.id), ["mem-high-score-middle", "mem-low-score-old"]);
       assert.equal(second.nextCursor, undefined);
     });
   });

--- a/scripts/tests/memory-v6-storage.test.ts
+++ b/scripts/tests/memory-v6-storage.test.ts
@@ -204,6 +204,28 @@ describe("MemoryV6Storage", () => {
     });
   });
 
+  it("search match snippet はbody由来の本文断片を返さない", async () => {
+    await withStorage(({ storage }) => {
+      storage.appendEntry(baseAppend({
+        id: "mem-body-only",
+        title: "権限境界",
+        body: "search権限だけでは直接読ませない秘密の本文断片",
+        preview: "検索結果の要約",
+        tags: [tag("topic", "permission")],
+      }));
+
+      const search = storage.searchEntries({
+        targets: [projectTarget],
+        query: "秘密の本文断片",
+      });
+
+      assert.equal(search.items.length, 1);
+      assert.equal(search.items[0]?.id, "mem-body-only");
+      assert.deepEqual(search.items[0]?.match?.fields, ["body"]);
+      assert.equal(search.items[0]?.match?.snippet, undefined);
+    });
+  });
+
   it("search storage は空queryでも防御的にactive entryをupdated_at順に返す", async () => {
     await withStorage(({ storage }) => {
       storage.appendEntry(baseAppend({

--- a/scripts/tests/withmate-memory-cli.test.ts
+++ b/scripts/tests/withmate-memory-cli.test.ts
@@ -535,6 +535,43 @@ describe("withmate-memory CLI", () => {
     }
   });
 
+  it("search shorthandは--tag / --tagsからtagsを作り、query未指定時はtag値をqueryに使う", async () => {
+    const stdout = createOutputCapture();
+    const tempDirectory = await mkdtemp(join(tmpdir(), "withmate-memory-cli-tags-"));
+    let capturedBody: any = null;
+    try {
+      const exitCode = await runWithMateMemoryCli([
+        "search",
+        "--project",
+        tempDirectory,
+        "--tag",
+        "delivery-cleanup",
+        "--tags",
+        "topic:relaygraph,source:docs",
+      ], {
+        env: TEST_RUNTIME_ENV,
+        stdout: stdout.stream,
+        fetch: async (url, init) => {
+          if (isStatusChallengeRequest(String(url))) {
+            return createStatusChallengeResponse(String(url));
+          }
+          capturedBody = JSON.parse(String(init?.body));
+          return new Response(JSON.stringify({ schemaVersion: MEMORY_V6_SCHEMA_VERSION, items: [] }), { status: 200 });
+        },
+      });
+
+      assert.equal(exitCode, WITHMATE_MEMORY_CLI_EXIT_CODES.ok);
+      assert.equal(capturedBody.query, "delivery-cleanup relaygraph docs");
+      assert.deepEqual(capturedBody.tags, [
+        { type: "topic", value: "delivery-cleanup" },
+        { type: "topic", value: "relaygraph" },
+        { type: "source", value: "docs" },
+      ]);
+    } finally {
+      await rm(tempDirectory, { recursive: true, force: true });
+    }
+  });
+
   it("project.pathの相対pathはCLI起動cwd基準の絶対pathへ正規化して送る", async () => {
     const stdout = createOutputCapture();
     const tempDirectory = await mkdtemp(join(tmpdir(), "withmate-memory-cli-cwd-"));
@@ -751,5 +788,6 @@ describe("withmate-memory CLI", () => {
     assert.match(message, /@file/);
     assert.match(message, /--stdin/);
     assert.match(message, /--project/);
+    assert.match(message, /--tag/);
   });
 });

--- a/scripts/withmate-memory.ts
+++ b/scripts/withmate-memory.ts
@@ -261,7 +261,7 @@ export async function parseWithMateMemoryCliArgs(
   const [rawCommand, ...rest] = args;
   const command = rawCommand ? commandAliases.get(rawCommand) : undefined;
   if (!command) {
-    throw usageError("Usage: withmate-memory <status|context|search|get-entry|list-tags|append|forget|schema|validate> [--json <json> | --file <path> | @file | --stdin] [--command <command>] [--project <path> | --project-id <id>] [--query <text>] [--entry-id <id>] [--limit <n>] [--api-url <url>] [--discovery-file <path>]");
+    throw usageError("Usage: withmate-memory <status|context|search|get-entry|list-tags|append|forget|schema|validate> [--json <json> | --file <path> | @file | --stdin] [--command <command>] [--project <path> | --project-id <id>] [--query <text>] [--tag <tag> | --tags <tags>] [--entry-id <id>] [--limit <n>] [--api-url <url>] [--discovery-file <path>]");
   }
 
   let jsonInput: string | null = null;
@@ -273,6 +273,7 @@ export async function parseWithMateMemoryCliArgs(
   let projectPath: string | undefined;
   let projectId: string | undefined;
   let query: string | undefined;
+  const tagOptions: string[] = [];
   let entryId: string | undefined;
   let limit: number | undefined;
 
@@ -302,6 +303,10 @@ export async function parseWithMateMemoryCliArgs(
       projectId = requireOptionValue(rest, ++index, arg);
     } else if (arg === "--query") {
       query = requireOptionValue(rest, ++index, arg);
+    } else if (arg === "--tag") {
+      tagOptions.push(requireOptionValue(rest, ++index, arg));
+    } else if (arg === "--tags") {
+      tagOptions.push(...parseTagsOption(requireOptionValue(rest, ++index, arg)));
     } else if (arg === "--entry-id") {
       entryId = requireOptionValue(rest, ++index, arg);
     } else if (arg === "--limit") {
@@ -335,8 +340,8 @@ export async function parseWithMateMemoryCliArgs(
         throw usageError("--stdin requires stdin.");
       }
       body = await parseJsonInput(await readStdin(deps.stdin));
-    } else if (hasShorthandOptions({ projectPath, projectId, query, entryId, limit })) {
-      body = buildShorthandBody(command, { projectPath, projectId, query, entryId, limit });
+    } else if (hasShorthandOptions({ projectPath, projectId, query, tags: tagOptions, entryId, limit })) {
+      body = buildShorthandBody(command, { projectPath, projectId, query, tags: tagOptions, entryId, limit });
     } else if (deps.stdin && !deps.stdin.isTTY) {
       body = await parseJsonInput(await readStdin(deps.stdin));
     }
@@ -359,14 +364,46 @@ function parseLimitOption(value: string): number {
   return limit;
 }
 
+function parseTagsOption(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function normalizeCliTagOptions(values: readonly string[]): Array<{ type: string; value: string }> {
+  const tags: Array<{ type: string; value: string }> = [];
+  const seen = new Set<string>();
+  for (const rawValue of values) {
+    const trimmed = rawValue.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const separatorIndex = trimmed.indexOf(":");
+    const type = separatorIndex > 0 ? trimmed.slice(0, separatorIndex).trim() : "topic";
+    const value = separatorIndex > 0 ? trimmed.slice(separatorIndex + 1).trim() : trimmed;
+    if (!type || !value) {
+      throw usageError("--tag and --tags values must be <tag> or <type>:<tag>.");
+    }
+    const key = `${type.normalize("NFC").toLowerCase()}\0${value.normalize("NFC").toLowerCase()}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    tags.push({ type, value });
+  }
+  return tags;
+}
+
 function hasShorthandOptions(options: {
   projectPath?: string;
   projectId?: string;
   query?: string;
+  tags?: readonly string[];
   entryId?: string;
   limit?: number;
 }): boolean {
-  return Boolean(options.projectPath || options.projectId || options.query || options.entryId || options.limit !== undefined);
+  return Boolean(options.projectPath || options.projectId || options.query || (options.tags && options.tags.length > 0) || options.entryId || options.limit !== undefined);
 }
 
 function buildProjectTarget(options: { projectPath?: string; projectId?: string }): unknown | null {
@@ -381,7 +418,7 @@ function buildProjectTarget(options: { projectPath?: string; projectId?: string 
 
 function buildShorthandBody(
   command: WithMateMemoryCliCommand,
-  options: { projectPath?: string; projectId?: string; query?: string; entryId?: string; limit?: number },
+  options: { projectPath?: string; projectId?: string; query?: string; tags?: readonly string[]; entryId?: string; limit?: number },
 ): unknown {
   if (command === "validate") {
     throw usageError("validate shorthand options are not supported. Use --json, --file, @file, or --stdin.");
@@ -392,13 +429,16 @@ function buildShorthandBody(
     if (!target) {
       throw usageError("search shorthand requires --project <path> or --project-id <id>.");
     }
-    if (!options.query) {
-      throw usageError("search shorthand requires --query <text>.");
+    const tags = normalizeCliTagOptions(options.tags ?? []);
+    const query = options.query ?? tags.map((tag) => tag.value).join(" ");
+    if (!query) {
+      throw usageError("search shorthand requires --query <text> or --tag <tag>.");
     }
     return {
       schemaVersion: MEMORY_V6_SCHEMA_VERSION,
       targets: [target],
-      query: options.query,
+      query,
+      ...(tags.length > 0 ? { tags } : {}),
       ...(options.limit !== undefined ? { limit: options.limit } : {}),
     };
   }

--- a/src-electron/memory-v6-service.ts
+++ b/src-electron/memory-v6-service.ts
@@ -156,7 +156,10 @@ export class MemoryV6Service {
       limit: validated.value.limit,
       cursor: validated.value.cursor,
     });
-    return createMemorySearchResponse(result.items, result.nextCursor);
+    return createMemorySearchResponse(result.items, {
+      nextCursor: result.nextCursor,
+      relatedTags: result.relatedTags,
+    });
   }
 
   getEntry(principal: MemoryV6Principal | null, request: unknown): MemoryV6ServiceResult<MemoryGetEntryResponse> {

--- a/src-electron/memory-v6-storage.ts
+++ b/src-electron/memory-v6-storage.ts
@@ -669,8 +669,7 @@ export class MemoryV6Storage {
 
     const snippet = tagSnippet(tags, queryPlan)
       ?? buildSnippet(entry.title, queryPlan)
-      ?? buildSnippet(entry.preview, queryPlan)
-      ?? buildSnippet(entry.body, queryPlan);
+      ?? buildSnippet(entry.preview, queryPlan);
 
     return {
       fields,

--- a/src-electron/memory-v6-storage.ts
+++ b/src-electron/memory-v6-storage.ts
@@ -11,7 +11,14 @@ import type {
   MemoryV6ReviewSearchHit,
   MemoryV6ReviewSearchResult,
 } from "../src/memory-v6/memory-review-state.js";
-import { toMemorySearchHit, type ActiveMemoryEntryDetail, type MemoryEntryDetail, type MemorySearchHit } from "../src/memory-v6/memory-state.js";
+import {
+  toMemorySearchHit,
+  type ActiveMemoryEntryDetail,
+  type MemoryEntryDetail,
+  type MemorySearchHit,
+  type MemorySearchMatch,
+  type MemorySearchMatchField,
+} from "../src/memory-v6/memory-state.js";
 import { isValidV6Database } from "./database-schema-v6.js";
 import {
   MEMORY_V6_ENTRY_SELECT_COLUMNS,
@@ -75,6 +82,7 @@ export type MemoryV6SearchInput = {
 
 export type MemoryV6SearchResult = {
   items: MemorySearchHit[];
+  relatedTags?: NormalizedMemoryTag[];
   nextCursor?: string;
 };
 
@@ -149,6 +157,17 @@ type SearchCursor = {
   id: string;
 };
 
+type SearchQueryPlan = {
+  normalizedQuery: string;
+  tokens: string[];
+};
+
+type ScoredSearchEntry = {
+  row: MemoryV6EntryRow;
+  entry: ActiveMemoryEntryDetail;
+  match: MemorySearchMatch;
+};
+
 function encodeCursor(cursor: SearchCursor): string {
   return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
 }
@@ -166,6 +185,102 @@ function decodeCursor(cursor: string | undefined): SearchCursor | null {
   } catch {
     return null;
   }
+}
+
+function normalizeSearchText(value: string): string {
+  return value
+    .normalize("NFC")
+    .toLowerCase()
+    .replace(/[\u2010-\u2015_-]+/g, " ")
+    .replace(/[/:]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function expandSearchToken(token: string): string[] {
+  switch (token) {
+    case "delivery":
+      return [token, "納品"];
+    case "納品":
+      return [token, "delivery"];
+    case "branch":
+      return [token, "ブランチ"];
+    case "ブランチ":
+      return [token, "branch"];
+    default:
+      return [token];
+  }
+}
+
+function buildSearchQueryPlan(query: string): SearchQueryPlan {
+  const normalizedQuery = normalizeSearchText(query);
+  const tokens = new Set<string>();
+  for (const token of normalizedQuery.split(" ")) {
+    if (!token) {
+      continue;
+    }
+    for (const expanded of expandSearchToken(token)) {
+      tokens.add(expanded);
+    }
+  }
+
+  return {
+    normalizedQuery,
+    tokens: [...tokens],
+  };
+}
+
+function scoreNormalizedText(text: string, plan: SearchQueryPlan, weight: number): number {
+  if (!text) {
+    return 0;
+  }
+  let score = 0;
+  if (plan.normalizedQuery && text.includes(plan.normalizedQuery)) {
+    score += weight * 2;
+  }
+  for (const token of plan.tokens) {
+    if (text.includes(token)) {
+      score += weight;
+    }
+  }
+  return score;
+}
+
+function buildSnippet(value: string, plan: SearchQueryPlan): string | undefined {
+  const normalizedValue = normalizeSearchText(value);
+  const token = plan.tokens.find((item) => normalizedValue.includes(item));
+  if (!token) {
+    return undefined;
+  }
+  const normalizedIndex = normalizedValue.indexOf(token);
+  const start = Math.max(0, normalizedIndex - 48);
+  const end = Math.min(value.length, normalizedIndex + token.length + 96);
+  const snippet = value.slice(start, end).trim();
+  if (!snippet) {
+    return undefined;
+  }
+  return `${start > 0 ? "..." : ""}${snippet}${end < value.length ? "..." : ""}`;
+}
+
+function tagSearchText(tag: NormalizedMemoryTag): string {
+  return normalizeSearchText([
+    tag.type,
+    tag.value,
+    tag.canonicalType,
+    tag.canonicalValue,
+    `${tag.type}:${tag.value}`,
+  ].join(" "));
+}
+
+function tagSnippet(tags: readonly NormalizedMemoryTag[], plan: SearchQueryPlan): string | undefined {
+  const matchedTags = tags
+    .filter((tag) => scoreNormalizedText(tagSearchText(tag), plan, 1) > 0)
+    .map((tag) => `${tag.type}:${tag.value}`);
+  return matchedTags.length > 0 ? `tags: ${matchedTags.join(", ")}` : undefined;
+}
+
+function uniqueSearchTokens(plan: SearchQueryPlan): string[] {
+  return plan.tokens.filter((token, index, tokens) => token.length > 0 && tokens.indexOf(token) === index);
 }
 
 function ownerRef(row: MemoryV6EntryRow): MemoryEntryDetail["owner"] {
@@ -360,11 +475,14 @@ export class MemoryV6Storage {
     const targetWhere = targetWhereSql("e", input.targets);
     const clauses = [`e.state = 'active'`, `(${targetWhere.sql})`];
     const params: SQLInputValue[] = [...targetWhere.params];
-    const query = input.query.trim().toLowerCase();
+    const queryPlan = buildSearchQueryPlan(input.query);
+    const queryTokens = uniqueSearchTokens(queryPlan);
+    const isQuerySearch = queryTokens.length > 0;
 
-    if (query) {
-      clauses.push(`
-        (
+    if (isQuerySearch) {
+      const tokenClauses: string[] = [];
+      for (const token of queryTokens) {
+        tokenClauses.push(`
           instr(lower(e.title), ?) > 0
           OR instr(lower(e.preview), ?) > 0
           OR instr(lower(e.body), ?) > 0
@@ -375,11 +493,14 @@ export class MemoryV6Storage {
               AND (
                 instr(lower(t.tag_type), ?) > 0
                 OR instr(lower(t.tag_value), ?) > 0
+                OR instr(lower(t.tag_type_canonical), ?) > 0
+                OR instr(lower(t.tag_value_canonical), ?) > 0
               )
           )
-        )
-      `);
-      params.push(query, query, query, query, query);
+        `);
+        params.push(token, token, token, token, token, token, token);
+      }
+      clauses.push(`(${tokenClauses.map((clause) => `(${clause})`).join(" OR ")})`);
     }
 
     if (input.kinds && input.kinds.length > 0) {
@@ -413,14 +534,30 @@ export class MemoryV6Storage {
       LIMIT ?
     `).all(...params, limit + 1) as MemoryV6EntryRow[];
 
-    const pageRows = rows.slice(0, limit);
-    const lastRow = pageRows[pageRows.length - 1];
+    const scoredEntries: ScoredSearchEntry[] = [];
+    for (const row of rows) {
+      const tags = this.getEntryTags(row.id);
+      const entry = this.rowToEntry(row, tags);
+      if (entry.state !== "active") {
+        continue;
+      }
+      if (!isQuerySearch) {
+        scoredEntries.push({ row, entry, match: { fields: [] } });
+        continue;
+      }
+      const match = this.scoreSearchEntry(entry, queryPlan, tags);
+      if (!match) {
+        continue;
+      }
+      scoredEntries.push({ row, entry, match });
+    }
+
+    const pageEntries = scoredEntries.slice(0, limit);
+    const lastRow = pageEntries[pageEntries.length - 1]?.row;
     return {
-      items: pageRows
-        .map((row) => this.rowToEntry(row))
-        .filter((entry): entry is ActiveMemoryEntryDetail => entry.state === "active")
-        .map(toMemorySearchHit),
-      ...(rows.length > limit && lastRow ? { nextCursor: encodeCursor({ updatedAt: lastRow.updated_at, id: lastRow.id }) } : {}),
+      items: pageEntries.map((item) => toMemorySearchHit(item.entry, item.match.fields.length > 0 ? item.match : undefined)),
+      ...(scoredEntries.length > limit && lastRow ? { nextCursor: encodeCursor({ updatedAt: lastRow.updated_at, id: lastRow.id }) } : {}),
+      ...(isQuerySearch && scoredEntries.length === 0 ? { relatedTags: this.relatedTags(input.targets, queryPlan) } : {}),
     };
   }
 
@@ -488,6 +625,66 @@ export class MemoryV6Storage {
       }),
       ...(rows.length > limit && lastRow ? { nextCursor: encodeCursor({ updatedAt: lastRow.updated_at, id: lastRow.id }) } : {}),
     };
+  }
+
+  private scoreSearchEntry(
+    entry: ActiveMemoryEntryDetail,
+    queryPlan: SearchQueryPlan,
+    tags: readonly NormalizedMemoryTag[],
+  ): MemorySearchMatch | null {
+    const normalizedTitle = normalizeSearchText(entry.title);
+    const normalizedPreview = normalizeSearchText(entry.preview);
+    const normalizedBody = normalizeSearchText(entry.body);
+    const normalizedTags = normalizeSearchText(tags.map((tag) => tagSearchText(tag)).join(" "));
+    const fields: MemorySearchMatchField[] = [];
+    let score = 0;
+
+    const titleScore = scoreNormalizedText(normalizedTitle, queryPlan, 6);
+    if (titleScore > 0) {
+      fields.push("title");
+      score += titleScore;
+    }
+
+    const previewScore = scoreNormalizedText(normalizedPreview, queryPlan, 4);
+    if (previewScore > 0) {
+      fields.push("preview");
+      score += previewScore;
+    }
+
+    const bodyScore = scoreNormalizedText(normalizedBody, queryPlan, 2);
+    if (bodyScore > 0) {
+      fields.push("body");
+      score += bodyScore;
+    }
+
+    const tagScore = scoreNormalizedText(normalizedTags, queryPlan, 8);
+    if (tagScore > 0) {
+      fields.push("tags");
+      score += tagScore;
+    }
+
+    if (score === 0) {
+      return null;
+    }
+
+    const snippet = tagSnippet(tags, queryPlan)
+      ?? buildSnippet(entry.title, queryPlan)
+      ?? buildSnippet(entry.preview, queryPlan)
+      ?? buildSnippet(entry.body, queryPlan);
+
+    return {
+      fields,
+      ...(snippet ? { snippet } : {}),
+    };
+  }
+
+  private relatedTags(targets: readonly MemoryV6ResolvedTarget[], queryPlan: SearchQueryPlan): NormalizedMemoryTag[] {
+    return this.listTags(targets)
+      .map((tag) => ({ tag, score: scoreNormalizedText(tagSearchText(tag), queryPlan, 1) }))
+      .filter((item) => item.score > 0)
+      .sort((left, right) => right.score - left.score || left.tag.canonicalValue.localeCompare(right.tag.canonicalValue))
+      .slice(0, 5)
+      .map((item) => item.tag);
   }
 
   listTags(targets: readonly MemoryV6ResolvedTarget[]): NormalizedMemoryTag[] {
@@ -675,7 +872,7 @@ export class MemoryV6Storage {
     return row ?? null;
   }
 
-  private rowToEntry(row: MemoryV6EntryRow): MemoryEntryDetail {
+  private rowToEntry(row: MemoryV6EntryRow, tags = this.getEntryTags(row.id)): MemoryEntryDetail {
     const base = {
       id: row.id,
       owner: ownerRef(row),
@@ -684,7 +881,7 @@ export class MemoryV6Storage {
       title: row.title,
       body: row.body,
       preview: row.preview,
-      tags: this.getEntryTags(row.id).map((tag) => ({ type: tag.type, value: tag.value })),
+      tags: tags.map((tag) => ({ type: tag.type, value: tag.value })),
       source: {
         type: row.source_type,
         sessionId: row.source_session_id,

--- a/src/memory-v6/memory-response-contract.ts
+++ b/src/memory-v6/memory-response-contract.ts
@@ -16,6 +16,7 @@ import {
 export type MemorySearchResponse = {
   schemaVersion: MemoryV6SchemaVersion;
   items: MemorySearchHit[];
+  relatedTags?: MemoryTag[];
   nextCursor?: string;
 };
 
@@ -64,11 +65,18 @@ export type MemoryResolveContextResponse = {
   permissions: MemoryPermission[];
 };
 
-export function createMemorySearchResponse(items: readonly MemorySearchHit[], nextCursor?: string): MemorySearchResponse {
+export function createMemorySearchResponse(
+  items: readonly MemorySearchHit[],
+  options: string | { nextCursor?: string; relatedTags?: readonly MemoryTag[] } = {},
+): MemorySearchResponse {
+  const normalizedOptions = typeof options === "string" ? { nextCursor: options } : options;
   return {
     schemaVersion: MEMORY_V6_SCHEMA_VERSION,
     items: [...items],
-    ...(nextCursor === undefined ? {} : { nextCursor }),
+    ...(normalizedOptions.relatedTags && normalizedOptions.relatedTags.length > 0
+      ? { relatedTags: normalizedOptions.relatedTags.map((tag) => ({ type: tag.type, value: tag.value })) }
+      : {}),
+    ...(normalizedOptions.nextCursor === undefined ? {} : { nextCursor: normalizedOptions.nextCursor }),
   };
 }
 

--- a/src/memory-v6/memory-state.ts
+++ b/src/memory-v6/memory-state.ts
@@ -64,7 +64,16 @@ export type MemoryEntryDetail =
   | SupersededMemoryEntryDetail
   | ForgottenMemoryEntryDetail;
 
-export type MemorySearchHit = Omit<MemoryEntrySummary, "state">;
+export type MemorySearchMatchField = "title" | "preview" | "body" | "tags";
+
+export type MemorySearchMatch = {
+  fields: MemorySearchMatchField[];
+  snippet?: string;
+};
+
+export type MemorySearchHit = Omit<MemoryEntrySummary, "state"> & {
+  match?: MemorySearchMatch;
+};
 
 export function toMemoryEntrySummary(entry: MemoryEntryDetail): MemoryEntrySummary {
   return {
@@ -81,7 +90,7 @@ export function toMemoryEntrySummary(entry: MemoryEntryDetail): MemoryEntrySumma
   };
 }
 
-export function toMemorySearchHit(entry: ActiveMemoryEntryDetail): MemorySearchHit {
+export function toMemorySearchHit(entry: ActiveMemoryEntryDetail, match?: MemorySearchMatch): MemorySearchHit {
   return {
     id: entry.id,
     owner: entry.owner,
@@ -92,6 +101,7 @@ export function toMemorySearchHit(entry: ActiveMemoryEntryDetail): MemorySearchH
     tags: entry.tags,
     createdAt: entry.createdAt,
     updatedAt: entry.updatedAt,
+    ...(match ? { match } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary
- Memory検索をtoken単位で照合し、title / preview / body / tags のmatch情報とsnippetを返すようにした
- `delivery-cleanup` と `delivery cleanup` のようなタグ表記揺れ、`delivery` / `納品`、`branch` / `ブランチ` を検索時に扱うようにした
- 0件時の関連タグ候補、CLIの `--tag` / `--tags` shorthand、Skill/設計ドキュメントを更新した

## Validation
- `npx tsx --test scripts/tests/memory-v6-contract.test.ts scripts/tests/memory-v6-storage.test.ts scripts/tests/memory-v6-service.test.ts scripts/tests/memory-v6-response-contract.test.ts scripts/tests/withmate-memory-cli.test.ts`
- `npm run typecheck`
- reviewer agent final review: 指摘なし

## Notes
- Public APIのempty query拒否は既存contract通り維持し、storage層のみ防御的fallbackとして扱う
