### PR TITLE
HomeのCharacter一覧UIを整理する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "6.3.7",
+  "version": "6.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "6.3.7",
+      "version": "6.3.8",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "6.3.7",
+  "version": "6.3.8",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/scripts/tests/home-components.test.tsx
+++ b/scripts/tests/home-components.test.tsx
@@ -6,6 +6,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { HomeLaunchDialog } from "../../src/home/HomeLaunchDialog.js";
+import { filterCharactersByName } from "../../src/home/HomeCharactersPanel.js";
 import { HomeMonitorContent } from "../../src/home/HomeMonitorContent.js";
 import { HomeRecentSessionsPanel } from "../../src/home/HomeRecentSessionsPanel.js";
 import { HomeRightPane } from "../../src/home/HomeRightPane.js";
@@ -914,10 +915,47 @@ describe("HomeRightPane", () => {
     assert.ok(html.includes("Mia"));
     assert.ok(html.includes("説明文"));
     assert.ok(html.includes("Create"));
-    assert.ok(html.includes("Edit"));
+    assert.ok(!html.includes("<h3>Characters</h3>"));
+    assert.ok(html.includes('aria-label="Characterを名前で検索"'));
+    assert.ok(html.includes('placeholder="名前で検索"'));
     assert.ok(html.includes("Default"));
+    assert.match(html, /<button class="home-character-card"/);
+    assert.ok(!html.includes("home-character-card-edit"));
+    assert.ok(!html.includes("2026-01-01T00:00:00.000Z"));
     assert.ok(!html.includes("Your Mate"));
     assert.ok(!html.includes("メイトーク"));
+  });
+
+  it("Character name 検索は前後の空白と大文字小文字を無視する", () => {
+    const characters = [
+      {
+        id: "char-mia",
+        name: "Mia",
+        description: "説明文",
+        iconFilePath: "",
+        theme: { main: "#3b82f6", sub: "#1d4ed8" },
+        state: "active" as const,
+        isDefault: true,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        archivedAt: null,
+      },
+      {
+        id: "char-noah",
+        name: "Noah",
+        description: "別の説明文",
+        iconFilePath: "",
+        theme: { main: "#10b981", sub: "#047857" },
+        state: "active" as const,
+        isDefault: false,
+        createdAt: "2026-01-02T00:00:00.000Z",
+        updatedAt: "2026-01-02T00:00:00.000Z",
+        archivedAt: null,
+      },
+    ];
+
+    assert.deepEqual(filterCharactersByName(characters, " NOA ").map((character) => character.id), ["char-noah"]);
+    assert.deepEqual(filterCharactersByName(characters, "   "), characters);
   });
 
   it("Character が空でも Create Character を表示できる", () => {

--- a/src/home/HomeCharactersPanel.tsx
+++ b/src/home/HomeCharactersPanel.tsx
@@ -1,5 +1,8 @@
+import { useState } from "react";
+
 import type { CharacterCatalogEntry } from "../character/character-catalog.js";
 import { buildCardThemeStyle, CharacterAvatar } from "../ui-utils.js";
+import { renderHomeSearchIcon } from "./home-icons.js";
 
 export type HomeCharactersPanelProps = {
   characters: readonly CharacterCatalogEntry[];
@@ -8,20 +11,47 @@ export type HomeCharactersPanelProps = {
   onEditCharacter: (characterId: string) => void;
 };
 
+export function filterCharactersByName(
+  characters: readonly CharacterCatalogEntry[],
+  searchText: string,
+): readonly CharacterCatalogEntry[] {
+  const normalizedSearchText = searchText.trim().toLocaleLowerCase();
+  return normalizedSearchText
+    ? characters.filter((character) => character.name.toLocaleLowerCase().includes(normalizedSearchText))
+    : characters;
+}
+
 export function HomeCharactersPanel({
   characters,
   feedback = "",
   onCreateCharacter,
   onEditCharacter,
 }: HomeCharactersPanelProps) {
+  const [searchText, setSearchText] = useState("");
+  const visibleCharacters = filterCharactersByName(characters, searchText);
+
   return (
     <div className="home-monitor-body">
       <section className="home-monitor-section">
         <div className="home-monitor-section-head">
-          <h3>Characters</h3>
-          <button className="launch-toggle compact" type="button" onClick={onCreateCharacter}>
-            Create
-          </button>
+          <div className="home-character-toolbar">
+            <label className="toolbar-search-field" aria-label="Characterを名前で検索">
+              <span className="toolbar-search-icon" aria-hidden="true">
+                {renderHomeSearchIcon()}
+              </span>
+              <input
+                className="toolbar-search-input"
+                type="search"
+                aria-label="Characterを名前で検索"
+                placeholder="名前で検索"
+                value={searchText}
+                onChange={(event) => setSearchText(event.target.value)}
+              />
+            </label>
+            <button className="launch-toggle compact" type="button" onClick={onCreateCharacter}>
+              Create
+            </button>
+          </div>
         </div>
         {feedback ? <p className="settings-feedback">{feedback}</p> : null}
         {characters.length === 0 ? (
@@ -31,9 +61,13 @@ export function HomeCharactersPanel({
               Create Character
             </button>
           </div>
+        ) : visibleCharacters.length === 0 ? (
+          <div className="home-monitor-empty">
+            <p>名前に一致するCharacterはありません。</p>
+          </div>
         ) : (
           <div className="home-character-list">
-            {characters.map((character) => (
+            {visibleCharacters.map((character) => (
               <button
                 key={character.id}
                 className="home-character-card"
@@ -48,9 +82,7 @@ export function HomeCharactersPanel({
                     {character.isDefault ? <span className="settings-character-badge">Default</span> : null}
                   </span>
                   <span>{character.description || character.id}</span>
-                  <span className="home-character-card-updated">updated {character.updatedAt || "-"}</span>
                 </span>
-                <span className="launch-toggle compact home-character-card-edit">Edit</span>
               </button>
             ))}
           </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -825,7 +825,21 @@ button:disabled {
 }
 
 .home-page .home-character-toolbar {
-  margin: 0 6px 4px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  width: 100%;
+}
+
+.home-page .home-character-toolbar .toolbar-search-field {
+  padding: 0 10px;
+  border-radius: 14px;
+}
+
+.home-page .home-character-toolbar .toolbar-search-input {
+  padding: 7px 0;
 }
 
 .home-page .home-monitor-body {
@@ -853,6 +867,7 @@ button:disabled {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
   gap: 12px;
 }
 
@@ -898,7 +913,7 @@ button:disabled {
 
 .home-page .home-character-card {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
   gap: 12px;
   width: 100%;
@@ -946,15 +961,6 @@ button:disabled {
   color: var(--muted);
   font-size: 0.78rem;
   line-height: 1.35;
-}
-
-.home-page .home-character-card-updated {
-  opacity: 0.86;
-}
-
-.home-page .home-character-card-edit {
-  color: var(--ink);
-  pointer-events: none;
 }
 
 .home-page .home-monitor-count {


### PR DESCRIPTION
## 概要
- CharacterカードからUpdatedAtとEdit表示を削除
- 名前検索を追加し、検索欄とCreateボタンを整理
- アプリバージョンを6.3.8へ更新

## 背景
カードクリックで編集画面を開けるためEdit表示は重複しており、UpdatedAtも一覧上では不要だった。Character数が増えた際に探しやすいよう名前検索を追加した。

## 確認
- `npm exec -- tsx --test scripts/tests/home-components.test.tsx scripts/tests/home-monitor-style.test.ts`
- `npm run typecheck`
- `npm run build`