### PR TITLE
feat: tool call前にキャラクターの応答を促す

### DIFF
--- a/docs/design/prompt-composition.md
+++ b/docs/design/prompt-composition.md
@@ -1,7 +1,7 @@
 # Prompt Composition
 
 - 作成日: 2026-03-13
-- 更新日: 2026-06-15
+- 更新日: 2026-07-14
 - 対象: WithMate における coding plane の prompt 合成
 
 ## Goal
@@ -48,14 +48,16 @@ coding plane に渡す turn prompt は、次のレイヤーを基本にする。
 
 1. `CharacterRuntimeSnapshot.definitionMarkdown`
 2. `Output Boundary`
-3. 必要最小限の WithMate run marker
-4. ユーザー入力
-5. 添付 reference
+3. `Tool Call Presence`
+4. 必要最小限の WithMate run marker
+5. ユーザー入力
+6. 添付 reference
 
 通常 session / companion の Character snapshot は session / companion 開始時点の保存済み値を使い、catalog の現在値へ追従しない。`character-authoring` session は turn 開始時に最新の `character.md` から runtime snapshot を作り直す。app 共通 system prompt は挿入しない。
 provider に渡す `Character Definition Snapshot` では、snapshot の取得時点説明を prompt 本体には入れない。保存済み snapshot の frontmatter は除外し、Character 名と説明を metadata として示したうえで、`character.md` 本文だけを markdown block として囲む。Character section の固定説明は、話し方への反映と coding agent 境界の guard に絞る。
 通常 session / companion では Character section の直後に `Output Boundary` を置き、Character 定義の適用先をユーザー向け自然言語レスポンスへ限定する。コード、設定、テスト、ドキュメント、コミットメッセージ案、PR本文案、生成ファイル、diff、artifact summary は、ユーザーが明示しない限り Character の口調・設定・台詞・メタ説明を混ぜず、repository instruction、既存文体、対象ファイルの目的を優先する。
-`character-authoring` session は `character.md` / `character-notes.md` 自体が成果物なので、`Output Boundary` と coding agent 境界の固定 guard を注入しない。
+通常 session / companion では `Output Boundary` の直後に `Tool Call Presence` を置き、tool call や command 実行前に短い自然言語レスポンスを返すことで、Character が無言のまま作業へ入ったように見える体験を避ける。
+`character-authoring` session は `character.md` / `character-notes.md` 自体が成果物なので、`Output Boundary`、`Tool Call Presence`、coding agent 境界の固定 guard を注入しない。
 
 ### 4.0.0 SingleMate target
 
@@ -73,6 +75,7 @@ Mate Core / Bond Profile / Work Style は provider instruction file へ同期し
 
 論理 prompt では `Character Definition Snapshot` section を system 側に置く。
 通常 session / companion では `Output Boundary` section も system 側に置く。`character-authoring` session では置かない。
+通常 session / companion では `Tool Call Presence` section も system 側に置く。`character-authoring` session では置かない。
 
 `# Session Memory`、`# Project Memory`、`# Project Context`、`# Character Memory` も coding plane prompt では作らない。
 
@@ -105,6 +108,17 @@ Mate Core / Bond Profile / Work Style は provider instruction file へ同期し
   - Character Definition Snapshot の直後に置く
   - Character 定義はユーザーへ返す自然言語の話し方・温度・反応にだけ使うことを明示する
   - コード、設定、テスト、ドキュメント、コミットメッセージ案、PR本文案、生成ファイル、diff、artifact summary へ Character の口調・設定・台詞・メタ説明を混ぜないことを明示する
+  - `character-authoring` session では注入しない
+
+### `# Tool Call Presence`
+
+- source:
+  - WithMate 固定の会話開始境界
+- 形式:
+  - Output Boundary の直後に置く
+  - tool call や command 実行を伴う場合は、最初の tool call より前に1〜3文程度の自然なレスポンスを返すよう明示する
+  - routine な tool call ごとの実況は要求しない
+  - tool call が不要な応答には前置きを要求しない
   - `character-authoring` session では注入しない
 
 ## Memory Injection Policy

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "6.3.2",
+  "version": "6.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "6.3.2",
+      "version": "6.3.3",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "6.3.2",
+  "version": "6.3.3",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/scripts/tests/provider-prompt.test.ts
+++ b/scripts/tests/provider-prompt.test.ts
@@ -253,6 +253,11 @@ describe("composeProviderPrompt", () => {
     assert.match(prompt.systemBodyText, /# Output Boundary/);
     assert.match(prompt.systemBodyText, /生成ファイル、diff、artifact summary には、ユーザーが明示しない限り Character の口調・設定・台詞・メタ説明を混ぜないでください。/);
     assert.match(prompt.systemBodyText, /成果物は repository instruction、既存文体、対象ファイルの目的を優先してください。/);
+    assert.match(prompt.systemBodyText, /# Tool Call Presence/);
+    assert.match(prompt.systemBodyText, /最初の tool call より前に、ユーザーへ1〜3文程度の短い自然言語レスポンスを返してください/);
+    assert.match(prompt.systemBodyText, /キャラクターが無言のまま作業へ入り、応答が止まったように見える体験を避ける/);
+    assert.match(prompt.systemBodyText, /routine な tool call ごとに実況する必要はありません/);
+    assert.match(prompt.systemBodyText, /tool call が不要な応答では、このルールのためだけに前置きを追加する必要はありません/);
     assert.doesNotMatch(prompt.systemBodyText, /厳密な無人格回答へ戻りすぎず/);
     assert.doesNotMatch(prompt.systemBodyText, /character-notes\.md/);
     assert.doesNotMatch(prompt.systemBodyText, /^---$/m);
@@ -267,6 +272,7 @@ describe("composeProviderPrompt", () => {
     assertSectionOrder(prompt.logicalPrompt.composedText, [
       "# Character Definition Snapshot",
       "# Output Boundary",
+      "# Tool Call Presence",
       "# User Input",
       "続けて",
     ]);
@@ -306,6 +312,7 @@ describe("composeProviderPrompt", () => {
     assert.match(prompt.systemBodyText, /authoring 対象の character\.md。/);
     assert.doesNotMatch(prompt.systemBodyText, /開始時点の Character 定義/);
     assert.doesNotMatch(prompt.systemBodyText, /# Output Boundary/);
+    assert.doesNotMatch(prompt.systemBodyText, /# Tool Call Presence/);
     assert.doesNotMatch(prompt.systemBodyText, /ユーザー向け自然言語レスポンスの話し方・温度・反応パターンに反映してください。/);
     assert.doesNotMatch(prompt.systemBodyText, /通常のcoding agentとして正確に扱い、Character定義で置き換えないでください。/);
     assert.doesNotMatch(prompt.systemBodyText, /生成ファイル、diff、artifact summary/);
@@ -352,6 +359,11 @@ describe("composeProviderPrompt", () => {
 
     assert.match(prompt.systemBodyText, /`````markdown\n# Examples/);
     assert.match(prompt.systemBodyText, /````\n`````\n\n# Output Boundary/);
-    assertSectionOrder(prompt.systemBodyText, ["`````markdown", "quad fence", "`````\n\n# Output Boundary"]);
+    assertSectionOrder(prompt.systemBodyText, [
+      "`````markdown",
+      "quad fence",
+      "`````\n\n# Output Boundary",
+      "# Tool Call Presence",
+    ]);
   });
 });

--- a/src-electron/provider-prompt.ts
+++ b/src-electron/provider-prompt.ts
@@ -16,6 +16,23 @@ function buildCharacterOutputBoundarySection(enabled: boolean): string {
   ].join("\n");
 }
 
+function buildToolCallPresenceSection(enabled: boolean): string {
+  if (!enabled) {
+    return "";
+  }
+
+  return [
+    "# Tool Call Presence",
+    "",
+    "tool call や command 実行を伴う場合は、最初の tool call より前に、ユーザーへ1〜3文程度の短い自然言語レスポンスを返してください。",
+    "発言は詳細な作業計画や tool call の説明である必要はありません。依頼への相づち、挨拶、キャラクターらしい反応など、会話として自然な内容で構いません。",
+    "キャラクターが無言のまま作業へ入り、応答が止まったように見える体験を避けることを優先してください。",
+    "開始時の発言を毎回同じ定型句に固定しないでください。",
+    "長い作業では適度に途中経過や反応を返してください。ただし、routine な tool call ごとに実況する必要はありません。",
+    "tool call が不要な応答では、このルールのためだけに前置きを追加する必要はありません。",
+  ].join("\n");
+}
+
 export function composeProviderPrompt(input: RunSessionTurnInput): ProviderPromptComposition {
   const isCharacterAuthoringSession = input.session.sessionKind === "character-authoring";
   const characterPromptBody = buildCharacterRuntimePromptSection(input.session.characterRuntimeSnapshot, {
@@ -24,7 +41,10 @@ export function composeProviderPrompt(input: RunSessionTurnInput): ProviderPromp
   const outputBoundaryBody = buildCharacterOutputBoundarySection(
     !isCharacterAuthoringSession && characterPromptBody.trim().length > 0,
   );
-  const systemPromptBody = [characterPromptBody, outputBoundaryBody]
+  const toolCallPresenceBody = buildToolCallPresenceSection(
+    !isCharacterAuthoringSession && characterPromptBody.trim().length > 0,
+  );
+  const systemPromptBody = [characterPromptBody, outputBoundaryBody, toolCallPresenceBody]
     .filter((section) => section.trim().length > 0)
     .join("\n\n");
   const referencedImages = input.attachments.filter((attachment) => attachment.kind === "image");


### PR DESCRIPTION
## 概要

- Character付きの通常session / companionのSystemPromptへ `Tool Call Presence` を追加
- 最初のtool callやcommand実行より前に、1〜3文の自然なレスポンスを返すよう指示
- routineなtool callごとの実況や、tool call不要時の不要な前置きは要求しない
- アプリバージョンを `6.3.2` から `6.3.3` へ更新

## 背景

tool callから開始すると、ユーザーにはCharacterが無言のまま固まって作業へ入ったように見える場合がありました。固定SystemPromptに会話開始境界がなかったため、Characterの自然な初動を明示するsectionを追加します。

## 影響

Character付きの通常session / companionだけが対象です。`character-authoring` sessionとCharacterなしのsessionには注入しません。

## 検証

- provider prompt targeted test: 6件成功
- 版上げ後 targeted test: 7件成功
- 全テスト（Electron同梱Node 24.18.0）: 1820件成功、0件失敗、1件skip
  - skipはWindowsでは対象外のPOSIX symlink test
- `npm run typecheck`: 成功
- `npm run build`: 成功