### PR TITLE
fix(diff): allow inline viewer scrolling

### DIFF
--- a/scripts/tests/diff-viewer-css.test.ts
+++ b/scripts/tests/diff-viewer-css.test.ts
@@ -1,0 +1,13 @@
+import { readFile } from "node:fs/promises";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("DiffViewer の inline view は本文を高さ制約付きスクロール領域にする", async () => {
+  const css = await readFile(new URL("../../src/styles.css", import.meta.url), "utf8");
+  const inlineViewRule = css.match(/\.diff-inline-view\s*\{(?<body>[^}]+)\}/)?.groups?.body ?? "";
+
+  assert.match(inlineViewRule, /display:\s*grid;/);
+  assert.match(inlineViewRule, /grid-template-rows:\s*minmax\(0,\s*1fr\);/);
+  assert.match(inlineViewRule, /height:\s*100%;/);
+  assert.match(inlineViewRule, /overflow:\s*hidden;/);
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -8252,8 +8252,11 @@ button:disabled {
 }
 
 .diff-inline-view {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr);
   min-width: 0;
   min-height: 0;
+  height: 100%;
   overflow: hidden;
   background: var(--editor);
 }


### PR DESCRIPTION
## Summary
- Constrain the inline diff view as a full-height grid row so its body can scroll.
- Add a CSS regression test for the inline diff scroll container contract.

## Validation
- node --test scripts/tests/diff-viewer-css.test.ts

## Not run
- npm test -- scripts/tests/diff-viewer-css.test.ts: local node_modules is missing, so tsx is not available.