### PR TITLE
fix(session): ターン終了時の応答表示ちらつきを抑止

### DIFF
--- a/scripts/tests/auxiliary-session-message-projection.test.ts
+++ b/scripts/tests/auxiliary-session-message-projection.test.ts
@@ -384,6 +384,24 @@ test("shouldProjectLiveAssistantBridge は live run が消えて persisted assis
   );
 });
 
+test("shouldProjectLiveAssistantBridge は settling 中の bridge を投影する", () => {
+  assert.equal(
+    shouldProjectLiveAssistantBridge({
+      bridge: {
+        sessionId: "session-1",
+        threadId: "thread-1",
+        messageIndex: 1,
+        text: "streaming response",
+      },
+      activeSessionId: "session-1",
+      hasLiveRun: false,
+      hasPersistedAssistant: false,
+      isSettling: true,
+    }),
+    true,
+  );
+});
+
 test("shouldProjectLiveAssistantBridge は live run 中または persisted assistant 検知後だけ bridge を投影する", () => {
   const bridge = {
     sessionId: "session-1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -858,6 +858,7 @@ export default function AgentSessionWindowApp() {
         : false,
     [displayedMessages, liveAssistantBridge, projectedAuxiliarySessions, selectedSession?.id],
   );
+  const isLiveAssistantBridgeSettling = selectedSessionLiveRun === null && !hasPersistedLiveAssistantBridge;
   const projectedLiveAssistant = useMemo<LiveAssistantProjection | null>(() => {
     if (!activeRunSessionId) {
       return null;
@@ -883,12 +884,14 @@ export default function AgentSessionWindowApp() {
       activeSessionId: activeRunSessionId,
       hasLiveRun: selectedSessionLiveRun !== null,
       hasPersistedAssistant: hasPersistedLiveAssistantBridge,
+      isSettling: isLiveAssistantBridgeSettling,
     })
       ? liveAssistantBridge
       : null;
   }, [
     activeRunSessionId,
     hasPersistedLiveAssistantBridge,
+    isLiveAssistantBridgeSettling,
     liveAssistantBridge,
     liveAssistantMessageIndex,
     liveRunAssistantText,
@@ -933,13 +936,35 @@ export default function AgentSessionWindowApp() {
       return;
     }
 
-    if (
-      liveAssistantBridge.sessionId !== activeRunSessionId ||
-      (selectedSessionLiveRun === null && !hasPersistedLiveAssistantBridge)
-    ) {
+    if (liveAssistantBridge.sessionId !== activeRunSessionId) {
       setLiveAssistantBridge(null);
+      return;
     }
-  }, [activeRunSessionId, hasPersistedLiveAssistantBridge, liveAssistantBridge, selectedSessionLiveRun]);
+
+    if (!isLiveAssistantBridgeSettling) {
+      return;
+    }
+
+    let secondFrameId: number | null = null;
+    const firstFrameId = requestAnimationFrame(() => {
+      secondFrameId = requestAnimationFrame(() => {
+        setLiveAssistantBridge((current) =>
+          current?.sessionId === liveAssistantBridge.sessionId &&
+          current.threadId === liveAssistantBridge.threadId &&
+          current.text === liveAssistantBridge.text
+            ? null
+            : current,
+        );
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(firstFrameId);
+      if (secondFrameId !== null) {
+        cancelAnimationFrame(secondFrameId);
+      }
+    };
+  }, [activeRunSessionId, isLiveAssistantBridgeSettling, liveAssistantBridge]);
   useEffect(() => {
     if (!liveAssistantBridge) {
       return;

--- a/src/CompanionReviewApp.tsx
+++ b/src/CompanionReviewApp.tsx
@@ -687,6 +687,7 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
         : false,
     [liveAssistantBridge, projectedAuxiliarySessions, snapshot?.session.id, snapshot?.session.messages],
   );
+  const isLiveAssistantBridgeSettling = selectedSessionLiveRun === null && !hasPersistedLiveAssistantBridge;
   const projectedLiveAssistant = useMemo<LiveAssistantProjection | null>(() => {
     if (!activeRunSessionId) {
       return null;
@@ -713,12 +714,14 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
       activeSessionId: activeRunSessionId,
       hasLiveRun: selectedSessionLiveRun !== null,
       hasPersistedAssistant: hasPersistedLiveAssistantBridge,
+      isSettling: isLiveAssistantBridgeSettling,
     })
       ? liveAssistantBridge
       : null;
   }, [
     activeRunSessionId,
     hasPersistedLiveAssistantBridge,
+    isLiveAssistantBridgeSettling,
     liveAssistantBridge,
     liveAssistantMessageIndex,
     selectedSessionLiveRun,
@@ -762,13 +765,35 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
       return;
     }
 
-    if (
-      liveAssistantBridge.sessionId !== activeRunSessionId ||
-      (selectedSessionLiveRun === null && !hasPersistedLiveAssistantBridge)
-    ) {
+    if (liveAssistantBridge.sessionId !== activeRunSessionId) {
       setLiveAssistantBridge(null);
+      return;
     }
-  }, [activeRunSessionId, hasPersistedLiveAssistantBridge, liveAssistantBridge, selectedSessionLiveRun]);
+
+    if (!isLiveAssistantBridgeSettling) {
+      return;
+    }
+
+    let secondFrameId: number | null = null;
+    const firstFrameId = requestAnimationFrame(() => {
+      secondFrameId = requestAnimationFrame(() => {
+        setLiveAssistantBridge((current) =>
+          current?.sessionId === liveAssistantBridge.sessionId &&
+          current.threadId === liveAssistantBridge.threadId &&
+          current.text === liveAssistantBridge.text
+            ? null
+            : current,
+        );
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(firstFrameId);
+      if (secondFrameId !== null) {
+        cancelAnimationFrame(secondFrameId);
+      }
+    };
+  }, [activeRunSessionId, isLiveAssistantBridgeSettling, liveAssistantBridge]);
   useEffect(() => {
     if (!liveAssistantBridge) {
       return;

--- a/src/auxiliary-session-message-projection.ts
+++ b/src/auxiliary-session-message-projection.ts
@@ -50,6 +50,7 @@ export type LiveAssistantBridgeProjectionInput = {
   activeSessionId: string | null | undefined;
   hasLiveRun: boolean;
   hasPersistedAssistant: boolean;
+  isSettling?: boolean;
 };
 
 export type LoadProjectedMessageArtifactOptions = {
@@ -266,8 +267,9 @@ export function shouldProjectLiveAssistantBridge({
   activeSessionId,
   hasLiveRun,
   hasPersistedAssistant,
+  isSettling = false,
 }: LiveAssistantBridgeProjectionInput): boolean {
-  return !!bridge && bridge.sessionId === activeSessionId && (hasLiveRun || hasPersistedAssistant);
+  return !!bridge && bridge.sessionId === activeSessionId && (hasLiveRun || hasPersistedAssistant || isSettling);
 }
 
 function normalizeLiveAssistantProjection(


### PR DESCRIPTION
## Summary
- ターン終了直後の live run / saved session 反映順序差で assistant response が一瞬消える問題を抑止
- final session 反映待ちの間だけ liveAssistantBridge を投影し、stale bridge は2フレーム後に破棄
- Session Window と Companion Review の同型処理を揃え、projection の unit test を追加

## Validation
- `npx tsx --test scripts/tests/auxiliary-session-message-projection.test.ts`
- `git diff --check`

## Not run
- `npm run typecheck` は `node_modules` が無く `tsc` が見つからないため未完了