### PR TITLE
fix(auxiliary): preserve character prompt snapshot

### DIFF
--- a/scripts/tests/auxiliary-runtime-projection.test.ts
+++ b/scripts/tests/auxiliary-runtime-projection.test.ts
@@ -53,6 +53,17 @@ function createSession(): Session {
     character: "Test",
     characterIconPath: "",
     characterThemeColors: { main: "#000", sub: "#fff" },
+    characterRuntimeSnapshot: {
+      characterId: "char-1",
+      name: "Test",
+      description: "Auxiliary projection character snapshot",
+      iconFilePath: "",
+      theme: { main: "#000", sub: "#fff" },
+      definitionMarkdown: "# Character\n\nAuxiliary projection keeps this prompt.",
+      definitionSha256: "character-sha",
+      definitionByteSize: 51,
+      snapshotAt: "2026-01-01T00:00:00.000Z",
+    },
     runState: "idle",
     approvalMode: "on-request",
     codexSandboxMode: "workspace-write",
@@ -97,6 +108,17 @@ function createCompanionSession(): CompanionSession {
     characterRoleMarkdown: "",
     characterIconPath: "",
     characterThemeColors: { main: "#000", sub: "#fff" },
+    characterRuntimeSnapshot: {
+      characterId: "companion-char",
+      name: "Companion",
+      description: "Companion auxiliary projection character snapshot",
+      iconFilePath: "",
+      theme: { main: "#000", sub: "#fff" },
+      definitionMarkdown: "# Character\n\nCompanion auxiliary projection keeps this prompt.",
+      definitionSha256: "companion-character-sha",
+      definitionByteSize: 61,
+      snapshotAt: "2026-01-01T00:00:00.000Z",
+    },
     createdAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
     messages: [{ role: "assistant", text: "companion response" }],
@@ -117,6 +139,7 @@ test("buildAuxiliaryRuntimeSessionProjection main keeps runtime projection diff 
   assert.equal(projection.allowedAdditionalDirectories, auxiliary.allowedAdditionalDirectories);
   assert.equal(projection.status, "running");
   assert.equal(projection.taskTitle, parent.taskTitle);
+  assert.equal(projection.characterRuntimeSnapshot, parent.characterRuntimeSnapshot);
   assert.deepEqual(projection.stream, []);
 });
 
@@ -158,6 +181,7 @@ test("buildAuxiliaryRuntimeSessionProjection companion keeps companion projectio
   assert.notEqual(projection.allowedAdditionalDirectories, auxiliary.allowedAdditionalDirectories);
   assert.equal(projection.status, "active");
   assert.equal(projection.taskTitle, auxiliary.title);
+  assert.equal(projection.characterRuntimeSnapshot, parent.characterRuntimeSnapshot);
   assert.equal("stream" in projection, false);
 });
 

--- a/scripts/tests/auxiliary-session-storage.test.ts
+++ b/scripts/tests/auxiliary-session-storage.test.ts
@@ -8,7 +8,10 @@ import { buildNewSession } from "../../src/app-state.js";
 import { DEFAULT_APPROVAL_MODE } from "../../src/approval-mode.js";
 import type { ModelCatalogSnapshot } from "../../src/model-catalog.js";
 import type { CompanionSession } from "../../src/companion-state.js";
-import { companionSessionToAuxiliaryParentSession } from "../../src-electron/auxiliary-parent-session.js";
+import {
+  companionSessionToAuxiliaryParentSession,
+  resolveAuxiliaryParentSession,
+} from "../../src-electron/auxiliary-parent-session.js";
 import { AuxiliarySessionService } from "../../src-electron/auxiliary-session-service.js";
 import { AuxiliarySessionStorage } from "../../src-electron/auxiliary-session-storage.js";
 import { CompanionStorage } from "../../src-electron/companion-storage.js";
@@ -95,6 +98,49 @@ async function removeDirectoryWithRetry(targetPath: string, attempts = 5): Promi
     }
   }
 }
+
+test("resolveAuxiliaryParentSession は cached summary より stored full session を優先する", async () => {
+  const storedSession = {
+    ...buildNewSession({
+      taskTitle: "main task",
+      workspaceLabel: "workspace",
+      workspacePath: "C:/workspace",
+      branch: "main",
+      characterId: "mate",
+      character: "Mate",
+      characterIconPath: "",
+      characterThemeColors: { main: "#6f8cff", sub: "#6fb8c7" },
+      characterRuntimeSnapshot: {
+        characterId: "mate",
+        name: "Mate",
+        description: "Stored snapshot",
+        iconFilePath: "",
+        theme: { main: "#6f8cff", sub: "#6fb8c7" },
+        definitionMarkdown: "# Character\n\nStored snapshot prompt.",
+        definitionSha256: "stored-character-sha",
+        definitionByteSize: 36,
+        snapshotAt: "2026-07-03T00:00:00.000Z",
+      },
+      approvalMode: DEFAULT_APPROVAL_MODE,
+    }),
+    id: "session-main",
+  };
+  const cachedSession = {
+    ...storedSession,
+    characterRuntimeSnapshot: null,
+    messages: [],
+  };
+
+  const resolved = await resolveAuxiliaryParentSession({
+    parentSessionId: storedSession.id,
+    getStoredSession: (sessionId) => sessionId === storedSession.id ? storedSession : null,
+    getCachedSession: (sessionId) => sessionId === cachedSession.id ? cachedSession : null,
+    getCompanionSession: () => null,
+  });
+
+  assert.equal(resolved, storedSession);
+  assert.equal(resolved?.characterRuntimeSnapshot?.definitionMarkdown, "# Character\n\nStored snapshot prompt.");
+});
 
 test("AuxiliarySessionService は親 session から実行 context を継承して active session を復元する", async () => {
   const tempDirectory = await mkdtemp(path.join(os.tmpdir(), "withmate-auxiliary-session-"));

--- a/src-electron/auxiliary-parent-session.ts
+++ b/src-electron/auxiliary-parent-session.ts
@@ -1,6 +1,8 @@
 import type { CompanionSession } from "../src/companion-state.js";
 import type { Session } from "../src/session-state.js";
 
+type Awaitable<T> = T | Promise<T>;
+
 export function companionSessionToAuxiliaryParentSession(session: CompanionSession): Session | null {
   if (session.status !== "active" && session.status !== "recovery-required") {
     return null;
@@ -35,4 +37,24 @@ export function companionSessionToAuxiliaryParentSession(session: CompanionSessi
     messages: session.messages,
     stream: [],
   };
+}
+
+export async function resolveAuxiliaryParentSession(input: {
+  parentSessionId: string;
+  getStoredSession: (sessionId: string) => Awaitable<Session | null>;
+  getCachedSession: (sessionId: string) => Session | null;
+  getCompanionSession: (sessionId: string) => Awaitable<CompanionSession | null>;
+}): Promise<Session | null> {
+  const storedSession = await input.getStoredSession(input.parentSessionId);
+  if (storedSession) {
+    return storedSession;
+  }
+
+  const cachedSession = input.getCachedSession(input.parentSessionId);
+  if (cachedSession) {
+    return cachedSession;
+  }
+
+  const companionSession = await input.getCompanionSession(input.parentSessionId);
+  return companionSession ? companionSessionToAuxiliaryParentSession(companionSession) : null;
 }

--- a/src-electron/main.ts
+++ b/src-electron/main.ts
@@ -57,7 +57,7 @@ import type { WorkspacePathCandidate } from "../src/workspace-path-candidate.js"
 import { AuditLogStorage } from "./audit-log-storage.js";
 import { AuditLogService } from "./audit-log-service.js";
 import { AppSettingsStorage } from "./app-settings-storage.js";
-import { companionSessionToAuxiliaryParentSession } from "./auxiliary-parent-session.js";
+import { resolveAuxiliaryParentSession } from "./auxiliary-parent-session.js";
 import { AuxiliarySessionService } from "./auxiliary-session-service.js";
 import { AuxiliarySessionStorage } from "./auxiliary-session-storage.js";
 import { CharacterService } from "./character-service.js";
@@ -2735,13 +2735,12 @@ function getSession(sessionId: string): Session | null {
 }
 
 async function getAuxiliaryParentSession(parentSessionId: string): Promise<Session | null> {
-  const session = getSession(parentSessionId);
-  if (session) {
-    return session;
-  }
-
-  const companionSession = await requireCompanionStorage().getSession(parentSessionId);
-  return companionSession ? companionSessionToAuxiliaryParentSession(companionSession) : null;
+  return resolveAuxiliaryParentSession({
+    parentSessionId,
+    getStoredSession: (sessionId) => requireSessionStorage().getSession(sessionId),
+    getCachedSession: getSession,
+    getCompanionSession: (sessionId) => requireCompanionStorage().getSession(sessionId),
+  });
 }
 
 async function getDisplaySession(sessionId: string): Promise<Session | null> {


### PR DESCRIPTION
## Summary
- Auxiliary parent session 解決で保存済み full session を優先し、cached summary 由来で `characterRuntimeSnapshot` が落ちる経路を修正
- Auxiliary runtime projection が parent の Character snapshot を保持することをテストで固定
- cached summary より stored full session を優先する回帰テストを追加

## Validation
- `npx tsx --test scripts/tests/auxiliary-session-storage.test.ts`
- `npx tsx --test scripts/tests/auxiliary-runtime-projection.test.ts`
- `npx tsx --test scripts/tests/provider-prompt.test.ts`

## Not run
- `npm run typecheck`: `tsc` が見つからず起動前に失敗。`node_modules` 未導入環境と判断

## Docs
- 設計書同期なし。Auxiliary parent 解決の wiring bugfix で、責務・永続化仕様・公開仕様の変更はなし