### PR TITLE
fix(home): キャラクター一覧をスクロール可能にする

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "6.3.5",
+  "version": "6.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "6.3.5",
+      "version": "6.3.6",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "6.3.5",
+  "version": "6.3.6",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/scripts/tests/home-monitor-style.test.ts
+++ b/scripts/tests/home-monitor-style.test.ts
@@ -21,3 +21,18 @@ test("Home Monitor の status badge は Home session と同じ状態 selector �
     );
   }
 });
+
+test("Home Characters は right pane 内の scroll container を使う", async () => {
+  const [componentSource, stylesSource] = await Promise.all([
+    readFile("src/home/HomeCharactersPanel.tsx", "utf8"),
+    readFile("src/styles.css", "utf8"),
+  ]);
+
+  assert.match(componentSource, /<div className="home-monitor-body">/);
+  const scrollContainerRule = stylesSource.match(/\.home-page \.home-monitor-body\s*{([^}]*)}/)?.[1];
+
+  assert.ok(scrollContainerRule);
+  assert.match(scrollContainerRule, /flex:\s*1 1 auto;/);
+  assert.match(scrollContainerRule, /min-height:\s*0;/);
+  assert.match(scrollContainerRule, /overflow-y:\s*auto;/);
+});

--- a/src/home/HomeCharactersPanel.tsx
+++ b/src/home/HomeCharactersPanel.tsx
@@ -15,7 +15,7 @@ export function HomeCharactersPanel({
   onEditCharacter,
 }: HomeCharactersPanelProps) {
   return (
-    <div className="home-monitor-content">
+    <div className="home-monitor-body">
       <section className="home-monitor-section">
         <div className="home-monitor-section-head">
           <h3>Characters</h3>


### PR DESCRIPTION
## 概要

- Home画面のCharacters一覧が、登録人数の増加時にも右ペイン内で縦スクロールできるようにしました。
- アプリversionを `6.3.6` へ更新しました。

## 原因

Characters panelのwrapperがCSS定義のない `home-monitor-content` を参照しており、親要素の `overflow: hidden` によって超過したカードが見切れていました。

## 変更内容

- Characters panelへ既存の右ペイン用scroll containerを適用
- scroll containerの `flex`、`min-height`、`overflow-y` を同一CSS宣言ブロック内で検証する回帰テストを追加
- `package.json` と `package-lock.json` のversionを `6.3.6` へ更新

## 影響

Characterを多数登録した場合でも、Home画面から一覧の最後まで到達できます。

## 検証

- `npx tsx --test scripts/tests/home-monitor-style.test.ts`
- `npx tsx --test scripts/tests/home-components.test.tsx`
- `npm run typecheck`
- `npm run build:renderer`

Electron実機で多数のCharacterを登録した目視確認は未実施です。