### PR TITLE
fix(session): Send ボタンを入力枠の外に配置

### DIFF
--- a/scripts/tests/session-message-column.test.ts
+++ b/scripts/tests/session-message-column.test.ts
@@ -661,6 +661,9 @@ test("SessionComposerExpanded は jump button を Hide の左に描画する", (
   );
 
   assert.ok(html.indexOf("末尾へ移動") < html.indexOf("Hide"));
+  const composerBoxHtml = html.match(/<div class="composer-box">(?<content>[\s\S]*?)<\/div><button class="session-send-button"/);
+  assert.ok(composerBoxHtml, "Send button は composer-box の外に描画する");
+  assert.doesNotMatch(composerBoxHtml.groups?.content ?? "", />Send<\/button>/);
 });
 
 test("SessionComposerExpanded は実行中の progress と Cancel を上部 toolbar に描画し、下段の送信ボタンを隠す", () => {

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -3267,22 +3267,39 @@ export function SessionComposerExpanded({
         </div>
       ) : null}
 
-      <div className={`composer-box${isRunning ? " running" : ""}${isComposerBlockedFeedbackActive ? " blocked-feedback-active" : ""}`}>
-        <textarea
-          ref={composerTextareaRef}
-          value={draft}
-          placeholder={placeholder}
-          onChange={(event) => onDraftChange(event.target.value, event.target.selectionStart ?? event.target.value.length)}
-          onFocus={onDraftFocus}
-          onKeyDown={onDraftKeyDown}
-          onPaste={onDraftPaste}
-          onSelect={(event) => onDraftSelect(event.currentTarget.selectionStart ?? 0)}
-          onCompositionStart={onDraftCompositionStart}
-          onCompositionEnd={onDraftCompositionEnd}
-          disabled={isComposerDisabled}
-          aria-describedby={composerSendability.shouldShowFeedback ? "composer-sendability-feedback" : undefined}
-          aria-invalid={composerSendability.feedbackTone === "blocked" ? true : undefined}
-        />
+      <div className={`composer-input-row${isRunning ? " running" : ""}`}>
+        <div className={`composer-box${isRunning ? " running" : ""}${isComposerBlockedFeedbackActive ? " blocked-feedback-active" : ""}`}>
+          <textarea
+            ref={composerTextareaRef}
+            value={draft}
+            placeholder={placeholder}
+            onChange={(event) => onDraftChange(event.target.value, event.target.selectionStart ?? event.target.value.length)}
+            onFocus={onDraftFocus}
+            onKeyDown={onDraftKeyDown}
+            onPaste={onDraftPaste}
+            onSelect={(event) => onDraftSelect(event.currentTarget.selectionStart ?? 0)}
+            onCompositionStart={onDraftCompositionStart}
+            onCompositionEnd={onDraftCompositionEnd}
+            disabled={isComposerDisabled}
+            aria-describedby={composerSendability.shouldShowFeedback ? "composer-sendability-feedback" : undefined}
+            aria-invalid={composerSendability.feedbackTone === "blocked" ? true : undefined}
+          />
+          {composerSendability.shouldShowFeedback ? (
+            <div
+              id="composer-sendability-feedback"
+              className={`composer-sendability-feedback ${composerSendability.feedbackTone ?? "helper"}`}
+            >
+              {composerSendability.primaryFeedback ? <p>{composerSendability.primaryFeedback}</p> : null}
+              {composerSendability.secondaryFeedback.length > 0 ? (
+                <ul>
+                  {composerSendability.secondaryFeedback.map((feedback) => (
+                    <li key={feedback}>{feedback}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
         {isRunning ? null : (
           <button
             className="session-send-button"
@@ -3294,21 +3311,6 @@ export function SessionComposerExpanded({
             Send
           </button>
         )}
-        {composerSendability.shouldShowFeedback ? (
-          <div
-            id="composer-sendability-feedback"
-            className={`composer-sendability-feedback ${composerSendability.feedbackTone ?? "helper"}`}
-          >
-            {composerSendability.primaryFeedback ? <p>{composerSendability.primaryFeedback}</p> : null}
-            {composerSendability.secondaryFeedback.length > 0 ? (
-              <ul>
-                {composerSendability.secondaryFeedback.map((feedback) => (
-                  <li key={feedback}>{feedback}</li>
-                ))}
-              </ul>
-            ) : null}
-          </div>
-        ) : null}
       </div>
 
       <div className="composer-settings">

--- a/src/styles.css
+++ b/src/styles.css
@@ -528,7 +528,7 @@ button:disabled {
 .artifact-toggle,
 .diff-button,
 .diff-close,
-.composer-box button,
+.composer-input-row > .session-send-button,
 .session-action-dock-compact-actions button {
   border: 0;
   border-radius: 999px;
@@ -4205,6 +4205,7 @@ button:disabled {
 }
 
 .message-card,
+.composer-input-row,
 .composer-box,
 .character-lock,
 .stream-stage,
@@ -5891,16 +5892,22 @@ button:disabled {
   overflow: auto;
 }
 
-.composer-box {
+.composer-input-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: stretch;
+}
+
+.composer-box {
+  display: grid;
   gap: 14px;
   padding: 16px;
   border: 1px solid rgba(32, 36, 55, 0.08);
   background: var(--surface-strong);
 }
 
-.composer-box.running {
+.composer-input-row.running {
   grid-template-columns: minmax(0, 1fr);
 }
 
@@ -6548,30 +6555,30 @@ button:disabled {
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
 }
 
-.composer-box button {
+.composer-input-row > .session-send-button {
   align-self: end;
   padding: 12px 22px;
   background: rgba(255, 255, 255, 0.16);
   color: var(--ink);
 }
 
-.session-page .composer-box button {
+.session-page .composer-input-row > .session-send-button {
   padding: 10px 18px;
 }
 
-.session-page .composer-box .session-send-button {
+.session-page .composer-input-row > .session-send-button {
   background: var(--character-main);
   color: var(--character-main-ink);
   box-shadow: 0 10px 22px color-mix(in srgb, var(--character-main) 28%, transparent);
 }
 
-.session-page .composer-box .session-send-button.danger {
+.session-page .composer-input-row > .session-send-button.danger {
   background: color-mix(in srgb, #f87171 82%, var(--character-main));
   color: #fff5f5;
   box-shadow: 0 10px 22px rgba(248, 113, 113, 0.24);
 }
 
-.composer-box button.loading {
+.composer-input-row > .session-send-button.loading {
   min-width: 82px;
 }
 
@@ -9307,6 +9314,7 @@ button:disabled {
   .session-card,
   .character-card,
   .message-row.assistant,
+  .composer-input-row,
   .composer-box,
   .choice-card {
     grid-template-columns: 1fr;
@@ -9387,7 +9395,7 @@ button:disabled {
   .artifact-toggle,
   .diff-button,
   .diff-close,
-  .composer-box button {
+  .composer-input-row > .session-send-button {
     width: 100%;
   }
 


### PR DESCRIPTION
## Summary
- Session composer の textarea 枠と Send ボタンを別要素として配置
- Send ボタン用の CSS selector を composer-input-row に移動
- Send が composer-box 外に描画される regression test を追加

## Validation
- npx tsx --test scripts/tests/session-message-column.test.ts --test-name-pattern 'SessionComposerExpanded|SessionActionDockCompactRow'
- npm run typecheck

## Notes
- origin/dev/20260704 は fetch 済みで、merge は Already up to date でした。