### PR TITLE
[codex] セッションタイトルをウィンドウへ同期

### DIFF
--- a/scripts/tests/window-title.test.ts
+++ b/scripts/tests/window-title.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  applySessionDocumentTitle,
+  resolveAgentSessionDocumentTitle,
+  resolveCompanionDocumentTitle,
+  resolveSessionDocumentTitle,
+} from "../../src/chat/window-title.js";
+
+test("resolveSessionDocumentTitle は session title を window title として使う", () => {
+  assert.equal(resolveSessionDocumentTitle("Issue 58 cleanup", "Session"), "Issue 58 cleanup");
+  assert.equal(resolveSessionDocumentTitle("  Issue 58 cleanup  ", "Session"), "Issue 58 cleanup");
+});
+
+test("resolveSessionDocumentTitle は空 title では fallback を使う", () => {
+  assert.equal(resolveSessionDocumentTitle("", "Session"), "Session");
+  assert.equal(resolveSessionDocumentTitle("   ", "Session"), "Session");
+  assert.equal(resolveSessionDocumentTitle(null, "WithMate Companion"), "WithMate Companion");
+});
+
+test("applySessionDocumentTitle は document がある場合だけ title を同期する", () => {
+  const previousDocument = globalThis.document;
+
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { title: "before" },
+  });
+
+  try {
+    applySessionDocumentTitle("Session Title");
+    assert.equal(globalThis.document.title, "Session Title");
+  } finally {
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: previousDocument,
+    });
+  }
+});
+
+test("resolveAgentSessionDocumentTitle は hydrate 前でも sessionId fallback を返す", () => {
+  assert.equal(
+    resolveAgentSessionDocumentTitle({ sessionTitle: undefined, sessionId: "session-1" }),
+    "WithMate Session - session-1",
+  );
+  assert.equal(
+    resolveAgentSessionDocumentTitle({ sessionTitle: "Issue 58 cleanup", sessionId: "session-1" }),
+    "Issue 58 cleanup",
+  );
+});
+
+test("resolveCompanionDocumentTitle は chat と merge の window title を分ける", () => {
+  assert.equal(
+    resolveCompanionDocumentTitle({ mode: "chat", sessionTitle: "Companion task", sessionId: "companion-1" }),
+    "Companion task",
+  );
+  assert.equal(
+    resolveCompanionDocumentTitle({ mode: "chat", sessionTitle: undefined, sessionId: "companion-1" }),
+    "Companion - companion-1",
+  );
+  assert.equal(
+    resolveCompanionDocumentTitle({ mode: "merge", sessionTitle: "Companion task", sessionId: "companion-1" }),
+    "Companion Merge - companion-1",
+  );
+});

--- a/src-electron/main.ts
+++ b/src-electron/main.ts
@@ -2070,7 +2070,7 @@ function requireSessionWindowBridge(): SessionWindowBridge<BrowserWindow> {
       createWindow: (sessionId) =>
         createCursorPlacedWindow({
           ...SESSION_WINDOW_DEFAULT_BOUNDS,
-          title: `WithMate Session - ${sessionId}`,
+          title: getSession(sessionId)?.taskTitle.trim() || `WithMate Session - ${sessionId}`,
         }),
       loadChatEntry: (window, mode) => requireWindowEntryLoader().loadChatEntry(window, mode),
       getSession,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,6 +78,7 @@ import {
 } from "./session-ui-projection.js";
 import { buildMainAuxiliaryRuntimeSession } from "./auxiliary-runtime-projection.js";
 import { ChatWindow, ChatWindowStatusScreen } from "./chat/chat-window.js";
+import { applySessionDocumentTitle, resolveAgentSessionDocumentTitle } from "./chat/window-title.js";
 import { resolveAuditLogOwner } from "./chat/audit-log-owner.js";
 import {
   buildAuxiliaryLaunchProviderItems,
@@ -730,6 +731,13 @@ export default function AgentSessionWindowApp() {
 
     setTitleDraft(selectedSession.taskTitle);
   }, [isEditingTitle, selectedSession]);
+
+  useEffect(() => {
+    applySessionDocumentTitle(resolveAgentSessionDocumentTitle({
+      sessionTitle: selectedSession?.taskTitle,
+      sessionId: selectedId,
+    }));
+  }, [selectedId, selectedSession?.taskTitle]);
 
   useEffect(() => {
     let active = true;

--- a/src/CompanionReviewApp.tsx
+++ b/src/CompanionReviewApp.tsx
@@ -81,6 +81,7 @@ import { getWithMateApi, isDesktopRuntime } from "./renderer-withmate-api.js";
 import { buildCompanionGroupMonitorEntries } from "./home/home-session-projection.js";
 import { SessionHeader } from "./session-components.js";
 import { ChatHeaderHandle, ChatWindow, ChatWindowStatusScreen } from "./chat/chat-window.js";
+import { applySessionDocumentTitle, resolveCompanionDocumentTitle } from "./chat/window-title.js";
 import { resolveAuditLogOwner } from "./chat/audit-log-owner.js";
 import { AuxiliaryLaunchProviderDialog } from "./chat/AuxiliaryLaunchProviderDialog.js";
 import {
@@ -422,6 +423,7 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
   const withmateApi = getWithMateApi();
   const viewMode = forcedViewMode ?? getCompanionWindowViewFromSearch(window.location.search);
   const isMergeView = viewMode === "merge";
+  const companionSessionId = useMemo(() => getCompanionSessionIdFromLocation(), []);
   const [snapshot, setSnapshot] = useState<CompanionReviewSnapshot | null>(null);
   const [selectedPath, setSelectedPath] = useState<string>("");
   const [selectedPaths, setSelectedPaths] = useState<string[]>([]);
@@ -498,7 +500,7 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
 
   useEffect(() => {
     let active = true;
-    const sessionId = getCompanionSessionIdFromLocation();
+    const sessionId = companionSessionId;
     const withmateApi = getWithMateApi();
 
     if (!withmateApi || !sessionId) {
@@ -541,7 +543,7 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
     return () => {
       active = false;
     };
-  }, [viewMode]);
+  }, [companionSessionId, viewMode]);
 
   useEffect(() => {
     applyComposerDraftClearCommand({
@@ -622,6 +624,14 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
 
     setTitleDraft(snapshot.session.taskTitle);
   }, [isEditingTitle, snapshot?.session.taskTitle]);
+
+  useEffect(() => {
+    applySessionDocumentTitle(resolveCompanionDocumentTitle({
+      mode: isMergeView ? "merge" : "chat",
+      sessionTitle: snapshot?.session.taskTitle,
+      sessionId: companionSessionId,
+    }));
+  }, [companionSessionId, isMergeView, snapshot?.session.taskTitle]);
 
   useEffect(() => {
     const withmateApi = getWithMateApi();

--- a/src/chat/window-title.ts
+++ b/src/chat/window-title.ts
@@ -1,0 +1,49 @@
+export function resolveSessionDocumentTitle(
+  sessionTitle: string | null | undefined,
+  fallbackTitle: string,
+): string {
+  const normalizedTitle = sessionTitle?.trim() ?? "";
+  return normalizedTitle || fallbackTitle;
+}
+
+export function resolveAgentSessionDocumentTitle(input: {
+  sessionTitle: string | null | undefined;
+  sessionId: string | null | undefined;
+}): string | null {
+  const normalizedSessionId = input.sessionId?.trim() ?? "";
+  const fallbackTitle = normalizedSessionId ? `WithMate Session - ${normalizedSessionId}` : "";
+  if (!fallbackTitle && !input.sessionTitle?.trim()) {
+    return null;
+  }
+
+  return resolveSessionDocumentTitle(input.sessionTitle, fallbackTitle || "Session");
+}
+
+export function resolveCompanionDocumentTitle(input: {
+  mode: "chat" | "merge";
+  sessionTitle: string | null | undefined;
+  sessionId: string | null | undefined;
+}): string | null {
+  const normalizedSessionId = input.sessionId?.trim() ?? "";
+  if (input.mode === "merge") {
+    return normalizedSessionId ? `Companion Merge - ${normalizedSessionId}` : "WithMate Companion";
+  }
+
+  const fallbackTitle = normalizedSessionId ? `Companion - ${normalizedSessionId}` : "WithMate Companion";
+  return resolveSessionDocumentTitle(input.sessionTitle, fallbackTitle);
+}
+
+export function applySessionDocumentTitle(
+  title: string | null | undefined,
+): void {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const normalizedTitle = title?.trim() ?? "";
+  if (!normalizedTitle) {
+    return;
+  }
+
+  document.title = normalizedTitle;
+}


### PR DESCRIPTION
## Summary
- 通常 Session window のタイトルを session taskTitle に同期
- hydrate 前は `WithMate Session - <sessionId>` を維持し、初期タイトルを `Session` で潰さないように修正
- Companion chat / Companion merge の title fallback を分け、merge window は `Companion Merge - <sessionId>` を維持
- title 決定ロジックを `src/chat/window-title.ts` に集約し、mode 別 fallback をテスト追加

## Validation
- `npx tsx --test scripts/tests/window-title.test.ts scripts/tests/session-app-render.test.ts scripts/tests/aux-window-service.test.ts`
- `npm run typecheck`
