### PR TITLE
feat(memory): add CLI help output

### DIFF
--- a/resources/skills/withmate-memory/SKILL.md
+++ b/resources/skills/withmate-memory/SKILL.md
@@ -69,6 +69,7 @@ When correcting a previous entry, append a replacement with `supersedes` instead
 Run the installed command from the target project directory:
 
 ```bash
+withmate-memory --help
 withmate-memory status
 withmate-memory context
 withmate-memory schema
@@ -83,7 +84,7 @@ withmate-memory append --file memory-entry.json
 withmate-memory forget --file forget-request.json
 ```
 
-Commands write one JSON object to stdout.
+Commands write one JSON object to stdout, except `--help`, `-h`, and `help`, which print usage text.
 
 For commands that require a request body, prefer `--stdin` or `--file <path>`. Inline `--json` is supported, but it is shell-sensitive. On Windows PowerShell or `.cmd` wrappers, double quotes inside JSON can be consumed before the CLI receives the argument. If `--json` fails with invalid JSON or a CLI usage error, pipe the request through `--stdin`, or write it to a temporary JSON file and retry with `--file`.
 
@@ -108,6 +109,8 @@ $request | withmate-memory search --stdin
 ```
 
 ### Request Shapes
+
+`help`, `--help`, and `-h` do not require a request body or runtime connection.
 
 `status` does not require a request body.
 

--- a/resources/skills/withmate-memory/bin/withmate-memory.mjs
+++ b/resources/skills/withmate-memory/bin/withmate-memory.mjs
@@ -31,7 +31,52 @@ const exitCodes = {
   transportError: 4,
 };
 
+const helpText = `Usage:
+  withmate-memory <command> [options]
+
+Commands:
+  help
+  status
+  context
+  search
+  get-entry
+  list-tags
+  append
+  forget
+  schema
+  validate
+
+Input options:
+  --json <json>       Read request body from an inline JSON string.
+  --file <path>       Read request body from a JSON file.
+  @file               Read request body from a JSON file.
+  --stdin             Read request body from standard input.
+
+Shorthand options:
+  --project <path>
+  --project-id <id>
+  --query <text>
+  --tag <tag>
+  --tags <tags>
+  --entry-id <id>
+  --limit <n>
+
+Connection options:
+  --api-url <url>
+  --discovery-file <path>
+
+Validation:
+  validate --command <context|search|get-entry|list-tags|append|forget>
+
+Examples:
+  withmate-memory status
+  withmate-memory search --project . --query "release workflow"
+  withmate-memory validate --command append --stdin
+  withmate-memory schema
+`;
+
 const commands = new Map([
+  ["help", { name: "help", local: true, defaultBody: {} }],
   ["status", { name: "status", method: "GET", path: "/v1/status", defaultBody: {} }],
   ["context", { name: "context", method: "POST", path: "/v1/context", defaultBody: { schemaVersion } }],
   ["resolve-context", { name: "context", method: "POST", path: "/v1/context", defaultBody: { schemaVersion } }],
@@ -133,9 +178,15 @@ async function readDiscovery(options) {
 
 async function parseArgs(argv) {
   const [rawCommand, ...rest] = argv;
+  if (!rawCommand || rawCommand === "--help" || rawCommand === "-h") {
+    return { route: { name: "help", local: true, defaultBody: {} }, body: {} };
+  }
   const route = rawCommand ? commands.get(rawCommand) : undefined;
   if (!route) {
-    throw usage("Usage: withmate-memory <status|context|search|get-entry|list-tags|append|forget|schema|validate> [--json <json> | --file <path> | @file | --stdin] [--command <command>] [--project <path> | --project-id <id>] [--query <text>] [--tag <tag> | --tags <tags>] [--entry-id <id>] [--limit <n>] [--api-url <url>] [--discovery-file <path>]");
+    throw usage("Usage: withmate-memory <help|status|context|search|get-entry|list-tags|append|forget|schema|validate> [--json <json> | --file <path> | @file | --stdin] [--command <command>] [--project <path> | --project-id <id>] [--query <text>] [--tag <tag> | --tags <tags>] [--entry-id <id>] [--limit <n>] [--api-url <url>] [--discovery-file <path>]");
+  }
+  if (route.name === "help" || rest.includes("--help") || rest.includes("-h")) {
+    return { route: { name: "help", local: true, defaultBody: {} }, body: {} };
   }
 
   let jsonInput = null;
@@ -361,7 +412,7 @@ function buildSchemaResponse() {
     schemaVersion,
     entryKinds,
     forgetReasons,
-    commands: ["status", "context", "search", "get-entry", "list-tags", "append", "forget", "schema", "validate"],
+    commands: ["help", "status", "context", "search", "get-entry", "list-tags", "append", "forget", "schema", "validate"],
     requestBodyInputs: ["--json", "--file", "@file", "--stdin"],
     targetSelectors: [
       {
@@ -991,6 +1042,10 @@ async function verifyRuntime(connection, signal) {
 async function main() {
   try {
     const request = await parseArgs(process.argv.slice(2));
+    if (request.route.name === "help") {
+      console.log(helpText.trimEnd());
+      return exitCodes.ok;
+    }
     if (request.route.name === "schema") {
       console.log(JSON.stringify(buildSchemaResponse()));
       return exitCodes.ok;

--- a/resources/skills/withmate-memory/reference/cli.md
+++ b/resources/skills/withmate-memory/reference/cli.md
@@ -7,6 +7,7 @@ Run it from the target project directory after WithMate is installed:
 
 ```bash
 withmate-memory <command> [--json <json> | --file <path> | --stdin]
+withmate-memory --help
 ```
 
 For commands that require a request body, prefer `--stdin` or `--file <path>`. Inline `--json` is supported, but it is shell-sensitive. On Windows PowerShell or `.cmd` wrappers, double quotes inside JSON can be consumed before the CLI receives the argument. If `--json` fails with invalid JSON or a CLI usage error, pipe the request through `--stdin`, or write it to a temporary JSON file and retry with `--file`.
@@ -16,6 +17,17 @@ On Windows, the installer places `withmate-memory.cmd` in the WithMate install d
 When a managed skill includes `bin/withmate-memory.mjs` and no `withmate-memory` command is available on `PATH`, use `node bin/withmate-memory.mjs <command>` as a temporary fallback.
 
 ## Commands
+
+### help
+
+```bash
+withmate-memory --help
+withmate-memory -h
+withmate-memory help
+withmate-memory search --help
+```
+
+Prints CLI usage text and exits without connecting to the runtime API.
 
 ### schema
 

--- a/scripts/tests/withmate-memory-cli.test.ts
+++ b/scripts/tests/withmate-memory-cli.test.ts
@@ -28,7 +28,7 @@ const TEST_RUNTIME_ENV = {
   WITHMATE_MEMORY_RUNTIME_INSTANCE_ID: TEST_RUNTIME_INSTANCE_ID,
 };
 
-function createOutputCapture(): { stream: { write(chunk: string): boolean }; lines(): string[]; json(): any } {
+function createOutputCapture(): { stream: { write(chunk: string): boolean }; text(): string; lines(): string[]; json(): any } {
   let output = "";
   return {
     stream: {
@@ -36,6 +36,9 @@ function createOutputCapture(): { stream: { write(chunk: string): boolean }; lin
         output += chunk;
         return true;
       },
+    },
+    text() {
+      return output;
     },
     lines() {
       return output.trim().split(/\r?\n/).filter(Boolean);
@@ -402,6 +405,43 @@ describe("withmate-memory CLI", () => {
       scope: "global",
       requiredFields: [],
     });
+  });
+
+  it("--helpはruntime接続なしでusage textを返す", async () => {
+    const stdout = createOutputCapture();
+    let fetchCalls = 0;
+    const exitCode = await runWithMateMemoryCli(["--help"], {
+      env: TEST_RUNTIME_ENV,
+      stdout: stdout.stream,
+      fetch: async () => {
+        fetchCalls += 1;
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      },
+    });
+
+    assert.equal(exitCode, WITHMATE_MEMORY_CLI_EXIT_CODES.ok);
+    assert.equal(fetchCalls, 0);
+    assert.match(stdout.text(), /Usage:\s+withmate-memory <command> \[options\]/);
+    assert.match(stdout.text(), /search --project \. --query/);
+    assert.match(stdout.text(), /validate --command <context\|search\|get-entry\|list-tags\|append\|forget>/);
+  });
+
+  it("command --helpもruntime接続なしでusage textを返す", async () => {
+    const stdout = createOutputCapture();
+    let fetchCalls = 0;
+    const exitCode = await runWithMateMemoryCli(["search", "--help"], {
+      env: TEST_RUNTIME_ENV,
+      stdout: stdout.stream,
+      fetch: async () => {
+        fetchCalls += 1;
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      },
+    });
+
+    assert.equal(exitCode, WITHMATE_MEMORY_CLI_EXIT_CODES.ok);
+    assert.equal(fetchCalls, 0);
+    assert.match(stdout.text(), /Commands:/);
+    assert.match(stdout.text(), /--stdin/);
   });
 
   it("validateはrequest bodyをruntimeへ送らずに検証する", async () => {

--- a/scripts/withmate-memory.ts
+++ b/scripts/withmate-memory.ts
@@ -44,6 +44,7 @@ export const WITHMATE_MEMORY_CLI_EXIT_CODES = {
 } as const;
 
 export type WithMateMemoryCliCommand =
+  | "help"
   | "status"
   | "context"
   | "search"
@@ -54,7 +55,7 @@ export type WithMateMemoryCliCommand =
   | "schema"
   | "validate";
 
-export type WithMateMemoryApiCommand = Exclude<WithMateMemoryCliCommand, "schema" | "validate">;
+export type WithMateMemoryApiCommand = Exclude<WithMateMemoryCliCommand, "help" | "schema" | "validate">;
 export type WithMateMemoryValidatedCommand = Exclude<WithMateMemoryApiCommand, "status">;
 
 export type WithMateMemoryCliRequest = {
@@ -95,6 +96,7 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
 const WITHMATE_MEMORY_API_SECRET_HEADER = "x-withmate-memory-api-secret";
 
 const commandAliases = new Map<string, WithMateMemoryCliCommand>([
+  ["help", "help"],
   ["status", "status"],
   ["context", "context"],
   ["resolve-context", "context"],
@@ -109,6 +111,50 @@ const commandAliases = new Map<string, WithMateMemoryCliCommand>([
   ["capabilities", "schema"],
   ["validate", "validate"],
 ]);
+
+const WITHMATE_MEMORY_CLI_HELP = `Usage:
+  withmate-memory <command> [options]
+
+Commands:
+  help
+  status
+  context
+  search
+  get-entry
+  list-tags
+  append
+  forget
+  schema
+  validate
+
+Input options:
+  --json <json>       Read request body from an inline JSON string.
+  --file <path>       Read request body from a JSON file.
+  @file               Read request body from a JSON file.
+  --stdin             Read request body from standard input.
+
+Shorthand options:
+  --project <path>
+  --project-id <id>
+  --query <text>
+  --tag <tag>
+  --tags <tags>
+  --entry-id <id>
+  --limit <n>
+
+Connection options:
+  --api-url <url>
+  --discovery-file <path>
+
+Validation:
+  validate --command <context|search|get-entry|list-tags|append|forget>
+
+Examples:
+  withmate-memory status
+  withmate-memory search --project . --query "release workflow"
+  withmate-memory validate --command append --stdin
+  withmate-memory schema
+`;
 
 const validatableCommands = new Set<WithMateMemoryValidatedCommand>([
   "context",
@@ -259,9 +305,15 @@ export async function parseWithMateMemoryCliArgs(
   deps: Pick<WithMateMemoryCliDeps, "stdin" | "readFile"> = {},
 ): Promise<WithMateMemoryCliRequest> {
   const [rawCommand, ...rest] = args;
+  if (!rawCommand || rawCommand === "--help" || rawCommand === "-h") {
+    return { command: "help", body: {} };
+  }
   const command = rawCommand ? commandAliases.get(rawCommand) : undefined;
   if (!command) {
-    throw usageError("Usage: withmate-memory <status|context|search|get-entry|list-tags|append|forget|schema|validate> [--json <json> | --file <path> | @file | --stdin] [--command <command>] [--project <path> | --project-id <id>] [--query <text>] [--tag <tag> | --tags <tags>] [--entry-id <id>] [--limit <n>] [--api-url <url>] [--discovery-file <path>]");
+    throw usageError("Usage: withmate-memory <help|status|context|search|get-entry|list-tags|append|forget|schema|validate> [--json <json> | --file <path> | @file | --stdin] [--command <command>] [--project <path> | --project-id <id>] [--query <text>] [--tag <tag> | --tags <tags>] [--entry-id <id>] [--limit <n>] [--api-url <url>] [--discovery-file <path>]");
+  }
+  if (command === "help" || rest.includes("--help") || rest.includes("-h")) {
+    return { command: "help", body: {} };
   }
 
   let jsonInput: string | null = null;
@@ -501,6 +553,7 @@ function buildSchemaResponse(): unknown {
     entryKinds: [...MEMORY_ENTRY_KINDS],
     forgetReasons: [...MEMORY_FORGET_REASONS],
     commands: [
+      "help",
       "status",
       "context",
       "search",
@@ -647,6 +700,10 @@ export async function runWithMateMemoryCli(
 
   try {
     const request = await parseWithMateMemoryCliArgs(args, deps);
+    if (request.command === "help") {
+      stdout.write(WITHMATE_MEMORY_CLI_HELP);
+      return WITHMATE_MEMORY_CLI_EXIT_CODES.ok;
+    }
     if (request.command === "schema") {
       stdout.write(`${JSON.stringify(buildSchemaResponse())}\n`);
       return WITHMATE_MEMORY_CLI_EXIT_CODES.ok;


### PR DESCRIPTION
## 概要
- withmate-memory CLI に `--help` / `-h` / `help` を追加
- `command --help` でも runtime API に接続せず usage text を返すようにした
- bundled helper、schema commands、Memory CLI ドキュメントを更新

## 検証
- `npx tsx --test scripts/tests/withmate-memory-cli.test.ts`
- `node resources/skills/withmate-memory/bin/withmate-memory.mjs --help`
- `node resources/skills/withmate-memory/bin/withmate-memory.mjs schema`
- `git diff --check`

## 未実行
- `npm run typecheck`: `node_modules` が無く `tsc` が解決できないため未完了