### PR TITLE
fix(provider): ファイルDiff取得を一時停止する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "6.3.3",
+  "version": "6.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "6.3.3",
+      "version": "6.3.4",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "6.3.3",
+  "version": "6.3.4",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/scripts/tests/codex-adapter.test.ts
+++ b/scripts/tests/codex-adapter.test.ts
@@ -366,7 +366,7 @@ describe("CodexAdapter thread settings", () => {
     }
   });
 
-  it("turn.completed 後の workspace snapshot が停止しても degraded result へ収束する", async () => {
+  it("workspace diff 無効時は停止した snapshot を待たず結果へ収束する", async () => {
     const workspacePath = await mkdtemp(path.join(os.tmpdir(), "withmate-codex-snapshot-timeout-"));
     const adapter = new CodexAdapter(undefined, { snapshotDeadlineMs: 5 }) as unknown as {
       getClient: () => {
@@ -416,7 +416,7 @@ describe("CodexAdapter thread settings", () => {
       assert.equal(result.assistantText, "done");
       assert.equal(
         result.providerMetadata?.some((entry) => entry.source === "codex-adapter.workspace-snapshot"),
-        true,
+        false,
       );
     } finally {
       _setWalkDirectoryStatOverrideForTesting(null);
@@ -1415,7 +1415,7 @@ describe("workspace snapshot targeted capture", () => {
     }
   });
 
-  it("collab_tool_call がある場合は file_change 候補だけを信用せず snapshot fallback で差分を拾う", async () => {
+  it("workspace diff 無効時は snapshot fallback を使わず明示された変更ファイルだけを残す", async () => {
     const workspacePath = await mkdtemp(path.join(os.tmpdir(), "withmate-codex-collab-diff-"));
     const adapter = new CodexAdapter() as unknown as {
       getClient: () => {
@@ -1497,12 +1497,11 @@ describe("workspace snapshot targeted capture", () => {
       });
 
       const result = await adapter.runSessionTurn(createCodexRunSessionTurnInput(workspacePath));
-      const changedPaths = result.artifact?.changedFiles.map((file) => file.path).sort();
+      const changedFiles = result.artifact?.changedFiles ?? [];
+      const changedPaths = changedFiles.map((file) => file.path).sort();
 
-      assert.deepEqual(changedPaths, [
-        "src/collab-side-effect.ts",
-        "src/explicit.ts",
-      ]);
+      assert.deepEqual(changedPaths, ["src/explicit.ts"]);
+      assert.deepEqual(changedFiles[0]?.diffRows, []);
     } finally {
       await rm(workspacePath, { recursive: true, force: true });
     }

--- a/scripts/tests/workspace-diff-policy.test.ts
+++ b/scripts/tests/workspace-diff-policy.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  createDisabledWorkspaceSnapshotCapture,
+  WORKSPACE_DIFF_CAPTURE_ENABLED,
+} from "../../src-electron/workspace-diff-policy.js";
+
+describe("workspace diff policy", () => {
+  it("workspace snapshot capture を一時的に無効化する", () => {
+    assert.equal(WORKSPACE_DIFF_CAPTURE_ENABLED, false);
+
+    const result = createDisabledWorkspaceSnapshotCapture();
+
+    assert.equal(result.snapshot.size, 0);
+    assert.deepEqual(result.stats, {
+      capturedFiles: 0,
+      capturedBytes: 0,
+      skippedBinaryOrOversizeFiles: 0,
+      skippedByLimitFiles: 0,
+      hitFileCountLimit: false,
+      hitTotalBytesLimit: false,
+    });
+  });
+});

--- a/src-electron/codex-adapter.ts
+++ b/src-electron/codex-adapter.ts
@@ -47,6 +47,10 @@ import {
   type WorkspaceSnapshot,
 } from "./snapshot-ignore.js";
 import { normalizeAllowedAdditionalDirectories } from "./additional-directories.js";
+import {
+  createDisabledWorkspaceSnapshotCapture,
+  WORKSPACE_DIFF_CAPTURE_ENABLED,
+} from "./workspace-diff-policy.js";
 import { composeProviderPrompt, isCanceledProviderMessage } from "./provider-prompt.js";
 import { normalizeCodexTokenUsage } from "./provider-token-usage.js";
 import {
@@ -1623,6 +1627,14 @@ export class CodexAdapter implements ProviderTurnAdapter {
     beforeSnapshot: WorkspaceSnapshot;
     beforeSnapshotStats: SnapshotCaptureStats;
   }> {
+    if (!WORKSPACE_DIFF_CAPTURE_ENABLED) {
+      const { snapshot, stats } = createDisabledWorkspaceSnapshotCapture();
+      return {
+        beforeSnapshot: snapshot,
+        beforeSnapshotStats: stats,
+      };
+    }
+
     const snapshotRoots = this.buildSnapshotRoots(input);
     const indexKey = this.buildSnapshotIndexKey(snapshotRoots);
     const cachedIndex = this.workspaceSnapshotIndexes.get(indexKey);
@@ -1652,6 +1664,15 @@ export class CodexAdapter implements ProviderTurnAdapter {
     afterSnapshotStats: SnapshotCaptureStats;
     useSnapshotFallback: boolean;
   }> {
+    if (!WORKSPACE_DIFF_CAPTURE_ENABLED) {
+      const { snapshot, stats } = createDisabledWorkspaceSnapshotCapture();
+      return {
+        afterSnapshot: snapshot,
+        afterSnapshotStats: stats,
+        useSnapshotFallback: false,
+      };
+    }
+
     const snapshotRoots = this.buildSnapshotRoots(input);
     const indexKey = this.buildSnapshotIndexKey(snapshotRoots);
     const cachedIndex = this.workspaceSnapshotIndexes.get(indexKey)

--- a/src-electron/copilot-adapter.ts
+++ b/src-electron/copilot-adapter.ts
@@ -40,6 +40,10 @@ import {
   type ResolvedModelSelection,
 } from "../src/model-catalog.js";
 import { buildArtifactFromOperations } from "./provider-artifact.js";
+import {
+  createDisabledWorkspaceSnapshotCapture,
+  WORKSPACE_DIFF_CAPTURE_ENABLED,
+} from "./workspace-diff-policy.js";
 import { composeProviderPrompt, isCanceledProviderMessage } from "./provider-prompt.js";
 import {
   ProviderTurnError,
@@ -2295,10 +2299,12 @@ export class CopilotAdapter implements ProviderTurnAdapter {
     beforeSnapshotStats: SnapshotCaptureStats,
     providerQuotaTelemetry: ProviderQuotaTelemetry | null,
   ): Promise<RunSessionTurnResult> {
-    const { snapshot: afterSnapshot, stats: afterSnapshotStats } = await captureWorkspaceSnapshot([
-      workspacePath,
-      ...normalizeAllowedAdditionalDirectories(workspacePath, session.allowedAdditionalDirectories),
-    ]);
+    const { snapshot: afterSnapshot, stats: afterSnapshotStats } = WORKSPACE_DIFF_CAPTURE_ENABLED
+      ? await captureWorkspaceSnapshot([
+          workspacePath,
+          ...normalizeAllowedAdditionalDirectories(workspacePath, session.allowedAdditionalDirectories),
+        ])
+      : createDisabledWorkspaceSnapshotCapture();
     const operations = toAuditOperations(steps);
     const providerMetadata = buildCopilotProviderMetadata(rawItems);
     for (const metadata of providerMetadata) {
@@ -2345,10 +2351,12 @@ export class CopilotAdapter implements ProviderTurnAdapter {
     const workspacePath = resolveRunWorkspacePath(input);
 
     const cliPath = resolveCopilotCliPath();
-    const { snapshot: beforeSnapshot, stats: beforeSnapshotStats } = await captureWorkspaceSnapshot([
-      workspacePath,
-      ...normalizeAllowedAdditionalDirectories(workspacePath, input.session.allowedAdditionalDirectories),
-    ]);
+    const { snapshot: beforeSnapshot, stats: beforeSnapshotStats } = WORKSPACE_DIFF_CAPTURE_ENABLED
+      ? await captureWorkspaceSnapshot([
+          workspacePath,
+          ...normalizeAllowedAdditionalDirectories(workspacePath, input.session.allowedAdditionalDirectories),
+        ])
+      : createDisabledWorkspaceSnapshotCapture();
     let session: CopilotSession;
     let selection: ResolvedModelSelection;
     try {

--- a/src-electron/workspace-diff-policy.ts
+++ b/src-electron/workspace-diff-policy.ts
@@ -1,0 +1,21 @@
+import type { SnapshotCaptureStats, WorkspaceSnapshot } from "./snapshot-ignore.js";
+
+// 永続設定を増やさず、ファイル Diff 生成のための workspace 読み取りを一時停止する。
+export const WORKSPACE_DIFF_CAPTURE_ENABLED = false;
+
+export function createDisabledWorkspaceSnapshotCapture(): {
+  snapshot: WorkspaceSnapshot;
+  stats: SnapshotCaptureStats;
+} {
+  return {
+    snapshot: new Map(),
+    stats: {
+      capturedFiles: 0,
+      capturedBytes: 0,
+      skippedBinaryOrOversizeFiles: 0,
+      skippedByLimitFiles: 0,
+      hitFileCountLimit: false,
+      hitTotalBytesLimit: false,
+    },
+  };
+}


### PR DESCRIPTION
## 概要

- Codex / Copilot の workspace snapshot 取得を共通ポリシーで一時停止
- snapshot 無効時も provider の turn 結果と操作ログを維持
- アプリバージョンを `6.3.4` へ更新

## 背景

ファイルDiff取得を一時的に無効化する必要があるため、永続設定や設定UIを増やさず、1か所のハードコードされたポリシーで切り替えられるようにしました。

## 影響

- workspace全体のファイル走査とDiff行生成を実行しません
- Codexではproviderが明示した変更ファイル名だけ残る場合がありますが、Diff行は空になります
- Copilotではsnapshot由来のChanged Filesは空になります
- 再有効化は `src-electron/workspace-diff-policy.ts` の定数変更で行えます

## 検証

- `npm run typecheck`
- Codex / Copilot / provider artifact / workspace diff policy / package config のテスト（90件成功）
- `npm run build`
- `git diff --check`