### PR TITLE
fix(audit-log): V6 summary page の初回カーソルを修正

### DIFF
--- a/scripts/tests/audit-log-storage-v6.test.ts
+++ b/scripts/tests/audit-log-storage-v6.test.ts
@@ -135,4 +135,49 @@ describe("AuditLogStorageV6", () => {
       await rm(userDataPath, { recursive: true, force: true });
     }
   });
+
+  it("summary page の cursor 0 は先頭ページとして扱う", async () => {
+    const userDataPath = await mkdtemp(path.join(tmpdir(), "withmate-audit-log-v6-"));
+    try {
+      const { dbPath } = await createOrVerifyV6FreshDatabase(userDataPath);
+      seedSession(dbPath);
+      const storage = new AuditLogStorageV6(dbPath);
+      try {
+        storage.createAuditLog(baseAuditLog({
+          createdAt: "2026-06-28T00:00:00.000Z",
+          assistantText: "first",
+        }));
+        const second = storage.createAuditLog(baseAuditLog({
+          createdAt: "2026-06-28T00:01:00.000Z",
+          assistantText: "second",
+        }));
+
+        const firstPage = storage.listSessionAuditLogSummaryPage("session-v6", {
+          cursor: 0,
+          limit: 1,
+        });
+
+        assert.equal(firstPage.total, 2);
+        assert.equal(firstPage.entries.length, 1);
+        assert.equal(firstPage.entries[0]?.id, second.id);
+        assert.equal(firstPage.entries[0]?.assistantTextPreview, "second");
+        assert.equal(firstPage.hasMore, true);
+        assert.equal(firstPage.nextCursor, second.id);
+
+        const secondPage = storage.listSessionAuditLogSummaryPage("session-v6", {
+          cursor: firstPage.nextCursor,
+          limit: 1,
+        });
+
+        assert.equal(secondPage.entries.length, 1);
+        assert.equal(secondPage.entries[0]?.assistantTextPreview, "first");
+        assert.equal(secondPage.hasMore, false);
+        assert.equal(secondPage.nextCursor, null);
+      } finally {
+        storage.close();
+      }
+    } finally {
+      await rm(userDataPath, { recursive: true, force: true });
+    }
+  });
 });

--- a/src-electron/audit-log-storage-v6.ts
+++ b/src-electron/audit-log-storage-v6.ts
@@ -63,7 +63,9 @@ function normalizePageRequest(request?: AuditLogSummaryPageRequest | null): { cu
     ? Math.trunc(request.limit)
     : DEFAULT_PAGE_LIMIT;
   return {
-    cursor: typeof request?.cursor === "number" && Number.isFinite(request.cursor) ? Math.trunc(request.cursor) : null,
+    cursor: typeof request?.cursor === "number" && Number.isFinite(request.cursor) && request.cursor > 0
+      ? Math.trunc(request.cursor)
+      : null,
     limit: Math.max(1, Math.min(MAX_PAGE_LIMIT, requestedLimit)),
   };
 }


### PR DESCRIPTION
## Summary
- V6 AuditLog summary page で `cursor: 0` を先頭ページとして扱うよう修正
- `cursor: 0` 初回取得の回帰テストを追加

## Tests
- `npx tsx --test scripts/tests/audit-log-storage-v6.test.ts`
- `npx tsx --test scripts/tests/audit-log-refresh.test.ts scripts/tests/session-audit-log-state.test.tsx`
- `npm run typecheck`