### PR TITLE
feat(session): Message履歴と本文取得を実装

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,155 @@
+# WithMate Coding Agent Working Agreements
+
+このファイルは、WithMateの新実装を扱うcoding agent向けのリポジトリ規約である。より深いdirectoryに対象を限定した`AGENTS.md`がある場合は、そのdirectory内だけ追加規約を適用する。
+
+## 作業の起点
+
+- WithMateは完全な0ベース再構築として進める。全体方針と文書の入口は`docs/index.md`を正本とする。
+- root直下のsource、test、schema、docsが新実装である。`old/`は旧実装の退避領域であり、現行設計の正本ではない。
+- 作業開始時にcurrent branch、`git status --short`、適用されるinstruction、現在のroadmap checkpoint、回答待ちのquestionを確認する。
+- 要求、制約、期待する観測結果、完了条件を短く整理し、関連するsourceとexecutable contractを読んでから判断する。
+- ユーザーが明示していないcommit、push、PR作成、外部write、破壊的操作は行わない。
+
+## 0ベース再構築
+
+- 旧実装のAPI、schema、責務境界、directory構成、依存関係をそのまま移植しない。
+- `old/`は、過去の挙動や失敗例を調査する必要がある場合だけ参考にする。旧roadmap、旧設計文書、旧testを現行contractの根拠にしない。
+- 既存機能を無条件に復元しない。採否は`docs/feature-inventory.md`、現行roadmap、accepted design、ユーザー要求から判断する。
+- 旧実装との互換layer、fallback、import、data migrationは、accepted contractとして明示されない限り追加しない。
+- 新実装から旧DB fileを参照、変更、自動削除しない。pathやtable名を推測して旧DBを開かない。
+- 現在の構造を守るためだけの局所修正より、accepted contractに整合する単純な最終状態を優先する。
+
+## 正式リリース前の手戻り
+
+リリース段階とDB schema運用の正本は`docs/design/sqlite-schema-lifecycle.md`である。現在は同文書の「正式release前のversion 1」を適用する。
+
+- 最初の正式releaseまでは、外部consumerとの互換契約が成立していないpre-release API、保存形式、内部構造を置き換えてよい。古い経路をfallbackとして残さず、依頼範囲のcaller、test、schema artifact、文書を同じ論理変更で現行契約へ揃える。
+- schema version 1のDDLとmanifestは、同じ論理変更内で更新できる。開発buildが作成したDBは互換保証の対象外であり、schema差分のためだけにmigration、compatibility reader、変換scriptを追加しない。
+- 互換性のない開発DBが残る場合は、明示的な再作成が必要であることを報告する。applicationやagentが既存DBを自動削除してはならない。
+- 手戻りを許容するのは、不要な後方互換性を抱えず設計を整えるためである。ユーザーの未コミット変更、Git履歴、旧DB、個人データを無断で破棄する許可ではない。
+- pre-releaseであっても、security、privacy、data integrity、transaction、concurrency、resource limit、error semanticsを弱めない。
+- accepted design、公開済みtype、信頼できるexecutable contractを変更する場合は、変更理由と利用者への影響を特定し、sourceとcontractを同じ論理変更で更新する。
+- `docs/design/sqlite-schema-lifecycle.md`が最初の正式releaseによるversion 1の凍結を示した後は、このpre-release例外を適用しない。version 2以降の前進migrationと回帰contractを追加し、このファイルも同じ変更で更新する。
+
+## Source of truth
+
+関心事ごとに正本を分ける。
+
+- 現在の実装と構造: root直下のsource code
+- 観測可能な期待動作、不変条件、failure mode: test、type、schema、static check
+- 現行schema: `schema/sqlite/v1.sql`と`schema/sqlite/manifest-v1.json`
+- 非局所的な設計制約: `docs/design/`
+- 長期的または後戻り困難な判断理由: `docs/adr/`
+- checkpoint、依存関係、scope: `docs/plans/20260712-withmate-rebuild-roadmap/plan.md`
+- roadmap上の判断: `docs/plans/20260712-withmate-rebuild-roadmap/decisions.md`
+- 回答待ち: `docs/plans/20260712-withmate-rebuild-roadmap/questions.md`
+- 検証済み進捗とaccepted risk: `docs/plans/20260712-withmate-rebuild-roadmap/worklog.md`
+- 外部runtimeの実測: `docs/investigations/`
+
+sourceとexecutable contractが矛盾する場合は、testを現在の実装へ合わせて弱める前に、ユーザー要求、accepted ADR、design、外部consumer、履歴上の根拠から意図を確定する。結果を実質的に変える判断を確定できない場合だけ、選択肢と影響を示して確認を求める。
+
+## Roadmapとscope
+
+- 現在のcheckpointと依存関係はroadmapを確認する。下位層のGateを飛ばしてGUIやProvider固有実装を先行させない。
+- checkpoint開始時は`questions.md`を確認し、回答待ちが作業結果を変える場合は実装を止める。
+- 依頼されたsliceの外にある将来機能を便乗実装しない。必要性を見つけた場合は、根拠と依存関係を報告する。
+- checkpoint完了はfile作成やtest件数ではなく、planに定義された観測可能なGateの通過で判断する。
+- scope変更は`decisions.md`へ理由を置き、plan、questions、worklogのうち直接影響する正本だけを更新する。
+
+## Architecture boundaries
+
+- 中核use caseはUIやProvider transportに依存しないApplication Serviceとして実装する。
+- CLIを先行clientとし、後続GUIも同じApplication contractを利用する。CLIやGUIからSQLiteまたはPersistence Worker内部へ直接到達しない。
+- SQLite connection、schema適用、repository read/write ownershipはPersistence Workerへ閉じる。
+- Provider固有protocol、ID、resume、error mappingはProvider Adapter境界へ閉じ、domain modelやpublic projectionへ漏らさない。
+- 永続化の正本、Application projection、CLI JSON、将来のGUI stateを混同しない。
+- 大きい本文やBLOBはbounded pageまたはchunkとして扱う。通常の一覧やsummaryで全件hydrate、N+1 read、payload複製を行わない。
+- authorization、workspace、Session、Run、Messageなどのowner tupleは、信頼境界ごとに再検証する。内部ID、raw payload、private path、secretをpublic responseやdiagnosticへ流さない。
+
+## Change workflow
+
+依頼種別に応じて作業範囲を守る。
+
+- answer、explain、review、diagnose、plan: 必要なread-only調査と報告まで行い、変更依頼がなければ編集しない。
+- change、build、fix: 依頼範囲の編集と非破壊的な検証まで進める。
+- external action: 対象、影響、可逆性、権限を確認し、明示的に許可された操作だけを行う。
+
+実装では次を守る。
+
+- bug fixは対象failure modeを可能な範囲で修正前に再現し、修正後に最も直接的な方法で解消を確認する。
+- public API、永続化、migration、外部副作用、authorization、concurrency、resource limit、ownerまたはscopeを変更する場合は、同じ不変条件を持つ兄弟入口、failure timing、public projection、recoveryを確認する。
+- 同じ問題が複数入口にある場合は、callerごとの回避より、不変条件を所有する最小の共有境界で修正する。
+- 一度に多数の仮説修正を入れず、failureを切り分けられる小さな変更を選ぶ。
+- 無関係なcleanup、rename、format、dependency更新、refactorを同じ差分へ混ぜない。
+- 現在の表現や内部call順を固定するtestではなく、利用者から観測できる結果、不変条件、failure modeを検証する。
+- failing test、type、schema、static checkを、現在のsourceに合わせるためだけに削除、skip、弱体化しない。
+
+## Code and comments
+
+- TypeScriptはstrict、ES modules、既存のproject reference構成に合わせる。
+- directoryとmoduleは、技術種別だけでなくdomain、feature、capability、ownershipなど安定した変更理由で分ける。
+- public型はinvalidな状態の組を表現しにくいdiscriminated unionやexact validationを優先する。
+- plain object、arrayの密度、文字列長、byte長、整数範囲、unknown fieldを信頼境界で検証する。type assertionをruntime validationの代用にしない。
+- コメントは処理内容ではなく、コードから復元できない理由、外部制約、競合対策、failure boundaryを書く。詳細は`docs/development/source-comment-guidelines.md`に従う。
+- TODO、FIXME、HACKを残す場合は、Issueまたはrepo相対planへのpointerと解消条件を付ける。
+- source、test、document、生成物へ個人環境の絶対path、token、secret、raw Provider responseを残さない。
+
+## Knowledge placement
+
+- validation ruleやfailure modeは、可能ならtest、type、schema、static checkへ置く。
+- 一つのcode locationの近くで理解できる理由はcode commentへ置く。
+- 複数の妥当な選択肢から一つを選ぶ場合、またはpublic contract、永続化、migration、security、concurrencyなど後戻りコストが高い新しい判断を行う場合はADRを作る。既存のaccepted ADRやdesignが同じ判断理由を所有している場合は、新しいADRを重複させない。
+- ADRにはcontext、decision、alternatives、consequencesを残し、現行class構成やAPI一覧を複製しない。
+- 恒久的なdesign文書には、複数subsystemへ波及し、sourceやtestだけから復元できない制約だけを残す。
+- 現行file構成、通常のAPI入出力、局所的な処理順を、実装の写経としてdesign文書へ同期しない。
+- 既存designが判断理由をすでに所有している場合は、新しいADRや重複文書を作らずpointerを使う。
+
+## Worktree and Git safety
+
+- 作業前後に`git status --short`を確認し、既存のstaged、unstaged、untracked changeをユーザーの作業として保護する。
+- ユーザーの変更をreset、checkout、restore、stash、clean、上書きしない。変更が重なる場合は差分を読み、共存できないときだけ確認を求める。
+- filesystemの削除、再帰移動、DB再作成など破壊的操作は、対象をread-onlyで特定し、依頼範囲と明示権限を確認してから行う。
+- commitとpushは別々の外部作用として扱い、それぞれユーザーが明示した場合だけ行う。
+- commitする場合は対象diffとstagingを確認し、1つの論理変更へ無関係な差分を混ぜない。commit messageはconventional commitsを使う。
+- `old/AGENTS.md`は旧treeを明示的に扱う作業でだけ参照する。新実装の規約としてrootへ持ち込まない。
+
+## Validation
+
+runtime要件は`package.json`を正本とする。現在はNode.js `>=24.16 <25`、npm `>=10.9 <12`である。
+
+変更に最も近いtargeted checkから始め、リスクに応じて次へ広げる。
+
+```text
+npm run check:runtime
+npm run format:check
+npm run lint
+npm run typecheck
+npm test
+npm run build
+npm run smoke:cli-session
+npm run smoke:cli-run
+npm run smoke:compiled-persistence
+```
+
+- すべての変更で全commandを儀式的に実行せず、対象failureと主要回帰を検出する最小構成を先に選ぶ。
+- 永続化、public contract、module boundary、CLI lifecycleを変更した場合は、targeted test後に関連するbroad checkとprocess smokeへ広げる。
+- schema変更ではDDLとmanifestを同じ論理変更で更新し、SQLite schema validator、foreign key、constraint、manifest hashを確認する。
+- 実行できないcheckは成功扱いせず、理由、代替確認、未検証リスクを報告する。
+- checkpointのGateを通過した場合は、実行した検証、未実行事項、残リスクをroadmapの`worklog.md`へ記録する。
+
+## Review and completion
+
+- reviewはfinding-firstとし、bug、regression、security、仕様逸脱、sourceとcontractの不一致、責務境界の崩れを優先する。
+- findingはseverityとは別に`blocking`、`risk-candidate`、`non-material`、`invalid`へ分類する。accepted contractへの違反、supported scopeでの現実的な到達条件、具体的な影響、sourceまたはexecutable contractの根拠がそろう場合だけblockingとする。
+- risk-candidateを受容する場合は、発生条件、影響、検知、復旧、再判断条件を`worklog.md`またはrepositoryの既存管理先へ残す。security侵害、secretや個人データの露出、不可逆なdata lossは自動的に受容しない。
+- public contract、永続化、外部副作用、authorization、concurrency、resource limitに関わる非自明な変更は、実装とtargeted check後に独立した反例reviewを行う。
+- blocking findingを修正した場合は、同じinvariant familyのtargeted checkとre-reviewで閉じる。
+- source、executable contract、knowledge placement、必要な文書、検証結果が一致し、未解決のblocking findingがない状態を完了とする。
+- 最終報告では、変更内容、実行した検証、未実行の検証、accepted risk、残リスク、commitや外部作用の有無を区別する。
+
+## Language and reporting
+
+- ユーザーへの回答、repository-owned document、commit messageは日本語で書く。identifier、API名、protocol field、error codeはsource上の表記を維持する。
+- pathはrepo root相対で示し、logや成果物に個人環境の絶対pathを残さない。
+- 実行していない操作を実行済みと書かない。推測、確認済み事実、未確認事項を分ける。
+- 結論から報告し、判断根拠、重要な注意点、次のactionを必要な範囲で続ける。

--- a/docs/plans/20260712-withmate-rebuild-roadmap/worklog.md
+++ b/docs/plans/20260712-withmate-rebuild-roadmap/worklog.md
@@ -129,3 +129,13 @@
 - Destination directoryの解決とidentity検証をexport helperへ移し、中断通知後も終了しないhelperを猶予時間後に強制終了するよう変更した。非協調helperを使うprocess-level testで、owner processがhard deadline内に終了することを確認した。
 - `payload_unavailable`をdiscriminated unionへ変更し、`pending`と`retryable: true`、それ以外のreasonと`retryable: false`だけをApplication型とCLI型で許可する。CLI projectorはraw responseの矛盾した組を両方向とも拒否する。
 - Node.js 24.18.0で全407 test、SQLite schema validator、typecheck、build、Run CLI process smokeを通した。既定shellのNode.js 22.22.1ではruntime guardが意図どおりfail-fastすることも確認した。
+
+## 2026-07-20: CP2 Session Message control plane
+
+- 初期Message content blockをexact keysの`{ type: "text", text: string }`へ固定し、dense array、10,000 block、UTF-8 4 MiB上限を共有validatorで検証する。normal Run admission、Run terminal、supplemental input、child startの全write siblingを同じ境界へ集約した。
+- `ApplicationSessionMessageOperations`へ`messages`と`messageContentChunk`を追加した。authorization後にSessionからinternal workspace scopeを解決し、Repositoryでworkspace / Session / Messageの組を再検証する。public pageはordinal順のopaque cursor、inline 64 KiB、bounded omissionを持ち、大きい本文とRunOutput / Provider payloadをhydrateしない。
+- `withmate session messages`と`withmate session message-content-chunk`を追加した。CLIはApplication responseを再検証し、chunkのactual bytesから`nextOffset`を確認してbase64へ一度だけ投影する。help / parse failureのruntime非起動、既存exit code、timeout / SIGINT、exactly-once shutdownを維持する。
+- 既存`smoke-cli-run.mjs`を拡張し、実DB上のuser / assistant Message、small-limit cursor、inline / chunked分離、base64長、actual offsetでの本文再構成、wrong scopeの`not_found`、RunOutput非混入、SQLite sidecar cleanupを確認した。
+- public contractは`src/shared/message-content.ts`、`src/shared/application-session-message-model.ts`、対応するtype / testを正本とする。ADR 006とD-006のhydrate分離、cursor、CLI ownershipの判断は変えていないため、新規ADRと設計文書の更新は行わない。
+- Node.js 24.18.0で全435 testとSQLite schema validator、runtime guard、format、module boundary / lint、typecheck、buildを通した。Session CLI、Run / Message CLI、compiled persistenceのprocess smokeもGreenで、SQLite sidecarが残らないことを確認した。
+- Session Message sliceは完了した。CP2全体はSession Run historyと統合Gateが残るため、引き続き進行中とする。

--- a/scripts/smoke-cli-run.mjs
+++ b/scripts/smoke-cli-run.mjs
@@ -18,8 +18,19 @@ const environment = isolatedEnvironment(appDataRoot);
 const databasePath = expectedDatabasePath(appDataRoot);
 const sessionCreateKey = "018f1f4e-7f0a-7000-8000-000000000501";
 const runAdmitKey = "018f1f4e-7f0a-7000-8000-000000000502";
+const wrongScopeSessionCreateKey = "018f1f4e-7f0a-7000-8000-000000000503";
+const interruptedRunAdmitKey = "018f1f4e-7f0a-7000-8000-000000000504";
 const runId = "run-smoke-1";
 const attemptId = "attempt-run-smoke-1";
+const interruptedRunId = "run-smoke-interrupted-1";
+const interruptedAttemptId = "attempt-run-smoke-interrupted-1";
+const interruptedMessageId = "message-run-smoke-interrupted-1";
+const userMessageId = "message-run-smoke-1";
+const assistantMessageId = "message-run-smoke-2";
+const userMessageBlocks = [{ type: "text", text: "observe me" }];
+const assistantMessageText = "a".repeat(70 * 1024);
+const assistantMessageBlocks = [{ type: "text", text: assistantMessageText }];
+const assistantMessageBytes = new TextEncoder().encode(JSON.stringify([{ text: assistantMessageText, type: "text" }]));
 const outputItemId = "output-run-smoke-1";
 const binaryOutputItemId = "output-run-smoke-binary-1";
 const outputSource = '{ "escaped": "\\u3042", "number": 1.0 }\n';
@@ -38,6 +49,12 @@ try {
   const invalid = invoke(["run", "status", "--session-id", "missing-run-id"], environment);
   assert.equal(invalid.status, 20);
   assert.equal(parseJsonOutput(invalid).kind, "usage_failure");
+  const messageHelp = invoke(["session", "messages", "--help"], environment);
+  assert.equal(messageHelp.status, 0);
+  assert.match(messageHelp.stdout, /^Usage: withmate session messages/u);
+  const invalidMessage = invoke(["session", "message-content-chunk", "--session-id", "missing"], environment);
+  assert.equal(invalidMessage.status, 20);
+  assert.equal(parseJsonOutput(invalidMessage).kind, "usage_failure");
   assert.equal(fs.existsSync(path.dirname(databasePath)), false, "Run help or parse failure started persistence");
 
   const created = runJson(
@@ -61,6 +78,27 @@ try {
     0,
   );
   const sessionId = created.applicationResponse.value.sessionId;
+  const wrongScopeCreated = runJson(
+    [
+      "session",
+      "create",
+      "--title",
+      "Wrong scope Session",
+      "--workspace",
+      workspacePath,
+      "--idempotency-key",
+      wrongScopeSessionCreateKey,
+      "--provider",
+      "codex",
+      "--default-character",
+      "character-1",
+      "--max-concurrent-child-runs",
+      "1",
+    ],
+    environment,
+    0,
+  );
+  const wrongScopeSessionId = wrongScopeCreated.applicationResponse.value.sessionId;
   const worker = new PersistenceWorkerClient({ databasePath, legacyDatabasePaths: [] });
   await worker.start();
   try {
@@ -72,7 +110,7 @@ try {
       sessionId,
       workspaceKey,
       idempotencyKey: runAdmitKey,
-      message: { id: "message-run-smoke-1", contentBlocks: [{ type: "text", text: "observe me" }] },
+      message: { id: userMessageId, contentBlocks: userMessageBlocks },
       run: {
         id: runId,
         executionSnapshot: {
@@ -175,24 +213,84 @@ try {
       terminalEvent: { id: "event-run-smoke-terminal", dedupeKey: "run-smoke-terminal" },
       preDispatchResolution: { kind: "not_applicable" },
       outcome: {
-        kind: "interrupted",
-        failureOrigin: "transport",
-        providerErrorCode: "must-not-leak",
-        errorSummary: "Provider dispatch was not started.",
+        kind: "completed",
+        finalAssistantMessage: { id: assistantMessageId, contentBlocks: assistantMessageBlocks },
       },
       outputs: [],
       childResult: null,
     });
     assert.equal(terminal.ok, true);
+
+    const interruptedAdmission = await writes.admitNormalRun({
+      sessionId,
+      workspaceKey,
+      idempotencyKey: interruptedRunAdmitKey,
+      message: { id: interruptedMessageId, contentBlocks: [{ type: "text", text: "interrupt me" }] },
+      run: {
+        id: interruptedRunId,
+        executionSnapshot: {
+          providerId: "codex",
+          model: "smoke-model",
+          reasoning: { effort: "medium" },
+          approval: { mode: "on-request" },
+          sandbox: { mode: "workspace-write" },
+          workspace: { key: workspaceKey },
+          character: null,
+        },
+      },
+      attemptId: interruptedAttemptId,
+      bindingIntent: { kind: "reuse", bindingId: "binding-run-smoke-1" },
+      dispatch: { providerRequest: { prompt: "interrupt me" }, providerIdempotencyKey: null },
+    });
+    assert.equal(interruptedAdmission.ok, true);
+    const interruptedDispatch = await writes.beginRunDispatch({
+      sessionId,
+      workspaceKey,
+      runId: interruptedRunId,
+      attemptId: interruptedAttemptId,
+      bindingId: "binding-run-smoke-1",
+      providerRequest: { prompt: "interrupt me" },
+      ephemeralOwnerToken: null,
+    });
+    assert.equal(interruptedDispatch.ok, true);
+    const interruptedDispatchResolution = await writes.resolveRunDispatch({
+      sessionId,
+      workspaceKey,
+      runId: interruptedRunId,
+      attemptId: interruptedAttemptId,
+      bindingId: "binding-run-smoke-1",
+      ephemeralOwnerToken: null,
+      outcome: { kind: "accepted", externalExecutionId: "execution-run-smoke-interrupted-1" },
+    });
+    assert.equal(interruptedDispatchResolution.ok, true);
+    const interruptedTerminal = await writes.completeRun({
+      sessionId,
+      workspaceKey,
+      runId: interruptedRunId,
+      attemptId: interruptedAttemptId,
+      terminalEvent: {
+        id: "event-run-smoke-interrupted-terminal",
+        dedupeKey: "run-smoke-interrupted-terminal",
+      },
+      preDispatchResolution: { kind: "not_applicable" },
+      outcome: {
+        kind: "interrupted",
+        failureOrigin: "transport",
+        providerErrorCode: "must-not-leak",
+        errorSummary: "Provider dispatch was interrupted.",
+      },
+      outputs: [],
+      childResult: null,
+    });
+    assert.equal(interruptedTerminal.ok, true);
   } finally {
     const shutdown = await worker.shutdown();
     assert.equal(shutdown.checkpoint, "completed");
   }
 
   const status = runJson(["run", "status", "--session-id", sessionId, "--run-id", runId], environment, 0);
-  assert.equal(status.applicationResponse.value.phase, "interrupted");
-  assert.equal(status.applicationResponse.value.failure.origin, "transport");
-  assert.equal(JSON.stringify(status).includes("must-not-leak"), false);
+  assert.equal(status.applicationResponse.value.phase, "completed");
+  assert.equal("failure" in status.applicationResponse.value, false);
 
   const events = runJson(
     ["run", "events", "--session-id", sessionId, "--run-id", runId, "--limit", "10"],
@@ -219,11 +317,27 @@ try {
     0,
   );
   assert.equal(follow.applicationResponse.value.reason, "terminal");
-  assert.equal(follow.applicationResponse.value.status.phase, "interrupted");
+  assert.equal(follow.applicationResponse.value.status.phase, "completed");
   assert.deepEqual(
     follow.applicationResponse.value.events.items.map((event) => event.kind),
     ["run_terminal"],
   );
+
+  const interruptedStatus = runJson(
+    ["run", "status", "--session-id", sessionId, "--run-id", interruptedRunId],
+    environment,
+    0,
+  );
+  assert.equal(interruptedStatus.applicationResponse.value.phase, "interrupted");
+  assert.equal(interruptedStatus.applicationResponse.value.failure.origin, "transport");
+  assert.equal(JSON.stringify(interruptedStatus).includes("must-not-leak"), false);
+  const interruptedFollow = runJson(
+    ["run", "follow", "--session-id", sessionId, "--run-id", interruptedRunId, "--wait-ms", "100", "--poll-ms", "25"],
+    environment,
+    0,
+  );
+  assert.equal(interruptedFollow.applicationResponse.value.status.phase, "interrupted");
+  assert.equal(JSON.stringify(interruptedFollow).includes("must-not-leak"), false);
 
   const outputCounts = runJson(["run", "output-counts", "--session-id", sessionId, "--run-id", runId], environment, 0);
   assert.equal(outputCounts.applicationResponse.value.totalCount, 2);
@@ -282,6 +396,102 @@ try {
     chunkOffset = value.nextOffset;
   }
   assert.deepEqual(Buffer.concat(chunks), Buffer.from(outputBytes));
+
+  const firstMessagePage = runJson(["session", "messages", "--session-id", sessionId, "--limit", "1"], environment, 0);
+  assert.equal(firstMessagePage.applicationResponse.value.items.length, 1);
+  assert.equal(firstMessagePage.applicationResponse.value.items[0].id, userMessageId);
+  assert.equal(firstMessagePage.applicationResponse.value.items[0].ordinal, 1);
+  assert.deepEqual(firstMessagePage.applicationResponse.value.items[0].content, {
+    state: "inline",
+    blocks: userMessageBlocks,
+  });
+  const messageCursor = firstMessagePage.applicationResponse.value.nextCursor;
+  assert.equal(typeof messageCursor, "string");
+  const secondMessagePage = runJson(
+    ["session", "messages", "--session-id", sessionId, "--cursor", messageCursor, "--limit", "1"],
+    environment,
+    0,
+  );
+  assert.equal(secondMessagePage.applicationResponse.value.items.length, 1);
+  assert.equal(secondMessagePage.applicationResponse.value.items[0].id, assistantMessageId);
+  assert.equal(secondMessagePage.applicationResponse.value.items[0].ordinal, 2);
+  assert.equal(secondMessagePage.applicationResponse.value.items[0].content.state, "chunked");
+  assert.equal("blocks" in secondMessagePage.applicationResponse.value.items[0].content, false);
+  assert.equal(
+    secondMessagePage.applicationResponse.value.items[0].contentByteLength,
+    assistantMessageBytes.byteLength,
+  );
+  assert.equal(JSON.stringify(secondMessagePage).includes("provider-output-must-not-leak"), false);
+  assert.equal(JSON.stringify(secondMessagePage).includes("smoke output"), false);
+  assert.equal(JSON.stringify(secondMessagePage).includes(assistantMessageText), false);
+
+  const messageChunks = [];
+  let messageOffset = 0;
+  for (;;) {
+    const messageChunk = runJson(
+      [
+        "session",
+        "message-content-chunk",
+        "--session-id",
+        sessionId,
+        "--message-id",
+        assistantMessageId,
+        "--offset",
+        String(messageOffset),
+        "--max-bytes",
+        String(32 * 1024),
+      ],
+      environment,
+      0,
+    );
+    const value = messageChunk.applicationResponse.value;
+    assert.equal(value.offset, messageOffset);
+    assert.equal(value.chunk.encoding, "base64");
+    const decoded = Buffer.from(value.chunk.data, "base64");
+    assert.equal(decoded.byteLength, value.chunk.byteLength);
+    messageChunks.push(decoded);
+    if (value.eof) break;
+    assert.equal(value.nextOffset, messageOffset + decoded.byteLength);
+    messageOffset = value.nextOffset;
+  }
+  assert.deepEqual(Buffer.concat(messageChunks), Buffer.from(assistantMessageBytes));
+
+  const missingMessage = runJson(
+    [
+      "session",
+      "message-content-chunk",
+      "--session-id",
+      sessionId,
+      "--message-id",
+      "missing-message",
+      "--offset",
+      "0",
+      "--max-bytes",
+      "1",
+    ],
+    environment,
+    22,
+  );
+  assert.equal(missingMessage.applicationResponse.error.code, "not_found");
+  const wrongScopeMessage = runJson(
+    [
+      "session",
+      "message-content-chunk",
+      "--session-id",
+      wrongScopeSessionId,
+      "--message-id",
+      assistantMessageId,
+      "--offset",
+      "0",
+      "--max-bytes",
+      "1",
+    ],
+    environment,
+    22,
+  );
+  assert.equal(wrongScopeMessage.applicationResponse.error.code, "not_found");
+  const wrongSessionMessage = runJson(["session", "messages", "--session-id", "missing-session"], environment, 22);
+  assert.equal(wrongSessionMessage.applicationResponse.error.code, "not_found");
 
   const binaryPreview = runJson(
     ["run", "output-preview", "--session-id", sessionId, "--run-id", runId, "--output-item-id", binaryOutputItemId],
@@ -379,11 +589,14 @@ try {
         "output-preview",
         "output-chunk",
         "output-export",
+        "messages",
+        "message-content-chunk",
       ],
       parseRuntimeIsolation: "verified",
       terminalDrain: "verified",
       providerMetadataProjection: "verified",
       runOutputControlPlane: "verified",
+      sessionMessageControlPlane: "verified",
       exportNoClobber: "verified",
       sqliteSidecars: "none",
     }),

--- a/scripts/validate-module-boundaries.mjs
+++ b/scripts/validate-module-boundaries.mjs
@@ -88,6 +88,7 @@ for (const rule of rules) {
 }
 
 const applicationSessionOwner = path.join(sourceRoot, "main", "application-session-service.ts");
+const applicationSessionMessageOwner = path.join(sourceRoot, "main", "application-session-message-service.ts");
 const applicationRunOwner = path.join(sourceRoot, "main", "application-run-service.ts");
 const applicationRunOutputOwner = path.join(sourceRoot, "main", "application-run-output-service.ts");
 const repositoryWriteClient = path.join(sourceRoot, "main", "repository-write-client.ts");
@@ -95,6 +96,7 @@ const repositoryReadClient = path.join(sourceRoot, "main", "repository-read-clie
 const persistenceWorkerClient = path.join(sourceRoot, "main", "persistence-worker-client.ts");
 const publicMainBarrel = path.join(sourceRoot, "main", "index.ts");
 const publicApplicationModel = path.join(sourceRoot, "shared", "application-service-model.ts");
+const publicApplicationSessionMessageModel = path.join(sourceRoot, "shared", "application-session-message-model.ts");
 const publicApplicationRunModel = path.join(sourceRoot, "shared", "application-run-model.ts");
 const publicApplicationRunOutputModel = path.join(sourceRoot, "shared", "application-run-output-model.ts");
 const rawWriteFixture = path.join(root, "test", "fixtures", "module-boundaries", "raw-persistence-write.ts");
@@ -149,7 +151,10 @@ for (const file of listSourceFiles(sourceRoot)) {
   const source = fs.readFileSync(file, "utf8");
   const sourceFile = typeProgram.getSourceFile(file) ?? ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true);
   const allowsRepositoryReadIntegration =
-    file === applicationSessionOwner || file === applicationRunOwner || file === applicationRunOutputOwner;
+    file === applicationSessionOwner ||
+    file === applicationSessionMessageOwner ||
+    file === applicationRunOwner ||
+    file === applicationRunOutputOwner;
   const allowsRepositoryWriteIntegration = file === applicationSessionOwner;
   const inspect = (node) => {
     if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
@@ -304,7 +309,12 @@ for (const file of listSourceFiles(sourceRoot)) {
   }
 }
 
-for (const file of [applicationSessionOwner, applicationRunOwner, applicationRunOutputOwner]) {
+for (const file of [
+  applicationSessionOwner,
+  applicationSessionMessageOwner,
+  applicationRunOwner,
+  applicationRunOutputOwner,
+]) {
   const source = fs.readFileSync(file, "utf8");
   if (containsRawRepositoryOperationName(source)) {
     violations.push(`${path.relative(root, file)} exposes a raw persistence operation name`);
@@ -322,6 +332,7 @@ for (const file of [applicationSessionOwner, applicationRunOwner, applicationRun
     for (const exportedName of exportedNames) {
       if (
         exportedName !== "ApplicationSessionOperations" &&
+        exportedName !== "ApplicationSessionMessageOperations" &&
         exportedName !== "ApplicationRunOperations" &&
         exportedName !== "ApplicationRunOutputOperations"
       ) {
@@ -332,6 +343,7 @@ for (const file of [applicationSessionOwner, applicationRunOwner, applicationRun
     }
     for (const exported of findExportsDeclaredOutside(sourceFile, [
       publicApplicationModel,
+      publicApplicationSessionMessageModel,
       publicApplicationRunModel,
       publicApplicationRunOutputModel,
     ])) {

--- a/src/cli/application-response.ts
+++ b/src/cli/application-response.ts
@@ -7,6 +7,8 @@ import {
   snapshotLocalRepositoryMetadata,
 } from "../shared/session-metadata.js";
 import { MAX_SESSION_TREE_SIZE } from "../shared/session-limits.js";
+import { APPLICATION_SESSION_MESSAGE_LIMITS } from "../shared/application-session-message-model.js";
+import { snapshotMessageContentBlocks } from "../shared/message-content.js";
 import {
   CLI_EXIT_CODES,
   CLI_SCHEMA_VERSION,
@@ -50,6 +52,8 @@ const operationModes: Readonly<Record<CliSessionOperation, OperationMode>> = {
   repositories: "read",
   read: "read",
   "directories-chunk": "read",
+  messages: "read",
+  "message-content-chunk": "read",
   archive: "write",
   unarchive: "write",
   close: "write",
@@ -266,6 +270,7 @@ function projectApplicationResponse(
     const issues = projectIssues(response.issues);
     const projectedValue = projectOperationValue(command, response.value);
     if (issues.length === 0) malformed();
+    if (isCommandFor(command, "message-content-chunk")) malformed();
     if (isCommandFor(command, "delete")) {
       const deletion = record(projectedValue);
       if (
@@ -280,9 +285,10 @@ function projectApplicationResponse(
       }
     } else if (mode === "read") {
       if (persistence.status !== "read" || issues.some((issue) => issue.kind !== "omission")) malformed();
-      if (isCommandFor(command, "list") || isCommandFor(command, "repositories")) {
+      if (isCommandFor(command, "list") || isCommandFor(command, "repositories") || isCommandFor(command, "messages")) {
         const page = record(projectedValue);
         if (!Array.isArray(page.items) || page.items.length + issues.length > command.limit) malformed();
+        if (isCommandFor(command, "messages")) validateMessagePageOmissions(page.items, issues);
       }
     } else {
       if (
@@ -314,6 +320,16 @@ function projectOperationValue(command: CliValidatedSessionCommand, value: unkno
   if (isCommandFor(command, "read")) return projectReadValue(value, command.sessionId);
   if (isCommandFor(command, "directories-chunk")) {
     return projectDirectoriesChunkValue(value, command.sessionId, command.offset, command.maxBytes);
+  }
+  if (isCommandFor(command, "messages")) return projectMessagesValue(value, command);
+  if (isCommandFor(command, "message-content-chunk")) {
+    return projectMessageContentChunkValue(
+      value,
+      command.sessionId,
+      command.messageId,
+      command.offset,
+      command.maxBytes,
+    );
   }
   if (isCommandFor(command, "archive")) return projectTransitionValue(value, command.sessionId, "archived");
   if (isCommandFor(command, "unarchive")) return projectTransitionValue(value, command.sessionId, "active");
@@ -537,6 +553,115 @@ function projectDirectoriesChunkValue(
   };
 }
 
+function projectMessagesValue(value: unknown, command: CommandFor<"messages">): unknown {
+  const page = exactRecord(value, ["sessionId", "items", "nextCursor"]);
+  const sessionId = boundedString(page.sessionId);
+  const nextCursor = optionalBoundedString(page.nextCursor, CLI_SESSION_LIMITS.maxCursorLength);
+  const rawItems = snapshotDenseArray(page.items, command.limit);
+  if (
+    sessionId !== command.sessionId ||
+    (rawItems.length === 0 && nextCursor !== undefined) ||
+    (nextCursor !== undefined && nextCursor === command.cursor)
+  ) {
+    malformed();
+  }
+  let previousOrdinal = 0;
+  const items = rawItems.map((candidate) => {
+    const item = exactRecord(candidate, ["id", "ordinal", "role", "contentByteLength", "createdAt", "content"]);
+    const id = boundedString(item.id);
+    const ordinal = positiveInteger(item.ordinal);
+    const role = enumValue(item.role, ["user", "assistant"] as const);
+    const contentByteLength = positiveInteger(item.contentByteLength);
+    const createdAt = nonNegativeInteger(item.createdAt);
+    if (
+      ordinal <= previousOrdinal ||
+      contentByteLength < 2 ||
+      contentByteLength > APPLICATION_SESSION_MESSAGE_LIMITS.maxContentBytes
+    ) {
+      malformed();
+    }
+    previousOrdinal = ordinal;
+    const content = exactRecord(item.content, ["state", "blocks"]);
+    const base = { id, ordinal, role, contentByteLength, createdAt } as const;
+    if (content.state === "inline") {
+      if (contentByteLength > APPLICATION_SESSION_MESSAGE_LIMITS.inlineMaxBytes || !Object.hasOwn(content, "blocks")) {
+        malformed();
+      }
+      const blocks = snapshotMessageContentBlocks(content.blocks);
+      if (blocks === undefined || new TextEncoder().encode(JSON.stringify(blocks)).byteLength !== contentByteLength) {
+        malformed();
+      }
+      return { ...base, content: { state: "inline" as const, blocks } };
+    }
+    if (
+      content.state !== "chunked" ||
+      contentByteLength <= APPLICATION_SESSION_MESSAGE_LIMITS.inlineMaxBytes ||
+      Object.hasOwn(content, "blocks")
+    ) {
+      malformed();
+    }
+    return { ...base, content: { state: "chunked" as const } };
+  });
+  return { sessionId, items, ...(nextCursor === undefined ? {} : { nextCursor }) };
+}
+
+function projectMessageContentChunkValue(
+  value: unknown,
+  expectedSessionId: string,
+  expectedMessageId: string,
+  expectedOffset: number,
+  requestedMaxBytes: number,
+): unknown {
+  const valueChunk = exactRecord(value, [
+    "sessionId",
+    "messageId",
+    "offset",
+    "totalBytes",
+    "byteLength",
+    "bytes",
+    "eof",
+    "nextOffset",
+  ]);
+  const sessionId = boundedString(valueChunk.sessionId);
+  const messageId = boundedString(valueChunk.messageId);
+  const offset = nonNegativeInteger(valueChunk.offset);
+  const totalBytes = positiveInteger(valueChunk.totalBytes);
+  const byteLength = nonNegativeInteger(valueChunk.byteLength);
+  const eof = valueChunk.eof;
+  const bytes = valueChunk.bytes;
+  if (typeof eof !== "boolean" || !(bytes instanceof ArrayBuffer)) malformed();
+  const actualByteLength = bytes.byteLength;
+  const endOffset = offset + actualByteLength;
+  const hasNextOffset = Object.hasOwn(valueChunk, "nextOffset");
+  const nextOffset = hasNextOffset ? nonNegativeInteger(valueChunk.nextOffset) : undefined;
+  if (
+    sessionId !== expectedSessionId ||
+    messageId !== expectedMessageId ||
+    offset !== expectedOffset ||
+    byteLength !== actualByteLength ||
+    actualByteLength > requestedMaxBytes ||
+    totalBytes < 2 ||
+    totalBytes > APPLICATION_SESSION_MESSAGE_LIMITS.maxContentBytes ||
+    !Number.isSafeInteger(endOffset) ||
+    (eof ? hasNextOffset : nextOffset !== endOffset) ||
+    (offset < totalBytes
+      ? actualByteLength === 0 || endOffset > totalBytes || eof !== (endOffset === totalBytes)
+      : actualByteLength !== 0 || !eof)
+  ) {
+    malformed();
+  }
+  const data = Buffer.from(bytes).toString("base64");
+  if (Buffer.from(data, "base64").byteLength !== actualByteLength) malformed();
+  const base = {
+    sessionId,
+    messageId,
+    offset,
+    totalBytes,
+    chunk: { encoding: "base64" as const, byteLength: actualByteLength, data },
+  } as const;
+  return eof ? { ...base, eof: true } : { ...base, eof: false, nextOffset: endOffset };
+}
+
 function projectTransitionValue(
   value: unknown,
   expectedSessionId: string,
@@ -727,13 +852,25 @@ function projectIssues(value: unknown): readonly CliApplicationIssue[] {
   return projectIssuesWithLimit(value, CLI_SESSION_LIMITS.listMaxItems);
 }
 
+function validateMessagePageOmissions(items: readonly unknown[], issues: readonly CliApplicationIssue[]): void {
+  const itemOrdinals = new Set<number>();
+  for (const candidate of items) itemOrdinals.add(positiveInteger(record(candidate).ordinal));
+  let previousOmissionOrdinal = 0;
+  for (const issue of issues) {
+    if (issue.kind !== "omission") malformed();
+    if (issue.ordinal === undefined) continue;
+    if (issue.ordinal <= previousOmissionOrdinal || itemOrdinals.has(issue.ordinal)) malformed();
+    previousOmissionOrdinal = issue.ordinal;
+  }
+}
+
 function projectIssuesWithLimit(value: unknown, maxIssues: number): readonly CliApplicationIssue[] {
   return snapshotDenseArray(value, maxIssues).map((candidate) => {
     const issue = record(candidate);
     if (issue.kind === "omission") {
       if (issue.code !== "response_size_limit") malformed();
       const message = boundedString(issue.message, 8_192);
-      const ordinal = issue.ordinal === undefined ? undefined : nonNegativeInteger(issue.ordinal);
+      const ordinal = issue.ordinal === undefined ? undefined : positiveInteger(issue.ordinal);
       return ordinal === undefined
         ? { kind: "omission", code: "response_size_limit", message }
         : { kind: "omission", code: "response_size_limit", message, ordinal };
@@ -790,14 +927,18 @@ function projectRunOutputPublication(value: unknown): CliRunOutputPublication {
 
 function snapshotDenseArray(value: unknown, maxLength: number): readonly unknown[] {
   if (!Array.isArray(value)) malformed();
+  if (Object.getPrototypeOf(value) !== Array.prototype) malformed();
   const length = value.length;
   if (length > maxLength) malformed();
+  const allowedKeys = new Set(["length", ...Array.from({ length }, (_unused, index) => String(index))]);
+  if (Reflect.ownKeys(value).some((key) => typeof key !== "string" || !allowedKeys.has(key))) malformed();
   const snapshot: unknown[] = [];
   for (let index = 0; index < length; index += 1) {
-    if (value.length !== length || !Object.hasOwn(value, index)) malformed();
-    const item = value[index];
-    if (value.length !== length) malformed();
-    snapshot.push(item);
+    const descriptor = Object.getOwnPropertyDescriptor(value, index);
+    if (descriptor === undefined || !descriptor.enumerable || !("value" in descriptor) || value.length !== length) {
+      malformed();
+    }
+    snapshot.push(descriptor.value);
   }
   return snapshot;
 }
@@ -870,7 +1011,22 @@ function runtimeProjectionFailure(command: CliCommandIdentity): CliRuntimeFailur
 
 function record(value: unknown): Readonly<Record<string, unknown>> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) malformed();
-  return value as Readonly<Record<string, unknown>>;
+  const prototype = Object.getPrototypeOf(value) as unknown;
+  if (prototype !== Object.prototype && prototype !== null) malformed();
+  const entries: [string, unknown][] = [];
+  for (const key of Reflect.ownKeys(value)) {
+    if (typeof key !== "string") malformed();
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (descriptor === undefined || !descriptor.enumerable || !("value" in descriptor)) malformed();
+    entries.push([key, descriptor.value]);
+  }
+  return Object.fromEntries(entries);
+}
+
+function exactRecord(value: unknown, allowedKeys: readonly string[]): Readonly<Record<string, unknown>> {
+  const projected = record(value);
+  if (Object.keys(projected).some((key) => !allowedKeys.includes(key))) malformed();
+  return projected;
 }
 
 function boundedString(value: unknown, maxLength: number = CLI_SESSION_LIMITS.maxIdentifierLength): string {

--- a/src/cli/contract.ts
+++ b/src/cli/contract.ts
@@ -4,6 +4,8 @@ import {
   APPLICATION_RUN_OUTPUT_CATEGORIES,
   APPLICATION_RUN_OUTPUT_LIMITS,
 } from "../shared/application-run-output-model.js";
+import { APPLICATION_SESSION_MESSAGE_LIMITS } from "../shared/application-session-message-model.js";
+import type { TextContentBlock } from "../shared/message-content.js";
 import { SESSION_METADATA_LIMITS, type LocalRepositoryMetadata } from "../shared/session-metadata.js";
 
 export const CLI_SCHEMA_VERSION = "withmate-cli-v1" as const;
@@ -55,6 +57,12 @@ export const CLI_RUN_LIMITS = {
 
 export const CLI_RUN_OUTPUT_CATEGORIES = APPLICATION_RUN_OUTPUT_CATEGORIES;
 
+export const CLI_SESSION_MESSAGE_LIMITS = {
+  messagesDefaultItems: APPLICATION_SESSION_MESSAGE_LIMITS.messagesDefaultItems,
+  messagesMaxItems: APPLICATION_SESSION_MESSAGE_LIMITS.messagesMaxItems,
+  chunkMaxBytes: APPLICATION_SESSION_MESSAGE_LIMITS.chunkMaxBytes,
+} as const;
+
 export type CliExitCode = (typeof CLI_EXIT_CODES)[keyof typeof CLI_EXIT_CODES];
 
 export type CliSessionOperation =
@@ -64,6 +72,8 @@ export type CliSessionOperation =
   | "repositories"
   | "read"
   | "directories-chunk"
+  | "messages"
+  | "message-content-chunk"
   | "archive"
   | "unarchive"
   | "close"
@@ -129,6 +139,23 @@ export type CliSessionDirectoriesChunkCommand = CliTimeoutOption &
   Readonly<{
     identity: CliCommandIdentity<"directories-chunk">;
     sessionId: string;
+    offset: number;
+    maxBytes: number;
+  }>;
+
+export type CliSessionMessagesCommand = CliTimeoutOption &
+  Readonly<{
+    identity: CliCommandIdentity<"messages">;
+    sessionId: string;
+    cursor?: string;
+    limit: number;
+  }>;
+
+export type CliSessionMessageContentChunkCommand = CliTimeoutOption &
+  Readonly<{
+    identity: CliCommandIdentity<"message-content-chunk">;
+    sessionId: string;
+    messageId: string;
     offset: number;
     maxBytes: number;
   }>;
@@ -214,6 +241,8 @@ export type CliValidatedSessionCommand =
   | CliLocalRepositoriesCommand
   | CliSessionReadCommand
   | CliSessionDirectoriesChunkCommand
+  | CliSessionMessagesCommand
+  | CliSessionMessageContentChunkCommand
   | CliSessionWriteCommand<"archive">
   | CliSessionWriteCommand<"unarchive">
   | CliSessionCloseCommand
@@ -569,6 +598,37 @@ export type CliSessionDirectoriesChunkValue = Readonly<{
   }>;
 }>;
 
+type CliSessionMessageItemBase = Readonly<{
+  id: string;
+  ordinal: number;
+  role: "user" | "assistant";
+  contentByteLength: number;
+  createdAt: number;
+}>;
+
+export type CliSessionMessageItem = CliSessionMessageItemBase &
+  (
+    | Readonly<{ content: Readonly<{ state: "inline"; blocks: readonly TextContentBlock[] }> }>
+    | Readonly<{ content: Readonly<{ state: "chunked"; blocks?: never }> }>
+  );
+
+export type CliSessionMessagesValue = Readonly<{
+  sessionId: string;
+  items: readonly CliSessionMessageItem[];
+  nextCursor?: string;
+}>;
+
+type CliSessionMessageContentChunkBase = Readonly<{
+  sessionId: string;
+  messageId: string;
+  offset: number;
+  totalBytes: number;
+  chunk: Readonly<{ encoding: "base64"; byteLength: number; data: string }>;
+}>;
+
+export type CliSessionMessageContentChunkValue = CliSessionMessageContentChunkBase &
+  (Readonly<{ eof: true; nextOffset?: never }> | Readonly<{ eof: false; nextOffset: number }>);
+
 export type CliSessionTransitionValue<TLifecycleStatus extends "active" | "archived" | "closed"> = Readonly<{
   sessionId: string;
   lifecycleStatus: TLifecycleStatus;
@@ -903,6 +963,8 @@ type CliOperationContract = {
   repositories: Readonly<{ mode: "read"; value: CliLocalRepositoryListValue }>;
   read: Readonly<{ mode: "read"; value: CliSessionReadValue }>;
   "directories-chunk": Readonly<{ mode: "read"; value: CliSessionDirectoriesChunkValue }>;
+  messages: Readonly<{ mode: "read"; value: CliSessionMessagesValue }>;
+  "message-content-chunk": Readonly<{ mode: "read"; value: CliSessionMessageContentChunkValue }>;
   archive: Readonly<{ mode: "write"; value: CliSessionTransitionValue<"archived"> }>;
   unarchive: Readonly<{ mode: "write"; value: CliSessionTransitionValue<"active"> }>;
   close: Readonly<{ mode: "write"; value: CliSessionTransitionValue<"closed"> }>;
@@ -911,7 +973,12 @@ type CliOperationContract = {
 
 type CliOperationApplicationResponse<TOperation extends CliSessionOperation> = TOperation extends "delete"
   ? CliSessionDeleteResponse
-  : CliApplicationResponse<CliOperationContract[TOperation]["value"], CliOperationContract[TOperation]["mode"]>;
+  : TOperation extends "message-content-chunk"
+    ? Exclude<
+        CliApplicationResponse<CliOperationContract[TOperation]["value"], "read">,
+        Readonly<{ overallStatus: "partial_success" }>
+      >
+    : CliApplicationResponse<CliOperationContract[TOperation]["value"], CliOperationContract[TOperation]["mode"]>;
 
 export type CliOperationOutput<TOperation extends CliSessionOperation = CliSessionOperation> = {
   [TCurrent in TOperation]: Readonly<{

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -24,6 +24,9 @@ Operations:
   repositories         List local Repositories registered by Sessions
   read                 Read a Session by Session ID
   directories-chunk    Read a bounded chunk of additional-directory configuration
+  messages             Read a bounded Message timeline page
+  message-content-chunk
+                       Read a bounded raw Message content chunk
   archive              Archive a Session
   unarchive            Unarchive a Session
   close                Close an active or archived Session
@@ -108,6 +111,29 @@ Optional options:
 
 Required options:
   --session-id <session-id>
+  --offset <non-negative-integer>
+  --max-bytes <1..262144>
+
+Optional options:
+  --timeout-ms <1..2147483647>
+  -h, --help
+`,
+  messages: `Usage: withmate session messages [options]
+
+Required options:
+  --session-id <session-id>
+
+Optional options:
+  --cursor <opaque-cursor>
+  --limit <1..100>    Default: 50
+  --timeout-ms <1..2147483647>
+  -h, --help
+`,
+  "message-content-chunk": `Usage: withmate session message-content-chunk [options]
+
+Required options:
+  --session-id <session-id>
+  --message-id <message-id>
   --offset <non-negative-integer>
   --max-bytes <1..262144>
 

--- a/src/cli/invocation.ts
+++ b/src/cli/invocation.ts
@@ -1,4 +1,4 @@
-import type { ApplicationSessionOperations } from "../main/index.js";
+import type { ApplicationSessionMessageOperations, ApplicationSessionOperations } from "../main/index.js";
 import { serializeCliStructuredOutput } from "./application-response.js";
 import { CLI_EXIT_CODES, type CliExitCode, type CliParseResult, type CliValidatedSessionCommand } from "./contract.js";
 import { helpText } from "./help.js";
@@ -14,6 +14,7 @@ export type CliInvocationResult = Readonly<{
 export type CliInvocationDependencies<TAuthorizationContext> = Readonly<{
   version: string;
   operations: ApplicationSessionOperations<TAuthorizationContext>;
+  messageOperations: ApplicationSessionMessageOperations<TAuthorizationContext>;
   authorization: TAuthorizationContext;
   signal?: AbortSignal;
 }>;

--- a/src/cli/lifecycle.ts
+++ b/src/cli/lifecycle.ts
@@ -1,6 +1,7 @@
 import type {
   ApplicationRunOperations,
   ApplicationRunOutputOperations,
+  ApplicationSessionMessageOperations,
   ApplicationSessionOperations,
 } from "../main/index.js";
 import { serializeCliStructuredOutput } from "./application-response.js";
@@ -24,6 +25,7 @@ export type CliLifecycleControl = Readonly<{ timeoutMs?: number; signal?: AbortS
 
 export type CliOperationRuntime<TAuthorizationContext> = Readonly<{
   operations: ApplicationSessionOperations<TAuthorizationContext>;
+  messageOperations: ApplicationSessionMessageOperations<TAuthorizationContext>;
   runOperations: ApplicationRunOperations<TAuthorizationContext>;
   runOutputOperations: ApplicationRunOutputOperations<TAuthorizationContext>;
   authorization: TAuthorizationContext;
@@ -86,6 +88,7 @@ export async function runCliLifecycle<TAuthorizationContext>(
       parsed.command.identity.namespace === "session"
         ? dispatchCliSessionCommand(parsed.command as CliValidatedSessionCommand, {
             operations: runtime.operations,
+            messageOperations: runtime.messageOperations,
             authorization: runtime.authorization,
             signal: abortController.signal,
             ...operationControl,

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -11,6 +11,7 @@ import {
   CLI_RUN_OUTPUT_CATEGORIES,
   CLI_SCHEMA_VERSION,
   CLI_SESSION_LIMITS,
+  CLI_SESSION_MESSAGE_LIMITS,
   type CliCommandIdentity,
   type CliParseResult,
   type CliRunOperation,
@@ -43,6 +44,8 @@ const sessionOperations = new Set<CliSessionOperation>([
   "repositories",
   "read",
   "directories-chunk",
+  "messages",
+  "message-content-chunk",
   "archive",
   "unarchive",
   "close",
@@ -124,6 +127,10 @@ function parseSessionCommand(
       return parseRead(identity as CliCommandIdentity<"read">, argv);
     case "directories-chunk":
       return parseDirectoriesChunk(identity as CliCommandIdentity<"directories-chunk">, argv);
+    case "messages":
+      return parseMessages(identity as CliCommandIdentity<"messages">, argv);
+    case "message-content-chunk":
+      return parseMessageContentChunk(identity as CliCommandIdentity<"message-content-chunk">, argv);
     case "archive":
       return parseWrite(identity as CliCommandIdentity<"archive">, argv);
     case "unarchive":
@@ -466,6 +473,51 @@ function parseDirectoriesChunk(
     command: {
       identity,
       sessionId: parsed.values["--session-id"] as string,
+      offset: parsed.values["--offset"] as number,
+      maxBytes: parsed.values["--max-bytes"] as number,
+      ...optionalTimeout(parsed.values),
+    },
+  };
+}
+
+function parseMessages(identity: CliCommandIdentity<"messages">, argv: readonly string[]): CliParseResult {
+  const parsed = parseOptions(identity, argv, {
+    "--session-id": requiredOption(parseIdentifier),
+    "--cursor": option((value) => parseBoundedString(value, CLI_SESSION_LIMITS.maxCursorLength)),
+    "--limit": option((value) => parseInteger(value, 1, CLI_SESSION_MESSAGE_LIMITS.messagesMaxItems)),
+    ...timeoutOption,
+  });
+  if (!parsed.ok) return parsed.result;
+  return {
+    kind: "command",
+    command: {
+      identity,
+      sessionId: parsed.values["--session-id"] as string,
+      ...(parsed.values["--cursor"] === undefined ? {} : { cursor: parsed.values["--cursor"] as string }),
+      limit: (parsed.values["--limit"] as number | undefined) ?? CLI_SESSION_MESSAGE_LIMITS.messagesDefaultItems,
+      ...optionalTimeout(parsed.values),
+    },
+  };
+}
+
+function parseMessageContentChunk(
+  identity: CliCommandIdentity<"message-content-chunk">,
+  argv: readonly string[],
+): CliParseResult {
+  const parsed = parseOptions(identity, argv, {
+    "--session-id": requiredOption(parseIdentifier),
+    "--message-id": requiredOption(parseIdentifier),
+    "--offset": requiredOption((value) => parseInteger(value, 0, Number.MAX_SAFE_INTEGER)),
+    "--max-bytes": requiredOption((value) => parseInteger(value, 1, CLI_SESSION_MESSAGE_LIMITS.chunkMaxBytes)),
+    ...timeoutOption,
+  });
+  if (!parsed.ok) return parsed.result;
+  return {
+    kind: "command",
+    command: {
+      identity,
+      sessionId: parsed.values["--session-id"] as string,
+      messageId: parsed.values["--message-id"] as string,
       offset: parsed.values["--offset"] as number,
       maxBytes: parsed.values["--max-bytes"] as number,
       ...optionalTimeout(parsed.values),

--- a/src/cli/session-dispatch.ts
+++ b/src/cli/session-dispatch.ts
@@ -1,4 +1,4 @@
-import type { ApplicationSessionOperations } from "../main/index.js";
+import type { ApplicationSessionMessageOperations, ApplicationSessionOperations } from "../main/index.js";
 import { projectCliOperationOutput, type CliOperationProjectionResult } from "./application-response.js";
 import {
   CLI_EXIT_CODES,
@@ -16,6 +16,7 @@ type CommandFor<TOperation extends CliSessionOperation> = Extract<
 
 export type CliSessionDispatchDependencies<TAuthorizationContext> = Readonly<{
   operations: ApplicationSessionOperations<TAuthorizationContext>;
+  messageOperations: ApplicationSessionMessageOperations<TAuthorizationContext>;
   authorization: TAuthorizationContext;
   signal?: AbortSignal;
   timeoutMs?: number;
@@ -92,6 +93,27 @@ export async function dispatchCliSessionCommand<TAuthorizationContext>(
     } else if (isCommandFor(command, "directories-chunk")) {
       response = await dependencies.operations.readDirectoriesChunk(
         { context, sessionId: command.sessionId, offset: command.offset, maxBytes: command.maxBytes },
+        options,
+      );
+    } else if (isCommandFor(command, "messages")) {
+      response = await dependencies.messageOperations.messages(
+        {
+          context,
+          sessionId: command.sessionId,
+          ...(command.cursor === undefined ? {} : { cursor: command.cursor }),
+          limit: command.limit,
+        },
+        options,
+      );
+    } else if (isCommandFor(command, "message-content-chunk")) {
+      response = await dependencies.messageOperations.messageContentChunk(
+        {
+          context,
+          sessionId: command.sessionId,
+          messageId: command.messageId,
+          offset: command.offset,
+          maxBytes: command.maxBytes,
+        },
         options,
       );
     } else if (isCommandFor(command, "archive")) {

--- a/src/main/application-session-message-service.ts
+++ b/src/main/application-session-message-service.ts
@@ -1,0 +1,828 @@
+import {
+  APPLICATION_SESSION_MESSAGE_LIMITS,
+  type ApplicationSessionMessageAccessValidationInput,
+  type ApplicationSessionMessageAccessValidator,
+  type ApplicationSessionMessageContentChunk,
+  type ApplicationSessionMessageContentChunkRequest,
+  type ApplicationSessionMessageItem,
+  type ApplicationSessionMessageOperation,
+  type ApplicationSessionMessageOperations,
+  type ApplicationSessionMessagePage,
+  type ApplicationSessionMessagesRequest,
+} from "../shared/application-session-message-model.js";
+import type {
+  ApplicationAccessDecision,
+  ApplicationOperationOptions,
+  ApplicationOperationResponse,
+} from "../shared/application-service-model.js";
+import { snapshotMessageContentBlocks } from "../shared/message-content.js";
+import type { PersistenceError } from "../shared/persistence-protocol.js";
+import { PersistenceClientError } from "./persistence-worker-client.js";
+import type { PersistenceWorkerClient } from "./persistence-worker-client.js";
+import { RepositoryReadClient } from "./repository-read-client.js";
+
+type SessionMessageReadPort = Pick<RepositoryReadClient, "sessionGet" | "messagesPage" | "messageContentChunk">;
+
+type ApplicationSessionMessageFailureResponse = Extract<
+  ApplicationOperationResponse<never, "read">,
+  Readonly<{ overallStatus: "failure" }>
+>;
+
+type PreparedOperation<TValue> =
+  | Readonly<{ ok: true; input: TValue; control: OperationControl }>
+  | Readonly<{ ok: false; response: ApplicationSessionMessageFailureResponse }>;
+
+type OperationControl = {
+  readonly deadlineAt?: number;
+  readonly signal?: AbortSignal;
+  persistenceStarted: boolean;
+};
+
+type OperationInterruption = "timeout" | "canceled";
+
+type ControlledSettlement<TValue> =
+  | Readonly<{ status: "fulfilled"; value: TValue }>
+  | Readonly<{ status: "rejected"; error: unknown }>
+  | Readonly<{ status: "interrupted"; interruption: OperationInterruption }>;
+
+type OperationResolution<TValue> =
+  Readonly<{ ok: true; value: TValue }> | Readonly<{ ok: false; response: ApplicationSessionMessageFailureResponse }>;
+
+type SessionMessageScope = Readonly<{ sessionId: string; workspaceKey: string }>;
+
+type MessageOmissionIssue = Readonly<{
+  kind: "omission";
+  code: "response_size_limit";
+  message: string;
+  ordinal?: number;
+}>;
+
+type ProjectedMessagePage = Readonly<{
+  value: ApplicationSessionMessagePage;
+  issues: readonly MessageOmissionIssue[];
+}>;
+
+const MESSAGE_ITEM_PROJECTION_KEYS = [
+  "omitted",
+  "reason",
+  "id",
+  "sessionId",
+  "ordinal",
+  "role",
+  "contentByteLength",
+  "contentState",
+  "contentBlocks",
+  "createdAt",
+] as const;
+
+const MESSAGE_VALUE_KEYS = [
+  "id",
+  "sessionId",
+  "role",
+  "contentByteLength",
+  "contentState",
+  "contentBlocks",
+  "createdAt",
+] as const;
+
+export type ApplicationSessionMessageServiceOptions<TAuthorizationContext> = Readonly<{
+  reads: SessionMessageReadPort;
+  access: ApplicationSessionMessageAccessValidator<TAuthorizationContext>;
+  snapshotAuthorization(value: unknown): TAuthorizationContext;
+}>;
+
+export function createApplicationSessionMessageOperations<TAuthorizationContext>(
+  worker: PersistenceWorkerClient,
+  options: Omit<ApplicationSessionMessageServiceOptions<TAuthorizationContext>, "reads">,
+): ApplicationSessionMessageOperations<TAuthorizationContext> {
+  return new ApplicationSessionMessageService({ reads: new RepositoryReadClient(worker), ...options });
+}
+
+export class ApplicationSessionMessageService<
+  TAuthorizationContext,
+> implements ApplicationSessionMessageOperations<TAuthorizationContext> {
+  readonly #reads: SessionMessageReadPort;
+  readonly #access: ApplicationSessionMessageAccessValidator<TAuthorizationContext>;
+  readonly #snapshotAuthorization: (value: unknown) => TAuthorizationContext;
+
+  constructor(options: ApplicationSessionMessageServiceOptions<TAuthorizationContext>) {
+    this.#reads = options.reads;
+    this.#access = options.access;
+    this.#snapshotAuthorization = options.snapshotAuthorization;
+  }
+
+  async messages(
+    request: ApplicationSessionMessagesRequest<TAuthorizationContext>,
+    options?: ApplicationOperationOptions,
+  ): Promise<ApplicationOperationResponse<ApplicationSessionMessagePage, "read">> {
+    const prepared = prepareOperation(options, () => decodeMessagesRequest(request, this.#snapshotAuthorization));
+    if (!prepared.ok) return prepared.response;
+    const scope = await this.#authorizeAndResolveScope("messages", prepared.input, prepared.control);
+    if (!scope.ok) return scope.response;
+    const limit = prepared.input.limit ?? APPLICATION_SESSION_MESSAGE_LIMITS.messagesDefaultItems;
+    const page = await readRepository(prepared.control, (repositoryOptions) =>
+      this.#reads.messagesPage(
+        {
+          ...scope.value,
+          ...(prepared.input.cursor === undefined ? {} : { cursor: prepared.input.cursor }),
+          limit,
+        },
+        repositoryOptions,
+      ),
+    );
+    if (!page.ok) return page.response;
+    const projected = projectOperationValue(prepared.control, () =>
+      projectMessagePage(page.value, scope.value, prepared.input.cursor, limit),
+    );
+    return projected.ok
+      ? readOutcome(prepared.control, projected.value.value, projected.value.issues)
+      : projected.response;
+  }
+
+  async messageContentChunk(
+    request: ApplicationSessionMessageContentChunkRequest<TAuthorizationContext>,
+    options?: ApplicationOperationOptions,
+  ): Promise<ApplicationOperationResponse<ApplicationSessionMessageContentChunk, "read">> {
+    const prepared = prepareOperation(options, () => decodeChunkRequest(request, this.#snapshotAuthorization));
+    if (!prepared.ok) return prepared.response;
+    const scope = await this.#authorizeAndResolveScope("message_content_chunk", prepared.input, prepared.control);
+    if (!scope.ok) return scope.response;
+    const chunk = await readRepository(prepared.control, (repositoryOptions) =>
+      this.#reads.messageContentChunk(
+        {
+          ...scope.value,
+          messageId: prepared.input.messageId,
+          offset: prepared.input.offset,
+          maxBytes: prepared.input.maxBytes,
+        },
+        repositoryOptions,
+      ),
+    );
+    if (!chunk.ok) return chunk.response;
+    const projected = projectOperationValue(prepared.control, () =>
+      projectMessageContentChunk(
+        chunk.value,
+        scope.value,
+        prepared.input.messageId,
+        prepared.input.offset,
+        prepared.input.maxBytes,
+      ),
+    );
+    return projected.ok ? readSuccess(prepared.control, projected.value) : projected.response;
+  }
+
+  async #authorizeAndResolveScope(
+    operation: ApplicationSessionMessageOperation,
+    input:
+      | ApplicationSessionMessagesRequest<TAuthorizationContext>
+      | ApplicationSessionMessageContentChunkRequest<TAuthorizationContext>,
+    control: OperationControl,
+  ): Promise<OperationResolution<SessionMessageScope>> {
+    const authorizationInput = {
+      operation,
+      access: "read",
+      context: input.context,
+      target:
+        operation === "messages"
+          ? { kind: "session_messages", sessionId: input.sessionId }
+          : {
+              kind: "session_message_content",
+              sessionId: input.sessionId,
+              messageId: (input as ApplicationSessionMessageContentChunkRequest<TAuthorizationContext>).messageId,
+              offset: (input as ApplicationSessionMessageContentChunkRequest<TAuthorizationContext>).offset,
+              maxBytes: (input as ApplicationSessionMessageContentChunkRequest<TAuthorizationContext>).maxBytes,
+            },
+    } as ApplicationSessionMessageAccessValidationInput<TAuthorizationContext>;
+    const authorization = await runControlled(control, () => this.#access.authorize(authorizationInput));
+    if (authorization.status === "interrupted") {
+      return { ok: false, response: operationInterruptionFailure(authorization.interruption) };
+    }
+    if (authorization.status === "rejected") return { ok: false, response: prePersistenceApplicationFailure() };
+    const decision = projectOperationValue(control, () => projectAccessDecision(authorization.value));
+    if (!decision.ok) return decision;
+    if (!decision.value.allowed) return { ok: false, response: accessFailure(decision.value.error) };
+
+    const session = await readRepository(control, (repositoryOptions) =>
+      this.#reads.sessionGet({ sessionId: input.sessionId }, repositoryOptions),
+    );
+    if (!session.ok) return session;
+    return projectOperationValue(control, () => {
+      const projected = projectionRecord(session.value, ["session"]);
+      const projectedSession = projectionRecord(projected.session, ["id", "workspaceKey"]);
+      const sessionId = boundedString(projectedSession.id);
+      const workspaceKey = boundedString(projectedSession.workspaceKey);
+      if (sessionId !== input.sessionId) throw new TypeError("Session scope mismatch.");
+      return { sessionId, workspaceKey };
+    });
+  }
+}
+
+function decodeMessagesRequest<TAuthorizationContext>(
+  value: unknown,
+  snapshotAuthorization: (value: unknown) => TAuthorizationContext,
+): ApplicationSessionMessagesRequest<TAuthorizationContext> {
+  const request = requestRecord(value, ["context", "sessionId", "cursor", "limit"]);
+  const cursor = optionalBoundedString(request.cursor, APPLICATION_SESSION_MESSAGE_LIMITS.maxCursorLength);
+  const limit = optionalInteger(request.limit, 1, APPLICATION_SESSION_MESSAGE_LIMITS.messagesMaxItems);
+  return {
+    ...decodeContextAndSession(request, snapshotAuthorization),
+    ...(cursor === undefined ? {} : { cursor }),
+    ...(limit === undefined ? {} : { limit }),
+  };
+}
+
+function decodeChunkRequest<TAuthorizationContext>(
+  value: unknown,
+  snapshotAuthorization: (value: unknown) => TAuthorizationContext,
+): ApplicationSessionMessageContentChunkRequest<TAuthorizationContext> {
+  const request = requestRecord(value, ["context", "sessionId", "messageId", "offset", "maxBytes"]);
+  return {
+    ...decodeContextAndSession(request, snapshotAuthorization),
+    messageId: boundedString(request.messageId),
+    offset: integer(request.offset, 0, Number.MAX_SAFE_INTEGER),
+    maxBytes: integer(request.maxBytes, 1, APPLICATION_SESSION_MESSAGE_LIMITS.chunkMaxBytes),
+  };
+}
+
+function decodeContextAndSession<TAuthorizationContext>(
+  request: Readonly<Record<string, unknown>>,
+  snapshotAuthorization: (value: unknown) => TAuthorizationContext,
+): Readonly<{
+  context: Readonly<{ authorization: TAuthorizationContext }>;
+  sessionId: string;
+}> {
+  const context = requestRecord(request.context, ["authorization"]);
+  return {
+    context: { authorization: snapshotAuthorization(context.authorization) },
+    sessionId: boundedString(request.sessionId),
+  };
+}
+
+function projectMessagePage(
+  value: unknown,
+  expected: SessionMessageScope,
+  inputCursor: string | undefined,
+  limit: number,
+): ProjectedMessagePage {
+  const page = projectionRecord(value, ["sessionId", "workspaceKey", "items", "nextCursor"]);
+  assertScope(page, expected);
+  if (!isDenseArray(page.items, limit)) throw new TypeError("Message page is invalid.");
+  const nextCursor = optionalBoundedString(page.nextCursor, APPLICATION_SESSION_MESSAGE_LIMITS.maxCursorLength);
+  if (page.items.length === 0 && nextCursor !== undefined) throw new TypeError("Empty Message page has a cursor.");
+  if (nextCursor !== undefined && nextCursor === inputCursor) throw new TypeError("Message cursor did not advance.");
+
+  const items: ApplicationSessionMessageItem[] = [];
+  const issues: MessageOmissionIssue[] = [];
+  let previousOrdinal = 0;
+  for (const rawValue of page.items) {
+    const rawItem = plainRecord(rawValue);
+    const item = projectionRecord(rawItem, MESSAGE_ITEM_PROJECTION_KEYS);
+    const ordinal = optionalInteger(item.ordinal, 1, Number.MAX_SAFE_INTEGER);
+    if (ordinal !== undefined && ordinal <= previousOrdinal) throw new TypeError("Message ordinals are invalid.");
+    if (ordinal !== undefined) previousOrdinal = ordinal;
+    if (item.omitted === true) {
+      if (item.reason !== "response_size_limit" || MESSAGE_VALUE_KEYS.some((key) => Object.hasOwn(rawItem, key))) {
+        throw new TypeError("Message omission is invalid.");
+      }
+      issues.push({
+        kind: "omission",
+        code: "response_size_limit",
+        message: "Message was omitted because the response size limit was reached.",
+        ...(ordinal === undefined ? {} : { ordinal }),
+      });
+      continue;
+    }
+    if (item.omitted !== undefined || item.reason !== undefined || ordinal === undefined) {
+      throw new TypeError("Message item is invalid.");
+    }
+    items.push(projectMessageItem(rawItem, item, expected, ordinal));
+  }
+  return {
+    value: {
+      sessionId: expected.sessionId,
+      items,
+      ...(nextCursor === undefined ? {} : { nextCursor }),
+    },
+    issues,
+  };
+}
+
+function projectMessageItem(
+  rawItem: Readonly<Record<string, unknown>>,
+  item: Readonly<Record<string, unknown>>,
+  expected: SessionMessageScope,
+  ordinal: number,
+): ApplicationSessionMessageItem {
+  const id = boundedString(item.id);
+  if (boundedString(item.sessionId) !== expected.sessionId) throw new TypeError("Message identity mismatch.");
+  const role = enumString(item.role, ["user", "assistant"] as const);
+  const contentByteLength = integer(item.contentByteLength, 2, APPLICATION_SESSION_MESSAGE_LIMITS.maxContentBytes);
+  const createdAt = integer(item.createdAt, 0, Number.MAX_SAFE_INTEGER);
+  const base = { id, ordinal, role, contentByteLength, createdAt } as const;
+  if (item.contentState === "inline") {
+    if (
+      contentByteLength > APPLICATION_SESSION_MESSAGE_LIMITS.inlineMaxBytes ||
+      !Object.hasOwn(rawItem, "contentBlocks")
+    ) {
+      throw new TypeError("Inline Message content is invalid.");
+    }
+    const blocks = snapshotMessageContentBlocks(item.contentBlocks);
+    if (blocks === undefined) throw new TypeError("Inline Message content blocks are invalid.");
+    if (new TextEncoder().encode(JSON.stringify(blocks)).byteLength !== contentByteLength) {
+      throw new TypeError("Inline Message content byte length is invalid.");
+    }
+    return { ...base, content: { state: "inline", blocks } };
+  }
+  if (
+    item.contentState !== "chunked" ||
+    contentByteLength <= APPLICATION_SESSION_MESSAGE_LIMITS.inlineMaxBytes ||
+    Object.hasOwn(rawItem, "contentBlocks")
+  ) {
+    throw new TypeError("Chunked Message content is invalid.");
+  }
+  return { ...base, content: { state: "chunked" } };
+}
+
+function projectMessageContentChunk(
+  value: unknown,
+  expected: SessionMessageScope,
+  expectedMessageId: string,
+  expectedOffset: number,
+  requestedMaxBytes: number,
+): ApplicationSessionMessageContentChunk {
+  const chunk = projectionRecord(value, ["sessionId", "messageId", "offset", "totalBytes", "eof", "bytes"]);
+  if (boundedString(chunk.sessionId) !== expected.sessionId || boundedString(chunk.messageId) !== expectedMessageId) {
+    throw new TypeError("Message content chunk scope mismatch.");
+  }
+  const offset = integer(chunk.offset, 0, Number.MAX_SAFE_INTEGER);
+  const totalBytes = integer(chunk.totalBytes, 2, APPLICATION_SESSION_MESSAGE_LIMITS.maxContentBytes);
+  if (offset !== expectedOffset || !(chunk.bytes instanceof ArrayBuffer) || typeof chunk.eof !== "boolean") {
+    throw new TypeError("Message content chunk is invalid.");
+  }
+  const byteLength = chunk.bytes.byteLength;
+  const endOffset = offset + byteLength;
+  if (
+    byteLength > requestedMaxBytes ||
+    !Number.isSafeInteger(endOffset) ||
+    (offset < totalBytes
+      ? byteLength === 0 || endOffset > totalBytes || chunk.eof !== (endOffset === totalBytes)
+      : byteLength !== 0 || !chunk.eof)
+  ) {
+    throw new TypeError("Message content chunk range is inconsistent.");
+  }
+  const bytes = cloneOwnedArrayBuffer(chunk.bytes);
+  if (bytes.byteLength !== byteLength) throw new TypeError("Message content chunk ownership is invalid.");
+  const result = {
+    sessionId: expected.sessionId,
+    messageId: expectedMessageId,
+    offset,
+    totalBytes,
+    byteLength,
+    bytes,
+  } as const;
+  return chunk.eof ? { ...result, eof: true } : { ...result, eof: false, nextOffset: endOffset };
+}
+
+function cloneOwnedArrayBuffer(source: ArrayBuffer): ArrayBuffer {
+  const sourceBytes = new Uint8Array(source);
+  const result = new ArrayBuffer(sourceBytes.byteLength);
+  const resultBytes = new Uint8Array(result);
+  for (let index = 0; index < sourceBytes.byteLength; index += 1) resultBytes[index] = sourceBytes[index]!;
+  return result;
+}
+
+function assertScope(value: Readonly<Record<string, unknown>>, expected: SessionMessageScope): void {
+  if (
+    boundedString(value.sessionId) !== expected.sessionId ||
+    boundedString(value.workspaceKey) !== expected.workspaceKey
+  ) {
+    throw new TypeError("Message page scope mismatch.");
+  }
+}
+
+function prepareOperation<TValue>(options: unknown, decodeRequest: () => TValue): PreparedOperation<TValue> {
+  const operationStartedAt = Date.now();
+  let decodedOptions: ApplicationOperationOptions | undefined;
+  try {
+    decodedOptions = decodeOperationOptions(options);
+  } catch {
+    return { ok: false, response: requestFailure() };
+  }
+  const control: OperationControl = {
+    ...(decodedOptions?.timeoutMs === undefined ? {} : { deadlineAt: operationStartedAt + decodedOptions.timeoutMs }),
+    ...(decodedOptions?.signal === undefined ? {} : { signal: decodedOptions.signal }),
+    persistenceStarted: false,
+  };
+  const beforeDecode = getOperationInterruption(control);
+  if (beforeDecode !== undefined) return { ok: false, response: operationInterruptionFailure(beforeDecode) };
+  let input: TValue;
+  try {
+    input = decodeRequest();
+  } catch {
+    return { ok: false, response: requestFailure() };
+  }
+  const afterDecode = getOperationInterruption(control);
+  return afterDecode === undefined
+    ? { ok: true, input, control }
+    : { ok: false, response: operationInterruptionFailure(afterDecode) };
+}
+
+function decodeOperationOptions(value: unknown): ApplicationOperationOptions | undefined {
+  if (value === undefined) return undefined;
+  const options = requestRecord(value, ["timeoutMs", "signal"]);
+  const timeoutMs = optionalInteger(options.timeoutMs, 1, 2_147_483_647);
+  if (options.signal !== undefined && !(options.signal instanceof AbortSignal)) throw new TypeError("Invalid signal.");
+  return {
+    ...(timeoutMs === undefined ? {} : { timeoutMs }),
+    ...(options.signal === undefined ? {} : { signal: options.signal as AbortSignal }),
+  };
+}
+
+async function readRepository<TValue>(
+  control: OperationControl,
+  execute: (options: ApplicationOperationOptions | undefined) => Promise<TValue>,
+): Promise<OperationResolution<TValue>> {
+  const interruption = getOperationInterruption(control);
+  if (interruption !== undefined) return { ok: false, response: interruptionFailure(control, interruption) };
+  const repositoryAbort = new AbortController();
+  const settlement = await runControlled(
+    control,
+    () => {
+      control.persistenceStarted = true;
+      return execute({ signal: repositoryAbort.signal });
+    },
+    () => repositoryAbort.abort(),
+  );
+  if (settlement.status === "interrupted") {
+    return { ok: false, response: interruptionFailure(control, settlement.interruption) };
+  }
+  if (settlement.status === "rejected") return { ok: false, response: mapThrownReadFailure(settlement.error) };
+  return { ok: true, value: settlement.value };
+}
+
+function projectOperationValue<TValue>(control: OperationControl, project: () => TValue): OperationResolution<TValue> {
+  try {
+    const value = project();
+    const interruption = getOperationInterruption(control);
+    return interruption === undefined
+      ? { ok: true, value }
+      : { ok: false, response: interruptionFailure(control, interruption) };
+  } catch {
+    const interruption = getOperationInterruption(control);
+    return {
+      ok: false,
+      response:
+        interruption === undefined
+          ? control.persistenceStarted
+            ? persistenceApplicationFailure()
+            : prePersistenceApplicationFailure()
+          : interruptionFailure(control, interruption),
+    };
+  }
+}
+
+async function runControlled<TValue>(
+  control: OperationControl,
+  start: () => Promise<TValue>,
+  interruptStartedWork?: () => void,
+): Promise<ControlledSettlement<TValue>> {
+  const beforeStart = getOperationInterruption(control);
+  if (beforeStart !== undefined) return { status: "interrupted", interruption: beforeStart };
+  let work: Promise<TValue>;
+  try {
+    work = Promise.resolve(start());
+  } catch (error) {
+    const interruption = getOperationInterruption(control);
+    return interruption === undefined ? { status: "rejected", error } : { status: "interrupted", interruption };
+  }
+  return new Promise((resolve) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const finish = (result: ControlledSettlement<TValue>) => {
+      if (settled) return;
+      settled = true;
+      if (timer !== undefined) clearTimeout(timer);
+      control.signal?.removeEventListener("abort", onAbort);
+      resolve(result);
+    };
+    const interrupt = (interruption: OperationInterruption) => {
+      if (settled) return;
+      try {
+        interruptStartedWork?.();
+      } catch {
+        // Interruption owns the public result even if the Repository abort hook fails.
+      }
+      finish({ status: "interrupted", interruption });
+    };
+    const onAbort = () => interrupt("canceled");
+    work.then(
+      (value) => {
+        const interruption = getOperationInterruption(control);
+        if (interruption === undefined) finish({ status: "fulfilled", value });
+        else interrupt(interruption);
+      },
+      (error: unknown) => {
+        const interruption = getOperationInterruption(control);
+        if (interruption === undefined) finish({ status: "rejected", error });
+        else interrupt(interruption);
+      },
+    );
+    const remaining = getRemainingTimeout(control);
+    if (remaining !== undefined) timer = setTimeout(() => interrupt("timeout"), remaining);
+    control.signal?.addEventListener("abort", onAbort, { once: true });
+    if (control.signal?.aborted) onAbort();
+  });
+}
+
+function readSuccess<TValue>(control: OperationControl, value: TValue): ApplicationOperationResponse<TValue, "read"> {
+  const response = { overallStatus: "success", value, persistence: { status: "read", effect: "none" } } as const;
+  const interruption = getOperationInterruption(control);
+  return interruption === undefined ? response : interruptionFailure(control, interruption);
+}
+
+function readOutcome<TValue>(
+  control: OperationControl,
+  value: TValue,
+  issues: readonly MessageOmissionIssue[],
+): ApplicationOperationResponse<TValue, "read"> {
+  if (issues.length === 0) return readSuccess(control, value);
+  const response = {
+    overallStatus: "partial_success",
+    value,
+    issues: issues as [MessageOmissionIssue, ...MessageOmissionIssue[]],
+    persistence: { status: "read", effect: "none" },
+  } as const;
+  const interruption = getOperationInterruption(control);
+  return interruption === undefined ? response : interruptionFailure(control, interruption);
+}
+
+function projectAccessDecision(value: unknown): ApplicationAccessDecision {
+  const decision = projectionRecord(value, ["allowed", "error"]);
+  if (decision.allowed === true) return { allowed: true };
+  if (decision.allowed !== false) throw new TypeError("Access decision is invalid.");
+  const error = projectionRecord(decision.error, ["code", "message", "retryable"]);
+  const code = enumString(error.code, [
+    "workspace_invalid",
+    "workspace_unavailable",
+    "authorization_invalid",
+    "forbidden",
+  ] as const);
+  if (typeof error.retryable !== "boolean") throw new TypeError("Access retryability is invalid.");
+  return {
+    allowed: false,
+    error: { code, message: boundedString(error.message, 4_096), retryable: error.retryable },
+  };
+}
+
+function requestFailure(): ApplicationSessionMessageFailureResponse {
+  return {
+    overallStatus: "failure",
+    error: {
+      kind: "request",
+      code: "request_invalid",
+      message: "Application operation request is invalid.",
+      retryable: false,
+    },
+    persistence: { status: "not_attempted", effect: "none" },
+  };
+}
+
+function accessFailure(
+  error: Extract<ApplicationAccessDecision, Readonly<{ allowed: false }>>["error"],
+): ApplicationSessionMessageFailureResponse {
+  return {
+    overallStatus: "failure",
+    error: { kind: "access", code: error.code, message: accessErrorMessage(error.code), retryable: error.retryable },
+    persistence: { status: "not_attempted", effect: "none" },
+  };
+}
+
+function operationInterruptionFailure(interruption: OperationInterruption): ApplicationSessionMessageFailureResponse {
+  return {
+    overallStatus: "failure",
+    error:
+      interruption === "timeout"
+        ? {
+            kind: "operation",
+            code: "operation_timeout",
+            message: "Application operation timed out.",
+            retryable: true,
+          }
+        : {
+            kind: "operation",
+            code: "operation_canceled",
+            message: "Application operation was canceled.",
+            retryable: false,
+          },
+    persistence: { status: "not_attempted", effect: "none" },
+  };
+}
+
+function interruptionFailure(
+  control: OperationControl,
+  interruption: OperationInterruption,
+): ApplicationSessionMessageFailureResponse {
+  if (!control.persistenceStarted) return operationInterruptionFailure(interruption);
+  return {
+    overallStatus: "failure",
+    error: {
+      kind: "persistence",
+      code: interruption === "timeout" ? "persistence_timeout" : "persistence_canceled",
+      message: interruption === "timeout" ? "Application operation timed out." : "Application operation was canceled.",
+      retryable: interruption === "timeout",
+      effect: "none",
+    },
+    persistence: { status: "failed", effect: "none" },
+  };
+}
+
+function prePersistenceApplicationFailure(): ApplicationSessionMessageFailureResponse {
+  return {
+    overallStatus: "failure",
+    error: {
+      kind: "application",
+      code: "internal_error",
+      message: "Application Service could not complete the operation.",
+      retryable: false,
+    },
+    persistence: { status: "not_attempted", effect: "none" },
+  };
+}
+
+function persistenceApplicationFailure(): ApplicationSessionMessageFailureResponse {
+  return {
+    overallStatus: "failure",
+    error: {
+      kind: "application",
+      code: "internal_error",
+      message: "Application Service could not complete the operation.",
+      retryable: false,
+    },
+    persistence: { status: "failed", effect: "none" },
+  };
+}
+
+function mapThrownReadFailure(error: unknown): ApplicationSessionMessageFailureResponse {
+  if (!(error instanceof PersistenceClientError)) return persistenceApplicationFailure();
+  const persistenceError = error.persistenceError;
+  if (
+    persistenceError.code === "request_invalid" ||
+    persistenceError.code === "cursor_invalid" ||
+    persistenceError.code === "not_found"
+  ) {
+    return {
+      overallStatus: "failure",
+      error: {
+        kind: "domain",
+        code: persistenceError.code,
+        message: repositoryDomainErrorMessage(persistenceError.code),
+        retryable: persistenceError.retryable,
+      },
+      persistence: { status: "rejected", effect: "none" },
+    };
+  }
+  return {
+    overallStatus: "failure",
+    error: {
+      kind: "persistence",
+      code: mapPersistenceErrorCode(persistenceError.code),
+      message: "Persistence could not complete the Message read.",
+      retryable: persistenceError.retryable,
+      effect: "none",
+    },
+    persistence: { status: "failed", effect: "none" },
+  };
+}
+
+function accessErrorMessage(
+  code: Extract<ApplicationAccessDecision, Readonly<{ allowed: false }>>["error"]["code"],
+): string {
+  switch (code) {
+    case "workspace_invalid":
+      return "The workspace authorization scope is invalid.";
+    case "workspace_unavailable":
+      return "The workspace authorization scope is unavailable.";
+    case "authorization_invalid":
+      return "The authorization context is invalid.";
+    case "forbidden":
+      return "The Message read is not authorized.";
+  }
+}
+
+function repositoryDomainErrorMessage(code: "request_invalid" | "cursor_invalid" | "not_found"): string {
+  switch (code) {
+    case "request_invalid":
+      return "The Message read request was rejected.";
+    case "cursor_invalid":
+      return "The Message cursor is invalid.";
+    case "not_found":
+      return "The requested Message resource was not found.";
+  }
+}
+
+function mapPersistenceErrorCode(code: PersistenceError["code"]) {
+  switch (code) {
+    case "worker_not_ready":
+    case "worker_closing":
+    case "worker_crashed":
+    case "worker_start_failed":
+    case "worker_shutdown_forced":
+    case "database_unavailable":
+      return "persistence_unavailable" as const;
+    case "queue_full":
+    case "database_busy":
+      return "persistence_busy" as const;
+    case "request_timeout":
+      return "persistence_timeout" as const;
+    case "request_canceled":
+      return "persistence_canceled" as const;
+    case "database_path_invalid":
+    case "database_identity_mismatch":
+    case "database_schema_unknown":
+    case "database_schema_too_new":
+    case "database_schema_too_old":
+    case "database_pragma_mismatch":
+    case "database_wal_unavailable":
+    case "database_bootstrap_failed":
+    case "schema_artifact_invalid":
+      return "persistence_configuration_invalid" as const;
+    case "database_schema_verification_failed":
+    case "database_integrity_check_failed":
+      return "persistence_integrity_failed" as const;
+    case "response_too_large":
+      return "persistence_response_too_large" as const;
+    default:
+      return "persistence_operation_failed" as const;
+  }
+}
+
+function getOperationInterruption(control: OperationControl): OperationInterruption | undefined {
+  if (control.deadlineAt !== undefined && control.deadlineAt <= Date.now()) return "timeout";
+  if (control.signal?.aborted) return "canceled";
+  return undefined;
+}
+
+function getRemainingTimeout(control: OperationControl): number | undefined {
+  return control.deadlineAt === undefined ? undefined : Math.max(0, control.deadlineAt - Date.now());
+}
+
+function requestRecord(value: unknown, allowedKeys: readonly string[]): Readonly<Record<string, unknown>> {
+  if (!isPlainObject(value) || Object.keys(value).some((key) => !allowedKeys.includes(key))) {
+    throw new TypeError("Request object is invalid.");
+  }
+  return Object.fromEntries(allowedKeys.map((key) => [key, value[key]]));
+}
+
+function projectionRecord(value: unknown, allowedKeys: readonly string[]): Readonly<Record<string, unknown>> {
+  const record = plainRecord(value);
+  return Object.fromEntries(allowedKeys.map((key) => [key, record[key]]));
+}
+
+function plainRecord(value: unknown): Readonly<Record<string, unknown>> {
+  if (!isPlainObject(value)) throw new TypeError("Projection object is invalid.");
+  return value;
+}
+
+function isPlainObject(value: unknown): value is Readonly<Record<string, unknown>> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value) as unknown;
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isDenseArray(value: unknown, maxLength: number): value is readonly unknown[] {
+  if (!Array.isArray(value) || value.length > maxLength) return false;
+  for (let index = 0; index < value.length; index += 1) {
+    if (!Object.hasOwn(value, index)) return false;
+  }
+  return true;
+}
+
+function boundedString(
+  value: unknown,
+  maxLength: number = APPLICATION_SESSION_MESSAGE_LIMITS.maxIdentifierLength,
+): string {
+  if (typeof value !== "string" || value.length === 0 || value.length > maxLength) {
+    throw new TypeError("String is invalid.");
+  }
+  return value;
+}
+
+function optionalBoundedString(value: unknown, maxLength: number): string | undefined {
+  return value === undefined ? undefined : boundedString(value, maxLength);
+}
+
+function integer(value: unknown, min: number, max: number): number {
+  if (!Number.isSafeInteger(value) || (value as number) < min || (value as number) > max) {
+    throw new TypeError("Integer is invalid.");
+  }
+  return value as number;
+}
+
+function optionalInteger(value: unknown, min: number, max: number): number | undefined {
+  return value === undefined ? undefined : integer(value, min, max);
+}
+
+function enumString<const TValues extends readonly string[]>(value: unknown, values: TValues): TValues[number] {
+  if (typeof value !== "string" || !values.includes(value)) throw new TypeError("Enum value is invalid.");
+  return value as TValues[number];
+}

--- a/src/main/cli-runtime.ts
+++ b/src/main/cli-runtime.ts
@@ -17,10 +17,16 @@ import type {
   ApplicationRunOutputAccessValidator,
   ApplicationRunOutputOperations,
 } from "../shared/application-run-output-model.js";
+import type {
+  ApplicationSessionMessageAccessValidationInput,
+  ApplicationSessionMessageAccessValidator,
+  ApplicationSessionMessageOperations,
+} from "../shared/application-session-message-model.js";
 import { resolveApplicationDataRoot, resolveWithMateDatabasePathFromRoot } from "./application-data-path.js";
 import { createApplicationRunOperations } from "./application-run-service.js";
 import { createApplicationRunOutputOperations } from "./application-run-output-service.js";
 import { createApplicationSessionOperations } from "./application-session-service.js";
+import { createApplicationSessionMessageOperations } from "./application-session-message-service.js";
 import { PersistenceWorkerClient } from "./persistence-worker-client.js";
 import { LocalSessionFilesCleanup } from "./session-files-cleanup.js";
 
@@ -34,6 +40,7 @@ export type CliRuntimeControl = Readonly<{ timeoutMs?: number; signal?: AbortSig
 
 export type CliRuntime = Readonly<{
   operations: ApplicationSessionOperations<LocalCliAuthorization>;
+  messageOperations: ApplicationSessionMessageOperations<LocalCliAuthorization>;
   runOperations: ApplicationRunOperations<LocalCliAuthorization>;
   runOutputOperations: ApplicationRunOutputOperations<LocalCliAuthorization>;
   authorization: LocalCliAuthorization;
@@ -60,6 +67,7 @@ export async function startCliRuntime(control: CliRuntimeControl = {}): Promise<
     const access = new LocalCliAccessValidator();
     return {
       operations: createApplicationSessionOperations(client, { access, sessionFiles, snapshotAuthorization }),
+      messageOperations: createApplicationSessionMessageOperations(client, { access, snapshotAuthorization }),
       runOperations: createApplicationRunOperations(client, { access, snapshotAuthorization }),
       runOutputOperations: createApplicationRunOutputOperations(client, { access, snapshotAuthorization }),
       authorization: localCliAuthorization,
@@ -105,7 +113,8 @@ class LocalCliAccessValidator
   implements
     ApplicationAccessValidator<LocalCliAuthorization>,
     ApplicationRunAccessValidator<LocalCliAuthorization>,
-    ApplicationRunOutputAccessValidator<LocalCliAuthorization>
+    ApplicationRunOutputAccessValidator<LocalCliAuthorization>,
+    ApplicationSessionMessageAccessValidator<LocalCliAuthorization>
 {
   async validateWorkspace(
     input: Extract<ApplicationAccessValidationInput<LocalCliAuthorization>, Readonly<{ operation: "create" }>>,
@@ -143,7 +152,8 @@ class LocalCliAccessValidator
     input:
       | ApplicationAccessValidationInput<LocalCliAuthorization>
       | ApplicationRunAccessValidationInput<LocalCliAuthorization>
-      | ApplicationRunOutputAccessValidationInput<LocalCliAuthorization>,
+      | ApplicationRunOutputAccessValidationInput<LocalCliAuthorization>
+      | ApplicationSessionMessageAccessValidationInput<LocalCliAuthorization>,
   ): Promise<ApplicationAccessDecision> {
     return isLocalCliAuthorization(input.context.authorization) ? { allowed: true } : authorizationInvalid();
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,3 +1,4 @@
 export type { ApplicationSessionOperations } from "../shared/application-service-model.js";
+export type { ApplicationSessionMessageOperations } from "../shared/application-session-message-model.js";
 export type { ApplicationRunOperations } from "../shared/application-run-model.js";
 export type { ApplicationRunOutputOperations } from "../shared/application-run-output-model.js";

--- a/src/persistence-worker/repository-read-model.ts
+++ b/src/persistence-worker/repository-read-model.ts
@@ -23,13 +23,21 @@ const RUN_OUTPUT_CATEGORIES = [
 
 export const REPOSITORY_PAGE_SQL = {
   messages: `
-    SELECT m.id, m.session_id, m.ordinal, m.role,
-           length(CAST(m.content_blocks_json AS BLOB)) AS content_byte_length,
-           CASE WHEN length(CAST(m.content_blocks_json AS BLOB)) <= ? THEN m.content_blocks_json END AS inline_content,
-           m.created_at, s.workspace_key
-    FROM messages m JOIN sessions s ON s.id = m.session_id
-    WHERE m.session_id = ? AND s.workspace_key = ? AND m.ordinal > ?
-    ORDER BY m.ordinal ASC LIMIT ?
+    SELECT CASE WHEN m.id IS NULL THEN 1 ELSE 0 END AS scope_only,
+           m.id, m.session_id, m.ordinal, m.role, m.content_byte_length, m.inline_content, m.created_at,
+           s.workspace_key
+    FROM sessions s
+    LEFT JOIN (
+      SELECT id, session_id, ordinal, role,
+             length(CAST(content_blocks_json AS BLOB)) AS content_byte_length,
+             CASE WHEN length(CAST(content_blocks_json AS BLOB)) <= ? THEN content_blocks_json END AS inline_content,
+             created_at
+      FROM messages
+      WHERE session_id = ? AND ordinal > ?
+      ORDER BY ordinal ASC LIMIT ?
+    ) m ON m.session_id = s.id
+    WHERE s.id = ? AND s.workspace_key = ?
+    ORDER BY m.ordinal ASC
   `,
   runEvents: `
     SELECT e.id, e.run_id, e.ordinal, e.event_code, e.subject_type, e.subject_id, e.summary, e.created_at
@@ -244,34 +252,37 @@ function sessionsPage(database: DatabaseSync, payload: Readonly<Record<string, u
   };
   const rows = database.prepare(query.sql).all(...query.parameters) as unknown as readonly SessionPageRow[];
   const page = splitPage(rows, limit);
-  const mappedPage = budgetPage(page, (row) => ({
-    id: row.id,
-    title: row.title,
-    workspaceKey: row.workspace_key,
-    workspacePath: row.workspace_path,
-    localRepositoryKey: row.local_repository_key,
-    repositoryName: row.repository_name,
-    defaultCharacterId: row.default_character_id,
-    lifecycleStatus: row.lifecycle_status,
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
-    lastActivityAt: row.last_activity_at,
-    executionState: row.active_run_id !== null ? "running" : (row.latest_run_phase ?? "not_started"),
-    ...(row.active_run_id === null ? {} : { activeRunId: row.active_run_id }),
-    ...(row.latest_run_id === null ? {} : { latestRunId: row.latest_run_id }),
-    stateChangedAt:
-      row.active_run_id === null
-        ? (row.latest_run_terminal_at ?? row.created_at)
-        : (row.active_run_created_at ?? row.created_at),
-  }));
-  return {
-    items: mappedPage.items,
-    ...(mappedPage.hasMore
-      ? {
-          nextCursor: encodeCursor("sessions", scope, [mappedPage.lastRow!.last_activity_at, mappedPage.lastRow!.id]),
-        }
-      : {}),
-  };
+  return budgetPage(
+    page,
+    (row) => ({
+      id: row.id,
+      title: row.title,
+      workspaceKey: row.workspace_key,
+      workspacePath: row.workspace_path,
+      localRepositoryKey: row.local_repository_key,
+      repositoryName: row.repository_name,
+      defaultCharacterId: row.default_character_id,
+      lifecycleStatus: row.lifecycle_status,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      lastActivityAt: row.last_activity_at,
+      executionState: row.active_run_id !== null ? "running" : (row.latest_run_phase ?? "not_started"),
+      ...(row.active_run_id === null ? {} : { activeRunId: row.active_run_id }),
+      ...(row.latest_run_id === null ? {} : { latestRunId: row.latest_run_id }),
+      stateChangedAt:
+        row.active_run_id === null
+          ? (row.latest_run_terminal_at ?? row.created_at)
+          : (row.active_run_created_at ?? row.created_at),
+    }),
+    (budgeted) => ({
+      items: budgeted.items,
+      ...(budgeted.hasMore && budgeted.lastRow !== undefined
+        ? {
+            nextCursor: encodeCursor("sessions", scope, [budgeted.lastRow.last_activity_at, budgeted.lastRow.id]),
+          }
+        : {}),
+    }),
+  );
 }
 
 function localRepositoriesPage(database: DatabaseSync, payload: Readonly<Record<string, unknown>>): unknown {
@@ -322,24 +333,27 @@ function localRepositoriesPage(database: DatabaseSync, payload: Readonly<Record<
       SESSION_METADATA_LIMITS.repositoryNamesPerItemMax,
     ) as unknown as readonly LocalRepositoryPageRow[];
   const page = splitPage(rows, limit);
-  const mappedPage = budgetPage(page, (row) => ({
-    localRepositoryKey: row.local_repository_key,
-    repositoryNames: decodeRepositoryNames(row.repository_names_json),
-    repositoryNameCount: row.repository_name_count,
-    sessionCount: row.session_count,
-    lastActivityAt: row.last_activity_at,
-  }));
-  return {
-    items: mappedPage.items,
-    ...(mappedPage.hasMore
-      ? {
-          nextCursor: encodeCursor("local_repositories", scope, [
-            mappedPage.lastRow!.last_activity_at,
-            mappedPage.lastRow!.local_repository_key,
-          ]),
-        }
-      : {}),
-  };
+  return budgetPage(
+    page,
+    (row) => ({
+      localRepositoryKey: row.local_repository_key,
+      repositoryNames: decodeRepositoryNames(row.repository_names_json),
+      repositoryNameCount: row.repository_name_count,
+      sessionCount: row.session_count,
+      lastActivityAt: row.last_activity_at,
+    }),
+    (budgeted) => ({
+      items: budgeted.items,
+      ...(budgeted.hasMore && budgeted.lastRow !== undefined
+        ? {
+            nextCursor: encodeCursor("local_repositories", scope, [
+              budgeted.lastRow.last_activity_at,
+              budgeted.lastRow.local_repository_key,
+            ]),
+          }
+        : {}),
+    }),
+  );
 }
 
 function sessionGet(database: DatabaseSync, payload: Readonly<Record<string, unknown>>): unknown {
@@ -397,16 +411,27 @@ function messagesPage(database: DatabaseSync, payload: Readonly<Record<string, u
   const limit = readLimit(payload.limit, REPOSITORY_READ_LIMITS.messages);
   const cursorScope = scopeDigest(scope);
   const afterOrdinal = decodeOrdinalCursor(payload.cursor, "messages", cursorScope);
-  const rows = database
+  const queryRows = database
     .prepare(REPOSITORY_PAGE_SQL.messages)
     .all(
       INLINE_MESSAGE_BYTES,
       scope.sessionId,
-      scope.workspaceKey,
       afterOrdinal,
       limit + 1,
-    ) as unknown as readonly MessageRow[];
-  assertScopeExists(database, scope.sessionId, scope.workspaceKey);
+      scope.sessionId,
+      scope.workspaceKey,
+    ) as unknown as readonly MessageQueryRow[];
+  if (queryRows.length === 0) throw notFound();
+  let rows: readonly MessageRow[];
+  if (queryRows[0]?.scope_only === 1) {
+    if (queryRows.length !== 1) throw new TypeError("Repository projection violates the persistence contract.");
+    rows = [];
+  } else {
+    if (queryRows.some((row) => row.scope_only !== 0)) {
+      throw new TypeError("Repository projection violates the persistence contract.");
+    }
+    rows = queryRows as unknown as readonly MessageRow[];
+  }
   const page = splitPage(rows, limit);
   return ordinalPage(scope, page, "messages", cursorScope, (row) => ({
     id: row.id,
@@ -460,23 +485,25 @@ function runEventsPage(database: DatabaseSync, payload: Readonly<Record<string, 
     .all(scope.runId, scope.sessionId, scope.workspaceKey, afterOrdinal, limit + 1) as unknown as readonly OrdinalRow[];
   assertRunScopeExists(database, scope);
   const page = splitPage(rows, limit);
-  const budgeted = budgetPage(page, (row) => ({
-    id: row.id,
-    runId: row.run_id,
-    ordinal: row.ordinal,
-    eventCode: row.event_code,
-    ...(row.subject_type === null ? {} : { subjectType: row.subject_type }),
-    ...(row.subject_id === null ? {} : { subjectId: row.subject_id }),
-    ...(row.summary === null ? {} : { summary: row.summary }),
-    createdAt: row.created_at,
-  }));
-  const continuationOrdinal = budgeted.lastRow?.ordinal ?? afterOrdinal;
-  return {
-    ...scope,
-    items: budgeted.items,
-    continuationCursor: encodeCursor("run_events", cursorScope, [continuationOrdinal]),
-    hasMore: budgeted.hasMore,
-  };
+  return budgetPage(
+    page,
+    (row) => ({
+      id: row.id,
+      runId: row.run_id,
+      ordinal: row.ordinal,
+      eventCode: row.event_code,
+      ...(row.subject_type === null ? {} : { subjectType: row.subject_type }),
+      ...(row.subject_id === null ? {} : { subjectId: row.subject_id }),
+      ...(row.summary === null ? {} : { summary: row.summary }),
+      createdAt: row.created_at,
+    }),
+    (budgeted) => ({
+      ...scope,
+      items: budgeted.items,
+      continuationCursor: encodeCursor("run_events", cursorScope, [budgeted.lastRow?.ordinal ?? afterOrdinal]),
+      hasMore: budgeted.hasMore,
+    }),
+  );
 }
 
 function runOutputCounts(database: DatabaseSync, payload: Readonly<Record<string, unknown>>): unknown {
@@ -555,27 +582,30 @@ function runInputDeliveriesPage(database: DatabaseSync, payload: Readonly<Record
     ) as unknown as readonly RunInputDeliveryRow[];
   assertRunScopeExists(database, scope);
   const page = splitPage(rows, limit);
-  const budgeted = budgetPage(page, (row) => ({
-    messageId: row.message_id,
-    runId: row.run_id,
-    attemptId: row.attempt_id,
-    bindingId: row.binding_id,
-    deliveryState: row.delivery_state,
-    createdAt: row.created_at,
-    dispatchingAt: row.dispatching_at,
-  }));
-  return {
-    ...scope,
-    items: budgeted.items,
-    ...(budgeted.hasMore && budgeted.lastRow !== undefined
-      ? {
-          nextCursor: encodeCursor("run_input_deliveries", cursorScope, [
-            budgeted.lastRow.created_at,
-            budgeted.lastRow.message_id,
-          ]),
-        }
-      : {}),
-  };
+  return budgetPage(
+    page,
+    (row) => ({
+      messageId: row.message_id,
+      runId: row.run_id,
+      attemptId: row.attempt_id,
+      bindingId: row.binding_id,
+      deliveryState: row.delivery_state,
+      createdAt: row.created_at,
+      dispatchingAt: row.dispatching_at,
+    }),
+    (budgeted) => ({
+      ...scope,
+      items: budgeted.items,
+      ...(budgeted.hasMore && budgeted.lastRow !== undefined
+        ? {
+            nextCursor: encodeCursor("run_input_deliveries", cursorScope, [
+              budgeted.lastRow.created_at,
+              budgeted.lastRow.message_id,
+            ]),
+          }
+        : {}),
+    }),
+  );
 }
 
 function runOutputsPage(database: DatabaseSync, payload: Readonly<Record<string, unknown>>): unknown {
@@ -898,15 +928,6 @@ function readRunScope(payload: Readonly<Record<string, unknown>>, keys: readonly
   return { ...scope, runId: requiredString(payload.runId, "runId") };
 }
 
-function assertScopeExists(database: DatabaseSync, sessionId: string, workspaceKey: string): void {
-  if (
-    database.prepare("SELECT 1 FROM sessions WHERE id = ? AND workspace_key = ?").get(sessionId, workspaceKey) ===
-    undefined
-  ) {
-    throw notFound();
-  }
-}
-
 function assertRunScopeExists(
   database: DatabaseSync,
   scope: Readonly<{ sessionId: string; runId: string; workspaceKey: string }>,
@@ -924,53 +945,99 @@ function assertRunScopeExists(
     throw notFound();
 }
 
-function ordinalPage<T extends OrdinalRow, R>(
+function ordinalPage<T extends OrdinalRow, R extends Readonly<Record<string, unknown>>>(
   scope: object,
   page: Readonly<{ items: readonly T[]; hasMore: boolean }>,
   kind: string,
   cursorScope: string,
   map: (row: T) => R,
 ): unknown {
-  const budgeted = budgetPage(page, map);
-  return {
+  return budgetPage(page, map, (budgeted) => ({
     ...scope,
     items: budgeted.items,
     ...(budgeted.hasMore && budgeted.lastRow !== undefined
       ? { nextCursor: encodeCursor(kind, cursorScope, [budgeted.lastRow.ordinal]) }
       : {}),
-  };
+  }));
 }
 
-function budgetPage<T extends Readonly<Record<string, unknown>>, R>(
-  page: Readonly<{ items: readonly T[]; hasMore: boolean }>,
-  map: (row: T) => R,
-): Readonly<{
-  items: readonly (R | Readonly<{ omitted: true; reason: "response_size_limit"; ordinal?: number }>)[];
+type PageOmission = Readonly<{ omitted: true; reason: "response_size_limit"; ordinal?: number }>;
+type BudgetedPage<T, R> = Readonly<{
+  items: readonly (R | PageOmission)[];
   hasMore: boolean;
   lastRow?: T;
-}> {
-  const items: (R | Readonly<{ omitted: true; reason: "response_size_limit"; ordinal?: number }>)[] = [];
-  let bytes = 0;
+}>;
+type PageProjection = Readonly<Record<string, unknown> & { items: readonly unknown[] }>;
+
+function budgetPage<
+  T extends Readonly<Record<string, unknown>>,
+  R extends Readonly<Record<string, unknown>>,
+  P extends PageProjection,
+>(
+  page: Readonly<{ items: readonly T[]; hasMore: boolean }>,
+  map: (row: T) => R,
+  project: (budgeted: BudgetedPage<T, R>) => P,
+): P {
+  const items: (R | PageOmission)[] = [];
+  let itemsJsonBytes = 0;
   let consumed = 0;
-  for (const row of page.items) {
+  for (let index = 0; index < page.items.length; index += 1) {
+    const row = page.items[index]!;
     const item = map(row);
-    const itemBytes = Buffer.byteLength(JSON.stringify(item));
-    if (itemBytes > MAX_PAGE_JSON_BYTES) {
-      const ordinal = typeof row.ordinal === "number" ? row.ordinal : undefined;
-      items.push({ omitted: true, reason: "response_size_limit", ...(ordinal === undefined ? {} : { ordinal }) });
-      consumed += 1;
+    const itemJsonBytes = jsonBytes(item);
+    const candidate = budgetedPage(page, [...items, item], index + 1);
+    if (pageJsonBytes(project, candidate, itemsJsonBytes + itemJsonBytes) <= MAX_PAGE_JSON_BYTES) {
+      items.push(item);
+      itemsJsonBytes += itemJsonBytes;
+      consumed = index + 1;
       continue;
     }
-    if (bytes + itemBytes > MAX_PAGE_JSON_BYTES) break;
-    items.push(item);
-    bytes += itemBytes;
-    consumed += 1;
+
+    const itemOnly = budgetedPage(page, [item], index + 1);
+    if (pageJsonBytes(project, itemOnly, itemJsonBytes) <= MAX_PAGE_JSON_BYTES) break;
+
+    const ordinal = typeof row.ordinal === "number" ? row.ordinal : undefined;
+    const omission: PageOmission = {
+      omitted: true,
+      reason: "response_size_limit",
+      ...(ordinal === undefined ? {} : { ordinal }),
+    };
+    const omissionJsonBytes = jsonBytes(omission);
+    const omittedCandidate = budgetedPage(page, [...items, omission], index + 1);
+    if (pageJsonBytes(project, omittedCandidate, itemsJsonBytes + omissionJsonBytes) > MAX_PAGE_JSON_BYTES) break;
+    items.push(omission);
+    itemsJsonBytes += omissionJsonBytes;
+    consumed = index + 1;
   }
+
+  const result = project(budgetedPage(page, items, consumed));
+  if (jsonBytes(result) > MAX_PAGE_JSON_BYTES) throw persistenceContractViolation();
+  return result;
+}
+
+function budgetedPage<T, R>(
+  page: Readonly<{ items: readonly T[]; hasMore: boolean }>,
+  items: readonly (R | PageOmission)[],
+  consumed: number,
+): BudgetedPage<T, R> {
   return {
     items,
     hasMore: page.hasMore || consumed < page.items.length,
     ...(consumed === 0 ? {} : { lastRow: page.items[consumed - 1] }),
   };
+}
+
+function pageJsonBytes<T, R, P extends PageProjection>(
+  project: (budgeted: BudgetedPage<T, R>) => P,
+  budgeted: BudgetedPage<T, R>,
+  itemsJsonBytes: number,
+): number {
+  const emptyItemsProjection = project({ ...budgeted, items: [] });
+  return jsonBytes(emptyItemsProjection) + itemsJsonBytes + Math.max(0, budgeted.items.length - 1);
+}
+
+function jsonBytes(value: Readonly<Record<string, unknown>>): number {
+  return Buffer.byteLength(JSON.stringify(value));
 }
 
 function splitPage<T>(rows: readonly T[], limit: number): Readonly<{ items: readonly T[]; hasMore: boolean }> {
@@ -1157,6 +1224,7 @@ type MessageRow = Readonly<{
   created_at: number;
   workspace_key: string;
 }>;
+type MessageQueryRow = Readonly<Record<string, unknown>> & Readonly<{ scope_only: number }>;
 type SessionPageRow = Readonly<{
   id: string;
   title: string;

--- a/src/persistence-worker/repository-write-model.ts
+++ b/src/persistence-worker/repository-write-model.ts
@@ -7,6 +7,7 @@ import {
   ALLOWED_ADDITIONAL_DIRECTORIES_LIMITS,
   normalizeAllowedAdditionalDirectories,
 } from "../shared/allowed-additional-directories.js";
+import { snapshotMessageContentBlocks } from "../shared/message-content.js";
 import { isCanonicalUuid, isPlainObject } from "../shared/persistence-runtime-protocol.js";
 import { MAX_SESSION_CONCURRENT_CHILD_RUNS, MAX_SESSION_TREE_SIZE } from "../shared/session-limits.js";
 import { isCanonicalSessionTitle, snapshotLocalRepositoryMetadata } from "../shared/session-metadata.js";
@@ -76,6 +77,7 @@ export const RUN_OUTPUT_PAYLOAD_LIMITS = {
 export const RUN_OUTPUT_SQLITE_WRITE_MARGIN_BYTES = 64 * 1024;
 export const SESSION_SUBTREE_DELETE_WAL_FIXED_MARGIN_BYTES = 64 * 1024;
 export const SESSION_SUBTREE_DELETE_WAL_PAGES_PER_ROW = 8;
+const USER_VISIBLE_TEXT_PATTERN = /[^\p{White_Space}\p{Default_Ignorable_Code_Point}\p{Cc}]/u;
 
 export type RepositoryWriteOperation = Readonly<{
   requestClass: "write";
@@ -3921,6 +3923,9 @@ function decodeStartupRepair(
 }
 
 function decodeNormalRunAdmission(payload: Readonly<Record<string, unknown>>): DecodeResult<NormalRunAdmissionCommand> {
+  const contentBlocks = isPlainObject(payload.message)
+    ? snapshotMessageContentBlocks(payload.message.contentBlocks)
+    : undefined;
   if (
     !hasExactKeys(payload, [
       "sessionId",
@@ -3939,7 +3944,7 @@ function decodeNormalRunAdmission(payload: Readonly<Record<string, unknown>>): D
     !isPlainObject(payload.message) ||
     !hasExactKeys(payload.message, ["id", "contentBlocks"]) ||
     !isBoundedString(payload.message.id, 1_024) ||
-    !isDenseJsonArray(payload.message.contentBlocks, 10_000) ||
+    contentBlocks === undefined ||
     !isPlainObject(payload.run) ||
     !hasExactKeys(payload.run, ["id", "executionSnapshot"]) ||
     !isBoundedString(payload.run.id, 1_024) ||
@@ -3954,7 +3959,13 @@ function decodeNormalRunAdmission(payload: Readonly<Record<string, unknown>>): D
   ) {
     return decodeFailure();
   }
-  return { ok: true, value: payload as unknown as NormalRunAdmissionCommand };
+  return {
+    ok: true,
+    value: {
+      ...(payload as unknown as NormalRunAdmissionCommand),
+      message: { id: payload.message.id as string, contentBlocks },
+    },
+  };
 }
 
 function decodeRetryRunAdmission(payload: Readonly<Record<string, unknown>>): DecodeResult<RetryRunAdmissionCommand> {
@@ -3992,6 +4003,9 @@ function decodeRetryRunAdmission(payload: Readonly<Record<string, unknown>>): De
 }
 
 function decodeChildStart(payload: Readonly<Record<string, unknown>>): DecodeResult<ChildStartCommand> {
+  const contentBlocks = isPlainObject(payload.message)
+    ? snapshotMessageContentBlocks(payload.message.contentBlocks)
+    : undefined;
   if (
     !hasExactKeys(payload, [
       "parentSessionId",
@@ -4046,7 +4060,7 @@ function decodeChildStart(payload: Readonly<Record<string, unknown>>): DecodeRes
     !isPlainObject(payload.message) ||
     !hasExactKeys(payload.message, ["id", "contentBlocks"]) ||
     !isBoundedString(payload.message.id, 1_024) ||
-    !isDenseJsonArray(payload.message.contentBlocks, 10_000) ||
+    contentBlocks === undefined ||
     !isPlainObject(payload.run) ||
     !hasExactKeys(payload.run, ["id", "executionSnapshot"]) ||
     !isBoundedString(payload.run.id, 1_024) ||
@@ -4064,7 +4078,13 @@ function decodeChildStart(payload: Readonly<Record<string, unknown>>): DecodeRes
   ) {
     return decodeFailure();
   }
-  return { ok: true, value: payload as unknown as ChildStartCommand };
+  return {
+    ok: true,
+    value: {
+      ...(payload as unknown as ChildStartCommand),
+      message: { id: payload.message.id as string, contentBlocks },
+    },
+  };
 }
 
 function decodeProviderBindingResolution(
@@ -4148,6 +4168,9 @@ function decodeRunDispatchResolution(
 }
 
 function decodeRunInputAdmission(payload: Readonly<Record<string, unknown>>): DecodeResult<RunInputAdmissionCommand> {
+  const contentBlocks = isPlainObject(payload.message)
+    ? snapshotMessageContentBlocks(payload.message.contentBlocks)
+    : undefined;
   if (
     !hasExactKeys(payload, [
       "sessionId",
@@ -4167,11 +4190,17 @@ function decodeRunInputAdmission(payload: Readonly<Record<string, unknown>>): De
     !isPlainObject(payload.message) ||
     !hasExactKeys(payload.message, ["id", "contentBlocks"]) ||
     !isBoundedString(payload.message.id, 1_024) ||
-    !isDenseJsonArray(payload.message.contentBlocks, 10_000)
+    contentBlocks === undefined
   ) {
     return decodeFailure();
   }
-  return { ok: true, value: payload as unknown as RunInputAdmissionCommand };
+  return {
+    ok: true,
+    value: {
+      ...(payload as unknown as RunInputAdmissionCommand),
+      message: { id: payload.message.id as string, contentBlocks },
+    },
+  };
 }
 
 function decodeRunInputBegin(payload: Readonly<Record<string, unknown>>): DecodeResult<RunInputBeginCommand> {
@@ -4274,6 +4303,7 @@ function decodeRunOutputResolvePending(
 }
 
 function decodeRunTerminal(payload: Readonly<Record<string, unknown>>): DecodeResult<RunTerminalCommand> {
+  const outcome = snapshotRunTerminalOutcome(payload.outcome);
   if (
     !hasExactKeys(payload, [
       "sessionId",
@@ -4295,13 +4325,13 @@ function decodeRunTerminal(payload: Readonly<Record<string, unknown>>): DecodeRe
     !isBoundedString(payload.terminalEvent.id, 1024) ||
     !isBoundedString(payload.terminalEvent.dedupeKey, 1024) ||
     !isRunTerminalPreDispatchResolution(payload.preDispatchResolution) ||
-    !isRunTerminalOutcome(payload.outcome) ||
+    outcome === undefined ||
     !isDenseTerminalOutputs(payload.outputs) ||
     !isChildTerminalResult(payload.childResult)
   ) {
     return decodeFailure();
   }
-  return { ok: true, value: payload as unknown as RunTerminalCommand };
+  return { ok: true, value: { ...(payload as unknown as RunTerminalCommand), outcome } };
 }
 
 function decodeChildResultCollect(payload: Readonly<Record<string, unknown>>): DecodeResult<ChildResultCollectCommand> {
@@ -5602,26 +5632,42 @@ function isRunTerminalPreDispatchResolution(value: unknown): value is RunTermina
   );
 }
 
-function isRunTerminalOutcome(value: unknown): value is RunTerminalCommand["outcome"] {
-  if (!isPlainObject(value) || typeof value.kind !== "string") return false;
+function snapshotRunTerminalOutcome(value: unknown): RunTerminalCommand["outcome"] | undefined {
+  if (!isPlainObject(value) || typeof value.kind !== "string") return undefined;
   if (value.kind === "completed") {
-    if (!hasExactKeys(value, ["kind", "finalAssistantMessage"])) return false;
-    if (value.finalAssistantMessage === null) return true;
-    return (
-      isPlainObject(value.finalAssistantMessage) &&
-      hasExactKeys(value.finalAssistantMessage, ["id", "contentBlocks"]) &&
-      isBoundedString(value.finalAssistantMessage.id, 1_024) &&
-      isDenseJsonArray(value.finalAssistantMessage.contentBlocks, 1_024)
-    );
+    if (!hasExactKeys(value, ["kind", "finalAssistantMessage"])) return undefined;
+    if (value.finalAssistantMessage === null) return { kind: "completed", finalAssistantMessage: null };
+    if (
+      !isPlainObject(value.finalAssistantMessage) ||
+      !hasExactKeys(value.finalAssistantMessage, ["id", "contentBlocks"]) ||
+      !isBoundedString(value.finalAssistantMessage.id, 1_024)
+    ) {
+      return undefined;
+    }
+    const contentBlocks = snapshotMessageContentBlocks(value.finalAssistantMessage.contentBlocks);
+    return contentBlocks === undefined || !contentBlocks.some((block) => USER_VISIBLE_TEXT_PATTERN.test(block.text))
+      ? undefined
+      : {
+          kind: "completed",
+          finalAssistantMessage: { id: value.finalAssistantMessage.id, contentBlocks },
+        };
   }
-  if (value.kind === "canceled") return hasExactKeys(value, ["kind"]);
-  return (
-    (value.kind === "failed" || value.kind === "interrupted") &&
-    hasExactKeys(value, ["kind", "failureOrigin", "providerErrorCode", "errorSummary"]) &&
-    isFailureOrigin(value.failureOrigin) &&
-    (value.providerErrorCode === null || isBoundedString(value.providerErrorCode, 1_024)) &&
-    (value.errorSummary === null || isBoundedString(value.errorSummary, 4_096))
-  );
+  if (value.kind === "canceled") return hasExactKeys(value, ["kind"]) ? { kind: "canceled" } : undefined;
+  if (
+    (value.kind !== "failed" && value.kind !== "interrupted") ||
+    !hasExactKeys(value, ["kind", "failureOrigin", "providerErrorCode", "errorSummary"]) ||
+    !isFailureOrigin(value.failureOrigin) ||
+    (value.providerErrorCode !== null && !isBoundedString(value.providerErrorCode, 1_024)) ||
+    (value.errorSummary !== null && !isBoundedString(value.errorSummary, 4_096))
+  ) {
+    return undefined;
+  }
+  return {
+    kind: value.kind,
+    failureOrigin: value.failureOrigin,
+    providerErrorCode: value.providerErrorCode,
+    errorSummary: value.errorSummary,
+  };
 }
 
 function isChildTerminalResult(value: unknown): value is RunTerminalCommand["childResult"] {
@@ -5648,7 +5694,7 @@ function isPayloadFormat(value: unknown): value is "text" | "json" | "binary" {
   return value === "text" || value === "json" || value === "binary";
 }
 
-function isFailureOrigin(value: unknown): boolean {
+function isFailureOrigin(value: unknown): value is "provider" | "transport" | "process" | "application" | "unknown" {
   return ["provider", "transport", "process", "application", "unknown"].includes(value as string);
 }
 
@@ -5683,14 +5729,6 @@ function isDenseBoundedStringArray(value: unknown, maxItems: number, maxLength: 
   if (!Array.isArray(value) || value.length > maxItems) return false;
   for (let index = 0; index < value.length; index += 1) {
     if (!Object.hasOwn(value, index) || !isBoundedString(value[index], maxLength)) return false;
-  }
-  return true;
-}
-
-function isDenseJsonArray(value: unknown, maxItems: number): value is unknown[] {
-  if (!Array.isArray(value) || value.length > maxItems) return false;
-  for (let index = 0; index < value.length; index += 1) {
-    if (!Object.hasOwn(value, index) || !isJsonValue(value[index])) return false;
   }
   return true;
 }

--- a/src/persistence-worker/worker-runtime.ts
+++ b/src/persistence-worker/worker-runtime.ts
@@ -327,6 +327,9 @@ function readMessageContentChunk(
     )
     .get(request.offset, request.maxBytes, messageId, sessionId, workspaceKey) as
     Readonly<{ byte_length: number; chunk: Uint8Array }> | undefined;
+  if (row === undefined) {
+    throw new RepositoryReadError("not_found", "Repository resource was not found.");
+  }
   return chunkResult(row, request, { sessionId, messageId }, context, "Message");
 }
 

--- a/src/shared/application-session-message-model.ts
+++ b/src/shared/application-session-message-model.ts
@@ -1,0 +1,104 @@
+import type {
+  ApplicationAccessDecision,
+  ApplicationOperationOptions,
+  ApplicationOperationResponse,
+  ApplicationSessionOperationContext,
+} from "./application-service-model.js";
+import { MESSAGE_CONTENT_LIMITS, type TextContentBlock } from "./message-content.js";
+import { REPOSITORY_READ_LIMITS } from "./repository-read-model.js";
+
+export const APPLICATION_SESSION_MESSAGE_LIMITS = {
+  maxIdentifierLength: 1_024,
+  maxCursorLength: 2_048,
+  messagesDefaultItems: REPOSITORY_READ_LIMITS.messages.default,
+  messagesMaxItems: REPOSITORY_READ_LIMITS.messages.max,
+  inlineMaxBytes: MESSAGE_CONTENT_LIMITS.inlineMaxBytes,
+  maxContentBytes: MESSAGE_CONTENT_LIMITS.maxJsonBytes,
+  chunkMaxBytes: 256 * 1_024,
+} as const;
+
+export type ApplicationSessionMessageOperation = "messages" | "message_content_chunk";
+
+type ApplicationSessionMessageItemBase = Readonly<{
+  id: string;
+  ordinal: number;
+  role: "user" | "assistant";
+  contentByteLength: number;
+  createdAt: number;
+}>;
+
+export type ApplicationSessionMessageItem = ApplicationSessionMessageItemBase &
+  (
+    | Readonly<{ content: Readonly<{ state: "inline"; blocks: readonly TextContentBlock[] }> }>
+    | Readonly<{ content: Readonly<{ state: "chunked"; blocks?: never }> }>
+  );
+
+export type ApplicationSessionMessagePage = Readonly<{
+  sessionId: string;
+  items: readonly ApplicationSessionMessageItem[];
+  nextCursor?: string;
+}>;
+
+type ApplicationSessionMessageContentChunkBase = Readonly<{
+  sessionId: string;
+  messageId: string;
+  offset: number;
+  totalBytes: number;
+  byteLength: number;
+  bytes: ArrayBuffer;
+}>;
+
+export type ApplicationSessionMessageContentChunk = ApplicationSessionMessageContentChunkBase &
+  (Readonly<{ eof: true; nextOffset?: never }> | Readonly<{ eof: false; nextOffset: number }>);
+
+export type ApplicationSessionMessagesRequest<TAuthorizationContext> = Readonly<{
+  context: ApplicationSessionOperationContext<TAuthorizationContext>;
+  sessionId: string;
+  cursor?: string;
+  limit?: number;
+}>;
+
+export type ApplicationSessionMessageContentChunkRequest<TAuthorizationContext> = Readonly<{
+  context: ApplicationSessionOperationContext<TAuthorizationContext>;
+  sessionId: string;
+  messageId: string;
+  offset: number;
+  maxBytes: number;
+}>;
+
+export type ApplicationSessionMessageAccessValidationInput<TAuthorizationContext> =
+  | Readonly<{
+      operation: "messages";
+      access: "read";
+      context: ApplicationSessionOperationContext<TAuthorizationContext>;
+      target: Readonly<{ kind: "session_messages"; sessionId: string }>;
+    }>
+  | Readonly<{
+      operation: "message_content_chunk";
+      access: "read";
+      context: ApplicationSessionOperationContext<TAuthorizationContext>;
+      target: Readonly<{
+        kind: "session_message_content";
+        sessionId: string;
+        messageId: string;
+        offset: number;
+        maxBytes: number;
+      }>;
+    }>;
+
+export interface ApplicationSessionMessageAccessValidator<TAuthorizationContext> {
+  authorize(
+    input: ApplicationSessionMessageAccessValidationInput<TAuthorizationContext>,
+  ): Promise<ApplicationAccessDecision>;
+}
+
+export interface ApplicationSessionMessageOperations<TAuthorizationContext> {
+  messages(
+    request: ApplicationSessionMessagesRequest<TAuthorizationContext>,
+    options?: ApplicationOperationOptions,
+  ): Promise<ApplicationOperationResponse<ApplicationSessionMessagePage, "read">>;
+  messageContentChunk(
+    request: ApplicationSessionMessageContentChunkRequest<TAuthorizationContext>,
+    options?: ApplicationOperationOptions,
+  ): Promise<ApplicationOperationResponse<ApplicationSessionMessageContentChunk, "read">>;
+}

--- a/src/shared/message-content.ts
+++ b/src/shared/message-content.ts
@@ -1,0 +1,80 @@
+export const MESSAGE_CONTENT_LIMITS = {
+  maxBlocks: 10_000,
+  maxJsonBytes: 4 * 1024 * 1024,
+  inlineMaxBytes: 64 * 1024,
+} as const;
+
+export type TextContentBlock = Readonly<{
+  type: "text";
+  text: string;
+}>;
+
+export function snapshotMessageContentBlocks(value: unknown): readonly TextContentBlock[] | undefined {
+  try {
+    if (!Array.isArray(value) || value.length > MESSAGE_CONTENT_LIMITS.maxBlocks || !isDensePlainArray(value)) {
+      return undefined;
+    }
+    const blocks: TextContentBlock[] = [];
+    let minimumJsonBytes = 2;
+    for (let index = 0; index < value.length; index += 1) {
+      const element = Object.getOwnPropertyDescriptor(value, String(index));
+      if (element === undefined || !("value" in element)) return undefined;
+      const block = snapshotTextContentBlock(element.value);
+      if (block === undefined) return undefined;
+      minimumJsonBytes += (index === 0 ? 0 : 1) + 25 + block.text.length;
+      if (minimumJsonBytes > MESSAGE_CONTENT_LIMITS.maxJsonBytes) return undefined;
+      blocks.push(block);
+    }
+    if (new TextEncoder().encode(JSON.stringify(blocks)).byteLength > MESSAGE_CONTENT_LIMITS.maxJsonBytes) {
+      return undefined;
+    }
+    return Object.freeze(blocks);
+  } catch {
+    return undefined;
+  }
+}
+
+function snapshotTextContentBlock(value: unknown): TextContentBlock | undefined {
+  if (!isPlainRecord(value)) return undefined;
+  const keys = Reflect.ownKeys(value);
+  if (keys.length !== 2 || !keys.includes("type") || !keys.includes("text")) return undefined;
+  const type = Object.getOwnPropertyDescriptor(value, "type");
+  const text = Object.getOwnPropertyDescriptor(value, "text");
+  if (
+    type === undefined ||
+    !("value" in type) ||
+    !type.enumerable ||
+    type.value !== "text" ||
+    text === undefined ||
+    !("value" in text) ||
+    !text.enumerable ||
+    typeof text.value !== "string"
+  ) {
+    return undefined;
+  }
+  return Object.freeze({ type: "text", text: text.value });
+}
+
+function isDensePlainArray(value: unknown): value is readonly unknown[] {
+  if (!Array.isArray(value) || Object.getPrototypeOf(value) !== Array.prototype) return false;
+  const keys = Reflect.ownKeys(value);
+  if (keys.some((key) => typeof key !== "string" || (key !== "length" && !isArrayIndex(key, value.length)))) {
+    return false;
+  }
+  for (let index = 0; index < value.length; index += 1) {
+    if (!Object.hasOwn(value, index)) return false;
+  }
+  return true;
+}
+
+function isArrayIndex(value: string, length: number): boolean {
+  if (!/^(0|[1-9][0-9]*)$/u.test(value)) return false;
+  const index = Number(value);
+  return Number.isSafeInteger(index) && index >= 0 && index < length && String(index) === value;
+}
+
+function isPlainRecord(value: unknown): value is Readonly<Record<PropertyKey, unknown>> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value) as unknown;
+  return prototype === Object.prototype || prototype === null;
+}

--- a/src/shared/repository-write-model.ts
+++ b/src/shared/repository-write-model.ts
@@ -1,4 +1,5 @@
 import type { LocalRepositoryMetadata, SessionMetadata } from "./session-metadata.js";
+import type { TextContentBlock } from "./message-content.js";
 
 export const REPOSITORY_WRITE_OPERATIONS = {
   sessionCreate: "repository.session.create",
@@ -100,7 +101,7 @@ export type NormalRunAdmissionCommand = Readonly<{
   idempotencyKey: string;
   message: Readonly<{
     id: string;
-    contentBlocks: readonly RepositoryJsonValue[];
+    contentBlocks: readonly TextContentBlock[];
   }>;
   run: RunAdmissionDraft;
   attemptId: string;
@@ -143,7 +144,7 @@ export type ChildStartCommand = Readonly<{
   }>;
   message: Readonly<{
     id: string;
-    contentBlocks: readonly RepositoryJsonValue[];
+    contentBlocks: readonly TextContentBlock[];
   }>;
   run: RunAdmissionDraft;
   attemptId: string;
@@ -200,7 +201,7 @@ export type RunInputAdmissionCommand = Readonly<{
   ephemeralOwnerToken: string | null;
   message: Readonly<{
     id: string;
-    contentBlocks: readonly RepositoryJsonValue[];
+    contentBlocks: readonly TextContentBlock[];
   }>;
 }>;
 
@@ -286,7 +287,7 @@ export type RunTerminalOutcome =
       kind: "completed";
       finalAssistantMessage: Readonly<{
         id: string;
-        contentBlocks: readonly RepositoryJsonValue[];
+        contentBlocks: readonly TextContentBlock[];
       }> | null;
     }>
   | Readonly<{

--- a/test/application-session-message-service.test.ts
+++ b/test/application-session-message-service.test.ts
@@ -1,0 +1,656 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ApplicationSessionMessageService,
+  type ApplicationSessionMessageServiceOptions,
+} from "../src/main/application-session-message-service.js";
+import { PersistenceClientError } from "../src/main/persistence-worker-client.js";
+import {
+  APPLICATION_SESSION_MESSAGE_LIMITS,
+  type ApplicationSessionMessageAccessValidator,
+} from "../src/shared/application-session-message-model.js";
+
+type Authorization = Readonly<{ principal: string }>;
+type Reads = ApplicationSessionMessageServiceOptions<Authorization>["reads"];
+type MessagePageProjection = Awaited<ReturnType<Reads["messagesPage"]>>;
+
+const authorization: Authorization = { principal: "owner" };
+
+test("invalid Message requests fail before authorization and Repository access", async () => {
+  let authorizationCalls = 0;
+  let repositoryCalls = 0;
+  const service = createService({
+    access: {
+      async authorize() {
+        authorizationCalls += 1;
+        return { allowed: true };
+      },
+    },
+    reads: reads({
+      sessionGet: async () => {
+        repositoryCalls += 1;
+        return sessionProjection();
+      },
+      messagesPage: async () => {
+        repositoryCalls += 1;
+        return pageProjection();
+      },
+      messageContentChunk: async () => {
+        repositoryCalls += 1;
+        return chunkProjection();
+      },
+    }),
+  });
+  const invalidMessages = [
+    { ...messagesRequest(), sessionId: "" },
+    { ...messagesRequest(), cursor: "x".repeat(APPLICATION_SESSION_MESSAGE_LIMITS.maxCursorLength + 1) },
+    { ...messagesRequest(), limit: 0 },
+    { ...messagesRequest(), limit: APPLICATION_SESSION_MESSAGE_LIMITS.messagesMaxItems + 1 },
+    { ...messagesRequest(), unexpected: true },
+  ];
+  const invalidChunks = [
+    { ...chunkRequest(), messageId: "" },
+    { ...chunkRequest(), offset: -1 },
+    { ...chunkRequest(), maxBytes: 0 },
+    { ...chunkRequest(), maxBytes: APPLICATION_SESSION_MESSAGE_LIMITS.chunkMaxBytes + 1 },
+    { ...chunkRequest(), unexpected: true },
+  ];
+
+  for (const request of invalidMessages) {
+    const response = await service.messages(request as never);
+    assertFailure(response, "request", "request_invalid", "not_attempted");
+  }
+  for (const request of invalidChunks) {
+    const response = await service.messageContentChunk(request as never);
+    assertFailure(response, "request", "request_invalid", "not_attempted");
+  }
+  assert.equal(authorizationCalls, 0);
+  assert.equal(repositoryCalls, 0);
+});
+
+test("authorization targets distinguish the Message page from content and rejection performs no Repository read", async () => {
+  const targets: unknown[] = [];
+  let repositoryCalls = 0;
+  const service = createService({
+    access: {
+      async authorize(input) {
+        targets.push(input);
+        return {
+          allowed: false,
+          error: { code: "forbidden", message: "secret Message body C:\\private", retryable: false },
+        };
+      },
+    },
+    reads: reads({
+      sessionGet: async () => {
+        repositoryCalls += 1;
+        return sessionProjection();
+      },
+    }),
+  });
+
+  const messages = await service.messages(messagesRequest());
+  const chunk = await service.messageContentChunk(chunkRequest());
+
+  assertFailure(messages, "access", "forbidden", "not_attempted");
+  assertFailure(chunk, "access", "forbidden", "not_attempted");
+  assert.equal(JSON.stringify([messages, chunk]).includes("secret Message body"), false);
+  assert.equal(repositoryCalls, 0);
+  assert.deepEqual(targets, [
+    {
+      operation: "messages",
+      access: "read",
+      context: { authorization },
+      target: { kind: "session_messages", sessionId: "session-1" },
+    },
+    {
+      operation: "message_content_chunk",
+      access: "read",
+      context: { authorization },
+      target: {
+        kind: "session_message_content",
+        sessionId: "session-1",
+        messageId: "message-1",
+        offset: 0,
+        maxBytes: 4,
+      },
+    },
+  ]);
+});
+
+test("Message page resolves internal workspace scope, preserves ordinal gaps, and projects inline and chunked states", async () => {
+  const calls: unknown[] = [];
+  const blocks = [{ type: "text", text: "hello" }] as const;
+  const service = createService({
+    reads: reads({
+      sessionGet: async (input, options) => {
+        calls.push({ operation: "sessionGet", input, signal: options?.signal instanceof AbortSignal });
+        return sessionProjection("session-1", "workspace-1", "archived");
+      },
+      messagesPage: async (input, options) => {
+        calls.push({ operation: "messagesPage", input, signal: options?.signal instanceof AbortSignal });
+        return pageProjection(
+          [
+            messageProjection({ id: "message-1", ordinal: 2, blocks }),
+            messageProjection({
+              id: "message-2",
+              ordinal: 5,
+              contentState: "chunked",
+              contentByteLength: APPLICATION_SESSION_MESSAGE_LIMITS.inlineMaxBytes + 1,
+            }),
+          ],
+          "cursor-2",
+        );
+      },
+    }),
+  });
+
+  const response = await service.messages({ ...messagesRequest(), cursor: "cursor-1", limit: 2 });
+
+  assert.equal(response.overallStatus, "success");
+  if (response.overallStatus === "success") {
+    assert.deepEqual(response.value, {
+      sessionId: "session-1",
+      items: [
+        {
+          id: "message-1",
+          ordinal: 2,
+          role: "user",
+          contentByteLength: jsonByteLength(blocks),
+          createdAt: 10,
+          content: { state: "inline", blocks },
+        },
+        {
+          id: "message-2",
+          ordinal: 5,
+          role: "user",
+          contentByteLength: APPLICATION_SESSION_MESSAGE_LIMITS.inlineMaxBytes + 1,
+          createdAt: 10,
+          content: { state: "chunked" },
+        },
+      ],
+      nextCursor: "cursor-2",
+    });
+    assert.equal(Object.hasOwn(response.value, "workspaceKey"), false);
+    assert.equal(Object.hasOwn(response.value.items[1]!, "contentBlocks"), false);
+  }
+  assert.deepEqual(calls, [
+    { operation: "sessionGet", input: { sessionId: "session-1" }, signal: true },
+    {
+      operation: "messagesPage",
+      input: { sessionId: "session-1", workspaceKey: "workspace-1", cursor: "cursor-1", limit: 2 },
+      signal: true,
+    },
+  ]);
+});
+
+test("Message page uses the Repository default limit and snapshots inline blocks", async () => {
+  const source = [{ type: "text", text: "before" }] as { type: "text"; text: string }[];
+  const service = createService({
+    reads: reads({
+      messagesPage: async (input) => {
+        assert.equal(input.limit, APPLICATION_SESSION_MESSAGE_LIMITS.messagesDefaultItems);
+        return pageProjection([messageProjection({ blocks: source })]);
+      },
+    }),
+  });
+
+  const response = await service.messages(messagesRequest());
+  source[0]!.text = "after";
+  source.push({ type: "text", text: "mutated" });
+
+  assert.equal(response.overallStatus, "success");
+  if (response.overallStatus === "success") {
+    assert.deepEqual(response.value.items[0]!.content, {
+      state: "inline",
+      blocks: [{ type: "text", text: "before" }],
+    });
+    assert.equal(
+      Object.isFrozen(
+        response.value.items[0]!.content.state === "inline" ? response.value.items[0]!.content.blocks : [],
+      ),
+      true,
+    );
+  }
+});
+
+test("Repository Message omission becomes bounded partial success and is not projected as an item", async () => {
+  const service = createService({
+    reads: reads({
+      messagesPage: async () =>
+        pageProjection(
+          [
+            messageProjection({ id: "message-1", ordinal: 1 }),
+            { omitted: true, reason: "response_size_limit", ordinal: 2 },
+            messageProjection({ id: "message-3", ordinal: 3 }),
+          ],
+          "cursor-3",
+        ),
+    }),
+  });
+
+  const response = await service.messages(messagesRequest());
+
+  assert.equal(response.overallStatus, "partial_success");
+  if (response.overallStatus === "partial_success") {
+    assert.deepEqual(
+      response.value.items.map((item) => item.id),
+      ["message-1", "message-3"],
+    );
+    assert.deepEqual(response.issues, [
+      {
+        kind: "omission",
+        code: "response_size_limit",
+        message: "Message was omitted because the response size limit was reached.",
+        ordinal: 2,
+      },
+    ]);
+    assert.equal(response.value.nextCursor, "cursor-3");
+  }
+});
+
+test("Message page rejects malformed scope, ordering, content tuples, and content blocks as internal failures", async () => {
+  const inlineBlocks = [{ type: "text", text: "hello" }] as const;
+  const invalidPages: unknown[] = [
+    pageProjection([messageProjection({ sessionId: "session-other" })]),
+    { ...pageProjection(), workspaceKey: "workspace-other" },
+    pageProjection([messageProjection({ ordinal: 0 })]),
+    pageProjection([messageProjection({ ordinal: 2 }), messageProjection({ id: "message-2", ordinal: 1 })]),
+    pageProjection([{ ...messageProjection(), role: "system" }]),
+    pageProjection([{ ...messageProjection(), contentByteLength: 1 }]),
+    pageProjection([
+      { ...messageProjection({ blocks: inlineBlocks }), contentByteLength: jsonByteLength(inlineBlocks) + 1 },
+    ]),
+    pageProjection([{ ...messageProjection(), contentState: "inline", contentBlocks: undefined }]),
+    pageProjection([
+      {
+        ...messageProjection(),
+        contentState: "inline",
+        contentByteLength: APPLICATION_SESSION_MESSAGE_LIMITS.inlineMaxBytes + 1,
+      },
+    ]),
+    pageProjection([
+      {
+        ...messageProjection(),
+        contentState: "chunked",
+        contentByteLength: APPLICATION_SESSION_MESSAGE_LIMITS.inlineMaxBytes,
+      },
+    ]),
+    pageProjection([
+      {
+        ...messageProjection(),
+        contentState: "chunked",
+        contentByteLength: APPLICATION_SESSION_MESSAGE_LIMITS.inlineMaxBytes + 1,
+        contentBlocks: inlineBlocks,
+      },
+    ]),
+    pageProjection([{ ...messageProjection(), contentBlocks: [{ type: "tool", text: "private" }] }]),
+    pageProjection([], "cursor-same"),
+  ];
+
+  for (const page of invalidPages) {
+    const service = createService({ reads: reads({ messagesPage: async () => page as never }) });
+    const response = await service.messages({ ...messagesRequest(), cursor: "cursor-same" });
+    assertFailure(response, "application", "internal_error", "failed");
+    assert.equal(JSON.stringify(response).includes("private"), false);
+  }
+});
+
+test("Repository not-found is uniformly bounded for missing Session, workspace, and Message", async () => {
+  for (const operation of ["session", "page", "chunk"] as const) {
+    const secret = "C:\\private\\message.json raw Message content";
+    const error = new PersistenceClientError({ code: "not_found", message: secret, retryable: false, effect: "none" });
+    const service = createService({
+      reads: reads({
+        sessionGet: async () => {
+          if (operation === "session") throw error;
+          return sessionProjection();
+        },
+        messagesPage: async () => {
+          if (operation === "page") throw error;
+          return pageProjection();
+        },
+        messageContentChunk: async () => {
+          if (operation === "chunk") throw error;
+          return chunkProjection();
+        },
+      }),
+    });
+    const response =
+      operation === "chunk"
+        ? await service.messageContentChunk(chunkRequest())
+        : await service.messages(messagesRequest());
+    assertFailure(response, "domain", "not_found", "rejected");
+    assert.equal(JSON.stringify(response).includes(secret), false);
+  }
+});
+
+test("invalid persisted Message content remains a bounded internal chunk failure", async () => {
+  const secret = "private legacy Message content";
+  const error = new PersistenceClientError({
+    code: "operation_failed",
+    message: secret,
+    retryable: false,
+    effect: "none",
+  });
+  const service = createService({
+    reads: reads({
+      messageContentChunk: async () => {
+        throw error;
+      },
+    }),
+  });
+
+  const response = await service.messageContentChunk(chunkRequest());
+
+  assertFailure(response, "persistence", "persistence_operation_failed", "failed");
+  assert.equal(JSON.stringify(response).includes(secret), false);
+});
+
+test("Message content chunk uses actual bytes for byteLength, nextOffset, EOF, and buffer ownership", async () => {
+  const source = Uint8Array.from([1, 2, 3]).buffer;
+  const requests: unknown[] = [];
+  const service = createService({
+    reads: reads({
+      messageContentChunk: async (input, options) => {
+        requests.push({ input, signal: options?.signal instanceof AbortSignal });
+        return chunkProjection({ offset: 4, bytes: source, totalBytes: 10, eof: false });
+      },
+    }),
+  });
+
+  const response = await service.messageContentChunk({ ...chunkRequest(), offset: 4, maxBytes: 8 });
+  new Uint8Array(source)[0] = 99;
+
+  assert.equal(response.overallStatus, "success");
+  if (response.overallStatus === "success") {
+    assert.deepEqual(
+      { ...response.value, bytes: [...new Uint8Array(response.value.bytes)] },
+      {
+        sessionId: "session-1",
+        messageId: "message-1",
+        offset: 4,
+        totalBytes: 10,
+        byteLength: 3,
+        bytes: [1, 2, 3],
+        eof: false,
+        nextOffset: 7,
+      },
+    );
+    assert.notEqual(response.value.bytes, source);
+  }
+  assert.deepEqual(requests, [
+    {
+      input: {
+        sessionId: "session-1",
+        workspaceKey: "workspace-1",
+        messageId: "message-1",
+        offset: 4,
+        maxBytes: 8,
+      },
+      signal: true,
+    },
+  ]);
+});
+
+test("Message content chunk ownership cannot be bypassed by an own ArrayBuffer slice method", async () => {
+  const source = Uint8Array.from([1, 2]).buffer;
+  Object.defineProperty(source, "slice", { value: () => source });
+  const service = createService({
+    reads: reads({
+      messageContentChunk: async () => chunkProjection({ bytes: source, totalBytes: 2, eof: true }),
+    }),
+  });
+
+  const response = await service.messageContentChunk(chunkRequest());
+  assert.equal(response.overallStatus, "success");
+  if (response.overallStatus === "success") {
+    assert.notEqual(response.value.bytes, source);
+    new Uint8Array(source)[0] = 99;
+    assert.deepEqual([...new Uint8Array(response.value.bytes)], [1, 2]);
+  }
+});
+
+test("Message content chunk accepts exact-end and beyond-end empty EOF results", async () => {
+  for (const offset of [4, 8]) {
+    const service = createService({
+      reads: reads({
+        messageContentChunk: async () =>
+          chunkProjection({ offset, totalBytes: 4, bytes: new ArrayBuffer(0), eof: true }),
+      }),
+    });
+    const response = await service.messageContentChunk({ ...chunkRequest(), offset });
+    assert.equal(response.overallStatus, "success");
+    if (response.overallStatus === "success") {
+      assert.equal(response.value.byteLength, 0);
+      assert.equal(response.value.eof, true);
+      assert.equal(Object.hasOwn(response.value, "nextOffset"), false);
+    }
+  }
+});
+
+test("Message content chunk rejects inconsistent scope, clamp, progress, range, and EOF metadata", async () => {
+  const invalidChunks = [
+    chunkProjection({ sessionId: "session-other" }),
+    chunkProjection({ messageId: "message-other" }),
+    chunkProjection({ offset: 1 }),
+    chunkProjection({ bytes: new ArrayBuffer(5), totalBytes: 10, eof: false }),
+    chunkProjection({ bytes: new ArrayBuffer(0), totalBytes: 10, eof: false }),
+    chunkProjection({ bytes: new ArrayBuffer(2), totalBytes: 10, eof: true }),
+    chunkProjection({ bytes: new ArrayBuffer(5), totalBytes: 4, eof: true }),
+  ];
+  for (const chunk of invalidChunks) {
+    const service = createService({ reads: reads({ messageContentChunk: async () => chunk }) });
+    const response = await service.messageContentChunk(chunkRequest());
+    assertFailure(response, "application", "internal_error", "failed");
+  }
+});
+
+test("Message content chunk validates 1 and 256 KiB boundaries and supports inline-sized content", async () => {
+  for (const maxBytes of [1, APPLICATION_SESSION_MESSAGE_LIMITS.chunkMaxBytes]) {
+    let observedMaxBytes = 0;
+    const service = createService({
+      reads: reads({
+        messageContentChunk: async (input) => {
+          observedMaxBytes = input.maxBytes;
+          return chunkProjection({ bytes: Uint8Array.from([91]).buffer, totalBytes: 2, eof: false });
+        },
+      }),
+    });
+    const response = await service.messageContentChunk({ ...chunkRequest(), maxBytes });
+    assert.equal(response.overallStatus, "success");
+    assert.equal(observedMaxBytes, maxBytes);
+  }
+});
+
+test("timeout and AbortSignal cancellation abort a started Repository Message read and never become success", async () => {
+  let timeoutAborted = false;
+  const timeoutService = createService({
+    reads: reads({
+      messagesPage: async (_input, options) =>
+        pendingUntilAbort(options?.signal, () => {
+          timeoutAborted = true;
+        }),
+    }),
+  });
+  const timeout = await timeoutService.messages(messagesRequest(), { timeoutMs: 5 });
+  assertFailure(timeout, "persistence", "persistence_timeout", "failed");
+  assert.equal(timeoutAborted, true);
+
+  let cancelAborted = false;
+  let markChunkReadStarted!: () => void;
+  const chunkReadStarted = new Promise<void>((resolve) => {
+    markChunkReadStarted = resolve;
+  });
+  const cancelService = createService({
+    reads: reads({
+      messageContentChunk: async (_input, options) => {
+        markChunkReadStarted();
+        return pendingUntilAbort(options?.signal, () => {
+          cancelAborted = true;
+        });
+      },
+    }),
+  });
+  const controller = new AbortController();
+  const pending = cancelService.messageContentChunk(chunkRequest(), { signal: controller.signal });
+  await chunkReadStarted;
+  controller.abort();
+  const canceled = await pending;
+  assertFailure(canceled, "persistence", "persistence_canceled", "failed");
+  assert.equal(cancelAborted, true);
+});
+
+function createService(
+  overrides: Partial<ApplicationSessionMessageServiceOptions<Authorization>> = {},
+): ApplicationSessionMessageService<Authorization> {
+  return new ApplicationSessionMessageService({
+    reads: overrides.reads ?? reads(),
+    access: overrides.access ?? allowAccess(),
+    snapshotAuthorization(value) {
+      if (typeof value !== "object" || value === null || (value as Authorization).principal !== "owner") {
+        throw new TypeError("invalid authorization");
+      }
+      return { principal: "owner" };
+    },
+  });
+}
+
+function allowAccess(): ApplicationSessionMessageAccessValidator<Authorization> {
+  return {
+    async authorize() {
+      return { allowed: true };
+    },
+  };
+}
+
+function reads(overrides: Partial<Reads> = {}): Reads {
+  return {
+    sessionGet: overrides.sessionGet ?? (async () => sessionProjection()),
+    messagesPage: overrides.messagesPage ?? (async () => pageProjection()),
+    messageContentChunk: overrides.messageContentChunk ?? (async () => chunkProjection()),
+  };
+}
+
+function messagesRequest() {
+  return { context: { authorization }, sessionId: "session-1" } as const;
+}
+
+function chunkRequest() {
+  return { ...messagesRequest(), messageId: "message-1", offset: 0, maxBytes: 4 } as const;
+}
+
+function sessionProjection(
+  id = "session-1",
+  workspaceKey = "workspace-1",
+  lifecycleStatus: "active" | "archived" | "closed" = "active",
+) {
+  return {
+    session: {
+      id,
+      title: "Session",
+      providerId: "provider",
+      workspaceKey,
+      workspacePath: "C:\\workspace",
+      localRepositoryKey: null,
+      repositoryName: null,
+      allowedAdditionalDirectoriesByteLength: 2,
+      allowedAdditionalDirectoriesState: "inline" as const,
+      allowedAdditionalDirectories: [],
+      defaultCharacterId: "character",
+      maxConcurrentChildRuns: 2,
+      lifecycleStatus,
+      createdAt: 1,
+      updatedAt: 1,
+      lastActivityAt: 1,
+    },
+    execution: { state: "not_started" as const },
+  };
+}
+
+function pageProjection(items: readonly unknown[] = [messageProjection()], nextCursor?: string): MessagePageProjection {
+  return {
+    sessionId: "session-1",
+    workspaceKey: "workspace-1",
+    items,
+    ...(nextCursor === undefined ? {} : { nextCursor }),
+  } as unknown as MessagePageProjection;
+}
+
+function messageProjection(
+  overrides: Readonly<{
+    id?: string;
+    sessionId?: string;
+    ordinal?: number;
+    blocks?: unknown;
+    contentState?: "inline" | "chunked";
+    contentByteLength?: number;
+  }> = {},
+) {
+  const blocks = overrides.blocks ?? [{ type: "text", text: "hello" }];
+  const contentState = overrides.contentState ?? "inline";
+  return {
+    id: overrides.id ?? "message-1",
+    sessionId: overrides.sessionId ?? "session-1",
+    ordinal: overrides.ordinal ?? 1,
+    role: "user" as const,
+    contentByteLength: overrides.contentByteLength ?? jsonByteLength(blocks),
+    contentState,
+    ...(contentState === "inline" ? { contentBlocks: blocks } : {}),
+    createdAt: 10,
+  };
+}
+
+function chunkProjection(
+  overrides: Readonly<{
+    sessionId?: string;
+    messageId?: string;
+    offset?: number;
+    totalBytes?: number;
+    eof?: boolean;
+    bytes?: ArrayBuffer;
+  }> = {},
+) {
+  return {
+    sessionId: overrides.sessionId ?? "session-1",
+    messageId: overrides.messageId ?? "message-1",
+    offset: overrides.offset ?? 0,
+    totalBytes: overrides.totalBytes ?? 4,
+    eof: overrides.eof ?? true,
+    bytes: overrides.bytes ?? new ArrayBuffer(4),
+  };
+}
+
+function jsonByteLength(value: unknown): number {
+  return new TextEncoder().encode(JSON.stringify(value)).byteLength;
+}
+
+function assertFailure(
+  response: Readonly<{
+    overallStatus: string;
+    error?: Readonly<{ kind: string; code: string }>;
+    persistence: Readonly<{ status: string }>;
+  }>,
+  kind: string,
+  code: string,
+  persistenceStatus: string,
+): void {
+  assert.equal(response.overallStatus, "failure");
+  assert.equal(response.error?.kind, kind);
+  assert.equal(response.error?.code, code);
+  assert.equal(response.persistence.status, persistenceStatus);
+}
+
+function pendingUntilAbort<TValue>(signal: AbortSignal | undefined, onAbort: () => void): Promise<TValue> {
+  return new Promise((_resolve, reject) => {
+    signal?.addEventListener(
+      "abort",
+      () => {
+        onAbort();
+        reject(new Error("aborted"));
+      },
+      { once: true },
+    );
+  });
+}

--- a/test/cli-contract.test.ts
+++ b/test/cli-contract.test.ts
@@ -51,6 +51,18 @@ const commands = {
     offset: 4,
     maxBytes: 4,
   },
+  messages: {
+    identity: { namespace: "session", operation: "messages" },
+    sessionId: "session-1",
+    limit: 50,
+  },
+  "message-content-chunk": {
+    identity: { namespace: "session", operation: "message-content-chunk" },
+    sessionId: "session-1",
+    messageId: "message-1",
+    offset: 0,
+    maxBytes: 4,
+  },
   archive: {
     identity: { namespace: "session", operation: "archive" },
     sessionId: "session-1",
@@ -110,6 +122,26 @@ const invalidUnknownEffect: CliOperationOutput<"archive"> = {
     persistence: { status: "failed", effect: "unknown" },
   },
 };
+const invalidPartialMessageChunk: CliOperationOutput<"message-content-chunk"> = {
+  schemaVersion: CLI_SCHEMA_VERSION,
+  kind: "operation",
+  command: { namespace: "session", operation: "message-content-chunk" },
+  applicationResponse: {
+    // @ts-expect-error Message content chunks cannot report omission partial success
+    overallStatus: "partial_success",
+    value: {
+      sessionId: "session-1",
+      messageId: "message-1",
+      offset: 0,
+      totalBytes: 2,
+      chunk: { encoding: "base64", byteLength: 2, data: "AAA=" },
+      eof: true,
+    },
+    issues: [{ kind: "omission", code: "response_size_limit", message: "omitted", ordinal: 1 }],
+    persistence: { status: "read", effect: "none" },
+  },
+};
+void invalidPartialMessageChunk;
 const invalidArchiveLifecycle: CliOperationOutput<"archive"> = {
   schemaVersion: CLI_SCHEMA_VERSION,
   kind: "operation",

--- a/test/cli-lifecycle.test.ts
+++ b/test/cli-lifecycle.test.ts
@@ -12,6 +12,7 @@ import { CLI_VERSION } from "../src/cli/version.js";
 import type {
   ApplicationRunOperations,
   ApplicationRunOutputOperations,
+  ApplicationSessionMessageOperations,
   ApplicationSessionOperations,
 } from "../src/main/index.js";
 import { resolveWithMateDatabasePath } from "../src/main/cli-runtime.js";
@@ -20,6 +21,7 @@ type Authorization = Readonly<{ transport: "test" }>;
 type Operations = ApplicationSessionOperations<Authorization>;
 type RunOperations = ApplicationRunOperations<Authorization>;
 type RunOutputOperations = ApplicationRunOutputOperations<Authorization>;
+type MessageOperations = ApplicationSessionMessageOperations<Authorization>;
 
 const authorization: Authorization = { transport: "test" };
 const readArgv = ["session", "read", "--session-id", "session-1"] as const;
@@ -53,7 +55,12 @@ test("help and parse failures do not register signals or start runtime", async (
 
   const help = await runCliLifecycle(["--help"], dependencies);
   const runHelp = await runCliLifecycle(["run", "--help"], dependencies);
+  const messageHelp = await runCliLifecycle(["session", "messages", "--help"], dependencies);
   const invalid = await runCliLifecycle(["session", "read"], dependencies);
+  const invalidMessage = await runCliLifecycle(
+    ["session", "message-content-chunk", "--session-id", "session-1"],
+    dependencies,
+  );
   const invalidRun = await runCliLifecycle(["run", "status", "--session-id", "session-1"], dependencies);
   const invalidExport = await runCliLifecycle(
     [
@@ -77,7 +84,9 @@ test("help and parse failures do not register signals or start runtime", async (
 
   assert.equal(help.exitCode, CLI_EXIT_CODES.success);
   assert.equal(runHelp.exitCode, CLI_EXIT_CODES.success);
+  assert.equal(messageHelp.exitCode, CLI_EXIT_CODES.success);
   assert.equal(invalid.exitCode, CLI_EXIT_CODES.usageInvalid);
+  assert.equal(invalidMessage.exitCode, CLI_EXIT_CODES.usageInvalid);
   assert.equal(invalidRun.exitCode, CLI_EXIT_CODES.usageInvalid);
   assert.equal(invalidExport.exitCode, CLI_EXIT_CODES.usageInvalid);
   assert.equal(unconfirmedDelete.exitCode, CLI_EXIT_CODES.usageInvalid);
@@ -168,6 +177,42 @@ test("Run output completion writes one JSON object and performs one clean shutdo
   assert.equal(result.exitCode, CLI_EXIT_CODES.success);
   assert.equal((output.command as Readonly<Record<string, unknown>>).operation, "output-counts");
   assert.equal(outputCalls, 1);
+  assert.equal(shutdowns, 1);
+});
+
+test("Session Message completion writes one JSON object and performs one clean shutdown", async () => {
+  let messageCalls = 0;
+  let shutdowns = 0;
+  const messageOperations = unsupportedMessageOperations({
+    messages: async () => {
+      messageCalls += 1;
+      return {
+        overallStatus: "success",
+        value: { sessionId: "session-1", items: [] },
+        persistence: { status: "read", effect: "none" },
+      };
+    },
+  });
+  const result = await runCliLifecycle(["session", "messages", "--session-id", "session-1"], {
+    version: CLI_VERSION,
+    startRuntime: async () =>
+      runtime(
+        successfulOperations(),
+        async () => {
+          shutdowns += 1;
+          return { checkpoint: "completed" };
+        },
+        unsupportedRunOperations(),
+        unsupportedRunOutputOperations(),
+        messageOperations,
+      ),
+  });
+
+  const output = oneJsonObject(result.stdout);
+  assert.equal(result.stderr, "");
+  assert.equal(result.exitCode, CLI_EXIT_CODES.success);
+  assert.equal((output.command as Readonly<Record<string, unknown>>).operation, "messages");
+  assert.equal(messageCalls, 1);
   assert.equal(shutdowns, 1);
 });
 
@@ -808,8 +853,19 @@ function runtime(
   }),
   runOperations: RunOperations = unsupportedRunOperations(),
   runOutputOperations: RunOutputOperations = unsupportedRunOutputOperations(),
+  messageOperations: MessageOperations = unsupportedMessageOperations(),
 ) {
-  return { operations, runOperations, runOutputOperations, authorization, shutdown } as const;
+  return { operations, messageOperations, runOperations, runOutputOperations, authorization, shutdown } as const;
+}
+
+function unsupportedMessageOperations(overrides: Partial<MessageOperations> = {}): MessageOperations {
+  const unsupported = async (): Promise<never> => {
+    throw new Error("unexpected Message operation");
+  };
+  return {
+    messages: overrides.messages ?? unsupported,
+    messageContentChunk: overrides.messageContentChunk ?? unsupported,
+  };
 }
 
 function unsupportedRunOperations(overrides: Partial<RunOperations> = {}): RunOperations {

--- a/test/cli-session-dispatch.test.ts
+++ b/test/cli-session-dispatch.test.ts
@@ -4,10 +4,11 @@ import test from "node:test";
 
 import { CLI_EXIT_CODES, CLI_SCHEMA_VERSION } from "../src/cli/contract.js";
 import { runCliWithSessionOperations } from "../src/cli/invocation.js";
-import type { ApplicationSessionOperations } from "../src/main/index.js";
+import type { ApplicationSessionMessageOperations, ApplicationSessionOperations } from "../src/main/index.js";
 
 type Authorization = Readonly<{ principal: string }>;
 type Operations = ApplicationSessionOperations<Authorization>;
+type MessageOperations = ApplicationSessionMessageOperations<Authorization>;
 type OperationName = keyof Operations;
 type Call = Readonly<{ operation: OperationName; request: unknown; options: unknown }>;
 
@@ -387,7 +388,14 @@ test("help, version, and argv failures have stable output without invoking opera
 });
 
 function dependencies(operations: Operations) {
-  return { version: "0.1.0", operations, authorization } as const;
+  return { version: "0.1.0", operations, messageOperations: unsupportedMessageOperations(), authorization } as const;
+}
+
+function unsupportedMessageOperations(): MessageOperations {
+  const unsupported = async (): Promise<never> => {
+    throw new Error("unexpected Message operation");
+  };
+  return { messages: unsupported, messageContentChunk: unsupported };
 }
 
 function recordingOperations(

--- a/test/cli-session-message-contract.test.ts
+++ b/test/cli-session-message-contract.test.ts
@@ -1,0 +1,549 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { CLI_EXIT_CODES, CLI_SESSION_MESSAGE_LIMITS, type CliValidatedSessionCommand } from "../src/cli/contract.js";
+import { helpText } from "../src/cli/help.js";
+import { parseCliArgv } from "../src/cli/parser.js";
+import { dispatchCliSessionCommand } from "../src/cli/session-dispatch.js";
+import type { ApplicationSessionMessageOperations, ApplicationSessionOperations } from "../src/main/index.js";
+
+type Authorization = Readonly<{ principal: "local-user" }>;
+type MessageOperations = ApplicationSessionMessageOperations<Authorization>;
+
+const authorization: Authorization = { principal: "local-user" };
+
+test("Session Message parser accepts the complete grammar and Repository-aligned defaults", () => {
+  assert.deepEqual(
+    parseCliArgv([
+      "session",
+      "messages",
+      "--session-id",
+      "session-1",
+      "--cursor",
+      "opaque-1",
+      "--limit",
+      "100",
+      "--timeout-ms",
+      "5000",
+    ]),
+    {
+      kind: "command",
+      command: {
+        identity: { namespace: "session", operation: "messages" },
+        sessionId: "session-1",
+        cursor: "opaque-1",
+        limit: 100,
+        timeoutMs: 5000,
+      },
+    },
+  );
+  assert.deepEqual(parseCliArgv(["session", "messages", "--session-id", "session-1"]), {
+    kind: "command",
+    command: {
+      identity: { namespace: "session", operation: "messages" },
+      sessionId: "session-1",
+      limit: CLI_SESSION_MESSAGE_LIMITS.messagesDefaultItems,
+    },
+  });
+  assert.deepEqual(
+    parseCliArgv([
+      "session",
+      "message-content-chunk",
+      "--session-id",
+      "session-1",
+      "--message-id",
+      "message-1",
+      "--offset",
+      "0",
+      "--max-bytes",
+      "262144",
+      "--timeout-ms",
+      "5000",
+    ]),
+    {
+      kind: "command",
+      command: {
+        identity: { namespace: "session", operation: "message-content-chunk" },
+        sessionId: "session-1",
+        messageId: "message-1",
+        offset: 0,
+        maxBytes: 262_144,
+        timeoutMs: 5000,
+      },
+    },
+  );
+});
+
+test("Session Message parser rejects missing, duplicate, unknown, and out-of-range options", () => {
+  const overlong = "x".repeat(2_049);
+  const invalidArgv = [
+    ["session", "messages"],
+    ["session", "messages", "--session-id", "session-1", "--session-id", "session-2"],
+    ["session", "messages", "--session-id", "session-1", "--unknown", "x"],
+    ["session", "messages", "--session-id", "session-1", "--cursor", overlong],
+    ["session", "messages", "--session-id", "session-1", "--limit", "0"],
+    ["session", "messages", "--session-id", "session-1", "--limit", "101"],
+    ["session", "message-content-chunk", "--session-id", "session-1", "--message-id", "message-1"],
+    [
+      "session",
+      "message-content-chunk",
+      "--session-id",
+      "session-1",
+      "--message-id",
+      "message-1",
+      "--offset",
+      "-1",
+      "--max-bytes",
+      "1",
+    ],
+    [
+      "session",
+      "message-content-chunk",
+      "--session-id",
+      "session-1",
+      "--message-id",
+      "message-1",
+      "--offset",
+      "0",
+      "--max-bytes",
+      "0",
+    ],
+    [
+      "session",
+      "message-content-chunk",
+      "--session-id",
+      "session-1",
+      "--message-id",
+      "message-1",
+      "--offset",
+      "0",
+      "--max-bytes",
+      "262145",
+    ],
+  ];
+
+  for (const argv of invalidArgv) {
+    const result = parseCliArgv(argv);
+    assert.equal(result.kind, "usage_failure", argv.join(" "));
+    if (result.kind === "usage_failure") assert.equal(result.exitCode, CLI_EXIT_CODES.usageInvalid);
+  }
+});
+
+test("Session Message help publishes the accepted command grammar", () => {
+  const sessionHelp = helpText({ kind: "session" });
+  const messagesHelp = helpText({
+    kind: "operation",
+    command: { namespace: "session", operation: "messages" },
+  });
+  const chunkHelp = helpText({
+    kind: "operation",
+    command: { namespace: "session", operation: "message-content-chunk" },
+  });
+
+  assert.match(sessionHelp, /messages/u);
+  assert.match(sessionHelp, /message-content-chunk/u);
+  assert.match(messagesHelp, /--limit <1\.\.100>\s+Default: 50/u);
+  assert.match(messagesHelp, /--cursor <opaque-cursor>/u);
+  assert.match(chunkHelp, /--message-id <message-id>/u);
+  assert.match(chunkHelp, /--offset <non-negative-integer>/u);
+  assert.match(chunkHelp, /--max-bytes <1\.\.262144>/u);
+});
+
+test("Message page dispatch propagates authorization and strictly projects inline, chunked, and omission results", async () => {
+  const calls: unknown[] = [];
+  const blocks = [{ type: "text", text: "hello" }] as const;
+  const command = parsedCommand([
+    "session",
+    "messages",
+    "--session-id",
+    "session-1",
+    "--cursor",
+    "cursor-1",
+    "--limit",
+    "3",
+    "--timeout-ms",
+    "5000",
+  ]);
+  const messageOperations = messageOperationsFixture({
+    messages: async (request, options) => {
+      calls.push({ request, options });
+      return {
+        overallStatus: "partial_success",
+        value: {
+          sessionId: "session-1",
+          items: [
+            {
+              id: "message-1",
+              ordinal: 1,
+              role: "user",
+              contentByteLength: jsonByteLength(blocks),
+              createdAt: 1,
+              content: { state: "inline", blocks },
+            },
+            {
+              id: "message-3",
+              ordinal: 3,
+              role: "assistant",
+              contentByteLength: 65_537,
+              createdAt: 3,
+              content: { state: "chunked" },
+            },
+          ],
+          nextCursor: "cursor-3",
+        },
+        issues: [
+          {
+            kind: "omission",
+            code: "response_size_limit",
+            message: "Message was omitted because the response size limit was reached.",
+            ordinal: 2,
+          },
+        ],
+        persistence: { status: "read", effect: "none" },
+      };
+    },
+  });
+
+  const result = await dispatchCliSessionCommand(command, dependencies(messageOperations));
+
+  assert.equal(result.ok, true);
+  assert.equal(result.exitCode, CLI_EXIT_CODES.partialSuccess);
+  assert.deepEqual(calls, [
+    {
+      request: {
+        context: { authorization },
+        sessionId: "session-1",
+        cursor: "cursor-1",
+        limit: 3,
+      },
+      options: { timeoutMs: 5000 },
+    },
+  ]);
+  assert.equal(result.output.kind, "operation");
+  if (result.output.kind === "operation") {
+    assert.deepEqual(result.output.applicationResponse, {
+      overallStatus: "partial_success",
+      value: {
+        sessionId: "session-1",
+        items: [
+          {
+            id: "message-1",
+            ordinal: 1,
+            role: "user",
+            contentByteLength: jsonByteLength(blocks),
+            createdAt: 1,
+            content: { state: "inline", blocks },
+          },
+          {
+            id: "message-3",
+            ordinal: 3,
+            role: "assistant",
+            contentByteLength: 65_537,
+            createdAt: 3,
+            content: { state: "chunked" },
+          },
+        ],
+        nextCursor: "cursor-3",
+      },
+      issues: [
+        {
+          kind: "omission",
+          code: "response_size_limit",
+          message: "Message was omitted because the response size limit was reached.",
+          ordinal: 2,
+        },
+      ],
+      persistence: { status: "read", effect: "none" },
+    });
+    assert.equal(JSON.stringify(result.output).includes("workspaceKey"), false);
+  }
+});
+
+test("Message content chunk dispatch emits base64 for actual bytes and preserves EOF coupling", async () => {
+  const calls: unknown[] = [];
+  const command = parsedCommand([
+    "session",
+    "message-content-chunk",
+    "--session-id",
+    "session-1",
+    "--message-id",
+    "message-1",
+    "--offset",
+    "4",
+    "--max-bytes",
+    "8",
+  ]);
+  const messageOperations = messageOperationsFixture({
+    messageContentChunk: async (request, options) => {
+      calls.push({ request, options });
+      return {
+        overallStatus: "success",
+        value: {
+          sessionId: "session-1",
+          messageId: "message-1",
+          offset: 4,
+          totalBytes: 10,
+          byteLength: 3,
+          bytes: Uint8Array.from([1, 2, 3]).buffer,
+          eof: false,
+          nextOffset: 7,
+        },
+        persistence: { status: "read", effect: "none" },
+      };
+    },
+  });
+
+  const result = await dispatchCliSessionCommand(command, dependencies(messageOperations));
+
+  assert.equal(result.ok, true);
+  assert.equal(result.exitCode, CLI_EXIT_CODES.success);
+  assert.deepEqual(calls, [
+    {
+      request: {
+        context: { authorization },
+        sessionId: "session-1",
+        messageId: "message-1",
+        offset: 4,
+        maxBytes: 8,
+      },
+      options: {},
+    },
+  ]);
+  assert.equal(result.output.kind, "operation");
+  if (result.output.kind === "operation" && result.output.applicationResponse.overallStatus === "success") {
+    assert.deepEqual(result.output.applicationResponse.value, {
+      sessionId: "session-1",
+      messageId: "message-1",
+      offset: 4,
+      totalBytes: 10,
+      chunk: { encoding: "base64", byteLength: 3, data: "AQID" },
+      eof: false,
+      nextOffset: 7,
+    });
+    assert.equal(Buffer.from(result.output.applicationResponse.value.chunk.data, "base64").byteLength, 3);
+    assert.equal(Object.hasOwn(result.output.applicationResponse.value, "bytes"), false);
+  }
+});
+
+test("CLI projector rejects malformed Message tuples, raw fields, and inconsistent chunk metadata", async () => {
+  const blocks = [{ type: "text", text: "hello" }] as const;
+  const pageCommand = parsedCommand(["session", "messages", "--session-id", "session-1"]);
+  const invalidPageValues = [
+    {
+      sessionId: "session-1",
+      items: [
+        {
+          id: "message-1",
+          ordinal: 1,
+          role: "user",
+          contentByteLength: jsonByteLength(blocks),
+          createdAt: 1,
+          content: { state: "chunked", blocks },
+        },
+      ],
+    },
+    {
+      sessionId: "session-1",
+      items: [
+        {
+          id: "message-1",
+          ordinal: 1,
+          role: "user",
+          contentByteLength: jsonByteLength(blocks),
+          createdAt: 1,
+          content: { state: "inline", blocks },
+          providerPayload: "private",
+        },
+      ],
+    },
+  ];
+  for (const value of invalidPageValues) {
+    const result = await dispatchCliSessionCommand(
+      pageCommand,
+      dependencies(messageOperationsFixture({ messages: async () => success(value) as never })),
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.exitCode, CLI_EXIT_CODES.runtimeFailure);
+    assert.equal(JSON.stringify(result.output).includes("private"), false);
+  }
+  const zeroOrdinalOmission = await dispatchCliSessionCommand(
+    pageCommand,
+    dependencies(
+      messageOperationsFixture({
+        messages: async () =>
+          ({
+            overallStatus: "partial_success",
+            value: { sessionId: "session-1", items: [] },
+            issues: [{ kind: "omission", code: "response_size_limit", message: "omitted", ordinal: 0 }],
+            persistence: { status: "read", effect: "none" },
+          }) as never,
+      }),
+    ),
+  );
+  assert.equal(zeroOrdinalOmission.ok, false);
+  assert.equal(zeroOrdinalOmission.exitCode, CLI_EXIT_CODES.runtimeFailure);
+
+  const invalidOmissionOrdinals = [
+    {
+      value: {
+        sessionId: "session-1",
+        items: [
+          {
+            id: "message-1",
+            ordinal: 1,
+            role: "user",
+            contentByteLength: jsonByteLength(blocks),
+            createdAt: 1,
+            content: { state: "inline", blocks },
+          },
+        ],
+      },
+      issues: [{ kind: "omission", code: "response_size_limit", message: "omitted", ordinal: 1 }],
+    },
+    {
+      value: { sessionId: "session-1", items: [] },
+      issues: [
+        { kind: "omission", code: "response_size_limit", message: "omitted", ordinal: 2 },
+        { kind: "omission", code: "response_size_limit", message: "omitted", ordinal: 1 },
+      ],
+    },
+  ];
+  for (const response of invalidOmissionOrdinals) {
+    const result = await dispatchCliSessionCommand(
+      pageCommand,
+      dependencies(
+        messageOperationsFixture({
+          messages: async () =>
+            ({
+              overallStatus: "partial_success",
+              ...response,
+              persistence: { status: "read", effect: "none" },
+            }) as never,
+        }),
+      ),
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.exitCode, CLI_EXIT_CODES.runtimeFailure);
+  }
+
+  const chunkCommand = parsedCommand([
+    "session",
+    "message-content-chunk",
+    "--session-id",
+    "session-1",
+    "--message-id",
+    "message-1",
+    "--offset",
+    "0",
+    "--max-bytes",
+    "4",
+  ]);
+  const invalidChunks = [
+    { byteLength: 3, bytes: new ArrayBuffer(2), eof: true },
+    { byteLength: 2, bytes: new ArrayBuffer(2), eof: false, nextOffset: 4 },
+    { byteLength: 2, bytes: new ArrayBuffer(2), eof: true, nextOffset: 2 },
+  ];
+  for (const invalid of invalidChunks) {
+    const value = {
+      sessionId: "session-1",
+      messageId: "message-1",
+      offset: 0,
+      totalBytes: 2,
+      ...invalid,
+    };
+    const result = await dispatchCliSessionCommand(
+      chunkCommand,
+      dependencies(messageOperationsFixture({ messageContentChunk: async () => success(value) as never })),
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.exitCode, CLI_EXIT_CODES.runtimeFailure);
+  }
+
+  const accessorChunk = {
+    sessionId: "session-1",
+    messageId: "message-1",
+    offset: 0,
+    totalBytes: 2,
+    byteLength: 2,
+    bytes: new ArrayBuffer(2),
+  } as Record<string, unknown>;
+  Object.defineProperty(accessorChunk, "eof", { enumerable: true, get: () => true });
+  const accessorResult = await dispatchCliSessionCommand(
+    chunkCommand,
+    dependencies(messageOperationsFixture({ messageContentChunk: async () => success(accessorChunk) as never })),
+  );
+  assert.equal(accessorResult.ok, false);
+  assert.equal(accessorResult.exitCode, CLI_EXIT_CODES.runtimeFailure);
+
+  const partialChunk = await dispatchCliSessionCommand(
+    chunkCommand,
+    dependencies(
+      messageOperationsFixture({
+        messageContentChunk: async () =>
+          ({
+            overallStatus: "partial_success",
+            value: {
+              sessionId: "session-1",
+              messageId: "message-1",
+              offset: 0,
+              totalBytes: 2,
+              byteLength: 2,
+              bytes: new ArrayBuffer(2),
+              eof: true,
+            },
+            issues: [{ kind: "omission", code: "response_size_limit", message: "omitted", ordinal: 1 }],
+            persistence: { status: "read", effect: "none" },
+          }) as never,
+      }),
+    ),
+  );
+  assert.equal(partialChunk.ok, false);
+  assert.equal(partialChunk.exitCode, CLI_EXIT_CODES.runtimeFailure);
+});
+
+function parsedCommand(argv: readonly string[]): CliValidatedSessionCommand {
+  const parsed = parseCliArgv(argv);
+  assert.equal(parsed.kind, "command");
+  if (parsed.kind !== "command" || parsed.command.identity.namespace !== "session") assert.fail("expected command");
+  return parsed.command as CliValidatedSessionCommand;
+}
+
+function dependencies(messageOperations: MessageOperations) {
+  return { operations: unsupportedSessionOperations(), messageOperations, authorization } as const;
+}
+
+function messageOperationsFixture(overrides: Partial<MessageOperations>): MessageOperations {
+  const unsupported = async (): Promise<never> => {
+    throw new Error("unexpected Message operation");
+  };
+  return {
+    messages: overrides.messages ?? unsupported,
+    messageContentChunk: overrides.messageContentChunk ?? unsupported,
+  };
+}
+
+function unsupportedSessionOperations(): ApplicationSessionOperations<Authorization> {
+  const unsupported = async (): Promise<never> => {
+    throw new Error("unexpected Session operation");
+  };
+  return {
+    create: unsupported,
+    updateTitle: unsupported,
+    list: unsupported,
+    listLocalRepositories: unsupported,
+    read: unsupported,
+    readDirectoriesChunk: unsupported,
+    archive: unsupported,
+    unarchive: unsupported,
+    close: unsupported,
+    delete: unsupported,
+  };
+}
+
+function success(value: unknown) {
+  return { overallStatus: "success", value, persistence: { status: "read", effect: "none" } } as const;
+}
+
+function jsonByteLength(value: unknown): number {
+  return new TextEncoder().encode(JSON.stringify(value)).byteLength;
+}

--- a/test/message-content.test.ts
+++ b/test/message-content.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { MESSAGE_CONTENT_LIMITS, snapshotMessageContentBlocks } from "../src/shared/message-content.js";
+
+test("Message content accepts and snapshots exact dense text blocks", () => {
+  const source = [
+    { type: "text", text: "hello" },
+    Object.assign(Object.create(null) as Record<string, unknown>, { type: "text", text: "world" }),
+  ];
+  const snapshot = snapshotMessageContentBlocks(source);
+  assert.deepEqual(snapshot, [
+    { type: "text", text: "hello" },
+    { type: "text", text: "world" },
+  ]);
+  source[0]!.text = "changed";
+  assert.equal(snapshot?.[0]?.text, "hello");
+  assert.equal(Object.isFrozen(snapshot), true);
+  assert.equal(Object.isFrozen(snapshot?.[0]), true);
+  assert.deepEqual(snapshotMessageContentBlocks([]), []);
+});
+
+test("Message content rejects sparse arrays and non-text block shapes", () => {
+  const sparse = new Array(1);
+  const inherited = Object.create({ type: "text", text: "inherited" }) as Record<string, unknown>;
+  const accessor = Object.defineProperties(
+    {},
+    {
+      type: { enumerable: true, value: "text" },
+      text: { enumerable: true, get: () => "accessor" },
+    },
+  );
+  for (const value of [
+    sparse,
+    [{ type: "text" }],
+    [{ type: "text", text: 1 }],
+    [{ type: "tool", text: "result" }],
+    [{ type: "text", text: "hello", extra: true }],
+    [inherited],
+    [accessor],
+  ]) {
+    assert.equal(snapshotMessageContentBlocks(value), undefined);
+  }
+});
+
+test("Message content enforces the exact UTF-8 JSON byte ceiling", () => {
+  const emptyJsonBytes = new TextEncoder().encode(JSON.stringify([{ type: "text", text: "" }])).byteLength;
+  const exactText = "x".repeat(MESSAGE_CONTENT_LIMITS.maxJsonBytes - emptyJsonBytes);
+  const exact = snapshotMessageContentBlocks([{ type: "text", text: exactText }]);
+  assert.equal(exact?.[0]?.text.length, exactText.length);
+  assert.equal(snapshotMessageContentBlocks([{ type: "text", text: `${exactText}x` }]), undefined);
+});
+
+test("Message content enforces the exact block count ceiling", () => {
+  const exact = Array.from({ length: MESSAGE_CONTENT_LIMITS.maxBlocks }, () => ({ type: "text", text: "" }));
+  assert.equal(snapshotMessageContentBlocks(exact)?.length, MESSAGE_CONTENT_LIMITS.maxBlocks);
+  exact.push({ type: "text", text: "" });
+  assert.equal(snapshotMessageContentBlocks(exact), undefined);
+});

--- a/test/persistence-worker-lifecycle.test.ts
+++ b/test/persistence-worker-lifecycle.test.ts
@@ -1172,14 +1172,31 @@ test("all Repository chunk operations clamp envelope metadata and advance withou
 
   const messages: WorkerToMainMessage[] = [];
   const transfers: Array<readonly ArrayBuffer[]> = [];
+  const messageChunkStatements: string[] = [];
   const generationId = "018f1f4e-7f0a-7000-8000-000000000001";
-  const runtime = new PersistenceWorkerRuntime(generationId, database, ":memory:", (message, transferList) => {
+  const observedDatabase = new Proxy(database, {
+    get(target, property) {
+      if (property === "prepare") {
+        return (sql: string) => {
+          if (sql.includes("FROM messages m JOIN sessions s ON s.id = m.session_id")) {
+            messageChunkStatements.push(sql);
+          }
+          return target.prepare(sql);
+        };
+      }
+      const value = Reflect.get(target, property, target) as unknown;
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+  const runtime = new PersistenceWorkerRuntime(generationId, observedDatabase, ":memory:", (message, transferList) => {
     messages.push(message);
     transfers.push(transferList ?? []);
   });
+  messageChunkStatements.length = 0;
   let sequence = 0;
   const send = async (operation: string, payload: Readonly<Record<string, unknown>>) => {
     const index = messages.length;
+    const messageStatementIndex = messageChunkStatements.length;
     sequence += 1;
     runtime.handleMessage({
       protocolVersion: PERSISTENCE_PROTOCOL_VERSION,
@@ -1194,6 +1211,12 @@ test("all Repository chunk operations clamp envelope metadata and advance withou
     await waitFor(() => messages.length === index + 1);
     const response = messages[index];
     assert.ok(response);
+    if (operation === "repository.message.content-chunk") {
+      const statements = messageChunkStatements.slice(messageStatementIndex);
+      assert.equal(statements.length, 1);
+      assert.match(statements[0] ?? "", /substr\(CAST\(m\.content_blocks_json AS BLOB\), \? \+ 1, \?\)/);
+      assert.doesNotMatch(statements[0] ?? "", /SELECT\s+m\.content_blocks_json\s*,/);
+    }
     return { response, transferList: transfers[index] ?? [] };
   };
 
@@ -1271,6 +1294,21 @@ test("all Repository chunk operations clamp envelope metadata and advance withou
     overlong.response.kind === "response" && !overlong.response.ok && overlong.response.error.code,
     "payload_chunk_invalid",
   );
+  for (const scope of [
+    { sessionId: "missing-session", messageId, workspaceKey },
+    { sessionId, messageId: "missing-message", workspaceKey },
+    { sessionId, messageId, workspaceKey: "missing-workspace" },
+  ]) {
+    const missingMessage = await send("repository.message.content-chunk", {
+      ...scope,
+      offset: 0,
+      maxBytes: 1,
+    });
+    assert.equal(
+      missingMessage.response.kind === "response" && !missingMessage.response.ok && missingMessage.response.error.code,
+      "not_found",
+    );
+  }
   database.close();
 });
 
@@ -1339,7 +1377,7 @@ function productionRunAdmission(sessionId: string, runId: string, idempotencyKey
     attemptId: `attempt-${runId}`,
     bindingIntent: { kind: "create" as const, bindingId: `binding-${runId}`, persistenceMode: "persistent" as const },
     dispatch: { providerRequest: { prompt: "hello" }, providerIdempotencyKey: null },
-  };
+  } as const;
 }
 
 function productionChildStart(parentSessionId: string, parentRunId: string, idempotencyKey: string) {
@@ -1391,7 +1429,7 @@ function productionChildStart(parentSessionId: string, parentRunId: string, idem
       providerIdempotencyKey: null,
     },
     deliveryId: "delivery-worker-child",
-  };
+  } as const;
 }
 
 function isClientError(error: unknown, code: string, effect: string): boolean {

--- a/test/public-application-service-api.test.ts
+++ b/test/public-application-service-api.test.ts
@@ -2,7 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import * as publicApi from "../src/main/index.js";
-import type { ApplicationSessionOperations } from "../src/main/index.js";
+import type { ApplicationSessionMessageOperations, ApplicationSessionOperations } from "../src/main/index.js";
+import type {
+  ApplicationSessionMessageContentChunk,
+  ApplicationSessionMessageItem,
+} from "../src/shared/application-session-message-model.js";
 import {
   type ApplicationCapacityExceededDetails,
   type ApplicationDomainError,
@@ -27,12 +31,62 @@ type PartialPersistenceIssue = Extract<Partial["issues"][number], Readonly<{ kin
 type DomainError = Extract<ApplicationDomainError, Readonly<{ code: ApplicationDomainErrorCode }>>;
 type CapacityError = Extract<DomainError, Readonly<{ code: "capacity_exceeded" }>>;
 type Operations = ApplicationSessionOperations<Authorization>;
+type MessageOperations = ApplicationSessionMessageOperations<Authorization>;
+type MessagePageResponse = Awaited<ReturnType<MessageOperations["messages"]>>;
+type MessageChunkResponse = Awaited<ReturnType<MessageOperations["messageContentChunk"]>>;
 type CreateResponse = Awaited<ReturnType<Operations["create"]>>;
 type ListResponse = Awaited<ReturnType<Operations["list"]>>;
 type DirectoriesChunkResponse = Awaited<ReturnType<Operations["readDirectoriesChunk"]>>;
 type DeleteResponse = Awaited<ReturnType<Operations["delete"]>>;
 type DeleteCleanupIssue = Extract<DeleteResponse, Readonly<{ overallStatus: "partial_success" }>>["issues"][number];
 const localRepositoryKey = `local-repository-v1-sha256-${"a".repeat(64)}`;
+
+const messageItemBase = {
+  id: "message-1",
+  ordinal: 1,
+  role: "user" as const,
+  contentByteLength: 2,
+  createdAt: 1,
+};
+// @ts-expect-error inline Message content requires blocks
+const invalidInlineMessage: ApplicationSessionMessageItem = { ...messageItemBase, content: { state: "inline" } };
+const invalidChunkedMessage: ApplicationSessionMessageItem = {
+  ...messageItemBase,
+  // @ts-expect-error chunked Message content cannot carry blocks
+  content: { state: "chunked", blocks: [] },
+};
+const invalidChunkedContentVariable = { state: "chunked" as const, blocks: [] };
+const invalidChunkedMessageVariable: ApplicationSessionMessageItem = {
+  ...messageItemBase,
+  // @ts-expect-error chunked Message content cannot carry blocks through a structural variable
+  content: invalidChunkedContentVariable,
+};
+// @ts-expect-error EOF Message chunks cannot expose a next offset
+const invalidEofMessageChunk: ApplicationSessionMessageContentChunk = {
+  sessionId: "session-1",
+  messageId: "message-1",
+  offset: 0,
+  totalBytes: 2,
+  byteLength: 2,
+  bytes: new ArrayBuffer(2),
+  eof: true,
+  nextOffset: 2,
+};
+// @ts-expect-error non-EOF Message chunks require a next offset
+const invalidProgressMessageChunk: ApplicationSessionMessageContentChunk = {
+  sessionId: "session-1",
+  messageId: "message-1",
+  offset: 0,
+  totalBytes: 2,
+  byteLength: 1,
+  bytes: new ArrayBuffer(1),
+  eof: false,
+};
+void invalidInlineMessage;
+void invalidChunkedMessage;
+void invalidChunkedMessageVariable;
+void invalidEofMessageChunk;
+void invalidProgressMessageChunk;
 
 const listItemBase = {
   id: "session-1",
@@ -378,4 +432,24 @@ test("public Application Service barrel exposes the transport-neutral Session co
   assert.equal(read, null);
   assert.equal(operations, null);
   assert.deepEqual(typeContract, [true, true, true, true, true, true, true, true, true, true, true, true]);
+});
+
+test("public Application Service barrel exposes the transport-neutral Session Message contract", () => {
+  const operations = null as MessageOperations | null;
+  type PageValue = Extract<MessagePageResponse, Readonly<{ overallStatus: "success" }>>["value"];
+  type ChunkValue = Extract<MessageChunkResponse, Readonly<{ overallStatus: "success" }>>["value"];
+  type InlineContent = Extract<PageValue["items"][number]["content"], Readonly<{ state: "inline" }>>;
+  type ChunkedContent = Extract<PageValue["items"][number]["content"], Readonly<{ state: "chunked" }>>;
+  type EofChunk = Extract<ChunkValue, Readonly<{ eof: true }>>;
+  type ProgressChunk = Extract<ChunkValue, Readonly<{ eof: false }>>;
+  const typeContract: readonly [
+    Equal<InlineContent["blocks"][number], Readonly<{ type: "text"; text: string }>>,
+    Equal<ChunkedContent["blocks"], undefined>,
+    Equal<EofChunk["nextOffset"], undefined>,
+    Equal<ProgressChunk["nextOffset"], number>,
+    Equal<ChunkValue["bytes"], ArrayBuffer>,
+  ] = [true, true, true, true, true];
+
+  assert.equal(operations, null);
+  assert.deepEqual(typeContract, [true, true, true, true, true]);
 });

--- a/test/public-repository-api.test.ts
+++ b/test/public-repository-api.test.ts
@@ -8,6 +8,7 @@ import * as publicApi from "../src/main/index.js";
 import type {
   ApplicationRunOperations,
   ApplicationRunOutputOperations,
+  ApplicationSessionMessageOperations,
   ApplicationSessionOperations,
 } from "../src/main/index.js";
 
@@ -15,6 +16,7 @@ type Authorization = Readonly<{ principalId: string }>;
 type SessionListInput = Parameters<ApplicationSessionOperations<Authorization>["list"]>[0];
 type RunStatusInput = Parameters<ApplicationRunOperations<Authorization>["status"]>[0];
 type RunOutputCountsInput = Parameters<ApplicationRunOutputOperations<Authorization>["outputCounts"]>[0];
+type MessageChunkInput = Parameters<ApplicationSessionMessageOperations<Authorization>["messageContentChunk"]>[0];
 
 test("public Main barrel exposes only the transport-neutral Application contract", () => {
   const sourcePath = new URL("../src/main/index.ts", import.meta.url);
@@ -30,9 +32,11 @@ test("public Main barrel exposes only the transport-neutral Application contract
   const listInput = null as SessionListInput | null;
   const statusInput = null as RunStatusInput | null;
   const outputCountsInput = null as RunOutputCountsInput | null;
+  const messageChunkInput = null as MessageChunkInput | null;
 
   assert.deepEqual(exportedModules, [
     "../shared/application-service-model.js",
+    "../shared/application-session-message-model.js",
     "../shared/application-run-model.js",
     "../shared/application-run-output-model.js",
   ]);
@@ -40,4 +44,5 @@ test("public Main barrel exposes only the transport-neutral Application contract
   assert.equal(listInput, null);
   assert.equal(statusInput, null);
   assert.equal(outputCountsInput, null);
+  assert.equal(messageChunkInput, null);
 });

--- a/test/repository-read-model.test.ts
+++ b/test/repository-read-model.test.ts
@@ -148,7 +148,7 @@ repositoryTest("timeline and output summary remain bounded without hydrating pay
     assert.equal(Object.hasOwn(messages.items[0] ?? {}, "contentBlocks"), false);
     assert.ok(messages.items.length < 6);
     assert.equal(typeof messages.nextCursor, "string");
-    assert.ok(Buffer.byteLength(JSON.stringify(messages)) < 256 * 1024);
+    assert.ok(Buffer.byteLength(JSON.stringify(messages)) <= 192 * 1024);
 
     const outputs = operationFor(
       database,
@@ -162,6 +162,99 @@ repositoryTest("timeline and output summary remain bounded without hydrating pay
     assert.equal(outputs.items.length, 200);
     assert.equal(typeof outputs.nextCursor, "string");
     assert.equal(JSON.stringify(outputs).includes("content"), false);
+  });
+});
+
+repositoryTest("Message page budgets its complete JSON body including scope and cursor", () => {
+  withDatabase((database) => {
+    insertSession(database, "session-1", 1);
+    const content = JSON.stringify([{ type: "text", text: "x".repeat(65_290) }]);
+    assert.ok(Buffer.byteLength(content) <= 64 * 1024);
+    for (let ordinal = 1; ordinal <= 4; ordinal += 1) {
+      insertMessage(database, `message-${ordinal}`, "session-1", ordinal, content);
+    }
+    const messages = operationFor(database, "repository.messages.page");
+
+    const first = messages({ sessionId: "session-1", workspaceKey: "workspace", limit: 4 }) as PageResult;
+    assert.ok(first.items.length > 0 && first.items.length < 4);
+    assert.ok(Buffer.byteLength(JSON.stringify(first)) <= 192 * 1024);
+    assert.equal(typeof first.nextCursor, "string");
+
+    const second = messages({
+      sessionId: "session-1",
+      workspaceKey: "workspace",
+      cursor: first.nextCursor,
+      limit: 4,
+    }) as PageResult;
+    assert.ok(Buffer.byteLength(JSON.stringify(second)) <= 192 * 1024);
+    assert.deepEqual(
+      [...first.items, ...second.items].map((item) => item.id),
+      ["message-1", "message-2", "message-3", "message-4"],
+    );
+  });
+});
+
+repositoryTest("Message page keeps one SQL snapshot when its Session is deleted after the statement", () => {
+  withDatabase((database) => {
+    insertSession(database, "session-empty", 1);
+    insertSession(database, "session-1", 1);
+    insertMessage(database, "message-1", "session-1", 1, "[]");
+    const emptyPage = operationFor(
+      database,
+      "repository.messages.page",
+    )({ sessionId: "session-empty", workspaceKey: "workspace" }) as PageResult;
+    assert.deepEqual(emptyPage.items, []);
+
+    const preparedSql: string[] = [];
+    let deleteAfterPageRead = true;
+    const observedDatabase = new Proxy(database, {
+      get(target, property) {
+        if (property === "prepare") {
+          return (sql: string) => {
+            preparedSql.push(sql);
+            const statement = target.prepare(sql);
+            if (sql !== REPOSITORY_PAGE_SQL.messages) return statement;
+            return new Proxy(statement, {
+              get(statementTarget, statementProperty) {
+                if (statementProperty === "all") {
+                  return (...parameters: Parameters<typeof statementTarget.all>) => {
+                    const rows = statementTarget.all(...parameters);
+                    if (deleteAfterPageRead) {
+                      deleteAfterPageRead = false;
+                      target.exec(`
+                        BEGIN IMMEDIATE;
+                        DELETE FROM messages WHERE session_id = 'session-1';
+                        DELETE FROM sessions WHERE id = 'session-1';
+                        COMMIT;
+                      `);
+                    }
+                    return rows;
+                  };
+                }
+                const value = Reflect.get(statementTarget, statementProperty, statementTarget) as unknown;
+                return typeof value === "function" ? value.bind(statementTarget) : value;
+              },
+            });
+          };
+        }
+        const value = Reflect.get(target, property, target) as unknown;
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+    const operation = operationFor(observedDatabase, "repository.messages.page");
+
+    const beforeDelete = operation({ sessionId: "session-1", workspaceKey: "workspace" }) as PageResult;
+    assert.deepEqual(
+      beforeDelete.items.map((item) => item.id),
+      ["message-1"],
+    );
+    assert.equal(preparedSql.length, 1);
+
+    assert.throws(
+      () => operation({ sessionId: "session-1", workspaceKey: "workspace" }),
+      (error: unknown) => error instanceof RepositoryReadError && error.code === "not_found",
+    );
+    assert.equal(preparedSql.length, 2);
   });
 });
 
@@ -575,7 +668,7 @@ repositoryTest("session pages apply the byte budget and continue from the last i
     assert.doesNotThrow(() => sessions({ workspaceKey: "workspace", limit: 1, cursor: maximumIdPage.nextCursor }));
     const first = sessions({ workspaceKey: "workspace", limit: 100 }) as PageResult;
     assert.ok(first.items.length < 100);
-    assert.ok(Buffer.byteLength(JSON.stringify(first)) < 256 * 1024);
+    assert.ok(Buffer.byteLength(JSON.stringify(first)) <= 192 * 1024);
     assert.equal(typeof first.nextCursor, "string");
     const second = sessions({ workspaceKey: "workspace", limit: 100, cursor: first.nextCursor }) as PageResult;
     assert.ok(second.items.length > 0);
@@ -704,7 +797,7 @@ repositoryTest("representative ordinal queries use covering indexes and never sc
       database
         .prepare(`EXPLAIN QUERY PLAN ${REPOSITORY_SESSION_PAGE_SQL.workspaceLifecycle}`)
         .all("workspace", "active", null, null, null, null, 10),
-      database.prepare(`EXPLAIN QUERY PLAN ${REPOSITORY_PAGE_SQL.messages}`).all(1024, "s", "w", 0, 10),
+      database.prepare(`EXPLAIN QUERY PLAN ${REPOSITORY_PAGE_SQL.messages}`).all(1024, "s", 0, 10, "s", "w"),
       database.prepare(`EXPLAIN QUERY PLAN ${REPOSITORY_PAGE_SQL.runEvents}`).all("r", "s", "w", 0, 10),
       database.prepare(`EXPLAIN QUERY PLAN ${REPOSITORY_PAGE_SQL.runOutputs}`).all("r", "s", "w", 0, 10),
       database

--- a/test/repository-write-model.test.ts
+++ b/test/repository-write-model.test.ts
@@ -607,6 +607,107 @@ repositoryTest("normal Run admission atomically creates Message, Run, Attempt, D
   });
 });
 
+repositoryTest("all Message write siblings reject non-text content blocks before mutation", () => {
+  withDatabase((database) => {
+    const invalidBlocks = [{ type: "tool", text: "must not be stored" }];
+    const admission = normalRunAdmissionCommand(
+      "018f1f4e-7f0a-7000-8000-000000000752",
+      "run-invalid-content",
+      "create",
+    );
+    const child = childStartCommand("018f1f4e-7f0a-7000-8000-000000000753", "invalid-content");
+    const input = runInputAdmissionCommand("018f1f4e-7f0a-7000-8000-000000000754");
+    const terminal = runTerminalCommand();
+    const malformed = [
+      [
+        REPOSITORY_WRITE_OPERATIONS.runAdmit,
+        { ...admission, message: { ...admission.message, contentBlocks: invalidBlocks } },
+      ],
+      [
+        REPOSITORY_WRITE_OPERATIONS.childStart,
+        { ...child, message: { ...child.message, contentBlocks: invalidBlocks } },
+      ],
+      [
+        REPOSITORY_WRITE_OPERATIONS.runInputAdmit,
+        { ...input, message: { ...input.message, contentBlocks: invalidBlocks } },
+      ],
+      [
+        REPOSITORY_WRITE_OPERATIONS.runTerminal,
+        {
+          ...terminal,
+          outcome: {
+            kind: "completed",
+            finalAssistantMessage: { id: "message-invalid-final", contentBlocks: invalidBlocks },
+          },
+        },
+      ],
+    ] as const;
+
+    for (const [operation, command] of malformed) {
+      const result = operationFor(database, operation, () => 100)(command) as CommandResult;
+      assert.equal(!result.ok && result.error.code, "request_invalid");
+    }
+    assert.equal(count(database, "messages"), 0);
+  });
+});
+
+repositoryTest("Run terminal rejects a non-null final assistant Message without visible text before mutation", () => {
+  withDatabase((database) => {
+    activatePersistentRun(database);
+    const terminal = operationFor(database, REPOSITORY_WRITE_OPERATIONS.runTerminal, () => 700);
+    const messageCountBefore = count(database, "messages");
+
+    for (const contentBlocks of [
+      [],
+      [{ type: "text", text: "" }],
+      [{ type: "text", text: " \n\t" }],
+      [{ type: "text", text: "\u200B" }],
+      [{ type: "text", text: "\u0000" }],
+    ]) {
+      const command = runTerminalCommand();
+      const result = terminal({
+        ...command,
+        outcome: {
+          kind: "completed",
+          finalAssistantMessage: { id: "message-empty-final", contentBlocks },
+        },
+      }) as CommandResult;
+      assert.equal(!result.ok && result.error.code, "request_invalid");
+    }
+
+    assert.equal(count(database, "messages"), messageCountBefore);
+    assert.equal(count(database, "run_events"), 0);
+    assert.equal(
+      (database.prepare("SELECT phase FROM runs WHERE id = 'run-1'").get() as { phase: string }).phase,
+      "active",
+    );
+  });
+});
+
+repositoryTest("Run terminal completes without a final Message when the final assistant Message is null", () => {
+  withDatabase((database) => {
+    activatePersistentRun(database);
+    const terminal = operationFor(database, REPOSITORY_WRITE_OPERATIONS.runTerminal, () => 700);
+    const command = {
+      ...runTerminalCommand(),
+      outcome: { kind: "completed", finalAssistantMessage: null },
+    } as const;
+
+    const first = terminal(command) as CommandResult;
+    const replay = terminal(command) as CommandResult;
+
+    assert.equal(first.ok && first.value.finalAssistantMessageId, null);
+    assert.equal(replay.ok && replay.replayed, true);
+    assert.equal(count(database, "messages"), 1);
+    assert.deepEqual(
+      {
+        ...database.prepare("SELECT phase, final_assistant_message_id FROM runs WHERE id = 'run-1'").get(),
+      },
+      { phase: "completed", final_assistant_message_id: null },
+    );
+  });
+});
+
 repositoryTest("normal Run admission reuses only the selected active Binding", () => {
   withDatabase((database) => {
     const create = operationFor(database, REPOSITORY_WRITE_OPERATIONS.sessionCreate, () => 100);


### PR DESCRIPTION
## 概要

CP02のSession Message control planeを追加し、Application Service、CLI、Persistence Worker、repository contractを接続します。

## 主な変更

- Session Message一覧、本文chunk取得、CLI JSON projectionを追加
- chunk取得を単一SQL statementのsnapshotとし、要求範囲だけをSQLiteから取得
- terminal Runで空のfinal assistant Messageを永続化しない不変条件を追加
- Message page全体を192 KiB以内に収めるresponse budgetを実装
- CLI smoke、module boundary、public API、repositoryの回帰contractを追加
- 0ベース再構築と正式release前の手戻り方針を`AGENTS.md`へ追加

## 検証

- `npm run check:runtime`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test`（438 tests）
- `npm run build`
- `npm run smoke:cli-session`
- `npm run smoke:cli-run`
- `npm run smoke:compiled-persistence`
- `git diff --check`