### PR TITLE
chore(session): add run stuck investigation logs

### DIFF
--- a/src-electron/session-persistence-service.ts
+++ b/src-electron/session-persistence-service.ts
@@ -19,6 +19,15 @@ import type { Awaitable } from "./persistent-store-lifecycle-service.js";
 import { sessionSummaryToSession } from "./session-summary-adapter.js";
 import type { CharacterRuntimeSnapshot } from "../src/character/character-catalog.js";
 
+const SESSION_RUN_STUCK_INVESTIGATION_LOG = "[investigate:session-run-stuck]";
+
+function logSessionRunStuckInvestigation(
+  event: string,
+  details: Record<string, unknown>,
+): void {
+  console.info(SESSION_RUN_STUCK_INVESTIGATION_LOG, event, details);
+}
+
 export type SessionPersistenceServiceDeps = {
   getSessions(): Session[];
   setSessions(nextSessions: Session[]): void;
@@ -151,12 +160,14 @@ export class SessionPersistenceService {
   }
 
   async upsertSession(nextSession: Session): Promise<Session> {
+    const startedAt = Date.now();
     const currentSession = this.deps.getSession(nextSession.id);
     if (currentSession) {
       assertSessionWritable(currentSession);
     }
 
     const sessionToStore = await this.mergeStoredMessagesForSummaryOnlySession(nextSession);
+    const storeStartedAt = Date.now();
     const stored = await this.deps.upsertStoredSession({
       ...sessionToStore,
       allowedAdditionalDirectories: normalizeAllowedAdditionalDirectories(
@@ -164,9 +175,25 @@ export class SessionPersistenceService {
         sessionToStore.allowedAdditionalDirectories,
       ),
     });
+    const storeDurationMs = Date.now() - storeStartedAt;
+    const cacheStartedAt = Date.now();
     this.syncStoredSession(stored);
     this.deps.setSessions(upsertSessionInList(this.deps.getSessions(), toCachedSession(stored)));
+    const cacheDurationMs = Date.now() - cacheStartedAt;
+    const broadcastStartedAt = Date.now();
     this.deps.broadcastSessions([stored.id]);
+    logSessionRunStuckInvestigation("persistence.upsert-session.done", {
+      sessionId: stored.id,
+      durationMs: Date.now() - startedAt,
+      storeDurationMs,
+      cacheDurationMs,
+      broadcastDurationMs: Date.now() - broadcastStartedAt,
+      messageCount: stored.messages.length,
+      runState: stored.runState,
+      status: stored.status,
+      cachedRunState: this.deps.getSession(stored.id)?.runState ?? null,
+      cachedStatus: this.deps.getSession(stored.id)?.status ?? null,
+    });
     return cloneSessions([stored])[0];
   }
 

--- a/src-electron/session-runtime-service.ts
+++ b/src-electron/session-runtime-service.ts
@@ -35,6 +35,15 @@ import type { Awaitable } from "./persistent-store-lifecycle-service.js";
 
 type CreateAuditLogInput = Omit<AuditLogEntry, "id">;
 
+const SESSION_RUN_STUCK_INVESTIGATION_LOG = "[investigate:session-run-stuck]";
+
+function logSessionRunStuckInvestigation(
+  event: string,
+  details: Record<string, unknown>,
+): void {
+  console.info(SESSION_RUN_STUCK_INVESTIGATION_LOG, event, details);
+}
+
 export type SessionRuntimeServiceDeps = {
   getSession(sessionId: string): Awaitable<Session | null>;
   upsertSession(session: Session): Awaitable<Session>;
@@ -438,11 +447,20 @@ export class SessionRuntimeService {
   }
 
   async runSessionTurn(sessionId: string, request: RunSessionTurnRequest): Promise<Session> {
+    const investigationStartedAt = Date.now();
     const storedSession = await this.deps.getSession(sessionId);
     if (!storedSession) {
       throw new Error("対象セッションが見つからないよ。");
     }
     const session = await Promise.resolve(this.deps.resolveRuntimeSessionForTurn?.(storedSession) ?? storedSession);
+    logSessionRunStuckInvestigation("runtime.start", {
+      sessionId,
+      provider: session.provider,
+      runState: session.runState,
+      status: session.status,
+      messageCount: session.messages.length,
+      hasThreadId: session.threadId.trim().length > 0,
+    });
 
     if (session.runState === "running") {
       throw new Error("このセッションはまだ実行中だよ。");
@@ -528,7 +546,14 @@ export class SessionRuntimeService {
         messages: [...session.messages, { role: "user", text: nextMessage }],
       };
 
+      const runningUpsertStartedAt = Date.now();
       await this.deps.upsertSession(runningSession);
+      logSessionRunStuckInvestigation("runtime.running-session-upsert.done", {
+        sessionId,
+        durationMs: Date.now() - runningUpsertStartedAt,
+        elapsedMs: Date.now() - investigationStartedAt,
+        messageCount: runningSession.messages.length,
+      });
       setupRunningSessionSaved = true;
       this.inFlightSessionRuns.add(sessionId);
       runAbortController = new AbortController();
@@ -547,7 +572,14 @@ export class SessionRuntimeService {
         session: runningSession,
         logicalPrompt: promptForAudit.logicalPrompt,
       });
+      const runningAuditCreateStartedAt = Date.now();
       runningAuditLog = await this.deps.createAuditLog(runningAuditEntry);
+      logSessionRunStuckInvestigation("runtime.running-audit-create.done", {
+        sessionId,
+        auditLogId: runningAuditLog.id,
+        durationMs: Date.now() - runningAuditCreateStartedAt,
+        elapsedMs: Date.now() - investigationStartedAt,
+      });
     } catch (error) {
       await revokeMemoryBinding();
       this.deps.resolvePendingApprovalRequest(sessionId, "deny");
@@ -708,6 +740,14 @@ export class SessionRuntimeService {
       while (true) {
         try {
           result = await runProviderTurn(activeRunningSession);
+          logSessionRunStuckInvestigation("runtime.provider-turn.done", {
+            sessionId,
+            elapsedMs: Date.now() - investigationStartedAt,
+            assistantChars: result.assistantText.length,
+            operationCount: result.operations.length,
+            rawItemsChars: result.rawItemsJson.length,
+            hasThreadId: (result.threadId ?? "").trim().length > 0,
+          });
           break;
         } catch (error) {
           const providerTurnError = error instanceof ProviderTurnError ? error : null;
@@ -757,7 +797,13 @@ export class SessionRuntimeService {
       const durationMs = calculateAuditDurationMs(runningAuditLog.createdAt, completedAt);
       const logicalPromptEstimate = estimateLogicalPromptTokens(result.logicalPrompt);
 
+      const flushAuditStartedAt = Date.now();
       await flushAuditWrites();
+      logSessionRunStuckInvestigation("runtime.audit-flush.done", {
+        sessionId,
+        durationMs: Date.now() - flushAuditStartedAt,
+        elapsedMs: Date.now() - investigationStartedAt,
+      });
       terminalAuditSettled = true;
       const completedAuditEntry = buildTerminalAuditEntry({
         baseEntry: runningAuditEntry,
@@ -788,7 +834,15 @@ export class SessionRuntimeService {
         usage: result.usage,
         errorMessage: "",
       });
+      const completedAuditUpdateStartedAt = Date.now();
       await this.deps.updateAuditLog(runningAuditLog.id, completedAuditEntry);
+      logSessionRunStuckInvestigation("runtime.completed-audit-update.done", {
+        sessionId,
+        auditLogId: runningAuditLog.id,
+        durationMs: Date.now() - completedAuditUpdateStartedAt,
+        elapsedMs: Date.now() - investigationStartedAt,
+        operationCount: completedAuditEntry.operations.length,
+      });
       runningAuditEntry = completedAuditEntry;
 
       const completedSession: Session = {
@@ -807,7 +861,16 @@ export class SessionRuntimeService {
         ],
       };
 
+      const completedSessionUpsertStartedAt = Date.now();
       const storedCompletedSession = await this.deps.upsertSession(completedSession);
+      logSessionRunStuckInvestigation("runtime.completed-session-upsert.done", {
+        sessionId,
+        durationMs: Date.now() - completedSessionUpsertStartedAt,
+        elapsedMs: Date.now() - investigationStartedAt,
+        messageCount: completedSession.messages.length,
+        storedRunState: storedCompletedSession.runState,
+        storedStatus: storedCompletedSession.status,
+      });
       activeRunningSession = storedCompletedSession;
       return storedCompletedSession;
     } catch (error: unknown) {
@@ -844,7 +907,14 @@ export class SessionRuntimeService {
         await revokeMemoryBinding();
       }
 
+      const failedFlushAuditStartedAt = Date.now();
       await flushAuditWrites();
+      logSessionRunStuckInvestigation("runtime.audit-flush.done", {
+        sessionId,
+        durationMs: Date.now() - failedFlushAuditStartedAt,
+        elapsedMs: Date.now() - investigationStartedAt,
+        terminalPhase: canceled ? "canceled" : "failed",
+      });
       terminalAuditSettled = true;
       const failedAuditEntry = buildTerminalAuditEntry({
         baseEntry: runningAuditEntry,
@@ -875,7 +945,16 @@ export class SessionRuntimeService {
         usage: partialResult?.usage ?? null,
         errorMessage: failureMessage,
       });
+      const failedAuditUpdateStartedAt = Date.now();
       await this.deps.updateAuditLog(runningAuditLog.id, failedAuditEntry);
+      logSessionRunStuckInvestigation("runtime.terminal-audit-update.done", {
+        sessionId,
+        auditLogId: runningAuditLog.id,
+        durationMs: Date.now() - failedAuditUpdateStartedAt,
+        elapsedMs: Date.now() - investigationStartedAt,
+        phase: failedAuditEntry.phase,
+        operationCount: failedAuditEntry.operations.length,
+      });
       runningAuditEntry = failedAuditEntry;
 
       const fallbackNotice = formatProviderFailureNotice({
@@ -904,7 +983,16 @@ export class SessionRuntimeService {
         ],
       };
 
+      const failedSessionUpsertStartedAt = Date.now();
       const storedFailedSession = await this.deps.upsertSession(failedSession);
+      logSessionRunStuckInvestigation("runtime.terminal-session-upsert.done", {
+        sessionId,
+        durationMs: Date.now() - failedSessionUpsertStartedAt,
+        elapsedMs: Date.now() - investigationStartedAt,
+        messageCount: failedSession.messages.length,
+        storedRunState: storedFailedSession.runState,
+        storedStatus: storedFailedSession.status,
+      });
       activeRunningSession = storedFailedSession;
       return storedFailedSession;
     } finally {
@@ -930,6 +1018,15 @@ export class SessionRuntimeService {
       }
       this.deps.clearWorkspaceFileIndex(session.workspacePath);
       this.deps.broadcastLiveSessionRun(sessionId);
+      logSessionRunStuckInvestigation("runtime.finally.done", {
+        sessionId,
+        elapsedMs: Date.now() - investigationStartedAt,
+        activeRunState: activeRunningSession.runState,
+        activeStatus: activeRunningSession.status,
+        preservedBackgroundTaskCount: preservedBackgroundTasks.length,
+        preservedReasoningChars: preservedReasoningText.length,
+        liveRunAfterFinally: this.deps.getLiveSessionRun(sessionId) ? "present" : "null",
+      });
     }
   }
 

--- a/src-electron/session-storage-v6.ts
+++ b/src-electron/session-storage-v6.ts
@@ -53,6 +53,15 @@ type ExistingMessageArtifactRow = {
   artifact_body: string | null;
 };
 
+const SESSION_RUN_STUCK_INVESTIGATION_LOG = "[investigate:session-run-stuck]";
+
+function logSessionRunStuckInvestigation(
+  event: string,
+  details: Record<string, unknown>,
+): void {
+  console.info(SESSION_RUN_STUCK_INVESTIGATION_LOG, event, details);
+}
+
 function toV6State(session: Session): string {
   if (session.status === "running") {
     return "active";
@@ -185,13 +194,32 @@ export class SessionStorageV6 {
       throw new Error("SessionStorageV6 に保存できない session 形式だよ。");
     }
 
+    const startedAt = Date.now();
     this.db.exec("BEGIN IMMEDIATE TRANSACTION");
     try {
       this.writeSession(normalized);
       this.db.exec("COMMIT");
-      return this.getSession(normalized.id) ?? normalized;
+      const stored = this.getSession(normalized.id) ?? normalized;
+      logSessionRunStuckInvestigation("storage-v6.upsert-session.done", {
+        sessionId: normalized.id,
+        durationMs: Date.now() - startedAt,
+        messageCount: normalized.messages.length,
+        runState: normalized.runState,
+        status: normalized.status,
+        storedRunState: stored.runState,
+        storedStatus: stored.status,
+      });
+      return stored;
     } catch (error) {
       this.db.exec("ROLLBACK");
+      logSessionRunStuckInvestigation("storage-v6.upsert-session.failed", {
+        sessionId: normalized.id,
+        durationMs: Date.now() - startedAt,
+        messageCount: normalized.messages.length,
+        runState: normalized.runState,
+        status: normalized.status,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
       throw error;
     }
   }
@@ -234,6 +262,7 @@ export class SessionStorageV6 {
   }
 
   private writeSession(session: Session): void {
+    const startedAt = Date.now();
     const snapshot = session.characterRuntimeSnapshot;
     const runtimePolicy = {
       appStatus: session.status,
@@ -335,6 +364,14 @@ export class SessionStorageV6 {
         encodeMessageArtifactForWrite(message, existingArtifactBodies.get(index)),
         session.updatedAt,
       );
+    });
+    logSessionRunStuckInvestigation("storage-v6.write-session.done", {
+      sessionId: session.id,
+      durationMs: Date.now() - startedAt,
+      messageCount: session.messages.length,
+      existingArtifactBodyCount: existingArtifactBodies.size,
+      runState: session.runState,
+      status: session.status,
     });
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -272,6 +272,14 @@ import {
 } from "./chat/session-shell-handlers.js";
 
 const DEFAULT_SESSION_RUNTIME_NAME = "Mate";
+const SESSION_RUN_STUCK_INVESTIGATION_LOG = "[investigate:session-run-stuck]";
+
+function logSessionRunStuckInvestigation(
+  event: string,
+  details: Record<string, unknown>,
+): void {
+  console.info(SESSION_RUN_STUCK_INVESTIGATION_LOG, event, details);
+}
 
 function liveRunStepBucketPriority(status: string): number {
   switch (status) {
@@ -1662,6 +1670,16 @@ export default function AgentSessionWindowApp() {
       return;
     }
 
+    const investigationStartedAt = Date.now();
+    logSessionRunStuckInvestigation("renderer.send.start", {
+      sessionId: selectedSession.id,
+      runState: selectedSession.runState,
+      status: selectedSession.status,
+      messageCount: selectedSession.messages.length,
+      hasLiveRun: !!selectedSessionLiveRun,
+      draftChars: messageText.length,
+    });
+
     if (composerBlockedReason) {
       throw new Error(composerBlockedReason);
     }
@@ -1681,6 +1699,12 @@ export default function AgentSessionWindowApp() {
 
     const nextMessage = messageText.trim();
     const preview = await previewRequest(messageText);
+    logSessionRunStuckInvestigation("renderer.composer-preview.done", {
+      sessionId: selectedSession.id,
+      elapsedMs: Date.now() - investigationStartedAt,
+      attachmentCount: preview.attachments.length,
+      errorCount: preview.errors.length,
+    });
     setComposerPreview(preview);
     const { blockedMessage } = resolveComposerSendPreflight({
       runState: selectedSessionRunState,
@@ -1708,17 +1732,38 @@ export default function AgentSessionWindowApp() {
       updateLiveRunState: (update) => setLiveRunState(update),
       applyRunningSession: (runningSession) => setSessions([runningSession]),
     });
+    logSessionRunStuckInvestigation("renderer.optimistic-running-applied", {
+      sessionId: updatedSession.id,
+      elapsedMs: Date.now() - investigationStartedAt,
+      messageCount: updatedSession.messages.length,
+      runState: updatedSession.runState,
+      status: updatedSession.status,
+    });
 
     try {
       const request: RunSessionTurnRequest = {
         userMessage: messageText,
       };
       const savedSession = await withmateApi.runSessionTurn(selectedSession.id, request);
+      logSessionRunStuckInvestigation("renderer.run-session-turn.resolved", {
+        sessionId: savedSession.id,
+        elapsedMs: Date.now() - investigationStartedAt,
+        messageCount: savedSession.messages.length,
+        runState: savedSession.runState,
+        status: savedSession.status,
+        hasLiveRun: !!selectedSessionLiveRun,
+      });
       applyResolvedSessionRunUpdate({
         savedSession,
         applySavedSession: (nextSession) => setSessions([nextSession]),
       });
     } catch (error) {
+      logSessionRunStuckInvestigation("renderer.run-session-turn.failed", {
+        sessionId: updatedSession.id,
+        elapsedMs: Date.now() - investigationStartedAt,
+        messageCount: updatedSession.messages.length,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
       console.error(error);
       rollbackOptimisticSessionRunUpdate({
         sessionId: updatedSession.id,

--- a/src/session-live-run-subscription.ts
+++ b/src/session-live-run-subscription.ts
@@ -1,5 +1,14 @@
 import type { LiveSessionRunState } from "./app-state.js";
 
+const SESSION_RUN_STUCK_INVESTIGATION_LOG = "[investigate:session-run-stuck]";
+
+function logSessionRunStuckInvestigation(
+  event: string,
+  details: Record<string, unknown>,
+): void {
+  console.info(SESSION_RUN_STUCK_INVESTIGATION_LOG, event, details);
+}
+
 export type LiveSessionRunSubscriptionApi = {
   getLiveSessionRun: (sessionId: string) => Promise<LiveSessionRunState | null>;
   subscribeLiveSessionRun: (
@@ -22,12 +31,33 @@ export function startLiveSessionRunSubscription(input: {
   let receivedSubscriptionUpdate = false;
 
   input.applyLiveRunState({ ownerSessionId: input.sessionId, state: null });
-  void input.api.getLiveSessionRun(input.sessionId).then((state) => {
-    if (active && !receivedSubscriptionUpdate) {
-      input.applyLiveRunState({ ownerSessionId: input.sessionId, state });
-      input.onSessionRunUpdated?.(input.sessionId);
-    }
+  logSessionRunStuckInvestigation("renderer.live-run-subscription.start", {
+    sessionId: input.sessionId,
   });
+  void input.api.getLiveSessionRun(input.sessionId)
+    .then((state) => {
+      logSessionRunStuckInvestigation("renderer.live-run-initial-get.done", {
+        sessionId: input.sessionId,
+        active,
+        receivedSubscriptionUpdate,
+        state: state ? "present" : "null",
+        assistantChars: state?.assistantText.length ?? 0,
+        stepCount: state?.steps.length ?? 0,
+        backgroundTaskCount: state?.backgroundTasks.length ?? 0,
+      });
+      if (active && !receivedSubscriptionUpdate) {
+        input.applyLiveRunState({ ownerSessionId: input.sessionId, state });
+        input.onSessionRunUpdated?.(input.sessionId);
+      }
+    })
+    .catch((error) => {
+      logSessionRunStuckInvestigation("renderer.live-run-initial-get.failed", {
+        sessionId: input.sessionId,
+        active,
+        receivedSubscriptionUpdate,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
+    });
 
   const unsubscribe = input.api.subscribeLiveSessionRun((sessionId, state) => {
     if (!active || sessionId !== input.sessionId) {
@@ -35,6 +65,14 @@ export function startLiveSessionRunSubscription(input: {
     }
 
     receivedSubscriptionUpdate = true;
+    logSessionRunStuckInvestigation("renderer.live-run-subscription.event", {
+      sessionId,
+      state: state ? "present" : "null",
+      assistantChars: state?.assistantText.length ?? 0,
+      stepCount: state?.steps.length ?? 0,
+      backgroundTaskCount: state?.backgroundTasks.length ?? 0,
+      errorChars: state?.errorMessage.length ?? 0,
+    });
     input.applyLiveRunState({ ownerSessionId: sessionId, state });
     input.onSessionRunUpdated?.(sessionId);
   });


### PR DESCRIPTION
## Summary

- Add temporary investigation logs with `[investigate:session-run-stuck]` prefix for Session send stuck analysis.
- Log renderer send/live-run subscription stages, main runtime stages, persistence upsert timing, and V6 storage write timing.
- Track the investigation in #268.

## Validation

- `npm run typecheck`
- `npx tsx --test scripts/tests/session-runtime-service.test.ts scripts/tests/session-live-run-subscription.test.ts scripts/tests/session-storage-v6.test.ts`
- `git diff --check`

Closes #268 is not included because this PR only adds investigation logging; the issue should stay open until collected logs identify the root cause.