### PR TITLE
fix(auxiliary): V6 DBでAuxiliary storageを有効化

### DIFF
--- a/docs/design/auxiliary-session.md
+++ b/docs/design/auxiliary-session.md
@@ -217,9 +217,9 @@ Auxiliary 単体の明示削除 UI は初期実装では持たない。
 
 ## Database Version Impact
 
-初期実装では V5 へは上げない。
-Auxiliary transcript は current V4 DB の optional feature table として `auxiliary_sessions` に保存する。
-この table は `AuxiliarySessionStorage` が `withmate-v4.db` に対してだけ初期化し、V2 / V3 / invalid DB path では legacy no-op storage を使う。
+Auxiliary 自体は required schema table ではなく、V6 runtime DB の optional feature table として扱う。
+Auxiliary transcript は `withmate-v6.db` の `auxiliary_sessions` に保存する。
+この table は `AuxiliarySessionStorage` が `withmate-v6.db` に対して初期化し、V4 以前 / invalid DB path では legacy no-op storage を使う。
 
 理由:
 

--- a/scripts/tests/persistent-store-lifecycle-service.test.ts
+++ b/scripts/tests/persistent-store-lifecycle-service.test.ts
@@ -6,6 +6,7 @@ import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
 
 import { DEFAULT_APPROVAL_MODE } from "../../src/approval-mode.js";
+import type { AuxiliarySession } from "../../src/auxiliary-session-state.js";
 import type { ModelCatalogSnapshot } from "../../src/model-catalog.js";
 import type { Session } from "../../src/session-state.js";
 import {
@@ -195,6 +196,32 @@ function readTableNames(dbPath: string): string[] {
   }
 }
 
+function createAuxiliarySessionFixture(overrides: Partial<AuxiliarySession> = {}): AuxiliarySession {
+  return {
+    id: "aux-v6",
+    parentSessionId: "session-v6",
+    status: "active",
+    runState: "idle",
+    title: "V6 auxiliary",
+    provider: "codex",
+    catalogRevision: 1,
+    model: "gpt-5.4",
+    reasoningEffort: "medium",
+    approvalMode: "untrusted",
+    codexSandboxMode: "workspace-write",
+    customAgentName: "",
+    allowedAdditionalDirectories: [],
+    threadId: "",
+    composerDraft: "",
+    messages: [],
+    displayAfterMessageIndex: null,
+    createdAt: "2026-07-02T00:00:00.000Z",
+    updatedAt: "2026-07-02T00:00:00.000Z",
+    closedAt: "",
+    ...overrides,
+  };
+}
+
 test("PersistentStoreLifecycleService は store を初期化して session dependency を同期する", async () => {
   const closeCalls: string[] = [];
   const sessionSummaries = [
@@ -358,6 +385,12 @@ test("PersistentStoreLifecycleService は v4 DB 起動時に Mate schema を初�
     const bundle = await service.initialize(dbPath, "model-catalog.json", userDataPath);
 
     assert.equal(bundle.mateStorage.getMateState(), "not_created");
+    assert.throws(
+      () => bundle.auxiliarySessionStorage.upsertAuxiliarySession(
+        createAuxiliarySessionFixture({ parentSessionId: "session-v4" }),
+      ),
+      /Auxiliary Session は legacy DB では利用できません/,
+    );
 
     const db = new DatabaseSync(dbPath);
     try {
@@ -1102,11 +1135,15 @@ test("PersistentStoreLifecycleService は V6 DB に legacy session/audit/memory/
 
     const service = createPersistentStoreLifecycleService();
     const bundle = await service.initialize(dbPath, bundledModelCatalogPath, userDataPath);
+    const auxiliary = bundle.auxiliarySessionStorage.upsertAuxiliarySession(createAuxiliarySessionFixture());
+    assert.equal(auxiliary.id, "aux-v6");
+    assert.equal(bundle.auxiliarySessionStorage.listAuxiliarySessions("session-v6")[0]?.id, "aux-v6");
     service.close(bundle, dbPath);
 
     const tables = readTableNames(dbPath);
     assert.equal(tables.includes("sessions_v6"), true);
     assert.equal(tables.includes("audit_events_v6"), true);
+    assert.equal(tables.includes("auxiliary_sessions"), true);
     assert.equal(tables.includes("sessions"), false);
     assert.equal(tables.includes("audit_logs"), false);
     assert.equal(tables.includes("session_memories"), false);

--- a/src-electron/persistent-store-lifecycle-service.ts
+++ b/src-electron/persistent-store-lifecycle-service.ts
@@ -179,9 +179,9 @@ export class PersistentStoreLifecycleService {
       : isV2Database
       ? new AuditLogStorageV2(dbPath)
       : this.deps.createAuditLogStorage(dbPath);
-    const auxiliarySessionStorage = isV6Database || isV3Database || isV2Database || basename(dbPath) !== APP_DATABASE_V4_FILENAME
-      ? new LegacyAuxiliarySessionStorage()
-      : this.deps.createAuxiliarySessionStorage?.(dbPath) ?? new AuxiliarySessionStorage(dbPath);
+    const auxiliarySessionStorage = isV6Database
+      ? this.deps.createAuxiliarySessionStorage?.(dbPath) ?? new AuxiliarySessionStorage(dbPath)
+      : new LegacyAuxiliarySessionStorage();
     const characterStorage = isV3Database || isV2Database || (
         basename(dbPath) !== APP_DATABASE_V4_FILENAME
         && basename(dbPath) !== APP_DATABASE_V6_FILENAME


### PR DESCRIPTION
## Summary
- V6 runtime DB で AuxiliarySessionStorage を使うように修正
- V4 以前 / invalid DB path は legacy no-op storage のままに維持
- Auxiliary session の DB version impact 設計記述を V6 runtime 前提へ更新

## Validation
- npx tsx --test scripts/tests/persistent-store-lifecycle-service.test.ts
- npx tsx --test scripts/tests/auxiliary-session-storage.test.ts
- npm run typecheck