### PR TITLE
feat: Windowsトレイの最小対応を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "files": [
       "dist/**",
       "dist-electron/**",
+      "build/icon.ico",
       "package.json",
       "!node_modules/@openai/codex-win32-*/**",
       "!node_modules/@openai/codex-darwin-*/**",

--- a/scripts/tests/app-tray-service.test.ts
+++ b/scripts/tests/app-tray-service.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  AppTrayService,
+  type AppTrayLike,
+  type AppTrayMenuItem,
+  type AppTrayWindowLike,
+} from "../../src-electron/app-tray-service.js";
+
+class FakeTray implements AppTrayLike {
+  readonly listeners = new Map<string, () => void>();
+  contextMenu: unknown = null;
+  destroyed = false;
+  toolTip = "";
+
+  setToolTip(toolTip: string): void {
+    this.toolTip = toolTip;
+  }
+
+  setContextMenu(menu: unknown): void {
+    this.contextMenu = menu;
+  }
+
+  on(event: "click" | "double-click", listener: () => void): void {
+    this.listeners.set(event, listener);
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+  }
+
+  isDestroyed(): boolean {
+    return this.destroyed;
+  }
+}
+
+class FakeWindow implements AppTrayWindowLike {
+  destroyed = false;
+  minimized = false;
+  restored = false;
+  shown = false;
+  focused = false;
+
+  isDestroyed(): boolean {
+    return this.destroyed;
+  }
+
+  isMinimized(): boolean {
+    return this.minimized;
+  }
+
+  restore(): void {
+    this.restored = true;
+    this.minimized = false;
+  }
+
+  show(): void {
+    this.shown = true;
+  }
+
+  focus(): void {
+    this.focused = true;
+  }
+}
+
+describe("AppTrayService", () => {
+  it("does not create a tray outside Windows", () => {
+    let createTrayCalled = false;
+    const service = new AppTrayService({
+      platform: "darwin",
+      iconPath: "build/icon.ico",
+      createTray: () => {
+        createTrayCalled = true;
+        return new FakeTray();
+      },
+      buildMenu: (items) => items,
+      openHomeWindow: async () => null,
+      quitApp: () => {},
+    });
+
+    service.initialize();
+
+    assert.equal(createTrayCalled, false);
+  });
+
+  it("creates a Windows tray with show and quit actions", async () => {
+    const tray = new FakeTray();
+    const window = new FakeWindow();
+    window.minimized = true;
+    let quitCalled = false;
+    const service = new AppTrayService({
+      platform: "win32",
+      iconPath: "build/icon.ico",
+      createTray: () => tray,
+      buildMenu: (items) => items,
+      openHomeWindow: async () => window,
+      quitApp: () => {
+        quitCalled = true;
+      },
+    });
+
+    service.initialize();
+
+    assert.equal(tray.toolTip, "WithMate");
+    const menu = tray.contextMenu as AppTrayMenuItem[];
+    assert.deepEqual(menu.map((item) => "label" in item ? item.label : item.type), [
+      "WithMate を表示",
+      "separator",
+      "終了",
+    ]);
+
+    tray.listeners.get("click")?.();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.equal(window.restored, true);
+    assert.equal(window.shown, true);
+    assert.equal(window.focused, true);
+
+    const quitItem = menu.find((item): item is Extract<AppTrayMenuItem, { label: string }> =>
+      "label" in item && item.label === "終了",
+    );
+    quitItem?.click();
+
+    assert.equal(quitCalled, true);
+  });
+
+  it("destroys the tray on dispose", () => {
+    const tray = new FakeTray();
+    const service = new AppTrayService({
+      platform: "win32",
+      iconPath: "build/icon.ico",
+      createTray: () => tray,
+      buildMenu: (items) => items,
+      openHomeWindow: async () => null,
+      quitApp: () => {},
+    });
+
+    service.initialize();
+    service.dispose();
+
+    assert.equal(tray.destroyed, true);
+  });
+});

--- a/scripts/tests/package-config.test.ts
+++ b/scripts/tests/package-config.test.ts
@@ -6,11 +6,13 @@ describe("package build config", () => {
   it("Windows installer exposes withmate-memory without editing the user Path value", async () => {
     const packageJson = JSON.parse(await readFile("package.json", "utf8")) as {
       build?: {
+        files?: string[];
         extraFiles?: Array<{ from?: string; to?: string }>;
         nsis?: { include?: string };
       };
     };
 
+    assert.ok(packageJson.build?.files?.includes("build/icon.ico"));
     assert.deepEqual(
       packageJson.build?.extraFiles?.find((entry) => entry.to === "withmate-memory.cmd"),
       { from: "build/cli/withmate-memory.cmd", to: "withmate-memory.cmd" },

--- a/src-electron/app-tray-service.ts
+++ b/src-electron/app-tray-service.ts
@@ -1,0 +1,93 @@
+export type AppTrayMenuItem =
+  | {
+      label: string;
+      click: () => void;
+    }
+  | {
+      type: "separator";
+    };
+
+export type AppTrayWindowLike = {
+  isDestroyed(): boolean;
+  isMinimized(): boolean;
+  restore(): void;
+  show(): void;
+  focus(): void;
+};
+
+export type AppTrayLike = {
+  setToolTip(toolTip: string): void;
+  setContextMenu(menu: unknown): void;
+  on(event: "click" | "double-click", listener: () => void): void;
+  destroy(): void;
+  isDestroyed?(): boolean;
+};
+
+export type AppTrayServiceDeps = {
+  platform: NodeJS.Platform;
+  iconPath: string;
+  createTray(iconPath: string): AppTrayLike;
+  buildMenu(items: AppTrayMenuItem[]): unknown;
+  openHomeWindow(): Promise<AppTrayWindowLike | null | undefined>;
+  quitApp(): void;
+};
+
+export class AppTrayService {
+  private tray: AppTrayLike | null = null;
+
+  constructor(private readonly deps: AppTrayServiceDeps) {}
+
+  initialize(): void {
+    if (this.deps.platform !== "win32" || this.tray) {
+      return;
+    }
+
+    const tray = this.deps.createTray(this.deps.iconPath);
+    tray.setToolTip("WithMate");
+    tray.setContextMenu(this.deps.buildMenu([
+      {
+        label: "WithMate を表示",
+        click: () => {
+          void this.showHomeWindow();
+        },
+      },
+      { type: "separator" },
+      {
+        label: "終了",
+        click: () => {
+          this.deps.quitApp();
+        },
+      },
+    ]));
+    tray.on("click", () => {
+      void this.showHomeWindow();
+    });
+    tray.on("double-click", () => {
+      void this.showHomeWindow();
+    });
+    this.tray = tray;
+  }
+
+  dispose(): void {
+    const tray = this.tray;
+    this.tray = null;
+    if (!tray || tray.isDestroyed?.()) {
+      return;
+    }
+
+    tray.destroy();
+  }
+
+  private async showHomeWindow(): Promise<void> {
+    const window = await this.deps.openHomeWindow();
+    if (!window || window.isDestroyed()) {
+      return;
+    }
+
+    if (window.isMinimized()) {
+      window.restore();
+    }
+    window.show();
+    window.focus();
+  }
+}

--- a/src-electron/main.ts
+++ b/src-electron/main.ts
@@ -5,7 +5,7 @@ import { homedir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { app, BrowserWindow, crashReporter, dialog, ipcMain, screen, shell } from "electron";
+import { app, BrowserWindow, crashReporter, dialog, ipcMain, Menu, screen, shell, Tray } from "electron";
 
 import type { RendererLogInput } from "../src/app-log-types.js";
 import { summarizeAuditLogDetailFragment } from "../src/audit-log-detail-metrics.js";
@@ -122,6 +122,7 @@ import {
 import { AppLifecycleService } from "./app-lifecycle-service.js";
 import { createAppLifecycleDeps } from "./app-lifecycle-deps.js";
 import { applyLaunchAtLoginSetting, shouldLaunchInBackground } from "./app-login-item.js";
+import { AppTrayService } from "./app-tray-service.js";
 import { createMainBootstrapDeps } from "./main-bootstrap-deps.js";
 import { MainInfrastructureRegistry } from "./main-infrastructure-registry.js";
 import { MainBootstrapService } from "./main-bootstrap-service.js";
@@ -212,6 +213,7 @@ const bundledCharacterAuthoringSkillPath = app.isPackaged
 const bundledMemorySkillPath = app.isPackaged
   ? path.join(process.resourcesPath, "resources", "skills", WITHMATE_MEMORY_SKILL_NAME)
   : path.resolve(currentDir, "../../resources/skills", WITHMATE_MEMORY_SKILL_NAME);
+const trayIconPath = path.resolve(currentDir, "../../build/icon.ico");
 const codexAdapter = new CodexAdapter((input) => writeAppLog({
   ...input,
   process: "main",
@@ -280,6 +282,7 @@ let mainSessionCommandFacade: MainSessionCommandFacade | null = null;
 let mainSessionPersistenceFacade: MainSessionPersistenceFacade | null = null;
 let mainWindowFacade: MainWindowFacade | null = null;
 let mainQueryService: MainQueryService | null = null;
+let appTrayService: AppTrayService | null = null;
 let walMaintenanceTimer: ReturnType<typeof setInterval> | null = null;
 let mainInfrastructureRegistry:
   | MainInfrastructureRegistry<
@@ -874,6 +877,22 @@ function createCursorPlacedWindow(
     x,
     y,
   });
+}
+
+function requireAppTrayService(): AppTrayService {
+  if (!appTrayService) {
+    appTrayService = new AppTrayService({
+      platform: process.platform,
+      iconPath: trayIconPath,
+      createTray: (iconPath) => new Tray(iconPath),
+      buildMenu: (items) => Menu.buildFromTemplate(items),
+      openHomeWindow: createHomeWindow,
+      quitApp: () => {
+        app.quit();
+      },
+    });
+  }
+  return appTrayService;
 }
 
 function publishAppBootStatus(status: AppBootStatus): void {
@@ -3214,6 +3233,7 @@ if (!hasSingleInstanceLock) {
       });
       await startMemoryV6RuntimeApiBestEffort();
       await requireMainBootstrapService().handleReady();
+      requireAppTrayService().initialize();
       applyLaunchAtLoginSetting(app, requireAppSettingsStorage().getSettings().launchAtLoginEnabled);
       await syncManagedMemorySkillBestEffort();
       publishAppBootStatus({
@@ -3279,6 +3299,7 @@ if (!hasSingleInstanceLock) {
       process: "main",
       message: "App will quit",
     });
+    appTrayService?.dispose();
     void stopMemoryV6RuntimeApiBestEffort();
   });
 }


### PR DESCRIPTION
## Summary
- Windows のみトレイアイコンを初期化する AppTrayService を追加
- トレイクリックとメニューの「WithMate を表示」で Home を表示し、「終了」で既存の終了フローに乗せる
- 配布後も tray icon を読めるよう build/icon.ico を package files に追加

## Validation
- npm run typecheck
- npx tsx --test scripts/tests/app-tray-service.test.ts scripts/tests/package-config.test.ts