### PR TITLE
TASK-142 user-global Memory targetを追加

### DIFF
--- a/docs/design/v6-memory-foundation.md
+++ b/docs/design/v6-memory-foundation.md
@@ -147,8 +147,9 @@ type MemoryOwnerRef =
 
 - `character`
 - `project`
+- `user` owner + `global` scope
 
-`user`はschemaで予約してもよいが、初期APIでのappend対象にはしない。
+`user` ownerは`global` scopeとのexact pairだけを初期公開し、それ以外の`user` owner組み合わせは予約扱いにする。
 
 ### Scope
 

--- a/docs/design/v6-memory-foundation.md
+++ b/docs/design/v6-memory-foundation.md
@@ -128,9 +128,9 @@ type MemoryPermission =
 
 `session_binding`はWithMate-launched provider turnから発行される短命bindingに基づく。current Character、session project、provider ID、permissionを解決でき、Character targetや`character: current`を使える。
 
-`local_user`は起動中WithMate runtime APIのsecret / status challengeを通過した同一OS userを表す。明示された`project` owner + `project` scopeのMemoryだけを扱い、current Character、session context、Character Memory、session-bound project inferenceは使えない。
+`local_user`は起動中WithMate runtime APIのsecret / status challengeを通過した同一OS userを表す。明示された`project` owner + `project` scope、または`user` owner + `global` scopeのMemoryだけを扱い、current Character、session context、Character Memory、session-bound project inferenceは使えない。
 
-binding referenceが存在しない、または失効済みbinding referenceをprincipalへ解決できない場合でも、runtime API secret検証済みでrequest targetが明示`project` owner + `project` scopeなら`local_user` principalとして処理してよい。`character: current`、Character owner、session-bound contextを要求するrequestは`MEMORY_BINDING_REQUIRED`または`MEMORY_FORBIDDEN`で拒否する。
+binding referenceが存在しない、または失効済みbinding referenceをprincipalへ解決できない場合でも、runtime API secret検証済みでrequest targetが明示`project` owner + `project` scope、または`user` owner + `global` scopeなら`local_user` principalとして処理してよい。`character: current`、Character owner、session-bound contextを要求するrequestは`MEMORY_BINDING_REQUIRED`または`MEMORY_FORBIDDEN`で拒否する。
 
 ### Owner
 
@@ -179,8 +179,9 @@ OwnerとScopeは別概念とする。
 | `character` | `character` | Character単位の関係性、好み、継続境界 |
 | `character` | `project` | 特定projectでそのCharacterと共有した作業文脈 |
 | `project` | `project` | Characterに依存しないproject decision / convention |
+| `user` | `global` | provider / host / projectに依存しないuser preference / convention / constraint |
 
-`project` owner + `character` scope、`user` owner、`session` scope、`global` scopeはschema上予約してもよいが、初期append対象にはしない。
+`project` owner + `character` scope、`session` scope、`user` owner + `global` scope以外の`user` owner、`user` owner以外の`global` scopeはschema上予約してもよいが、append対象にはしない。`user` owner + `global` scopeはexact pairだけを許可し、secret、token、project固有の非公開情報ではなく、user共通のpreference / convention / constraintに限定して扱う。
 session中に得た決定・制約・継続文脈をagentがdurable Memory entryとしてappendすることは許可するが、V6 foundationはmutableなSession working stateをfirst-class domainとして扱わない。
 
 ### Entry
@@ -368,7 +369,8 @@ type MemorySearchRequest = {
 type MemoryTargetSelector =
   | { owner: "project"; project: ProjectTargetRef; scope: "project" }
   | { owner: "character"; character: CharacterTargetRef; scope: "character" }
-  | { owner: "character"; character: CharacterTargetRef; scope: "project"; project: ProjectTargetRef };
+  | { owner: "character"; character: CharacterTargetRef; scope: "project"; project: ProjectTargetRef }
+  | { owner: "user"; scope: "global" };
 
 type ProjectTargetRef =
   | { type: "id"; id: string }
@@ -430,7 +432,7 @@ type MemoryGetEntryResponse = {
 
 - ID指定でfull bodyを取得する。
 - binding permissionとowner / scope accessを再検証する。
-- binding referenceがない`local_user` requestでは明示project targetを必須とし、entryのowner / scopeがtargetと一致する場合だけ返す。
+- binding referenceがない`local_user` requestでは明示targetを必須とし、entryのowner / scopeがtargetと一致する場合だけ返す。targetなしはentry存在に関係なく`MEMORY_TARGET_REQUIRED`、target不一致は`not_found`に畳む。
 - search hitのpreviewが現在の回答、実装、判断に影響しそうな場合に使う。
 - 正確な文言、理由、制約、過去の決定が重要な場合はpreviewだけで断定しない。
 - search hitを全件機械的に取得しない。必要な最小件数を、関係ありそうなpreviewから順に取得する。
@@ -568,10 +570,11 @@ value.normalize("NFC").toLowerCase()
 CLIはuser-facing entrypointであり、app外の人間やagentが自由に呼べる薄いclientとする。
 CLIはDBを直接触らず、起動中のWithMateが提供するruntime Memory APIへ接続する。
 WithMateが起動していない場合、CLIはすべてのMemory操作を拒否し、machine-readable errorを返す。
-WithMate起動中は、WithMate外のCodex / shell / CLIからもproject owner + project scopeのMemoryを明示targetで検索、取得、tag一覧、append、forgetできる。
+WithMate起動中は、WithMate外のCodex / shell / CLIからもproject owner + project scope、またはuser owner + global scopeのMemoryを明示targetで検索、取得、tag一覧、append、forgetできる。
 session bindingはCLI利用全体の認可ではなく、current Characterやcurrent WithMate session contextを解決するための追加contextである。
 binding referenceがない外部CLI requestは、runtime secretとnonce challengeを通過した同一OS userの`local_user` principalとして扱う。
-`local_user` principalは`project` owner + `project` scopeだけを扱い、`character: current`、WithMate session context、session-bound project inferenceは使えない。
+`local_user` principalは`project` owner + `project` scope、または`user` owner + `global` scopeだけを扱い、`character: current`、WithMate session context、session-bound project inferenceは使えない。
+`session_binding` principalでも`user` owner + `global` scopeを扱うには、`memory.search`、`memory.append`、`memory.get_entry`、`memory.list_tags`、`memory.forget`など操作別permissionを満たす必要がある。retrieval ranking、暗黙target注入、毎turn prompt注入は行わない。
 runtime binding由来のappend / forgetでも、対応するV6 `sessions_v6` rowがまだ存在しない段階ではMemory entryの`source.sessionId`は`null`として保存する。
 `--self` flagは採用しない。
 current CLIは`WITHMATE_MEMORY_API_URL`またはruntime discovery fileからlocalhost APIを発見する。
@@ -678,7 +681,13 @@ character target:
 
 character targetはWithMate-launched session binding内に限定する。
 `--character current`はruntime bindingがある場合だけ使える。
-WithMate外CLI / `local_user` principalは現時点ではproject owner + project scopeのMemoryだけを扱い、明示Character IDを指定したCharacter Memory利用も許可しない。
+user-global target:
+
+- request bodyの`target`または`targets[]`に`{ "owner": "user", "scope": "global" }`を明示する。
+- CLI shorthandは用意せず、`--file` / `--stdin` / `--json`でrequest bodyを渡す。
+- user-global Memoryは全project / provider bindingから見えるため、user-level preference / convention / constraintに限定し、secret、token、project固有の非公開情報は保存しない。
+
+WithMate外CLI / `local_user` principalは現時点ではproject owner + project scope、またはuser owner + global scopeのMemoryだけを扱い、明示Character IDを指定したCharacter Memory利用も許可しない。
 外部CLIからの明示Character ID対応は、別途principal / 認可設計を定義してから扱う。
 project targetはcurrent working directoryから暗黙推定しない。
 `--project .`はcurrent directoryを使う明示指定として許可する。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/resources/skills/withmate-memory/SKILL.md
+++ b/resources/skills/withmate-memory/SKILL.md
@@ -22,7 +22,7 @@ Do not use Memory for trivial local edits where the current files and user messa
 
 - Use the installed `withmate-memory` CLI instead of reading WithMate database files directly.
 - Prefer `withmate-memory ...` commands. If the command is not on `PATH` and this managed skill includes `bin/withmate-memory.mjs`, use `node bin/withmate-memory.mjs ...` as a temporary bundled-helper fallback.
-- Project Memory is available from external Codex or shell sessions while WithMate is running; use explicit project targets.
+- Project Memory and user-global Memory are available from external Codex or shell sessions while WithMate is running; use explicit targets.
 - Search before relying on remembered project or character decisions.
 - Use `get-entry` only for search hits whose exact body matters.
 - Append only durable decisions, constraints, conventions, preferences, or context that will matter in future sessions.
@@ -111,7 +111,7 @@ $request | withmate-memory search --stdin
 
 `status` does not require a request body.
 
-`schema` does not require a request body and returns supported commands, request body input modes, memory entry kinds, and forget reasons.
+`schema` does not require a request body and returns supported commands, request body input modes, target selector forms, memory entry kinds, and forget reasons.
 
 `validate` validates a request body locally without writing Memory:
 
@@ -140,6 +140,18 @@ withmate-memory validate --command append --stdin
 Search supports natural-language terms across title, preview, body, and tags. Hyphenated and spaced tag words such as `delivery-cleanup` and `delivery cleanup` are treated as related candidates. Shorthand `--tag <tag>` defaults to `topic:<tag>`, and `--tags` accepts comma-separated `<type>:<tag>` values.
 
 Search results may include `match` on each hit with matched fields and a short snippet. `match.fields` can report body matches, but snippets are limited to tags, title, and preview; use `get-entry` when the exact body matters. When no entries match, the response may include `relatedTags`.
+
+For provider-independent user preferences, conventions, constraints, or other cross-project context, use an explicit user-global target:
+
+```json
+{
+  "schemaVersion": "withmate-memory-v1",
+  "targets": [
+    { "owner": "user", "scope": "global" }
+  ],
+  "query": "shared preference"
+}
+```
 
 `get-entry`:
 
@@ -202,8 +214,9 @@ Search results may include `match` on each hit with matched fields and a short s
 ## Target Selection
 
 - Use a project target with `{ "project": { "type": "path", "path": "." } }` when the current directory is the intended project, including from outside WithMate-launched sessions. The helper resolves relative project paths against its own cwd before sending the request.
+- Use a user-global target with `{ "owner": "user", "scope": "global" }` only for provider-independent user preferences, conventions, constraints, or other cross-project context. Do not store secrets, tokens, or project-specific private details there.
 - Use character targets only inside a WithMate-launched session where session binding context is available.
-- External Codex or shell sessions can use project memory only; explicit character IDs are not supported for `local_user` principals yet.
+- External Codex or shell sessions can use project Memory and user-global Memory; explicit character IDs are not supported for `local_user` principals yet.
 - Do not infer project or character targets silently when a command requires an explicit target.
 
 ## Error Handling

--- a/resources/skills/withmate-memory/bin/withmate-memory.mjs
+++ b/resources/skills/withmate-memory/bin/withmate-memory.mjs
@@ -363,6 +363,32 @@ function buildSchemaResponse() {
     forgetReasons,
     commands: ["status", "context", "search", "get-entry", "list-tags", "append", "forget", "schema", "validate"],
     requestBodyInputs: ["--json", "--file", "@file", "--stdin"],
+    targetSelectors: [
+      {
+        owner: "project",
+        scope: "project",
+        requiredFields: ["project"],
+        projectTypes: ["id", "path", "alias"],
+      },
+      {
+        owner: "character",
+        scope: "character",
+        requiredFields: ["character"],
+        characterTypes: ["id", "current"],
+      },
+      {
+        owner: "character",
+        scope: "project",
+        requiredFields: ["character", "project"],
+        characterTypes: ["id", "current"],
+        projectTypes: ["id", "path", "alias"],
+      },
+      {
+        owner: "user",
+        scope: "global",
+        requiredFields: [],
+      },
+    ],
   };
 }
 
@@ -394,6 +420,7 @@ const memoryTagKeys = new Set(["type", "value"]);
 const projectProjectTargetKeys = new Set(["owner", "scope", "project"]);
 const characterCharacterTargetKeys = new Set(["owner", "scope", "character"]);
 const characterProjectTargetKeys = new Set(["owner", "scope", "character", "project"]);
+const userGlobalTargetKeys = new Set(["owner", "scope"]);
 
 const maxSearchQueryLength = 500;
 const maxTitleLength = 160;
@@ -570,6 +597,13 @@ function normalizeCharacterTarget(value, field) {
 function normalizeMemoryTarget(value, field) {
   if (!isRecord(value)) {
     return validationError("MEMORY_INVALID_FIELD", `${field} must be an object.`, field);
+  }
+  if (value.owner === "user" && value.scope === "global") {
+    const unknownKeys = rejectUnknownKeys(value, userGlobalTargetKeys, field);
+    if (!unknownKeys.ok) {
+      return unknownKeys;
+    }
+    return { ok: true, value: { owner: "user", scope: "global" } };
   }
   if (value.owner === "project" && value.scope === "project") {
     const unknownKeys = rejectUnknownKeys(value, projectProjectTargetKeys, field);

--- a/resources/skills/withmate-memory/reference/cli.md
+++ b/resources/skills/withmate-memory/reference/cli.md
@@ -1,7 +1,7 @@
 # WithMate Memory Helper Reference
 
 The bundled helper is a thin client for the running WithMate V6 Memory API. It does not read or write database files directly.
-Project-scoped Memory can be used from external Codex or shell sessions while WithMate is running. Current character and current session context require a WithMate-launched session binding.
+Project-scoped Memory and user-global Memory can be used from external Codex or shell sessions while WithMate is running. Current character and current session context require a WithMate-launched session binding.
 
 Run it from the target project directory after WithMate is installed:
 
@@ -23,7 +23,7 @@ When a managed skill includes `bin/withmate-memory.mjs` and no `withmate-memory`
 withmate-memory schema
 ```
 
-Returns supported commands, request body input modes, memory entry kinds, and forget reasons.
+Returns supported commands, request body input modes, target selector forms, memory entry kinds, and forget reasons.
 
 ### validate
 
@@ -77,6 +77,18 @@ Request shape:
 Search returns active entry previews only. Use `get-entry` when the exact body matters.
 Search uses natural-language terms across title, preview, body, and tags. Hyphenated and spaced tag words such as `delivery-cleanup` and `delivery cleanup` are treated as related candidates. Shorthand `--tag <tag>` defaults to `topic:<tag>`, and `--tags` accepts comma-separated `<type>:<tag>` values. Search results may include matched fields and a short snippet; body matches may be reported in `match.fields`, but snippets are limited to tags, title, and preview. 0-result responses may include related tag candidates.
 
+For provider-independent user preferences, conventions, constraints, or other cross-project context, use an explicit user-global target:
+
+```json
+{
+  "schemaVersion": "withmate-memory-v1",
+  "targets": [
+    { "owner": "user", "scope": "global" }
+  ],
+  "query": "shared preference"
+}
+```
+
 ### get-entry
 
 ```bash
@@ -94,7 +106,7 @@ Request shape:
 }
 ```
 
-External Codex or shell sessions must include `target`. WithMate-launched sessions with a binding may omit it.
+External Codex or shell sessions must include `target`, using either a project target or `{ "owner": "user", "scope": "global" }`. WithMate-launched sessions with a binding may omit it.
 
 ### list-tags
 
@@ -168,9 +180,10 @@ Input shape:
 - Search results exclude forgotten and superseded entries.
 - Project targets with `{ "type": "path", "path": "." }` are valid from external Codex sessions.
 - Relative project paths are resolved by the helper against the CLI process cwd before being sent to WithMate.
-- External `get-entry` requests require an explicit project target.
+- External `get-entry` requests require an explicit target.
 - Character targets and `context` require a WithMate-launched session binding.
-- External Codex or shell sessions currently support project memory only; explicit Character ID access needs a separate principal and authorization design.
+- External Codex or shell sessions currently support project Memory and user-global Memory; explicit Character ID access needs a separate principal and authorization design.
+- User-global Memory is visible across projects and provider bindings. Store only user-level preferences, conventions, constraints, or other cross-project context there; do not store secrets, tokens, or project-specific private details.
 - Append is idempotent when an idempotency key is supplied.
 - Forget hides entries from normal search and skill results.
 - Memory failures should not fail unrelated coding work.

--- a/scripts/tests/database-schema-v6.test.ts
+++ b/scripts/tests/database-schema-v6.test.ts
@@ -266,6 +266,55 @@ describe("database-schema-v6", () => {
       assert.equal(tableSql(db, "memory_entries_v6").includes("'active', 'superseded', 'forgotten'"), true);
       assert.equal(tableSql(db, "memory_entries_v6").includes("superseded_by_id IS NOT NULL"), true);
       assert.equal(tableSql(db, "memory_entries_v6").includes("forgotten_at IS NOT NULL"), true);
+      assert.equal(tableSql(db, "memory_entries_v6").includes("owner_type <> 'user' OR owner_id = 'local-user'"), true);
+      assert.equal(tableSql(db, "memory_entries_v6").includes("scope_type <> 'global' OR scope_id = 'global'"), true);
+      assert.throws(() => {
+        db.prepare(`
+          INSERT INTO memory_entries_v6 (
+            id,
+            owner_type,
+            owner_id,
+            scope_type,
+            scope_id,
+            kind,
+            title,
+            body,
+            body_sha256,
+            preview,
+            state,
+            source_type,
+            source_session_id,
+            source_app_message_id,
+            source_provider_message_id,
+            source_provider_id,
+            superseded_by_id,
+            created_at,
+            updated_at,
+            forgotten_at
+          ) VALUES (
+            'mem-malformed-user-global',
+            'user',
+            'other-user',
+            'global',
+            'global',
+            'note',
+            'bad',
+            'bad',
+            'sha',
+            'bad',
+            'active',
+            'agent',
+            NULL,
+            NULL,
+            NULL,
+            'codex',
+            NULL,
+            '2026-06-29T00:00:00.000Z',
+            '2026-06-29T00:00:00.000Z',
+            NULL
+          )
+        `).run();
+      });
       assert.equal(hasForeignKey(db, "memory_entries_v6", "source_session_id", "sessions_v6"), true);
       assert.equal(hasForeignKey(db, "memory_entries_v6", "source_session_id", "session_messages_v6"), true);
       assert.equal(findForeignKey(db, "memory_entries_v6", "source_app_message_id")?.table, "session_messages_v6");

--- a/scripts/tests/memory-v6-contract.test.ts
+++ b/scripts/tests/memory-v6-contract.test.ts
@@ -23,6 +23,11 @@ const characterTarget = {
   character: { type: "current" },
 };
 
+const userGlobalTarget = {
+  owner: "user",
+  scope: "global",
+};
+
 describe("memory-v6 contract validation", () => {
   it("valid resolve_context request を検証できる", () => {
     const result = validateMemoryResolveContextRequest({
@@ -140,6 +145,28 @@ describe("memory-v6 contract validation", () => {
     assert.deepEqual(listTags.value.targets, [projectTarget]);
   });
 
+  it("user-global target を正規化できる", () => {
+    const search = validateMemorySearchRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      targets: [userGlobalTarget],
+      query: "tone",
+    });
+    assert.equal(search.ok, true);
+    assert.deepEqual(search.value.targets, [userGlobalTarget]);
+
+    const append = validateMemoryAppendRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      target: userGlobalTarget,
+      kind: "preference",
+      title: "応答方針",
+      body: "ユーザー共通の応答方針。",
+      preview: "ユーザー共通の応答方針。",
+      tags: [],
+    });
+    assert.equal(append.ok, true);
+    assert.deepEqual(append.value.target, userGlobalTarget);
+  });
+
   it("invalid schemaVersion を拒否する", () => {
     const result = validateMemoryResolveContextRequest({ schemaVersion: "withmate-memory-v0" });
 
@@ -243,6 +270,18 @@ describe("memory-v6 contract validation", () => {
     });
     assert.equal(projectTargetWithCharacter.ok, false);
     assert.equal(projectTargetWithCharacter.error.field, "targets[0].character");
+
+    const userGlobalWithProject = validateMemorySearchRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      targets: [{
+        owner: "user",
+        scope: "global",
+        project: { type: "id", id: "project-a" },
+      }],
+      query: "test",
+    });
+    assert.equal(userGlobalWithProject.ok, false);
+    assert.equal(userGlobalWithProject.error.field, "targets[0].project");
   });
 
   it("targets上限とduplicate targetを拒否する", () => {

--- a/scripts/tests/memory-v6-service.test.ts
+++ b/scripts/tests/memory-v6-service.test.ts
@@ -35,6 +35,16 @@ const otherProjectTarget = {
   scope: { type: "project", id: "project-b" },
 } satisfies MemoryV6ResolvedTarget;
 
+const userGlobalResolvedTarget = {
+  owner: { type: "user", id: "local-user" },
+  scope: { type: "global", id: "global" },
+} satisfies MemoryV6ResolvedTarget;
+
+const userGlobalTarget = {
+  owner: "user",
+  scope: "global",
+};
+
 function tag(type: string, value: string): NormalizedMemoryTag {
   return {
     type,
@@ -258,6 +268,14 @@ describe("MemoryV6Service", () => {
       assert.equal("error" in unauthorized, true);
       assert.equal(unauthorized.error.code, "MEMORY_UNAUTHORIZED");
 
+      const unauthorizedUserGlobal = service.search(principal({ permissions: ["memory.resolve_context"] }), {
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        targets: [userGlobalTarget],
+        query: "memory",
+      });
+      assert.equal("error" in unauthorizedUserGlobal, true);
+      assert.equal(unauthorizedUserGlobal.error.code, "MEMORY_UNAUTHORIZED");
+
       const forbidden = service.append(principal(), appendRequest({
         target: {
           owner: "project",
@@ -436,6 +454,106 @@ describe("MemoryV6Service", () => {
       });
       assert.equal("error" in forget, false);
       assert.deepEqual(forget.results, [{ entryId: append.entry.id, status: "forgotten" }]);
+    });
+  });
+
+  it("session_binding は明示user-global targetで共通Memoryを扱える", async () => {
+    await withService(({ service }) => {
+      const append = service.append(principal(), appendRequest({
+        target: userGlobalTarget,
+        title: "共通応答方針",
+        body: "全projectで短く検証結果を添える。",
+        preview: "全projectで短く検証結果を添える。",
+        tags: [{ type: "topic", value: "global-preference" }],
+      }));
+      assert.equal("error" in append, false);
+      assert.equal(append.entry.owner.type, "user");
+      assert.equal(append.entry.owner.id, "local-user");
+      assert.equal(append.entry.scope.type, "global");
+      assert.equal(append.entry.scope.id, "global");
+
+      const search = service.search(principal(), {
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        targets: [userGlobalTarget],
+        query: "検証結果",
+      });
+      assert.equal("error" in search, false);
+      assert.deepEqual(search.items.map((item) => item.id), [append.entry.id]);
+
+      const tags = service.listTags(principal(), {
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        targets: [userGlobalTarget],
+      });
+      assert.equal("error" in tags, false);
+      assert.deepEqual(tags.tags, [{ type: "topic", value: "global-preference" }]);
+
+      const detail = service.getEntry(principal(), {
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        entryId: append.entry.id,
+      });
+      assert.equal("error" in detail, false);
+      assert.equal(detail.entry.body, "全projectで短く検証結果を添える。");
+
+      const forget = service.forget(principal(), {
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        target: userGlobalTarget,
+        entryIds: [append.entry.id],
+        reason: "user_request",
+      });
+      assert.equal("error" in forget, false);
+      assert.deepEqual(forget.results, [{ entryId: append.entry.id, status: "forgotten" }]);
+    });
+  });
+
+  it("local_user は明示user-global targetで共通Memoryを扱える", async () => {
+    await withService(({ service, storage }) => {
+      const localUser = createLocalUserMemoryPrincipal();
+      storage.appendEntry({
+        id: "mem-user-global-local",
+        target: userGlobalResolvedTarget,
+        kind: "preference",
+        title: "共通検証方針",
+        body: "検証結果は短く添える。",
+        preview: "検証結果は短く添える。",
+        tags: [tag("topic", "global-preference")],
+        source: {
+          type: "agent",
+          sessionId: null,
+          messageId: null,
+          providerId: "codex",
+        },
+      });
+
+      const search = service.search(localUser, {
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        targets: [userGlobalTarget],
+        query: "検証結果",
+      });
+      assert.equal("error" in search, false);
+      assert.deepEqual(search.items.map((item) => item.id), ["mem-user-global-local"]);
+
+      const detail = service.getEntry(localUser, {
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        entryId: "mem-user-global-local",
+        target: userGlobalTarget,
+      });
+      assert.equal("error" in detail, false);
+      assert.equal(detail.entry.body, "検証結果は短く添える。");
+
+      const missingTarget = service.getEntry(localUser, {
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        entryId: "mem-user-global-local",
+      });
+      assert.equal("error" in missingTarget, true);
+      assert.equal(missingTarget.error.code, "MEMORY_TARGET_REQUIRED");
+
+      const mismatchTarget = service.getEntry(localUser, {
+        schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+        entryId: "mem-user-global-local",
+        target: { owner: "project", scope: "project", project: { type: "id", id: "project-a" } },
+      });
+      assert.equal("error" in mismatchTarget, true);
+      assert.equal(mismatchTarget.error.code, "MEMORY_ENTRY_NOT_FOUND");
     });
   });
 

--- a/scripts/tests/memory-v6-storage.test.ts
+++ b/scripts/tests/memory-v6-storage.test.ts
@@ -201,6 +201,64 @@ describe("MemoryV6Storage", () => {
     });
   });
 
+  it("malformed user-global row はhydrationで公開しない", async () => {
+    await withStorage(({ storage, dbPath }) => {
+      const db = new DatabaseSync(dbPath);
+      try {
+        db.exec("PRAGMA ignore_check_constraints = ON;");
+        db.prepare(`
+          INSERT INTO memory_entries_v6 (
+            id,
+            owner_type,
+            owner_id,
+            scope_type,
+            scope_id,
+            kind,
+            title,
+            body,
+            body_sha256,
+            preview,
+            state,
+            source_type,
+            source_session_id,
+            source_app_message_id,
+            source_provider_message_id,
+            source_provider_id,
+            superseded_by_id,
+            created_at,
+            updated_at,
+            forgotten_at
+          ) VALUES (
+            'mem-malformed-user-global',
+            'user',
+            'other-user',
+            'global',
+            'global',
+            'note',
+            'bad',
+            'bad',
+            'sha',
+            'bad',
+            'active',
+            'agent',
+            NULL,
+            NULL,
+            NULL,
+            'codex',
+            NULL,
+            '2026-06-29T00:00:00.000Z',
+            '2026-06-29T00:00:00.000Z',
+            NULL
+          )
+        `).run();
+      } finally {
+        db.close();
+      }
+
+      assert.equal(storage.getEntry("mem-malformed-user-global"), null);
+    });
+  });
+
   it("search は自然文queryをtoken化し、タグ表記揺れとmatch情報と0件時候補を返す", async () => {
     await withStorage(({ storage }) => {
       storage.appendEntry(baseAppend({

--- a/scripts/tests/memory-v6-storage.test.ts
+++ b/scripts/tests/memory-v6-storage.test.ts
@@ -24,6 +24,11 @@ const characterTarget = {
   scope: { type: "character", id: "character-a" },
 } satisfies MemoryV6ResolvedTarget;
 
+const userGlobalTarget = {
+  owner: { type: "user", id: "local-user" },
+  scope: { type: "global", id: "global" },
+} satisfies MemoryV6ResolvedTarget;
+
 function tag(type: string, value: string): NormalizedMemoryTag {
   return {
     type,
@@ -157,6 +162,42 @@ describe("MemoryV6Storage", () => {
       assert.deepEqual(storage.listTags([projectTarget]), [tag("topic", "memory")]);
       assert.equal(tableNames(dbPath).includes("session_memories"), false);
       assert.equal(tableNames(dbPath).includes("project_memory_entries"), false);
+    });
+  });
+
+  it("user-global target のappend / search / tag catalog / forgetを扱う", async () => {
+    await withStorage(({ storage }) => {
+      const appended = storage.appendEntry(baseAppend({
+        id: "mem-user-global",
+        target: userGlobalTarget,
+        kind: "preference",
+        title: "共通検証方針",
+        body: "全projectで検証結果を短く添える。",
+        preview: "検証結果を短く添える。",
+        tags: [tag("topic", "global-preference")],
+      }));
+
+      assert.equal(appended.entry.owner.type, "user");
+      assert.equal(appended.entry.owner.id, "local-user");
+      assert.equal(appended.entry.scope.type, "global");
+      assert.equal(appended.entry.scope.id, "global");
+
+      const search = storage.searchEntries({
+        targets: [userGlobalTarget],
+        query: "検証結果",
+      });
+      assert.deepEqual(search.items.map((item) => item.id), ["mem-user-global"]);
+      assert.deepEqual(storage.listTags([userGlobalTarget]), [tag("topic", "global-preference")]);
+
+      const forget = storage.forgetEntries({
+        target: userGlobalTarget,
+        entryIds: ["mem-user-global", "missing-entry"],
+        reason: "user_request",
+      });
+      assert.deepEqual(forget, [
+        { entryId: "mem-user-global", status: "forgotten" },
+        { entryId: "missing-entry", status: "not_found" },
+      ]);
     });
   });
 

--- a/scripts/tests/withmate-memory-cli.test.ts
+++ b/scripts/tests/withmate-memory-cli.test.ts
@@ -397,6 +397,11 @@ describe("withmate-memory CLI", () => {
     ]);
     assert.deepEqual(stdout.json().forgetReasons, ["user_request", "incorrect", "outdated", "privacy", "other"]);
     assert.deepEqual(stdout.json().requestBodyInputs, ["--json", "--file", "@file", "--stdin"]);
+    assert.deepEqual(stdout.json().targetSelectors.at(-1), {
+      owner: "user",
+      scope: "global",
+      requiredFields: [],
+    });
   });
 
   it("validateはrequest bodyをruntimeへ送らずに検証する", async () => {
@@ -426,6 +431,27 @@ describe("withmate-memory CLI", () => {
     assert.equal(stdout.json().valid, true);
     assert.equal(stdout.json().command, "append");
     assert.equal(stdout.json().value.tags[0].canonicalValue, "cli");
+  });
+
+  it("validateはuser-global targetを受け付ける", async () => {
+    const stdout = createOutputCapture();
+    const requestBody = {
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      targets: [{ owner: "user", scope: "global" }],
+      query: "global preference",
+    };
+
+    const exitCode = await runWithMateMemoryCli(["validate", "--command", "search", "--json", JSON.stringify(requestBody)], {
+      env: TEST_RUNTIME_ENV,
+      stdout: stdout.stream,
+      fetch: async () => {
+        throw new Error("validate should not call runtime");
+      },
+    });
+
+    assert.equal(exitCode, WITHMATE_MEMORY_CLI_EXIT_CODES.ok);
+    assert.equal(stdout.json().valid, true);
+    assert.deepEqual(stdout.json().value.targets, [{ owner: "user", scope: "global" }]);
   });
 
   it("validateはinvalid requestをJSON errorで返す", async () => {

--- a/scripts/withmate-memory.ts
+++ b/scripts/withmate-memory.ts
@@ -512,6 +512,32 @@ function buildSchemaResponse(): unknown {
       "validate",
     ],
     requestBodyInputs: ["--json", "--file", "@file", "--stdin"],
+    targetSelectors: [
+      {
+        owner: "project",
+        scope: "project",
+        requiredFields: ["project"],
+        projectTypes: ["id", "path", "alias"],
+      },
+      {
+        owner: "character",
+        scope: "character",
+        requiredFields: ["character"],
+        characterTypes: ["id", "current"],
+      },
+      {
+        owner: "character",
+        scope: "project",
+        requiredFields: ["character", "project"],
+        characterTypes: ["id", "current"],
+        projectTypes: ["id", "path", "alias"],
+      },
+      {
+        owner: "user",
+        scope: "global",
+        requiredFields: [],
+      },
+    ],
   };
 }
 

--- a/src-electron/database-schema-v6.ts
+++ b/src-electron/database-schema-v6.ts
@@ -495,6 +495,12 @@ export const CREATE_V6_MEMORY_ENTRIES_TABLE_SQL = `
     FOREIGN KEY (source_session_id) REFERENCES sessions_v6(id) ON DELETE SET NULL,
     FOREIGN KEY (source_app_message_id, source_session_id) REFERENCES session_messages_v6(id, session_id) ON DELETE SET NULL,
     FOREIGN KEY (superseded_by_id) REFERENCES memory_entries_v6(id) ON DELETE RESTRICT,
+    CHECK (owner_type <> 'user' OR owner_id = 'local-user'),
+    CHECK (scope_type <> 'global' OR scope_id = 'global'),
+    CHECK (
+      (owner_type <> 'user' AND scope_type <> 'global')
+      OR (owner_type = 'user' AND owner_id = 'local-user' AND scope_type = 'global' AND scope_id = 'global')
+    ),
     CHECK ((state = 'active') = (superseded_by_id IS NULL AND forgotten_at IS NULL) OR state <> 'active'),
     CHECK (state <> 'superseded' OR (superseded_by_id IS NOT NULL AND forgotten_at IS NULL)),
     CHECK (state <> 'forgotten' OR forgotten_at IS NOT NULL)

--- a/src-electron/memory-v6-context-resolver.ts
+++ b/src-electron/memory-v6-context-resolver.ts
@@ -79,6 +79,13 @@ export function resolveMemoryV6Target(
   principal: MemoryV6Principal,
   deps: MemoryV6TargetResolverDeps = {},
 ): MemoryV6TargetResolutionResult {
+  if (selector.owner === "user" && selector.scope === "global") {
+    return withAccessCheck(principal, {
+      owner: { type: "user", id: "local-user" },
+      scope: { type: "global", id: "global" },
+    });
+  }
+
   if (selector.owner === "project" && selector.scope === "project") {
     const project = resolveProject(selector.project, deps, "target.project");
     if ("code" in project) {
@@ -99,6 +106,10 @@ export function resolveMemoryV6Target(
       owner: { type: "character", id: character.id },
       scope: { type: "character", id: character.id },
     });
+  }
+
+  if (selector.owner !== "character" || selector.scope !== "project") {
+    return { ok: false, error: memoryForbiddenError() };
   }
 
   const character = resolveCharacter(selector.character, principal, deps, "target.character");

--- a/src-electron/memory-v6-permission.ts
+++ b/src-electron/memory-v6-permission.ts
@@ -77,12 +77,13 @@ export function requireMemoryPermission(principal: MemoryV6Principal | null, per
 }
 
 export function canAccessMemoryTarget(principal: MemoryV6Principal, target: MemoryV6ResolvedTarget): boolean {
+  const isUserGlobalTarget = target.owner.type === "user" && target.scope.type === "global";
   if (principal.type === "local_user") {
-    return target.owner.type === "project" && target.scope.type === "project";
+    return isUserGlobalTarget || (target.owner.type === "project" && target.scope.type === "project");
   }
 
   if (target.owner.type === "user" || target.scope.type === "session" || target.scope.type === "global") {
-    return false;
+    return isUserGlobalTarget;
   }
 
   const characterIds = new Set([

--- a/src-electron/memory-v6-service.ts
+++ b/src-electron/memory-v6-service.ts
@@ -180,7 +180,7 @@ export class MemoryV6Service {
       if (!validated.value.target) {
         return toMemoryErrorResponse({
           code: "MEMORY_TARGET_REQUIRED",
-          message: "Project target is required for external get-entry.",
+          message: "Explicit memory target is required for external get-entry.",
           field: "target",
         });
       }

--- a/src-electron/memory-v6-storage.ts
+++ b/src-electron/memory-v6-storage.ts
@@ -297,6 +297,18 @@ function scopeRef(row: MemoryV6EntryRow): MemoryEntryDetail["scope"] {
   return { type: row.scope_type, id: row.scope_id };
 }
 
+function hasValidTargetInvariant(row: MemoryV6EntryRow): boolean {
+  const hasUserOwner = row.owner_type === "user";
+  const hasGlobalScope = row.scope_type === "global";
+  if (!hasUserOwner && !hasGlobalScope) {
+    return true;
+  }
+  return hasUserOwner
+    && row.owner_id === "local-user"
+    && hasGlobalScope
+    && row.scope_id === "global";
+}
+
 function buildAppendFingerprint(input: AppendMemoryEntryInput): string {
   return fingerprint({
     operation: "append",
@@ -366,7 +378,7 @@ export class MemoryV6Storage {
       const supersedes = uniqueIds(input.supersedes ?? []);
       const supersededRows = supersedes.map((supersededId) => {
         const row = this.getEntryRow(supersededId);
-        if (!row || row.state !== "active" || targetKey({ owner: ownerRef(row), scope: scopeRef(row) }) !== targetKey(input.target)) {
+        if (!row || row.state !== "active" || !this.rowMatchesTarget(row, input.target)) {
           throw new MemoryV6EntryNotFoundError(supersededId);
         }
         return row;
@@ -536,6 +548,9 @@ export class MemoryV6Storage {
 
     const scoredEntries: ScoredSearchEntry[] = [];
     for (const row of rows) {
+      if (!hasValidTargetInvariant(row)) {
+        continue;
+      }
       const tags = this.getEntryTags(row.id);
       const entry = this.rowToEntry(row, tags);
       if (entry.state !== "active") {
@@ -608,7 +623,8 @@ export class MemoryV6Storage {
       LIMIT ?
     `).all(...params, limit + 1) as MemoryV6EntryRow[];
 
-    const pageRows = rows.slice(0, limit);
+    const validRows = rows.filter((row) => hasValidTargetInvariant(row));
+    const pageRows = validRows.slice(0, limit);
     const lastRow = pageRows[pageRows.length - 1];
     return {
       items: pageRows.map((row) => {
@@ -623,7 +639,7 @@ export class MemoryV6Storage {
           sourceProviderId: entry.source.providerId,
         } satisfies MemoryV6ReviewSearchHit;
       }),
-      ...(rows.length > limit && lastRow ? { nextCursor: encodeCursor({ updatedAt: lastRow.updated_at, id: lastRow.id }) } : {}),
+      ...(validRows.length > limit && lastRow ? { nextCursor: encodeCursor({ updatedAt: lastRow.updated_at, id: lastRow.id }) } : {}),
     };
   }
 
@@ -729,7 +745,7 @@ export class MemoryV6Storage {
 
       const results: MemoryV6ForgetResult[] = entryIds.map((entryId) => {
         const row = this.getEntryRow(entryId);
-        if (!row || targetKey({ owner: ownerRef(row), scope: scopeRef(row) }) !== targetKey(input.target)) {
+        if (!row || !this.rowMatchesTarget(row, input.target)) {
           this.insertMutationEvent("forget", null, bindingIdHash, input.sessionId ?? null, "not_found", reason, updatedAt);
           return { entryId, status: "not_found" };
         }
@@ -868,7 +884,11 @@ export class MemoryV6Storage {
       FROM memory_entries_v6
       WHERE id = ?
     `).get(entryId) as MemoryV6EntryRow | undefined;
-    return row ?? null;
+    return row && hasValidTargetInvariant(row) ? row : null;
+  }
+
+  private rowMatchesTarget(row: MemoryV6EntryRow, target: MemoryV6ResolvedTarget): boolean {
+    return hasValidTargetInvariant(row) && targetKey({ owner: ownerRef(row), scope: scopeRef(row) }) === targetKey(target);
   }
 
   private rowToEntry(row: MemoryV6EntryRow, tags = this.getEntryTags(row.id)): MemoryEntryDetail {

--- a/src/memory-v6/memory-contract.ts
+++ b/src/memory-v6/memory-contract.ts
@@ -38,7 +38,8 @@ export type CharacterTargetRef =
 export type MemoryTargetSelector =
   | { owner: "project"; project: ProjectTargetRef; scope: "project" }
   | { owner: "character"; character: CharacterTargetRef; scope: "character" }
-  | { owner: "character"; character: CharacterTargetRef; scope: "project"; project: ProjectTargetRef };
+  | { owner: "character"; character: CharacterTargetRef; scope: "project"; project: ProjectTargetRef }
+  | { owner: "user"; scope: "global" };
 
 export type MemoryTag = {
   type: string;

--- a/src/memory-v6/memory-validation.ts
+++ b/src/memory-v6/memory-validation.ts
@@ -46,6 +46,7 @@ const MEMORY_TAG_KEYS = new Set(["type", "value"]);
 const PROJECT_PROJECT_TARGET_KEYS = new Set(["owner", "scope", "project"]);
 const CHARACTER_CHARACTER_TARGET_KEYS = new Set(["owner", "scope", "character"]);
 const CHARACTER_PROJECT_TARGET_KEYS = new Set(["owner", "scope", "character", "project"]);
+const USER_GLOBAL_TARGET_KEYS = new Set(["owner", "scope"]);
 
 const MAX_SEARCH_QUERY_LENGTH = 500;
 const MAX_TITLE_LENGTH = 160;
@@ -251,6 +252,14 @@ function normalizeCharacterTarget(value: unknown, field: string): MemoryValidati
 function normalizeMemoryTarget(value: unknown, field: string): MemoryValidationResult<MemoryTargetSelector> {
   if (!isRecord(value)) {
     return error("MEMORY_INVALID_FIELD", `${field} must be an object.`, field);
+  }
+
+  if (value.owner === "user" && value.scope === "global") {
+    const unknownKeys = rejectUnknownKeys(value, USER_GLOBAL_TARGET_KEYS, field);
+    if (!unknownKeys.ok) {
+      return unknownKeys;
+    }
+    return { ok: true, value: { owner: "user", scope: "global" } };
   }
 
   if (value.owner === "project" && value.scope === "project") {


### PR DESCRIPTION
## 概要
- Memory V6 の target selector に `{ owner: "user", scope: "global" }` を追加
- user-global target を `user/local-user` + `global/global` に解決し、`local_user` / `session_binding` の権限境界を更新
- WithMate Memory CLI / bundled helper の schema / validate と Skill docs / design docs を更新

## 検証
- `npx tsx --test scripts/tests/memory-v6-contract.test.ts scripts/tests/memory-v6-storage.test.ts scripts/tests/memory-v6-service.test.ts scripts/tests/withmate-memory-cli.test.ts`
- `npm run typecheck`
- reviewer agent 2回: findingsなし

## 残リスク
- user-global に secret / token / project固有の非公開情報を保存しない制約は、現時点ではドキュメント上の運用ルール
- 実行中 runtime API を使った外部CLI E2Eは未実施
