### PR TITLE
fix(session): lazy load v6 message artifacts

### DIFF
--- a/docs/design/v6-database-foundation.md
+++ b/docs/design/v6-database-foundation.md
@@ -166,6 +166,8 @@ V6 session tableは`sessions_v6`とし、V6 runtimeで必要なmetadata、provid
 resume時に実行policyがdefaultへ戻らないよう、`catalog_revision`、`approval_mode`、`codex_sandbox_mode`、`allowed_additional_directories_json`、`session_kind`、`custom_agent_name`、`runtime_policy_json`を保存する。
 Character付きsessionでは`character_snapshot_json`をvalid JSONとして必須にし、neutral sessionでは`NULL`を許可する。
 message tableは`session_messages_v6`とし、V5以前message履歴は移行しない。
+message bodyはSession表示に必要な軽量projectionを保持し、assistant artifactのfull detailは`artifact_body`へ分離する。
+`getSession()`はartifact summaryだけを返し、operation detailsやdiff rowsなどの重いdetailはmessage artifact detail APIで遅延取得する。
 Memory provenanceはapp messageを指す`source_app_message_id`とprovider外部IDを指す`source_provider_message_id`を分ける。
 
 auditは`audit_events_v6`で通常turn、Memory mutation、runtime binding、diagnosticsを分離して設計する。

--- a/scripts/tests/database-schema-v6.test.ts
+++ b/scripts/tests/database-schema-v6.test.ts
@@ -218,6 +218,7 @@ describe("database-schema-v6", () => {
         "seq",
         "role",
         "body",
+        "artifact_body",
         "created_at",
       ]);
       assert.equal(findForeignKey(db, "session_messages_v6", "session_id")?.on_delete.toUpperCase(), "CASCADE");

--- a/scripts/tests/session-storage-v6.test.ts
+++ b/scripts/tests/session-storage-v6.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { describe, it } from "node:test";
+
+import { DEFAULT_APPROVAL_MODE } from "../../src/approval-mode.js";
+import { buildNewSession, type MessageArtifact } from "../../src/session-state.js";
+import { SessionStorageV6 } from "../../src-electron/session-storage-v6.js";
+
+async function removeDirectoryWithRetry(targetPath: string, attempts = 5): Promise<void> {
+  for (let index = 0; index < attempts; index += 1) {
+    try {
+      await rm(targetPath, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      const isBusyError = typeof error === "object" && error !== null && "code" in error && error.code === "EBUSY";
+      if (!isBusyError || index === attempts - 1) {
+        throw error;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 50 * (index + 1)));
+    }
+  }
+}
+
+function createArtifact(): MessageArtifact {
+  return {
+    title: "Run result",
+    activitySummary: ["edited file"],
+    operationTimeline: [
+      {
+        type: "tool",
+        summary: "apply patch",
+        details: "large operation details",
+      },
+    ],
+    changedFiles: [
+      {
+        kind: "edit",
+        path: "src/example.ts",
+        summary: "updated example",
+        diffRows: [
+          {
+            kind: "add",
+            rightNumber: 1,
+            rightText: "const value = true;",
+          },
+        ],
+      },
+    ],
+    runChecks: [{ label: "npm test", value: "pass" }],
+  };
+}
+
+describe("SessionStorageV6", () => {
+  it("既存の artifact_body なし schema は constructor で補完する", async () => {
+    const tempDirectory = await mkdtemp(path.join(os.tmpdir(), "withmate-session-storage-v6-"));
+    const dbPath = path.join(tempDirectory, "withmate-v6.db");
+    let storage: SessionStorageV6 | null = null;
+
+    try {
+      const db = new DatabaseSync(dbPath);
+      db.exec(`
+        CREATE TABLE session_messages_v6 (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          session_id TEXT NOT NULL,
+          seq INTEGER NOT NULL,
+          role TEXT NOT NULL CHECK (role IN ('user', 'assistant', 'tool', 'system')),
+          body TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          UNIQUE (session_id, seq),
+          UNIQUE (id, session_id)
+        );
+      `);
+      db.close();
+
+      storage = new SessionStorageV6(dbPath);
+      storage.close();
+      storage = null;
+
+      const reopenedDb = new DatabaseSync(dbPath);
+      const columns = (reopenedDb.prepare("PRAGMA table_info(session_messages_v6)").all() as Array<{ name: string }>)
+        .map((column) => column.name);
+      reopenedDb.close();
+      assert.equal(columns.includes("artifact_body"), true);
+    } finally {
+      storage?.close();
+      await removeDirectoryWithRetry(tempDirectory);
+    }
+  });
+
+  it("getSession は artifact summary を返し、detail は getSessionMessageArtifact で遅延取得する", async () => {
+    const tempDirectory = await mkdtemp(path.join(os.tmpdir(), "withmate-session-storage-v6-"));
+    const dbPath = path.join(tempDirectory, "withmate-v6.db");
+    let storage: SessionStorageV6 | null = null;
+
+    try {
+      storage = new SessionStorageV6(dbPath);
+      const artifact = createArtifact();
+      const session = storage.upsertSession({
+        ...buildNewSession({
+          taskTitle: "artifact detail",
+          workspaceLabel: "workspace",
+          workspacePath: "C:/workspace",
+          branch: "main",
+          characterId: "char-a",
+          character: "A",
+          characterIconPath: "",
+          characterThemeColors: { main: "#6f8cff", sub: "#6fb8c7" },
+          approvalMode: DEFAULT_APPROVAL_MODE,
+        }),
+        messages: [
+          {
+            role: "assistant",
+            text: "done",
+            artifact,
+          },
+        ],
+      });
+
+      const loaded = storage.getSession(session.id);
+      const loadedArtifact = loaded?.messages[0]?.artifact;
+      assert.ok(loadedArtifact);
+      assert.equal(loadedArtifact.detailAvailable, true);
+      assert.equal(loadedArtifact.operationTimeline?.[0]?.details, undefined);
+      assert.deepEqual(loadedArtifact.changedFiles[0]?.diffRows, []);
+      assert.deepEqual(loadedArtifact.runChecks, artifact.runChecks);
+
+      const fullArtifact = storage.getSessionMessageArtifact(session.id, 0);
+      assert.equal(fullArtifact?.operationTimeline?.[0]?.details, "large operation details");
+      assert.equal(fullArtifact?.changedFiles[0]?.diffRows[0]?.rightText, "const value = true;");
+      assert.deepEqual(fullArtifact?.runChecks, artifact.runChecks);
+    } finally {
+      storage?.close();
+      await removeDirectoryWithRetry(tempDirectory);
+    }
+  });
+
+  it("artifact_body がない既存 row でも getSessionMessageArtifact は body から復元する", async () => {
+    const tempDirectory = await mkdtemp(path.join(os.tmpdir(), "withmate-session-storage-v6-"));
+    const dbPath = path.join(tempDirectory, "withmate-v6.db");
+    let storage: SessionStorageV6 | null = null;
+    let reopened: SessionStorageV6 | null = null;
+
+    try {
+      const artifact = createArtifact();
+      storage = new SessionStorageV6(dbPath);
+      const session = storage.upsertSession({
+        ...buildNewSession({
+          taskTitle: "legacy artifact detail",
+          workspaceLabel: "workspace",
+          workspacePath: "C:/workspace",
+          branch: "main",
+          characterId: "char-a",
+          character: "A",
+          characterIconPath: "",
+          characterThemeColors: { main: "#6f8cff", sub: "#6fb8c7" },
+          approvalMode: DEFAULT_APPROVAL_MODE,
+        }),
+        messages: [{ role: "assistant", text: "done", artifact }],
+      });
+      storage.close();
+      storage = null;
+
+      const db = new DatabaseSync(dbPath);
+      db.prepare("UPDATE session_messages_v6 SET body = ?, artifact_body = NULL WHERE session_id = ? AND seq = 0")
+        .run(JSON.stringify({ role: "assistant", text: "done", artifact }), session.id);
+      db.close();
+
+      reopened = new SessionStorageV6(dbPath);
+      const loadedArtifact = reopened.getSessionMessageArtifact(session.id, 0);
+      assert.equal(loadedArtifact?.operationTimeline?.[0]?.details, "large operation details");
+      assert.equal(loadedArtifact?.changedFiles[0]?.diffRows[0]?.rightText, "const value = true;");
+    } finally {
+      storage?.close();
+      reopened?.close();
+      await removeDirectoryWithRetry(tempDirectory);
+    }
+  });
+});

--- a/src-electron/database-schema-v6.ts
+++ b/src-electron/database-schema-v6.ts
@@ -426,6 +426,7 @@ export const CREATE_V6_SESSION_MESSAGES_TABLE_SQL = `
     seq INTEGER NOT NULL,
     role TEXT NOT NULL CHECK (role IN ('user', 'assistant', 'tool', 'system')),
     body TEXT NOT NULL,
+    artifact_body TEXT,
     created_at TEXT NOT NULL,
     FOREIGN KEY (session_id) REFERENCES sessions_v6(id) ON DELETE CASCADE,
     UNIQUE (session_id, seq),

--- a/src-electron/session-storage-v6.ts
+++ b/src-electron/session-storage-v6.ts
@@ -7,6 +7,7 @@ import {
   normalizeMessage,
   normalizeSession,
   normalizeSessionSummary,
+  summarizeMessageArtifact,
   type Message,
   type MessageArtifact,
   type Session,
@@ -44,6 +45,7 @@ type SessionV6Row = {
 type MessageV6Row = {
   role: "user" | "assistant" | "tool" | "system";
   body: string;
+  artifact_body?: string | null;
 };
 
 function toV6State(session: Session): string {
@@ -72,7 +74,25 @@ function parseJsonArray(value: string): unknown[] {
 }
 
 function encodeMessage(message: Message): string {
-  return JSON.stringify(message);
+  return JSON.stringify(message.artifact
+    ? { ...message, artifact: summarizeMessageArtifact(message.artifact) }
+    : message);
+}
+
+function encodeMessageArtifact(message: Message): string | null {
+  return message.artifact ? JSON.stringify(message.artifact) : null;
+}
+
+function decodeMessageArtifact(value: string | null | undefined): MessageArtifact | null {
+  if (!value) {
+    return null;
+  }
+
+  return normalizeMessage({
+    role: "assistant",
+    text: "",
+    artifact: parseJsonObject(value),
+  })?.artifact ?? null;
 }
 
 function decodeMessage(row: MessageV6Row): Message | null {
@@ -94,6 +114,7 @@ export class SessionStorageV6 {
     for (const statement of CREATE_V6_SCHEMA_SQL) {
       this.db.exec(statement);
     }
+    this.ensureSchema();
   }
 
   listSessions(): Session[] {
@@ -121,11 +142,11 @@ export class SessionStorageV6 {
 
   getSessionMessageArtifact(sessionId: string, messageIndex: number): MessageArtifact | null {
     const row = this.db.prepare(`
-      SELECT role, body
+      SELECT role, body, artifact_body
       FROM session_messages_v6
       WHERE session_id = ? AND seq = ?
     `).get(sessionId, messageIndex) as MessageV6Row | undefined;
-    return row ? decodeMessage(row)?.artifact ?? null : null;
+    return row ? decodeMessageArtifact(row.artifact_body) ?? decodeMessage(row)?.artifact ?? null : null;
   }
 
   upsertSession(session: Session): Session {
@@ -263,12 +284,31 @@ export class SessionStorageV6 {
 
     this.db.prepare("DELETE FROM session_messages_v6 WHERE session_id = ?").run(session.id);
     const insertMessage = this.db.prepare(`
-      INSERT INTO session_messages_v6 (session_id, seq, role, body, created_at)
-      VALUES (?, ?, ?, ?, ?)
+      INSERT INTO session_messages_v6 (session_id, seq, role, body, artifact_body, created_at)
+      VALUES (?, ?, ?, ?, ?, ?)
     `);
     session.messages.forEach((message, index) => {
-      insertMessage.run(session.id, index, message.role, encodeMessage(message), session.updatedAt);
+      insertMessage.run(
+        session.id,
+        index,
+        message.role,
+        encodeMessage(message),
+        encodeMessageArtifact(message),
+        session.updatedAt,
+      );
     });
+  }
+
+  private ensureSchema(): void {
+    const columns = new Set(
+      (this.db.prepare("PRAGMA table_info(session_messages_v6)").all() as Array<{ name?: unknown }>)
+        .map((column) => column.name)
+        .filter((name): name is string => typeof name === "string"),
+    );
+
+    if (!columns.has("artifact_body")) {
+      this.db.exec("ALTER TABLE session_messages_v6 ADD COLUMN artifact_body TEXT;");
+    }
   }
 
   private rowToSessionSummary(row: SessionV6Row): SessionSummary {


### PR DESCRIPTION
## Summary
- V6 session message storage now keeps initial message bodies lightweight by storing summarized artifacts in `body`
- Full assistant artifact JSON is stored in nullable `artifact_body` and loaded through `getSessionMessageArtifact`
- Existing V6 DBs without `artifact_body` are upgraded in `SessionStorageV6`, with fallback support for legacy rows
- Updated V6 database design notes and schema tests

## Validation
- `npx tsx --test scripts/tests/session-storage-v6.test.ts scripts/tests/database-schema-v6.test.ts`
- `npm run typecheck`
- `npm test`
- `git diff --check`