### PR TITLE
fix(memory): Memory Review の横幅レイアウトを Window 全体に広げる

### DIFF
--- a/src/memory-v6/MemoryV6ReviewScreen.tsx
+++ b/src/memory-v6/MemoryV6ReviewScreen.tsx
@@ -167,7 +167,7 @@ export function MemoryV6ReviewScreen({ homePageClassName, getApi }: MemoryV6Revi
   return (
     <div className={`${homePageClassName} home-page-memory-review`.trim()}>
       <main className="home-layout home-layout-settings-window memory-review-layout">
-        <section className="panel memory-review-shell">
+        <section className="memory-review-shell">
           <header className="memory-review-header">
             <div>
               <h1>Memory Review</h1>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1905,18 +1905,30 @@ button:disabled {
   grid-template-rows: minmax(0, 1fr);
 }
 
+.home-page-memory-review {
+  grid-template-columns: minmax(0, 1fr);
+  padding: clamp(18px, 2vw, 32px);
+}
+
 .memory-review-layout {
   grid-template-columns: minmax(0, 1fr);
-  padding: 24px;
+  justify-self: stretch;
+  width: 100%;
+  min-width: 0;
+  height: 100%;
+  padding: 0;
 }
 
 .memory-review-shell {
   display: grid;
   grid-template-rows: auto auto auto minmax(0, 1fr);
   gap: 16px;
+  justify-self: stretch;
+  width: 100%;
+  min-width: 0;
   min-height: 0;
-  height: min(820px, calc(100vh - 48px));
-  padding: 18px;
+  height: 100%;
+  padding: 0;
 }
 
 .memory-review-header,
@@ -1986,7 +1998,7 @@ button:disabled {
 
 .memory-review-grid {
   display: grid;
-  grid-template-columns: minmax(320px, 0.9fr) minmax(0, 1.4fr);
+  grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
   gap: 16px;
   min-height: 0;
 }


### PR DESCRIPTION
## Summary
- Memory Review の外側 `panel` ラッパーを外し、Window 全体を親レイアウトとして扱うように変更
- Memory Review 画面の横幅制約を解除し、リスト:詳細を `1:2` の比率で自動計算する grid に調整
- 余計な説明文や挙動変更は含めず、既存文言は維持

## Validation
- `npm run typecheck`
- `git diff --check`

## Notes
- 実機での Electron 画面確認は依頼どおり未実施です。