### PR TITLE
feat(session): Session Run履歴control planeを追加

### DIFF
--- a/docs/plans/20260712-withmate-rebuild-roadmap/worklog.md
+++ b/docs/plans/20260712-withmate-rebuild-roadmap/worklog.md
@@ -139,3 +139,13 @@
 - public contractは`src/shared/message-content.ts`、`src/shared/application-session-message-model.ts`、対応するtype / testを正本とする。ADR 006とD-006のhydrate分離、cursor、CLI ownershipの判断は変えていないため、新規ADRと設計文書の更新は行わない。
 - Node.js 24.18.0で全435 testとSQLite schema validator、runtime guard、format、module boundary / lint、typecheck、buildを通した。Session CLI、Run / Message CLI、compiled persistenceのprocess smokeもGreenで、SQLite sidecarが残らないことを確認した。
 - Session Message sliceは完了した。CP2全体はSession Run historyと統合Gateが残るため、引き続き進行中とする。
+
+## 2026-07-20: CP2 Session Run history control plane
+
+- Repository readへSession / Workspace scope付きの`runs.page`を追加した。Run headerだけを`runs_session_ordinal_uq`によるordinal keysetで1 statement取得し、default 50 / maximum 100、opaque scope cursor、192 KiB response budget、ordinal付きomissionを適用する。execution snapshot、Message本文、RunEvent、RunOutput、RunAttempt、RunDispatch、ProviderBindingは取得しない。
+- `ApplicationSessionRunOperations.runs`を追加した。`session_runs` authorization後にSessionからinternal Workspace scopeを解決し、Repository境界で再検証する。Run historyと既存Run statusは永続phase / failure / cancellation / timestamp projectionを共有し、completedでfinal assistant Messageがない組を含むphase-specific unionへ投影する。
+- `withmate session runs --session-id <id> [--cursor <cursor>] [--limit <1..100>] [--timeout-ms <ms>]`を追加した。既存Session CLIのversion付きJSON、exit code、timeout / SIGINT、exactly-once shutdownを維持し、Application responseをstrict allowlistで再検証する。
+- 実DB process smokeで、3件のRunのordinal page、small-limit cursor、別Sessionへのcursor流用拒否、completedかつfinal assistant Messageなし、historyとstatusのtimestamp一致、historyで得たRun IDからevents / outputへの遷移、internal field非露出、help時のruntime非起動、SQLite sidecar cleanupを確認した。
+- Node.js 24.18.0で全459 testとSQLite schema validator、runtime guard、format、module boundary / lint、typecheck、buildを通した。Session CLI、Run / Message / Session Run history CLI、compiled persistenceのprocess smokeもGreenだった。
+- public contractは`src/shared/application-session-run-model.ts`、共有phase projection、対応するtype / testを正本とする。既存ADR 006 / 011とD-006のauthorization、projection ownership、CP2 / CP3 / CP5分離を変更していないため、新規ADRとdesign文書の更新は行わない。
+- Session Run history sliceは完了した。CP2全体は次の`test/cp02-control-plane-gate`による統合Gateが残るため、引き続き進行中とする。

--- a/scripts/smoke-cli-run.mjs
+++ b/scripts/smoke-cli-run.mjs
@@ -20,11 +20,15 @@ const sessionCreateKey = "018f1f4e-7f0a-7000-8000-000000000501";
 const runAdmitKey = "018f1f4e-7f0a-7000-8000-000000000502";
 const wrongScopeSessionCreateKey = "018f1f4e-7f0a-7000-8000-000000000503";
 const interruptedRunAdmitKey = "018f1f4e-7f0a-7000-8000-000000000504";
+const noFinalRunAdmitKey = "018f1f4e-7f0a-7000-8000-000000000505";
 const runId = "run-smoke-1";
 const attemptId = "attempt-run-smoke-1";
 const interruptedRunId = "run-smoke-interrupted-1";
 const interruptedAttemptId = "attempt-run-smoke-interrupted-1";
 const interruptedMessageId = "message-run-smoke-interrupted-1";
+const noFinalRunId = "run-smoke-no-final-1";
+const noFinalAttemptId = "attempt-run-smoke-no-final-1";
+const noFinalMessageId = "message-run-smoke-no-final-1";
 const userMessageId = "message-run-smoke-1";
 const assistantMessageId = "message-run-smoke-2";
 const userMessageBlocks = [{ type: "text", text: "observe me" }];
@@ -52,6 +56,9 @@ try {
   const messageHelp = invoke(["session", "messages", "--help"], environment);
   assert.equal(messageHelp.status, 0);
   assert.match(messageHelp.stdout, /^Usage: withmate session messages/u);
+  const runHistoryHelp = invoke(["session", "runs", "--help"], environment);
+  assert.equal(runHistoryHelp.status, 0);
+  assert.match(runHistoryHelp.stdout, /^Usage: withmate session runs/u);
   const invalidMessage = invoke(["session", "message-content-chunk", "--session-id", "missing"], environment);
   assert.equal(invalidMessage.status, 20);
   assert.equal(parseJsonOutput(invalidMessage).kind, "usage_failure");
@@ -283,17 +290,131 @@ try {
       childResult: null,
     });
     assert.equal(interruptedTerminal.ok, true);
+
+    const noFinalAdmission = await writes.admitNormalRun({
+      sessionId,
+      workspaceKey,
+      idempotencyKey: noFinalRunAdmitKey,
+      message: { id: noFinalMessageId, contentBlocks: [{ type: "text", text: "complete without a reply" }] },
+      run: {
+        id: noFinalRunId,
+        executionSnapshot: {
+          providerId: "codex",
+          model: "smoke-model",
+          reasoning: { effort: "medium" },
+          approval: { mode: "on-request" },
+          sandbox: { mode: "workspace-write" },
+          workspace: { key: workspaceKey },
+          character: null,
+        },
+      },
+      attemptId: noFinalAttemptId,
+      bindingIntent: { kind: "reuse", bindingId: "binding-run-smoke-1" },
+      dispatch: { providerRequest: { prompt: "complete without a reply" }, providerIdempotencyKey: null },
+    });
+    assert.equal(noFinalAdmission.ok, true);
+    const noFinalDispatch = await writes.beginRunDispatch({
+      sessionId,
+      workspaceKey,
+      runId: noFinalRunId,
+      attemptId: noFinalAttemptId,
+      bindingId: "binding-run-smoke-1",
+      providerRequest: { prompt: "complete without a reply" },
+      ephemeralOwnerToken: null,
+    });
+    assert.equal(noFinalDispatch.ok, true);
+    const noFinalDispatchResolution = await writes.resolveRunDispatch({
+      sessionId,
+      workspaceKey,
+      runId: noFinalRunId,
+      attemptId: noFinalAttemptId,
+      bindingId: "binding-run-smoke-1",
+      ephemeralOwnerToken: null,
+      outcome: { kind: "accepted", externalExecutionId: "execution-run-smoke-no-final-1" },
+    });
+    assert.equal(noFinalDispatchResolution.ok, true);
+    const noFinalTerminal = await writes.completeRun({
+      sessionId,
+      workspaceKey,
+      runId: noFinalRunId,
+      attemptId: noFinalAttemptId,
+      terminalEvent: { id: "event-run-smoke-no-final-terminal", dedupeKey: "run-smoke-no-final-terminal" },
+      preDispatchResolution: { kind: "not_applicable" },
+      outcome: { kind: "completed", finalAssistantMessage: null },
+      outputs: [],
+      childResult: null,
+    });
+    assert.equal(noFinalTerminal.ok, true);
   } finally {
     const shutdown = await worker.shutdown();
     assert.equal(shutdown.checkpoint, "completed");
   }
 
-  const status = runJson(["run", "status", "--session-id", sessionId, "--run-id", runId], environment, 0);
+  const firstRunPage = runJson(["session", "runs", "--session-id", sessionId, "--limit", "1"], environment, 0);
+  assert.equal(firstRunPage.applicationResponse.value.items.length, 1);
+  const firstRun = firstRunPage.applicationResponse.value.items[0];
+  assert.equal(firstRun.runId, runId);
+  assert.equal(firstRun.ordinal, 1);
+  assert.equal(firstRun.phase, "completed");
+  assert.equal(firstRun.finalAssistantMessageId, assistantMessageId);
+  const status = runJson(["run", "status", "--session-id", sessionId, "--run-id", firstRun.runId], environment, 0);
   assert.equal(status.applicationResponse.value.phase, "completed");
   assert.equal("failure" in status.applicationResponse.value, false);
+  for (const field of ["createdAt", "startedAt", "terminalAt", "updatedAt"]) {
+    assert.equal(status.applicationResponse.value[field], firstRun[field], `Run history drifted from status: ${field}`);
+  }
+  const runCursor = firstRunPage.applicationResponse.value.nextCursor;
+  assert.equal(typeof runCursor, "string");
+  const firstRunPageJson = JSON.stringify(firstRunPage);
+  for (const forbidden of [
+    "executionSnapshot",
+    "providerId",
+    "providerErrorCode",
+    "terminalEventReceivedAt",
+    "externalSideEffectState",
+    '"version":',
+    "workspaceKey",
+    "attemptId",
+    "outputs",
+  ]) {
+    assert.equal(firstRunPageJson.includes(forbidden), false, `Run history exposed ${forbidden}`);
+  }
+  const secondRunPage = runJson(
+    ["session", "runs", "--session-id", sessionId, "--cursor", runCursor, "--limit", "1"],
+    environment,
+    0,
+  );
+  assert.equal(secondRunPage.applicationResponse.value.items.length, 1);
+  assert.equal(secondRunPage.applicationResponse.value.items[0].runId, interruptedRunId);
+  assert.equal(secondRunPage.applicationResponse.value.items[0].ordinal, 2);
+  assert.equal(secondRunPage.applicationResponse.value.items[0].phase, "interrupted");
+  assert.deepEqual(secondRunPage.applicationResponse.value.items[0].failure, {
+    origin: "transport",
+    summary: "Provider dispatch was interrupted.",
+  });
+  assert.equal(JSON.stringify(secondRunPage).includes("must-not-leak"), false);
+  const secondRunCursor = secondRunPage.applicationResponse.value.nextCursor;
+  assert.equal(typeof secondRunCursor, "string");
+  const thirdRunPage = runJson(
+    ["session", "runs", "--session-id", sessionId, "--cursor", secondRunCursor, "--limit", "1"],
+    environment,
+    0,
+  );
+  assert.equal(thirdRunPage.applicationResponse.value.items.length, 1);
+  assert.equal(thirdRunPage.applicationResponse.value.items[0].runId, noFinalRunId);
+  assert.equal(thirdRunPage.applicationResponse.value.items[0].ordinal, 3);
+  assert.equal(thirdRunPage.applicationResponse.value.items[0].phase, "completed");
+  assert.equal("finalAssistantMessageId" in thirdRunPage.applicationResponse.value.items[0], false);
+  assert.equal("nextCursor" in thirdRunPage.applicationResponse.value, false);
+  const reusedRunCursor = runJson(
+    ["session", "runs", "--session-id", wrongScopeSessionId, "--cursor", runCursor, "--limit", "1"],
+    environment,
+    22,
+  );
+  assert.equal(reusedRunCursor.applicationResponse.error.code, "cursor_invalid");
 
   const events = runJson(
-    ["run", "events", "--session-id", sessionId, "--run-id", runId, "--limit", "10"],
+    ["run", "events", "--session-id", sessionId, "--run-id", firstRun.runId, "--limit", "10"],
     environment,
     0,
   );
@@ -339,7 +460,11 @@ try {
   assert.equal(interruptedFollow.applicationResponse.value.status.phase, "interrupted");
   assert.equal(JSON.stringify(interruptedFollow).includes("must-not-leak"), false);
 
-  const outputCounts = runJson(["run", "output-counts", "--session-id", sessionId, "--run-id", runId], environment, 0);
+  const outputCounts = runJson(
+    ["run", "output-counts", "--session-id", sessionId, "--run-id", firstRun.runId],
+    environment,
+    0,
+  );
   assert.equal(outputCounts.applicationResponse.value.totalCount, 2);
   assert.equal(outputCounts.applicationResponse.value.byCategory.diagnostic, 2);
 
@@ -492,6 +617,8 @@ try {
   assert.equal(wrongScopeMessage.applicationResponse.error.code, "not_found");
   const wrongSessionMessage = runJson(["session", "messages", "--session-id", "missing-session"], environment, 22);
   assert.equal(wrongSessionMessage.applicationResponse.error.code, "not_found");
+  const wrongSessionRuns = runJson(["session", "runs", "--session-id", "missing-session"], environment, 22);
+  assert.equal(wrongSessionRuns.applicationResponse.error.code, "not_found");
 
   const binaryPreview = runJson(
     ["run", "output-preview", "--session-id", sessionId, "--run-id", runId, "--output-item-id", binaryOutputItemId],
@@ -590,6 +717,7 @@ try {
         "output-chunk",
         "output-export",
         "messages",
+        "runs",
         "message-content-chunk",
       ],
       parseRuntimeIsolation: "verified",
@@ -597,6 +725,7 @@ try {
       providerMetadataProjection: "verified",
       runOutputControlPlane: "verified",
       sessionMessageControlPlane: "verified",
+      sessionRunHistoryControlPlane: "verified",
       exportNoClobber: "verified",
       sqliteSidecars: "none",
     }),

--- a/scripts/validate-module-boundaries.mjs
+++ b/scripts/validate-module-boundaries.mjs
@@ -24,6 +24,7 @@ const repositoryReadCapabilityNames = new Set([
   "sessionDirectoriesChunk",
   "messagesPage",
   "messageContentChunk",
+  "runsPage",
   "runGet",
   "runEventsPage",
   "runSnapshotChunk",
@@ -89,6 +90,7 @@ for (const rule of rules) {
 
 const applicationSessionOwner = path.join(sourceRoot, "main", "application-session-service.ts");
 const applicationSessionMessageOwner = path.join(sourceRoot, "main", "application-session-message-service.ts");
+const applicationSessionRunOwner = path.join(sourceRoot, "main", "application-session-run-service.ts");
 const applicationRunOwner = path.join(sourceRoot, "main", "application-run-service.ts");
 const applicationRunOutputOwner = path.join(sourceRoot, "main", "application-run-output-service.ts");
 const repositoryWriteClient = path.join(sourceRoot, "main", "repository-write-client.ts");
@@ -97,6 +99,7 @@ const persistenceWorkerClient = path.join(sourceRoot, "main", "persistence-worke
 const publicMainBarrel = path.join(sourceRoot, "main", "index.ts");
 const publicApplicationModel = path.join(sourceRoot, "shared", "application-service-model.ts");
 const publicApplicationSessionMessageModel = path.join(sourceRoot, "shared", "application-session-message-model.ts");
+const publicApplicationSessionRunModel = path.join(sourceRoot, "shared", "application-session-run-model.ts");
 const publicApplicationRunModel = path.join(sourceRoot, "shared", "application-run-model.ts");
 const publicApplicationRunOutputModel = path.join(sourceRoot, "shared", "application-run-output-model.ts");
 const rawWriteFixture = path.join(root, "test", "fixtures", "module-boundaries", "raw-persistence-write.ts");
@@ -153,6 +156,7 @@ for (const file of listSourceFiles(sourceRoot)) {
   const allowsRepositoryReadIntegration =
     file === applicationSessionOwner ||
     file === applicationSessionMessageOwner ||
+    file === applicationSessionRunOwner ||
     file === applicationRunOwner ||
     file === applicationRunOutputOwner;
   const allowsRepositoryWriteIntegration = file === applicationSessionOwner;
@@ -312,6 +316,7 @@ for (const file of listSourceFiles(sourceRoot)) {
 for (const file of [
   applicationSessionOwner,
   applicationSessionMessageOwner,
+  applicationSessionRunOwner,
   applicationRunOwner,
   applicationRunOutputOwner,
 ]) {
@@ -333,6 +338,7 @@ for (const file of [
       if (
         exportedName !== "ApplicationSessionOperations" &&
         exportedName !== "ApplicationSessionMessageOperations" &&
+        exportedName !== "ApplicationSessionRunOperations" &&
         exportedName !== "ApplicationRunOperations" &&
         exportedName !== "ApplicationRunOutputOperations"
       ) {
@@ -344,6 +350,7 @@ for (const file of [
     for (const exported of findExportsDeclaredOutside(sourceFile, [
       publicApplicationModel,
       publicApplicationSessionMessageModel,
+      publicApplicationSessionRunModel,
       publicApplicationRunModel,
       publicApplicationRunOutputModel,
     ])) {

--- a/src/cli/application-response.ts
+++ b/src/cli/application-response.ts
@@ -13,6 +13,7 @@ import {
   CLI_EXIT_CODES,
   CLI_SCHEMA_VERSION,
   CLI_SESSION_LIMITS,
+  CLI_SESSION_RUN_LIMITS,
   type CliApplicationError,
   type CliApplicationIssue,
   type CliApplicationResponse,
@@ -53,6 +54,7 @@ const operationModes: Readonly<Record<CliSessionOperation, OperationMode>> = {
   read: "read",
   "directories-chunk": "read",
   messages: "read",
+  runs: "read",
   "message-content-chunk": "read",
   archive: "write",
   unarchive: "write",
@@ -84,6 +86,8 @@ const RUN_OUTPUT_EXPORT_DOMAIN_CODES = [
   "destination_invalid",
   "payload_integrity_mismatch",
 ] as const;
+
+const RUN_HISTORY_DOMAIN_CODES = ["request_invalid", "cursor_invalid", "not_found"] as const;
 
 export function projectCliOperationOutput(
   command: CliValidatedCommand,
@@ -252,10 +256,13 @@ function projectApplicationResponse(
   mode: OperationMode,
   value: unknown,
 ): ProjectedApplicationResponse {
-  const response = record(value);
+  const response = isCommandFor(command, "runs")
+    ? exactRecord(value, ["overallStatus", "value", "issues", "error", "persistence"])
+    : record(value);
   const overallStatus = response.overallStatus;
   if (overallStatus === "success") {
-    const persistence = projectPersistenceStatus(response.persistence);
+    if (isCommandFor(command, "runs")) requireAbsent(response, ["issues", "error"]);
+    const persistence = projectSessionPersistenceStatus(command, response.persistence);
     if (mode === "read" ? persistence.status !== "read" : persistence.status !== "committed") malformed();
     const projectedValue = projectOperationValue(command, response.value);
     if (isCommandFor(command, "delete") && record(projectedValue).cleanupStatus !== "completed") malformed();
@@ -266,9 +273,16 @@ function projectApplicationResponse(
     } as ProjectedApplicationResponse;
   }
   if (overallStatus === "partial_success") {
-    const persistence = projectPersistenceStatus(response.persistence);
-    const issues = projectIssues(response.issues);
-    const projectedValue = projectOperationValue(command, response.value);
+    if (isCommandFor(command, "runs")) requireAbsent(response, ["error"]);
+    const persistence = projectSessionPersistenceStatus(command, response.persistence);
+    const issues = isCommandFor(command, "runs")
+      ? projectRunOmissionIssues(response.issues, command.limit)
+      : projectIssues(response.issues);
+    const projectedValue = projectOperationValue(
+      command,
+      response.value,
+      issues.some((issue) => issue.kind === "omission"),
+    );
     if (issues.length === 0) malformed();
     if (isCommandFor(command, "message-content-chunk")) malformed();
     if (isCommandFor(command, "delete")) {
@@ -285,10 +299,16 @@ function projectApplicationResponse(
       }
     } else if (mode === "read") {
       if (persistence.status !== "read" || issues.some((issue) => issue.kind !== "omission")) malformed();
-      if (isCommandFor(command, "list") || isCommandFor(command, "repositories") || isCommandFor(command, "messages")) {
+      if (
+        isCommandFor(command, "list") ||
+        isCommandFor(command, "repositories") ||
+        isCommandFor(command, "messages") ||
+        isCommandFor(command, "runs")
+      ) {
         const page = record(projectedValue);
         if (!Array.isArray(page.items) || page.items.length + issues.length > command.limit) malformed();
         if (isCommandFor(command, "messages")) validateMessagePageOmissions(page.items, issues);
+        if (isCommandFor(command, "runs")) validateRunPageOmissions(page.items, issues);
       }
     } else {
       if (
@@ -306,13 +326,20 @@ function projectApplicationResponse(
     } as ProjectedApplicationResponse;
   }
   if (overallStatus !== "failure") malformed();
-  const error = projectApplicationError(response.error);
-  const persistence = projectPersistenceStatus(response.persistence);
+  if (isCommandFor(command, "runs")) requireAbsent(response, ["value", "issues"]);
+  const error = isCommandFor(command, "runs")
+    ? projectRunApplicationError(response.error)
+    : projectApplicationError(response.error);
+  const persistence = projectSessionPersistenceStatus(command, response.persistence);
   if (!failureCombinationIsValid(mode, isCommandFor(command, "delete"), error, persistence)) malformed();
   return { overallStatus, error, persistence } as ProjectedApplicationResponse;
 }
 
-function projectOperationValue(command: CliValidatedSessionCommand, value: unknown): unknown {
+function projectOperationValue(
+  command: CliValidatedSessionCommand,
+  value: unknown,
+  allowOmissionOnlyCursor: boolean = false,
+): unknown {
   if (isCommandFor(command, "create")) return projectCreateValue(value, command.title, command.workspacePath);
   if (isCommandFor(command, "rename")) return projectRenameValue(value, command.sessionId, command.title);
   if (isCommandFor(command, "list")) return projectListValue(value, command);
@@ -321,7 +348,8 @@ function projectOperationValue(command: CliValidatedSessionCommand, value: unkno
   if (isCommandFor(command, "directories-chunk")) {
     return projectDirectoriesChunkValue(value, command.sessionId, command.offset, command.maxBytes);
   }
-  if (isCommandFor(command, "messages")) return projectMessagesValue(value, command);
+  if (isCommandFor(command, "messages")) return projectMessagesValue(value, command, allowOmissionOnlyCursor);
+  if (isCommandFor(command, "runs")) return projectRunsValue(value, command, allowOmissionOnlyCursor);
   if (isCommandFor(command, "message-content-chunk")) {
     return projectMessageContentChunkValue(
       value,
@@ -553,14 +581,18 @@ function projectDirectoriesChunkValue(
   };
 }
 
-function projectMessagesValue(value: unknown, command: CommandFor<"messages">): unknown {
+function projectMessagesValue(
+  value: unknown,
+  command: CommandFor<"messages">,
+  allowOmissionOnlyCursor: boolean,
+): unknown {
   const page = exactRecord(value, ["sessionId", "items", "nextCursor"]);
   const sessionId = boundedString(page.sessionId);
   const nextCursor = optionalBoundedString(page.nextCursor, CLI_SESSION_LIMITS.maxCursorLength);
   const rawItems = snapshotDenseArray(page.items, command.limit);
   if (
     sessionId !== command.sessionId ||
-    (rawItems.length === 0 && nextCursor !== undefined) ||
+    (rawItems.length === 0 && nextCursor !== undefined && !allowOmissionOnlyCursor) ||
     (nextCursor !== undefined && nextCursor === command.cursor)
   ) {
     malformed();
@@ -603,6 +635,136 @@ function projectMessagesValue(value: unknown, command: CommandFor<"messages">): 
     return { ...base, content: { state: "chunked" as const } };
   });
   return { sessionId, items, ...(nextCursor === undefined ? {} : { nextCursor }) };
+}
+
+function projectRunsValue(value: unknown, command: CommandFor<"runs">, allowOmissionOnlyCursor: boolean): unknown {
+  const page = exactRecord(value, ["sessionId", "items", "nextCursor"]);
+  const sessionId = boundedString(page.sessionId);
+  const nextCursor = optionalBoundedString(page.nextCursor, CLI_SESSION_LIMITS.maxCursorLength);
+  const rawItems = snapshotDenseArray(page.items, command.limit);
+  if (
+    sessionId !== command.sessionId ||
+    (rawItems.length === 0 && nextCursor !== undefined && !allowOmissionOnlyCursor) ||
+    (nextCursor !== undefined && nextCursor === command.cursor)
+  ) {
+    malformed();
+  }
+  let previousOrdinal = 0;
+  const items = rawItems.map((candidate) => {
+    const item = exactRecord(candidate, [
+      "runId",
+      "ordinal",
+      "initiatingMessageId",
+      "finalAssistantMessageId",
+      "retryOfRunId",
+      "phase",
+      "failure",
+      "cancellation",
+      "createdAt",
+      "startedAt",
+      "terminalAt",
+      "updatedAt",
+    ]);
+    const runId = boundedString(item.runId);
+    const ordinal = positiveInteger(item.ordinal);
+    const initiatingMessageId = boundedString(item.initiatingMessageId);
+    const finalAssistantMessageId = optionalBoundedString(item.finalAssistantMessageId);
+    const retryOfRunId = optionalBoundedString(item.retryOfRunId);
+    const createdAt = nonNegativeInteger(item.createdAt);
+    const startedAt = item.startedAt === undefined ? undefined : nonNegativeInteger(item.startedAt);
+    const updatedAt = nonNegativeInteger(item.updatedAt);
+    const phase = enumValue(item.phase, [
+      "queued",
+      "starting",
+      "active",
+      "canceling",
+      "finalizing",
+      "completed",
+      "failed",
+      "canceled",
+      "interrupted",
+    ] as const);
+    if (ordinal <= previousOrdinal) malformed();
+    previousOrdinal = ordinal;
+    const base = {
+      runId,
+      ordinal,
+      initiatingMessageId,
+      ...(retryOfRunId === undefined ? {} : { retryOfRunId }),
+      createdAt,
+      ...(startedAt === undefined ? {} : { startedAt }),
+      updatedAt,
+    } as const;
+    switch (phase) {
+      case "queued":
+      case "starting":
+      case "active":
+      case "finalizing":
+        requireAbsent(item, ["finalAssistantMessageId", "failure", "cancellation", "terminalAt"]);
+        return { ...base, phase };
+      case "canceling":
+        requireAbsent(item, ["finalAssistantMessageId", "failure", "terminalAt"]);
+        return {
+          ...base,
+          phase,
+          ...(item.cancellation === undefined ? {} : { cancellation: projectRunCancellation(item.cancellation) }),
+        };
+      case "completed":
+        requireAbsent(item, ["failure", "cancellation"]);
+        return {
+          ...base,
+          phase,
+          ...(finalAssistantMessageId === undefined ? {} : { finalAssistantMessageId }),
+          terminalAt: nonNegativeInteger(item.terminalAt),
+        };
+      case "failed":
+      case "interrupted":
+        requireAbsent(item, ["finalAssistantMessageId"]);
+        return {
+          ...base,
+          phase,
+          terminalAt: nonNegativeInteger(item.terminalAt),
+          failure: projectRunFailure(item.failure),
+          ...(item.cancellation === undefined ? {} : { cancellation: projectRunCancellation(item.cancellation) }),
+        };
+      case "canceled":
+        requireAbsent(item, ["finalAssistantMessageId", "failure"]);
+        return {
+          ...base,
+          phase,
+          terminalAt: nonNegativeInteger(item.terminalAt),
+          ...(item.cancellation === undefined ? {} : { cancellation: projectRunCancellation(item.cancellation) }),
+        };
+    }
+  });
+  return { sessionId, items, ...(nextCursor === undefined ? {} : { nextCursor }) };
+}
+
+function projectRunFailure(value: unknown) {
+  const failure = exactRecord(value, ["origin", "summary"]);
+  return {
+    origin: enumValue(failure.origin, [
+      "provider",
+      "transport",
+      "process",
+      "application",
+      "persistence",
+      "unknown",
+    ] as const),
+    ...(failure.summary === undefined
+      ? {}
+      : { summary: boundedString(failure.summary, CLI_SESSION_RUN_LIMITS.maxSummaryLength) }),
+  };
+}
+
+function projectRunCancellation(value: unknown) {
+  const cancellation = exactRecord(value, ["requestedAt", "acknowledgedAt"]);
+  return {
+    requestedAt: nonNegativeInteger(cancellation.requestedAt),
+    ...(cancellation.acknowledgedAt === undefined
+      ? {}
+      : { acknowledgedAt: nonNegativeInteger(cancellation.acknowledgedAt) }),
+  };
 }
 
 function projectMessageContentChunkValue(
@@ -696,6 +858,37 @@ function projectPersistenceStatus(value: unknown): CliPersistenceStatus {
       malformed();
   }
   malformed();
+}
+
+function projectSessionPersistenceStatus(command: CliValidatedSessionCommand, value: unknown): CliPersistenceStatus {
+  if (!isCommandFor(command, "runs")) return projectPersistenceStatus(value);
+  const persistence = record(value);
+  switch (persistence.status) {
+    case "not_attempted":
+    case "read":
+    case "rejected":
+      return projectPersistenceStatus(exactRecord(persistence, ["status", "effect"]));
+    case "committed":
+      return projectPersistenceStatus(exactRecord(persistence, ["status", "effect", "replayed"]));
+    case "failed":
+      return projectPersistenceStatus(
+        exactRecord(
+          persistence,
+          persistence.effect === "unknown" ? ["status", "effect", "reconciliation"] : ["status", "effect"],
+        ),
+      );
+    default:
+      malformed();
+  }
+}
+
+function projectRunApplicationError(value: unknown): CliApplicationError {
+  const error = record(value);
+  const allowedKeys =
+    error.kind === "persistence"
+      ? ["kind", "code", "message", "retryable", "effect"]
+      : ["kind", "code", "message", "retryable"];
+  return projectApplicationError(exactRecord(error, allowedKeys), RUN_HISTORY_DOMAIN_CODES);
 }
 
 function projectApplicationError(
@@ -864,6 +1057,36 @@ function validateMessagePageOmissions(items: readonly unknown[], issues: readonl
   }
 }
 
+function validateRunPageOmissions(items: readonly unknown[], issues: readonly CliApplicationIssue[]): void {
+  const itemOrdinals = new Set<number>();
+  for (const candidate of items) itemOrdinals.add(positiveInteger(record(candidate).ordinal));
+  let previousOmissionOrdinal = 0;
+  for (const issue of issues) {
+    if (
+      issue.kind !== "omission" ||
+      issue.ordinal === undefined ||
+      issue.ordinal <= previousOmissionOrdinal ||
+      itemOrdinals.has(issue.ordinal)
+    ) {
+      malformed();
+    }
+    previousOmissionOrdinal = issue.ordinal;
+  }
+}
+
+function projectRunOmissionIssues(value: unknown, maxIssues: number): readonly CliApplicationIssue[] {
+  return snapshotDenseArray(value, maxIssues).map((candidate) => {
+    const issue = exactRecord(candidate, ["kind", "code", "message", "ordinal"]);
+    if (issue.kind !== "omission" || issue.code !== "response_size_limit") malformed();
+    return {
+      kind: "omission" as const,
+      code: "response_size_limit" as const,
+      message: boundedString(issue.message, 8_192),
+      ordinal: positiveInteger(issue.ordinal),
+    };
+  });
+}
+
 function projectIssuesWithLimit(value: unknown, maxIssues: number): readonly CliApplicationIssue[] {
   return snapshotDenseArray(value, maxIssues).map((candidate) => {
     const issue = record(candidate);
@@ -1027,6 +1250,10 @@ function exactRecord(value: unknown, allowedKeys: readonly string[]): Readonly<R
   const projected = record(value);
   if (Object.keys(projected).some((key) => !allowedKeys.includes(key))) malformed();
   return projected;
+}
+
+function requireAbsent(value: Readonly<Record<string, unknown>>, keys: readonly string[]): void {
+  if (keys.some((key) => Object.hasOwn(value, key))) malformed();
 }
 
 function boundedString(value: unknown, maxLength: number = CLI_SESSION_LIMITS.maxIdentifierLength): string {

--- a/src/cli/contract.ts
+++ b/src/cli/contract.ts
@@ -5,6 +5,7 @@ import {
   APPLICATION_RUN_OUTPUT_LIMITS,
 } from "../shared/application-run-output-model.js";
 import { APPLICATION_SESSION_MESSAGE_LIMITS } from "../shared/application-session-message-model.js";
+import { APPLICATION_SESSION_RUN_LIMITS } from "../shared/application-session-run-model.js";
 import type { TextContentBlock } from "../shared/message-content.js";
 import { SESSION_METADATA_LIMITS, type LocalRepositoryMetadata } from "../shared/session-metadata.js";
 
@@ -63,6 +64,12 @@ export const CLI_SESSION_MESSAGE_LIMITS = {
   chunkMaxBytes: APPLICATION_SESSION_MESSAGE_LIMITS.chunkMaxBytes,
 } as const;
 
+export const CLI_SESSION_RUN_LIMITS = {
+  runsDefaultItems: APPLICATION_SESSION_RUN_LIMITS.runsDefaultItems,
+  runsMaxItems: APPLICATION_SESSION_RUN_LIMITS.runsMaxItems,
+  maxSummaryLength: APPLICATION_SESSION_RUN_LIMITS.maxSummaryLength,
+} as const;
+
 export type CliExitCode = (typeof CLI_EXIT_CODES)[keyof typeof CLI_EXIT_CODES];
 
 export type CliSessionOperation =
@@ -73,6 +80,7 @@ export type CliSessionOperation =
   | "read"
   | "directories-chunk"
   | "messages"
+  | "runs"
   | "message-content-chunk"
   | "archive"
   | "unarchive"
@@ -146,6 +154,14 @@ export type CliSessionDirectoriesChunkCommand = CliTimeoutOption &
 export type CliSessionMessagesCommand = CliTimeoutOption &
   Readonly<{
     identity: CliCommandIdentity<"messages">;
+    sessionId: string;
+    cursor?: string;
+    limit: number;
+  }>;
+
+export type CliSessionRunsCommand = CliTimeoutOption &
+  Readonly<{
+    identity: CliCommandIdentity<"runs">;
     sessionId: string;
     cursor?: string;
     limit: number;
@@ -242,6 +258,7 @@ export type CliValidatedSessionCommand =
   | CliSessionReadCommand
   | CliSessionDirectoriesChunkCommand
   | CliSessionMessagesCommand
+  | CliSessionRunsCommand
   | CliSessionMessageContentChunkCommand
   | CliSessionWriteCommand<"archive">
   | CliSessionWriteCommand<"unarchive">
@@ -692,6 +709,64 @@ export type CliRunCancellationSummary = Readonly<{
   acknowledgedAt?: number;
 }>;
 
+type CliSessionRunItemBase = Readonly<{
+  runId: string;
+  ordinal: number;
+  initiatingMessageId: string;
+  finalAssistantMessageId?: string;
+  retryOfRunId?: string;
+  createdAt: number;
+  startedAt?: number;
+  updatedAt: number;
+}>;
+
+export type CliSessionRunItem =
+  | (CliSessionRunItemBase &
+      Readonly<{
+        phase: "queued" | "starting" | "active" | "finalizing";
+        finalAssistantMessageId?: never;
+        terminalAt?: never;
+        failure?: never;
+        cancellation?: never;
+      }>)
+  | (CliSessionRunItemBase &
+      Readonly<{
+        phase: "canceling";
+        finalAssistantMessageId?: never;
+        terminalAt?: never;
+        failure?: never;
+        cancellation?: CliRunCancellationSummary;
+      }>)
+  | (CliSessionRunItemBase &
+      Readonly<{
+        phase: "completed";
+        terminalAt: number;
+        failure?: never;
+        cancellation?: never;
+      }>)
+  | (CliSessionRunItemBase &
+      Readonly<{
+        phase: "failed" | "interrupted";
+        finalAssistantMessageId?: never;
+        terminalAt: number;
+        failure: CliRunFailureSummary;
+        cancellation?: CliRunCancellationSummary;
+      }>)
+  | (CliSessionRunItemBase &
+      Readonly<{
+        phase: "canceled";
+        finalAssistantMessageId?: never;
+        terminalAt: number;
+        failure?: never;
+        cancellation?: CliRunCancellationSummary;
+      }>);
+
+export type CliSessionRunsValue = Readonly<{
+  sessionId: string;
+  items: readonly CliSessionRunItem[];
+  nextCursor?: string;
+}>;
+
 type CliRunStatusBase = Readonly<{
   sessionId: string;
   runId: string;
@@ -964,6 +1039,7 @@ type CliOperationContract = {
   read: Readonly<{ mode: "read"; value: CliSessionReadValue }>;
   "directories-chunk": Readonly<{ mode: "read"; value: CliSessionDirectoriesChunkValue }>;
   messages: Readonly<{ mode: "read"; value: CliSessionMessagesValue }>;
+  runs: Readonly<{ mode: "read"; value: CliSessionRunsValue }>;
   "message-content-chunk": Readonly<{ mode: "read"; value: CliSessionMessageContentChunkValue }>;
   archive: Readonly<{ mode: "write"; value: CliSessionTransitionValue<"archived"> }>;
   unarchive: Readonly<{ mode: "write"; value: CliSessionTransitionValue<"active"> }>;

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -25,6 +25,7 @@ Operations:
   read                 Read a Session by Session ID
   directories-chunk    Read a bounded chunk of additional-directory configuration
   messages             Read a bounded Message timeline page
+  runs                 Read a bounded persisted Run history page
   message-content-chunk
                        Read a bounded raw Message content chunk
   archive              Archive a Session
@@ -119,6 +120,17 @@ Optional options:
   -h, --help
 `,
   messages: `Usage: withmate session messages [options]
+
+Required options:
+  --session-id <session-id>
+
+Optional options:
+  --cursor <opaque-cursor>
+  --limit <1..100>    Default: 50
+  --timeout-ms <1..2147483647>
+  -h, --help
+`,
+  runs: `Usage: withmate session runs [options]
 
 Required options:
   --session-id <session-id>

--- a/src/cli/invocation.ts
+++ b/src/cli/invocation.ts
@@ -1,4 +1,8 @@
-import type { ApplicationSessionMessageOperations, ApplicationSessionOperations } from "../main/index.js";
+import type {
+  ApplicationSessionMessageOperations,
+  ApplicationSessionOperations,
+  ApplicationSessionRunOperations,
+} from "../main/index.js";
 import { serializeCliStructuredOutput } from "./application-response.js";
 import { CLI_EXIT_CODES, type CliExitCode, type CliParseResult, type CliValidatedSessionCommand } from "./contract.js";
 import { helpText } from "./help.js";
@@ -15,6 +19,7 @@ export type CliInvocationDependencies<TAuthorizationContext> = Readonly<{
   version: string;
   operations: ApplicationSessionOperations<TAuthorizationContext>;
   messageOperations: ApplicationSessionMessageOperations<TAuthorizationContext>;
+  sessionRunOperations: ApplicationSessionRunOperations<TAuthorizationContext>;
   authorization: TAuthorizationContext;
   signal?: AbortSignal;
 }>;

--- a/src/cli/lifecycle.ts
+++ b/src/cli/lifecycle.ts
@@ -3,6 +3,7 @@ import type {
   ApplicationRunOutputOperations,
   ApplicationSessionMessageOperations,
   ApplicationSessionOperations,
+  ApplicationSessionRunOperations,
 } from "../main/index.js";
 import { serializeCliStructuredOutput } from "./application-response.js";
 import {
@@ -26,6 +27,7 @@ export type CliLifecycleControl = Readonly<{ timeoutMs?: number; signal?: AbortS
 export type CliOperationRuntime<TAuthorizationContext> = Readonly<{
   operations: ApplicationSessionOperations<TAuthorizationContext>;
   messageOperations: ApplicationSessionMessageOperations<TAuthorizationContext>;
+  sessionRunOperations: ApplicationSessionRunOperations<TAuthorizationContext>;
   runOperations: ApplicationRunOperations<TAuthorizationContext>;
   runOutputOperations: ApplicationRunOutputOperations<TAuthorizationContext>;
   authorization: TAuthorizationContext;
@@ -89,6 +91,7 @@ export async function runCliLifecycle<TAuthorizationContext>(
         ? dispatchCliSessionCommand(parsed.command as CliValidatedSessionCommand, {
             operations: runtime.operations,
             messageOperations: runtime.messageOperations,
+            sessionRunOperations: runtime.sessionRunOperations,
             authorization: runtime.authorization,
             signal: abortController.signal,
             ...operationControl,

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -12,6 +12,7 @@ import {
   CLI_SCHEMA_VERSION,
   CLI_SESSION_LIMITS,
   CLI_SESSION_MESSAGE_LIMITS,
+  CLI_SESSION_RUN_LIMITS,
   type CliCommandIdentity,
   type CliParseResult,
   type CliRunOperation,
@@ -45,6 +46,7 @@ const sessionOperations = new Set<CliSessionOperation>([
   "read",
   "directories-chunk",
   "messages",
+  "runs",
   "message-content-chunk",
   "archive",
   "unarchive",
@@ -129,6 +131,8 @@ function parseSessionCommand(
       return parseDirectoriesChunk(identity as CliCommandIdentity<"directories-chunk">, argv);
     case "messages":
       return parseMessages(identity as CliCommandIdentity<"messages">, argv);
+    case "runs":
+      return parseRuns(identity as CliCommandIdentity<"runs">, argv);
     case "message-content-chunk":
       return parseMessageContentChunk(identity as CliCommandIdentity<"message-content-chunk">, argv);
     case "archive":
@@ -495,6 +499,26 @@ function parseMessages(identity: CliCommandIdentity<"messages">, argv: readonly 
       sessionId: parsed.values["--session-id"] as string,
       ...(parsed.values["--cursor"] === undefined ? {} : { cursor: parsed.values["--cursor"] as string }),
       limit: (parsed.values["--limit"] as number | undefined) ?? CLI_SESSION_MESSAGE_LIMITS.messagesDefaultItems,
+      ...optionalTimeout(parsed.values),
+    },
+  };
+}
+
+function parseRuns(identity: CliCommandIdentity<"runs">, argv: readonly string[]): CliParseResult {
+  const parsed = parseOptions(identity, argv, {
+    "--session-id": requiredOption(parseIdentifier),
+    "--cursor": option((value) => parseBoundedString(value, CLI_SESSION_LIMITS.maxCursorLength)),
+    "--limit": option((value) => parseInteger(value, 1, CLI_SESSION_RUN_LIMITS.runsMaxItems)),
+    ...timeoutOption,
+  });
+  if (!parsed.ok) return parsed.result;
+  return {
+    kind: "command",
+    command: {
+      identity,
+      sessionId: parsed.values["--session-id"] as string,
+      ...(parsed.values["--cursor"] === undefined ? {} : { cursor: parsed.values["--cursor"] as string }),
+      limit: (parsed.values["--limit"] as number | undefined) ?? CLI_SESSION_RUN_LIMITS.runsDefaultItems,
       ...optionalTimeout(parsed.values),
     },
   };

--- a/src/cli/session-dispatch.ts
+++ b/src/cli/session-dispatch.ts
@@ -1,4 +1,8 @@
-import type { ApplicationSessionMessageOperations, ApplicationSessionOperations } from "../main/index.js";
+import type {
+  ApplicationSessionMessageOperations,
+  ApplicationSessionOperations,
+  ApplicationSessionRunOperations,
+} from "../main/index.js";
 import { projectCliOperationOutput, type CliOperationProjectionResult } from "./application-response.js";
 import {
   CLI_EXIT_CODES,
@@ -17,6 +21,7 @@ type CommandFor<TOperation extends CliSessionOperation> = Extract<
 export type CliSessionDispatchDependencies<TAuthorizationContext> = Readonly<{
   operations: ApplicationSessionOperations<TAuthorizationContext>;
   messageOperations: ApplicationSessionMessageOperations<TAuthorizationContext>;
+  sessionRunOperations: ApplicationSessionRunOperations<TAuthorizationContext>;
   authorization: TAuthorizationContext;
   signal?: AbortSignal;
   timeoutMs?: number;
@@ -97,6 +102,16 @@ export async function dispatchCliSessionCommand<TAuthorizationContext>(
       );
     } else if (isCommandFor(command, "messages")) {
       response = await dependencies.messageOperations.messages(
+        {
+          context,
+          sessionId: command.sessionId,
+          ...(command.cursor === undefined ? {} : { cursor: command.cursor }),
+          limit: command.limit,
+        },
+        options,
+      );
+    } else if (isCommandFor(command, "runs")) {
+      response = await dependencies.sessionRunOperations.runs(
         {
           context,
           sessionId: command.sessionId,

--- a/src/main/application-run-projection.ts
+++ b/src/main/application-run-projection.ts
@@ -1,0 +1,203 @@
+import {
+  APPLICATION_RUN_LIMITS,
+  type ApplicationRunCancellationSummary,
+  type ApplicationRunFailureSummary,
+  type ApplicationRunPhase,
+} from "../shared/application-run-model.js";
+
+type PersistedRunBase = Readonly<{
+  retryOfRunId?: string;
+  createdAt: number;
+  startedAt?: number;
+  updatedAt: number;
+}>;
+
+export type PersistedRunProjection =
+  | (PersistedRunBase &
+      Readonly<{
+        phase: "queued" | "starting" | "active" | "finalizing";
+        terminalAt?: never;
+        failure?: never;
+        cancellation?: never;
+      }>)
+  | (PersistedRunBase &
+      Readonly<{
+        phase: "canceling";
+        terminalAt?: never;
+        failure?: never;
+        cancellation?: ApplicationRunCancellationSummary;
+      }>)
+  | (PersistedRunBase &
+      Readonly<{
+        phase: "completed";
+        terminalAt: number;
+        failure?: never;
+        cancellation?: never;
+      }>)
+  | (PersistedRunBase &
+      Readonly<{
+        phase: "failed" | "interrupted";
+        terminalAt: number;
+        failure: ApplicationRunFailureSummary;
+        cancellation?: ApplicationRunCancellationSummary;
+      }>)
+  | (PersistedRunBase &
+      Readonly<{
+        phase: "canceled";
+        terminalAt: number;
+        failure?: never;
+        cancellation?: ApplicationRunCancellationSummary;
+      }>);
+
+export const PERSISTED_RUN_PROJECTION_KEYS = [
+  "retryOfRunId",
+  "phase",
+  "failureOrigin",
+  "errorSummary",
+  "cancelRequestedAt",
+  "cancelAcknowledgedAt",
+  "createdAt",
+  "startedAt",
+  "terminalAt",
+  "updatedAt",
+] as const;
+
+export function projectPersistedRun(value: unknown): PersistedRunProjection {
+  const run = projectionRecord(value, PERSISTED_RUN_PROJECTION_KEYS);
+  const phase = runPhase(run.phase);
+  const retryOfRunId = optionalBoundedString(run.retryOfRunId, APPLICATION_RUN_LIMITS.maxIdentifierLength);
+  const createdAt = nonNegativeInteger(run.createdAt);
+  const startedAt = optionalNonNegativeInteger(run.startedAt);
+  const updatedAt = nonNegativeInteger(run.updatedAt);
+  const terminalAt = optionalNonNegativeInteger(run.terminalAt);
+  const failureOrigin = optionalFailureOrigin(run.failureOrigin);
+  const errorSummary = optionalBoundedString(run.errorSummary, APPLICATION_RUN_LIMITS.maxSummaryLength);
+  const requestedAt = optionalNonNegativeInteger(run.cancelRequestedAt);
+  const acknowledgedAt = optionalNonNegativeInteger(run.cancelAcknowledgedAt);
+  if (acknowledgedAt !== undefined && requestedAt === undefined) {
+    throw new TypeError("Cancel acknowledgment has no request.");
+  }
+  const cancellation =
+    requestedAt === undefined
+      ? undefined
+      : { requestedAt, ...(acknowledgedAt === undefined ? {} : { acknowledgedAt }) };
+  const base = {
+    ...(retryOfRunId === undefined ? {} : { retryOfRunId }),
+    createdAt,
+    ...(startedAt === undefined ? {} : { startedAt }),
+    updatedAt,
+  } as const;
+
+  if (isTerminalPhase(phase) !== (terminalAt !== undefined)) {
+    throw new TypeError(
+      isTerminalPhase(phase) ? "Terminal Run has no terminal time." : "Non-terminal Run has terminal time.",
+    );
+  }
+  if (phase !== "failed" && phase !== "interrupted" && (failureOrigin !== undefined || errorSummary !== undefined)) {
+    throw new TypeError("Non-failure Run has failure details.");
+  }
+  if ((phase === "failed" || phase === "interrupted") && failureOrigin === undefined) {
+    throw new TypeError("Failure Run has no origin.");
+  }
+  if (!["canceling", "failed", "interrupted", "canceled"].includes(phase) && cancellation !== undefined) {
+    throw new TypeError("Run phase has cancellation details.");
+  }
+
+  switch (phase) {
+    case "queued":
+    case "starting":
+    case "active":
+    case "finalizing":
+      return { ...base, phase };
+    case "canceling":
+      return { ...base, phase, ...(cancellation === undefined ? {} : { cancellation }) };
+    case "completed":
+      return { ...base, phase, terminalAt: terminalAt as number };
+    case "failed":
+    case "interrupted":
+      return {
+        ...base,
+        phase,
+        terminalAt: terminalAt as number,
+        failure: {
+          origin: failureOrigin as ApplicationRunFailureSummary["origin"],
+          ...(errorSummary === undefined ? {} : { summary: errorSummary }),
+        },
+        ...(cancellation === undefined ? {} : { cancellation }),
+      };
+    case "canceled":
+      return {
+        ...base,
+        phase,
+        terminalAt: terminalAt as number,
+        ...(cancellation === undefined ? {} : { cancellation }),
+      };
+  }
+}
+
+function isTerminalPhase(phase: ApplicationRunPhase): boolean {
+  return phase === "completed" || phase === "failed" || phase === "canceled" || phase === "interrupted";
+}
+
+function projectionRecord(value: unknown, allowedKeys: readonly string[]): Readonly<Record<string, unknown>> {
+  if (!isPlainObject(value)) throw new TypeError("Projection object is invalid.");
+  return Object.fromEntries(allowedKeys.map((key) => [key, value[key]]));
+}
+
+function isPlainObject(value: unknown): value is Readonly<Record<string, unknown>> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value) as unknown;
+  return prototype === Object.prototype || prototype === null;
+}
+
+function boundedString(value: unknown, maxLength: number): string {
+  if (typeof value !== "string" || value.length === 0 || value.length > maxLength) {
+    throw new TypeError("String is invalid.");
+  }
+  return value;
+}
+
+function optionalBoundedString(value: unknown, maxLength: number): string | undefined {
+  return value === undefined ? undefined : boundedString(value, maxLength);
+}
+
+function nonNegativeInteger(value: unknown): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) throw new TypeError("Integer is invalid.");
+  return value as number;
+}
+
+function optionalNonNegativeInteger(value: unknown): number | undefined {
+  return value === undefined ? undefined : nonNegativeInteger(value);
+}
+
+function runPhase(value: unknown): ApplicationRunPhase {
+  if (
+    value !== "queued" &&
+    value !== "starting" &&
+    value !== "active" &&
+    value !== "canceling" &&
+    value !== "finalizing" &&
+    value !== "completed" &&
+    value !== "failed" &&
+    value !== "canceled" &&
+    value !== "interrupted"
+  ) {
+    throw new TypeError("Run phase is invalid.");
+  }
+  return value;
+}
+
+function optionalFailureOrigin(value: unknown): ApplicationRunFailureSummary["origin"] | undefined {
+  if (value === undefined) return undefined;
+  if (
+    value !== "provider" &&
+    value !== "transport" &&
+    value !== "process" &&
+    value !== "application" &&
+    value !== "persistence" &&
+    value !== "unknown"
+  ) {
+    throw new TypeError("Failure origin is invalid.");
+  }
+  return value;
+}

--- a/src/main/application-run-service.ts
+++ b/src/main/application-run-service.ts
@@ -4,7 +4,6 @@ import type {
   ApplicationRunEvent,
   ApplicationRunEventPage,
   ApplicationRunEventsRequest,
-  ApplicationRunFailureSummary,
   ApplicationRunFollowRequest,
   ApplicationRunFollowResult,
   ApplicationRunLiveActivity,
@@ -22,6 +21,7 @@ import type {
 } from "../shared/application-service-model.js";
 import type { PersistenceError } from "../shared/persistence-protocol.js";
 import type { RunEventPage } from "../shared/repository-read-model.js";
+import { projectPersistedRun } from "./application-run-projection.js";
 import { PersistenceClientError } from "./persistence-worker-client.js";
 import type { PersistenceWorkerClient } from "./persistence-worker-client.js";
 import { RepositoryReadClient } from "./repository-read-client.js";
@@ -593,81 +593,56 @@ function projectRunStatus(
   const runId = boundedString(run.id);
   const sessionId = boundedString(run.sessionId);
   if (runId !== expected.runId || sessionId !== expected.sessionId) throw new TypeError("Run identity mismatch.");
-  const phase = runPhase(run.phase);
-  const retryOfRunId = optionalBoundedString(run.retryOfRunId, APPLICATION_RUN_LIMITS.maxIdentifierLength);
-  const createdAt = nonNegativeInteger(run.createdAt);
-  const startedAt = optionalNonNegativeInteger(run.startedAt);
-  const updatedAt = nonNegativeInteger(run.updatedAt);
-  const terminalAt = optionalNonNegativeInteger(run.terminalAt);
   const version = nonNegativeInteger(run.version);
-  const failureOrigin = optionalFailureOrigin(run.failureOrigin);
-  const errorSummary = optionalBoundedString(run.errorSummary, APPLICATION_RUN_LIMITS.maxSummaryLength);
-  const requestedAt = optionalNonNegativeInteger(run.cancelRequestedAt);
-  const acknowledgedAt = optionalNonNegativeInteger(run.cancelAcknowledgedAt);
-  if (acknowledgedAt !== undefined && requestedAt === undefined)
-    throw new TypeError("Cancel acknowledgment has no request.");
-  const cancellation =
-    requestedAt === undefined
-      ? undefined
-      : { requestedAt, ...(acknowledgedAt === undefined ? {} : { acknowledgedAt }) };
+  const persisted = projectPersistedRun(run);
   const base = {
     sessionId,
     runId,
-    ...(retryOfRunId === undefined ? {} : { retryOfRunId }),
-    createdAt,
-    ...(startedAt === undefined ? {} : { startedAt }),
-    updatedAt,
+    ...(persisted.retryOfRunId === undefined ? {} : { retryOfRunId: persisted.retryOfRunId }),
+    createdAt: persisted.createdAt,
+    ...(persisted.startedAt === undefined ? {} : { startedAt: persisted.startedAt }),
+    updatedAt: persisted.updatedAt,
   } as const;
 
-  if (!terminalPhases.has(phase) && terminalAt !== undefined)
-    throw new TypeError("Non-terminal Run has terminal time.");
-  if (terminalPhases.has(phase) && terminalAt === undefined) throw new TypeError("Terminal Run has no terminal time.");
-  if (phase !== "failed" && phase !== "interrupted" && (failureOrigin !== undefined || errorSummary !== undefined)) {
-    throw new TypeError("Non-failure Run has failure details.");
-  }
-  if ((phase === "failed" || phase === "interrupted") && failureOrigin === undefined) {
-    throw new TypeError("Failure Run has no origin.");
-  }
-
   let status: ApplicationRunStatus;
-  switch (phase) {
+  switch (persisted.phase) {
     case "queued":
     case "starting":
     case "finalizing":
-      status = { ...base, phase, liveActivity: null };
+      status = { ...base, phase: persisted.phase, liveActivity: null };
       break;
     case "active":
-      status = { ...base, phase, liveActivity: null };
+      status = { ...base, phase: persisted.phase, liveActivity: null };
       break;
     case "canceling":
-      status = { ...base, phase, liveActivity: null, ...(cancellation === undefined ? {} : { cancellation }) };
-      break;
-    case "completed":
-      status = { ...base, phase, liveActivity: null, terminalAt: terminalAt as number };
-      break;
-    case "failed":
-    case "interrupted": {
-      const failure: ApplicationRunFailureSummary = {
-        origin: failureOrigin as ApplicationRunFailureSummary["origin"],
-        ...(errorSummary === undefined ? {} : { summary: errorSummary }),
-      };
       status = {
         ...base,
-        phase,
+        phase: persisted.phase,
         liveActivity: null,
-        terminalAt: terminalAt as number,
-        failure,
-        ...(cancellation === undefined ? {} : { cancellation }),
+        ...(persisted.cancellation === undefined ? {} : { cancellation: persisted.cancellation }),
       };
       break;
-    }
+    case "completed":
+      status = { ...base, phase: persisted.phase, liveActivity: null, terminalAt: persisted.terminalAt };
+      break;
+    case "failed":
+    case "interrupted":
+      status = {
+        ...base,
+        phase: persisted.phase,
+        liveActivity: null,
+        terminalAt: persisted.terminalAt,
+        failure: persisted.failure,
+        ...(persisted.cancellation === undefined ? {} : { cancellation: persisted.cancellation }),
+      };
+      break;
     case "canceled":
       status = {
         ...base,
-        phase,
+        phase: persisted.phase,
         liveActivity: null,
-        terminalAt: terminalAt as number,
-        ...(cancellation === undefined ? {} : { cancellation }),
+        terminalAt: persisted.terminalAt,
+        ...(persisted.cancellation === undefined ? {} : { cancellation: persisted.cancellation }),
       };
       break;
   }
@@ -1052,10 +1027,6 @@ function nonNegativeInteger(value: unknown): number {
   return result;
 }
 
-function optionalNonNegativeInteger(value: unknown): number | undefined {
-  return optionalInteger(value, 0, Number.MAX_SAFE_INTEGER);
-}
-
 function positiveInteger(value: unknown): number {
   const result = optionalInteger(value, 1, Number.MAX_SAFE_INTEGER);
   if (result === undefined) throw new TypeError("Positive integer is required.");
@@ -1065,24 +1036,4 @@ function positiveInteger(value: unknown): number {
 function enumString<TValue extends string>(value: unknown, allowed: readonly TValue[]): TValue {
   if (typeof value !== "string" || !allowed.includes(value as TValue)) throw new TypeError("Enum is invalid.");
   return value as TValue;
-}
-
-function runPhase(value: unknown): ApplicationRunPhase {
-  return enumString(value, [
-    "queued",
-    "starting",
-    "active",
-    "canceling",
-    "finalizing",
-    "completed",
-    "failed",
-    "canceled",
-    "interrupted",
-  ]);
-}
-
-function optionalFailureOrigin(value: unknown): ApplicationRunFailureSummary["origin"] | undefined {
-  return value === undefined
-    ? undefined
-    : enumString(value, ["provider", "transport", "process", "application", "persistence", "unknown"] as const);
 }

--- a/src/main/application-session-run-service.ts
+++ b/src/main/application-session-run-service.ts
@@ -1,0 +1,690 @@
+import {
+  APPLICATION_SESSION_RUN_LIMITS,
+  type ApplicationSessionRunAccessValidationInput,
+  type ApplicationSessionRunAccessValidator,
+  type ApplicationSessionRunItem,
+  type ApplicationSessionRunOperations,
+  type ApplicationSessionRunPage,
+  type ApplicationSessionRunsRequest,
+} from "../shared/application-session-run-model.js";
+import type {
+  ApplicationAccessDecision,
+  ApplicationOperationOptions,
+  ApplicationOperationResponse,
+} from "../shared/application-service-model.js";
+import type { PersistenceError } from "../shared/persistence-protocol.js";
+import { PERSISTED_RUN_PROJECTION_KEYS, projectPersistedRun } from "./application-run-projection.js";
+import { PersistenceClientError } from "./persistence-worker-client.js";
+import type { PersistenceWorkerClient } from "./persistence-worker-client.js";
+import { RepositoryReadClient } from "./repository-read-client.js";
+
+type SessionRunReadPort = Pick<RepositoryReadClient, "sessionGet" | "runsPage">;
+
+type ApplicationSessionRunFailureResponse = Extract<
+  ApplicationOperationResponse<never, "read">,
+  Readonly<{ overallStatus: "failure" }>
+>;
+
+type PreparedOperation<TValue> =
+  | Readonly<{ ok: true; input: TValue; control: OperationControl }>
+  | Readonly<{ ok: false; response: ApplicationSessionRunFailureResponse }>;
+
+type OperationControl = {
+  readonly deadlineAt?: number;
+  readonly signal?: AbortSignal;
+  persistenceStarted: boolean;
+};
+
+type OperationInterruption = "timeout" | "canceled";
+
+type ControlledSettlement<TValue> =
+  | Readonly<{ status: "fulfilled"; value: TValue }>
+  | Readonly<{ status: "rejected"; error: unknown }>
+  | Readonly<{ status: "interrupted"; interruption: OperationInterruption }>;
+
+type OperationResolution<TValue> =
+  Readonly<{ ok: true; value: TValue }> | Readonly<{ ok: false; response: ApplicationSessionRunFailureResponse }>;
+
+type SessionRunScope = Readonly<{ sessionId: string; workspaceKey: string }>;
+
+type RunOmissionIssue = Readonly<{
+  kind: "omission";
+  code: "response_size_limit";
+  message: string;
+  ordinal: number;
+}>;
+
+type ProjectedRunPage = Readonly<{
+  value: ApplicationSessionRunPage;
+  issues: readonly RunOmissionIssue[];
+}>;
+
+const RUN_ITEM_PROJECTION_KEYS = [
+  "omitted",
+  "reason",
+  "runId",
+  "sessionId",
+  "ordinal",
+  "initiatingMessageId",
+  "finalAssistantMessageId",
+  ...PERSISTED_RUN_PROJECTION_KEYS,
+] as const;
+
+const RUN_VALUE_KEYS = RUN_ITEM_PROJECTION_KEYS.filter(
+  (key) => key !== "omitted" && key !== "reason" && key !== "ordinal",
+);
+
+export type ApplicationSessionRunServiceOptions<TAuthorizationContext> = Readonly<{
+  reads: SessionRunReadPort;
+  access: ApplicationSessionRunAccessValidator<TAuthorizationContext>;
+  snapshotAuthorization(value: unknown): TAuthorizationContext;
+}>;
+
+export function createApplicationSessionRunOperations<TAuthorizationContext>(
+  worker: PersistenceWorkerClient,
+  options: Omit<ApplicationSessionRunServiceOptions<TAuthorizationContext>, "reads">,
+): ApplicationSessionRunOperations<TAuthorizationContext> {
+  return new ApplicationSessionRunService({ reads: new RepositoryReadClient(worker), ...options });
+}
+
+export class ApplicationSessionRunService<
+  TAuthorizationContext,
+> implements ApplicationSessionRunOperations<TAuthorizationContext> {
+  readonly #reads: SessionRunReadPort;
+  readonly #access: ApplicationSessionRunAccessValidator<TAuthorizationContext>;
+  readonly #snapshotAuthorization: (value: unknown) => TAuthorizationContext;
+
+  constructor(options: ApplicationSessionRunServiceOptions<TAuthorizationContext>) {
+    this.#reads = options.reads;
+    this.#access = options.access;
+    this.#snapshotAuthorization = options.snapshotAuthorization;
+  }
+
+  async runs(
+    request: ApplicationSessionRunsRequest<TAuthorizationContext>,
+    options?: ApplicationOperationOptions,
+  ): Promise<ApplicationOperationResponse<ApplicationSessionRunPage, "read">> {
+    const prepared = prepareOperation(options, () => decodeRunsRequest(request, this.#snapshotAuthorization));
+    if (!prepared.ok) return prepared.response;
+    const scope = await this.#authorizeAndResolveScope(prepared.input, prepared.control);
+    if (!scope.ok) return scope.response;
+    const limit = prepared.input.limit ?? APPLICATION_SESSION_RUN_LIMITS.runsDefaultItems;
+    const page = await readRepository(prepared.control, (repositoryOptions) =>
+      this.#reads.runsPage(
+        {
+          ...scope.value,
+          ...(prepared.input.cursor === undefined ? {} : { cursor: prepared.input.cursor }),
+          limit,
+        },
+        repositoryOptions,
+      ),
+    );
+    if (!page.ok) return page.response;
+    const projected = projectOperationValue(prepared.control, () =>
+      projectRunPage(page.value, scope.value, prepared.input.cursor, limit),
+    );
+    return projected.ok
+      ? readOutcome(prepared.control, projected.value.value, projected.value.issues)
+      : projected.response;
+  }
+
+  async #authorizeAndResolveScope(
+    input: ApplicationSessionRunsRequest<TAuthorizationContext>,
+    control: OperationControl,
+  ): Promise<OperationResolution<SessionRunScope>> {
+    const authorizationInput: ApplicationSessionRunAccessValidationInput<TAuthorizationContext> = {
+      operation: "runs",
+      access: "read",
+      context: input.context,
+      target: { kind: "session_runs", sessionId: input.sessionId },
+    };
+    const authorization = await runControlled(control, () => this.#access.authorize(authorizationInput));
+    if (authorization.status === "interrupted") {
+      return { ok: false, response: operationInterruptionFailure(authorization.interruption) };
+    }
+    if (authorization.status === "rejected") return { ok: false, response: prePersistenceApplicationFailure() };
+    const decision = projectOperationValue(control, () => projectAccessDecision(authorization.value));
+    if (!decision.ok) return decision;
+    if (!decision.value.allowed) return { ok: false, response: accessFailure(decision.value.error) };
+
+    const session = await readRepository(control, (repositoryOptions) =>
+      this.#reads.sessionGet({ sessionId: input.sessionId }, repositoryOptions),
+    );
+    if (!session.ok) return session;
+    return projectOperationValue(control, () => {
+      const projected = projectionRecord(session.value, ["session"]);
+      const projectedSession = projectionRecord(projected.session, ["id", "workspaceKey"]);
+      const sessionId = boundedString(projectedSession.id);
+      const workspaceKey = boundedString(projectedSession.workspaceKey);
+      if (sessionId !== input.sessionId) throw new TypeError("Session scope mismatch.");
+      return { sessionId, workspaceKey };
+    });
+  }
+}
+
+function decodeRunsRequest<TAuthorizationContext>(
+  value: unknown,
+  snapshotAuthorization: (value: unknown) => TAuthorizationContext,
+): ApplicationSessionRunsRequest<TAuthorizationContext> {
+  const request = requestRecord(value, ["context", "sessionId", "cursor", "limit"]);
+  const context = requestRecord(request.context, ["authorization"]);
+  const cursor = optionalBoundedString(request.cursor, APPLICATION_SESSION_RUN_LIMITS.maxCursorLength);
+  const limit = optionalInteger(request.limit, 1, APPLICATION_SESSION_RUN_LIMITS.runsMaxItems);
+  return {
+    context: { authorization: snapshotAuthorization(context.authorization) },
+    sessionId: boundedString(request.sessionId),
+    ...(cursor === undefined ? {} : { cursor }),
+    ...(limit === undefined ? {} : { limit }),
+  };
+}
+
+function projectRunPage(
+  value: unknown,
+  expected: SessionRunScope,
+  inputCursor: string | undefined,
+  limit: number,
+): ProjectedRunPage {
+  const page = exactProjectionRecord(value, ["sessionId", "workspaceKey", "items", "nextCursor"]);
+  if (
+    boundedString(page.sessionId) !== expected.sessionId ||
+    boundedString(page.workspaceKey) !== expected.workspaceKey
+  ) {
+    throw new TypeError("Run page scope mismatch.");
+  }
+  if (!isDenseArray(page.items, limit)) throw new TypeError("Run page is invalid.");
+  const nextCursor = optionalBoundedString(page.nextCursor, APPLICATION_SESSION_RUN_LIMITS.maxCursorLength);
+  if (page.items.length === 0 && nextCursor !== undefined) throw new TypeError("Empty Run page has a cursor.");
+  if (nextCursor !== undefined && nextCursor === inputCursor) throw new TypeError("Run cursor did not advance.");
+
+  const items: ApplicationSessionRunItem[] = [];
+  const issues: RunOmissionIssue[] = [];
+  let previousOrdinal = 0;
+  for (const rawValue of page.items) {
+    const originalItem = plainRecord(rawValue);
+    const rawItem = exactProjectionRecord(originalItem, RUN_ITEM_PROJECTION_KEYS);
+    const ordinal = integer(rawItem.ordinal, 1, Number.MAX_SAFE_INTEGER);
+    if (ordinal <= previousOrdinal) throw new TypeError("Run ordinals are invalid.");
+    previousOrdinal = ordinal;
+    if (rawItem.omitted === true) {
+      if (rawItem.reason !== "response_size_limit" || RUN_VALUE_KEYS.some((key) => Object.hasOwn(originalItem, key))) {
+        throw new TypeError("Run omission is invalid.");
+      }
+      issues.push({
+        kind: "omission",
+        code: "response_size_limit",
+        message: "Run was omitted because the response size limit was reached.",
+        ordinal,
+      });
+      continue;
+    }
+    if (Object.hasOwn(originalItem, "omitted") || Object.hasOwn(originalItem, "reason")) {
+      throw new TypeError("Run item is invalid.");
+    }
+    items.push(projectRunItem(rawItem, expected, ordinal));
+  }
+  return {
+    value: {
+      sessionId: expected.sessionId,
+      items,
+      ...(nextCursor === undefined ? {} : { nextCursor }),
+    },
+    issues,
+  };
+}
+
+function projectRunItem(
+  item: Readonly<Record<string, unknown>>,
+  expected: SessionRunScope,
+  ordinal: number,
+): ApplicationSessionRunItem {
+  const runId = boundedString(item.runId);
+  if (boundedString(item.sessionId) !== expected.sessionId) throw new TypeError("Run identity mismatch.");
+  const initiatingMessageId = boundedString(item.initiatingMessageId);
+  const finalAssistantMessageId = optionalBoundedString(
+    item.finalAssistantMessageId,
+    APPLICATION_SESSION_RUN_LIMITS.maxIdentifierLength,
+  );
+  const persisted = projectPersistedRun(item);
+  const identity = { runId, ordinal, initiatingMessageId } as const;
+  if (persisted.phase === "completed") {
+    return {
+      ...identity,
+      ...persisted,
+      ...(finalAssistantMessageId === undefined ? {} : { finalAssistantMessageId }),
+    };
+  }
+  if (finalAssistantMessageId !== undefined) throw new TypeError("Non-completed Run has a final Message.");
+  return { ...identity, ...persisted };
+}
+
+function prepareOperation<TValue>(options: unknown, decodeRequest: () => TValue): PreparedOperation<TValue> {
+  const operationStartedAt = Date.now();
+  let decodedOptions: ApplicationOperationOptions | undefined;
+  try {
+    decodedOptions = decodeOperationOptions(options);
+  } catch {
+    return { ok: false, response: requestFailure() };
+  }
+  const control: OperationControl = {
+    ...(decodedOptions?.timeoutMs === undefined ? {} : { deadlineAt: operationStartedAt + decodedOptions.timeoutMs }),
+    ...(decodedOptions?.signal === undefined ? {} : { signal: decodedOptions.signal }),
+    persistenceStarted: false,
+  };
+  const beforeDecode = getOperationInterruption(control);
+  if (beforeDecode !== undefined) return { ok: false, response: operationInterruptionFailure(beforeDecode) };
+  let input: TValue;
+  try {
+    input = decodeRequest();
+  } catch {
+    return { ok: false, response: requestFailure() };
+  }
+  const afterDecode = getOperationInterruption(control);
+  return afterDecode === undefined
+    ? { ok: true, input, control }
+    : { ok: false, response: operationInterruptionFailure(afterDecode) };
+}
+
+function decodeOperationOptions(value: unknown): ApplicationOperationOptions | undefined {
+  if (value === undefined) return undefined;
+  const options = requestRecord(value, ["timeoutMs", "signal"]);
+  const timeoutMs = optionalInteger(options.timeoutMs, 1, 2_147_483_647);
+  if (options.signal !== undefined && !(options.signal instanceof AbortSignal)) throw new TypeError("Invalid signal.");
+  return {
+    ...(timeoutMs === undefined ? {} : { timeoutMs }),
+    ...(options.signal === undefined ? {} : { signal: options.signal as AbortSignal }),
+  };
+}
+
+async function readRepository<TValue>(
+  control: OperationControl,
+  execute: (options: ApplicationOperationOptions | undefined) => Promise<TValue>,
+): Promise<OperationResolution<TValue>> {
+  const interruption = getOperationInterruption(control);
+  if (interruption !== undefined) return { ok: false, response: interruptionFailure(control, interruption) };
+  const repositoryAbort = new AbortController();
+  const settlement = await runControlled(
+    control,
+    () => {
+      control.persistenceStarted = true;
+      return execute({ signal: repositoryAbort.signal });
+    },
+    () => repositoryAbort.abort(),
+  );
+  if (settlement.status === "interrupted") {
+    return { ok: false, response: interruptionFailure(control, settlement.interruption) };
+  }
+  if (settlement.status === "rejected") return { ok: false, response: mapThrownReadFailure(settlement.error) };
+  return { ok: true, value: settlement.value };
+}
+
+function projectOperationValue<TValue>(control: OperationControl, project: () => TValue): OperationResolution<TValue> {
+  try {
+    const value = project();
+    const interruption = getOperationInterruption(control);
+    return interruption === undefined
+      ? { ok: true, value }
+      : { ok: false, response: interruptionFailure(control, interruption) };
+  } catch {
+    const interruption = getOperationInterruption(control);
+    return {
+      ok: false,
+      response:
+        interruption === undefined
+          ? control.persistenceStarted
+            ? persistenceApplicationFailure()
+            : prePersistenceApplicationFailure()
+          : interruptionFailure(control, interruption),
+    };
+  }
+}
+
+async function runControlled<TValue>(
+  control: OperationControl,
+  start: () => Promise<TValue>,
+  interruptStartedWork?: () => void,
+): Promise<ControlledSettlement<TValue>> {
+  const beforeStart = getOperationInterruption(control);
+  if (beforeStart !== undefined) return { status: "interrupted", interruption: beforeStart };
+  let work: Promise<TValue>;
+  try {
+    work = Promise.resolve(start());
+  } catch (error) {
+    const interruption = getOperationInterruption(control);
+    return interruption === undefined ? { status: "rejected", error } : { status: "interrupted", interruption };
+  }
+  return new Promise((resolve) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const finish = (result: ControlledSettlement<TValue>) => {
+      if (settled) return;
+      settled = true;
+      if (timer !== undefined) clearTimeout(timer);
+      control.signal?.removeEventListener("abort", onAbort);
+      resolve(result);
+    };
+    const interrupt = (interruption: OperationInterruption) => {
+      if (settled) return;
+      try {
+        interruptStartedWork?.();
+      } catch {
+        // Interruption owns the public result even if the Repository abort hook fails.
+      }
+      finish({ status: "interrupted", interruption });
+    };
+    const onAbort = () => interrupt("canceled");
+    work.then(
+      (value) => {
+        const interruption = getOperationInterruption(control);
+        if (interruption === undefined) finish({ status: "fulfilled", value });
+        else interrupt(interruption);
+      },
+      (error: unknown) => {
+        const interruption = getOperationInterruption(control);
+        if (interruption === undefined) finish({ status: "rejected", error });
+        else interrupt(interruption);
+      },
+    );
+    const remaining = getRemainingTimeout(control);
+    if (remaining !== undefined) timer = setTimeout(() => interrupt("timeout"), remaining);
+    control.signal?.addEventListener("abort", onAbort, { once: true });
+    if (control.signal?.aborted) onAbort();
+  });
+}
+
+function readSuccess<TValue>(control: OperationControl, value: TValue): ApplicationOperationResponse<TValue, "read"> {
+  const response = { overallStatus: "success", value, persistence: { status: "read", effect: "none" } } as const;
+  const interruption = getOperationInterruption(control);
+  return interruption === undefined ? response : interruptionFailure(control, interruption);
+}
+
+function readOutcome<TValue>(
+  control: OperationControl,
+  value: TValue,
+  issues: readonly RunOmissionIssue[],
+): ApplicationOperationResponse<TValue, "read"> {
+  if (issues.length === 0) return readSuccess(control, value);
+  const response = {
+    overallStatus: "partial_success",
+    value,
+    issues: issues as [RunOmissionIssue, ...RunOmissionIssue[]],
+    persistence: { status: "read", effect: "none" },
+  } as const;
+  const interruption = getOperationInterruption(control);
+  return interruption === undefined ? response : interruptionFailure(control, interruption);
+}
+
+function projectAccessDecision(value: unknown): ApplicationAccessDecision {
+  const decision = projectionRecord(value, ["allowed", "error"]);
+  if (decision.allowed === true) return { allowed: true };
+  if (decision.allowed !== false) throw new TypeError("Access decision is invalid.");
+  const error = projectionRecord(decision.error, ["code", "message", "retryable"]);
+  const code = enumString(error.code, [
+    "workspace_invalid",
+    "workspace_unavailable",
+    "authorization_invalid",
+    "forbidden",
+  ] as const);
+  if (typeof error.retryable !== "boolean") throw new TypeError("Access retryability is invalid.");
+  return {
+    allowed: false,
+    error: { code, message: boundedString(error.message, 4_096), retryable: error.retryable },
+  };
+}
+
+function requestFailure(): ApplicationSessionRunFailureResponse {
+  return {
+    overallStatus: "failure",
+    error: {
+      kind: "request",
+      code: "request_invalid",
+      message: "Application operation request is invalid.",
+      retryable: false,
+    },
+    persistence: { status: "not_attempted", effect: "none" },
+  };
+}
+
+function accessFailure(
+  error: Extract<ApplicationAccessDecision, Readonly<{ allowed: false }>>["error"],
+): ApplicationSessionRunFailureResponse {
+  return {
+    overallStatus: "failure",
+    error: { kind: "access", code: error.code, message: accessErrorMessage(error.code), retryable: error.retryable },
+    persistence: { status: "not_attempted", effect: "none" },
+  };
+}
+
+function operationInterruptionFailure(interruption: OperationInterruption): ApplicationSessionRunFailureResponse {
+  return {
+    overallStatus: "failure",
+    error:
+      interruption === "timeout"
+        ? {
+            kind: "operation",
+            code: "operation_timeout",
+            message: "Application operation timed out.",
+            retryable: true,
+          }
+        : {
+            kind: "operation",
+            code: "operation_canceled",
+            message: "Application operation was canceled.",
+            retryable: false,
+          },
+    persistence: { status: "not_attempted", effect: "none" },
+  };
+}
+
+function interruptionFailure(
+  control: OperationControl,
+  interruption: OperationInterruption,
+): ApplicationSessionRunFailureResponse {
+  if (!control.persistenceStarted) return operationInterruptionFailure(interruption);
+  return {
+    overallStatus: "failure",
+    error: {
+      kind: "persistence",
+      code: interruption === "timeout" ? "persistence_timeout" : "persistence_canceled",
+      message: interruption === "timeout" ? "Application operation timed out." : "Application operation was canceled.",
+      retryable: interruption === "timeout",
+      effect: "none",
+    },
+    persistence: { status: "failed", effect: "none" },
+  };
+}
+
+function prePersistenceApplicationFailure(): ApplicationSessionRunFailureResponse {
+  return {
+    overallStatus: "failure",
+    error: {
+      kind: "application",
+      code: "internal_error",
+      message: "Application Service could not complete the operation.",
+      retryable: false,
+    },
+    persistence: { status: "not_attempted", effect: "none" },
+  };
+}
+
+function persistenceApplicationFailure(): ApplicationSessionRunFailureResponse {
+  return {
+    overallStatus: "failure",
+    error: {
+      kind: "application",
+      code: "internal_error",
+      message: "Application Service could not complete the operation.",
+      retryable: false,
+    },
+    persistence: { status: "failed", effect: "none" },
+  };
+}
+
+function mapThrownReadFailure(error: unknown): ApplicationSessionRunFailureResponse {
+  if (!(error instanceof PersistenceClientError)) return persistenceApplicationFailure();
+  const persistenceError = error.persistenceError;
+  if (
+    persistenceError.code === "request_invalid" ||
+    persistenceError.code === "cursor_invalid" ||
+    persistenceError.code === "not_found"
+  ) {
+    return {
+      overallStatus: "failure",
+      error: {
+        kind: "domain",
+        code: persistenceError.code,
+        message: repositoryDomainErrorMessage(persistenceError.code),
+        retryable: persistenceError.retryable,
+      },
+      persistence: { status: "rejected", effect: "none" },
+    };
+  }
+  return {
+    overallStatus: "failure",
+    error: {
+      kind: "persistence",
+      code: mapPersistenceErrorCode(persistenceError.code),
+      message: "Persistence could not complete the Run history read.",
+      retryable: persistenceError.retryable,
+      effect: "none",
+    },
+    persistence: { status: "failed", effect: "none" },
+  };
+}
+
+function accessErrorMessage(
+  code: Extract<ApplicationAccessDecision, Readonly<{ allowed: false }>>["error"]["code"],
+): string {
+  switch (code) {
+    case "workspace_invalid":
+      return "The workspace authorization scope is invalid.";
+    case "workspace_unavailable":
+      return "The workspace authorization scope is unavailable.";
+    case "authorization_invalid":
+      return "The authorization context is invalid.";
+    case "forbidden":
+      return "The Run history read is not authorized.";
+  }
+}
+
+function repositoryDomainErrorMessage(code: "request_invalid" | "cursor_invalid" | "not_found"): string {
+  switch (code) {
+    case "request_invalid":
+      return "The Run history read request was rejected.";
+    case "cursor_invalid":
+      return "The Run history cursor is invalid.";
+    case "not_found":
+      return "The requested Run history resource was not found.";
+  }
+}
+
+function mapPersistenceErrorCode(code: PersistenceError["code"]) {
+  switch (code) {
+    case "worker_not_ready":
+    case "worker_closing":
+    case "worker_crashed":
+    case "worker_start_failed":
+    case "worker_shutdown_forced":
+    case "database_unavailable":
+      return "persistence_unavailable" as const;
+    case "queue_full":
+    case "database_busy":
+      return "persistence_busy" as const;
+    case "request_timeout":
+      return "persistence_timeout" as const;
+    case "request_canceled":
+      return "persistence_canceled" as const;
+    case "database_path_invalid":
+    case "database_identity_mismatch":
+    case "database_schema_unknown":
+    case "database_schema_too_new":
+    case "database_schema_too_old":
+    case "database_pragma_mismatch":
+    case "database_wal_unavailable":
+    case "database_bootstrap_failed":
+    case "schema_artifact_invalid":
+      return "persistence_configuration_invalid" as const;
+    case "database_schema_verification_failed":
+    case "database_integrity_check_failed":
+      return "persistence_integrity_failed" as const;
+    case "response_too_large":
+      return "persistence_response_too_large" as const;
+    default:
+      return "persistence_operation_failed" as const;
+  }
+}
+
+function getOperationInterruption(control: OperationControl): OperationInterruption | undefined {
+  if (control.deadlineAt !== undefined && control.deadlineAt <= Date.now()) return "timeout";
+  if (control.signal?.aborted) return "canceled";
+  return undefined;
+}
+
+function getRemainingTimeout(control: OperationControl): number | undefined {
+  return control.deadlineAt === undefined ? undefined : Math.max(0, control.deadlineAt - Date.now());
+}
+
+function requestRecord(value: unknown, allowedKeys: readonly string[]): Readonly<Record<string, unknown>> {
+  if (!isPlainObject(value) || Object.keys(value).some((key) => !allowedKeys.includes(key))) {
+    throw new TypeError("Request object is invalid.");
+  }
+  return Object.fromEntries(allowedKeys.map((key) => [key, value[key]]));
+}
+
+function projectionRecord(value: unknown, allowedKeys: readonly string[]): Readonly<Record<string, unknown>> {
+  const record = plainRecord(value);
+  return Object.fromEntries(allowedKeys.map((key) => [key, record[key]]));
+}
+
+function exactProjectionRecord(value: unknown, allowedKeys: readonly string[]): Readonly<Record<string, unknown>> {
+  const record = plainRecord(value);
+  if (Object.keys(record).some((key) => !allowedKeys.includes(key))) {
+    throw new TypeError("Projection object has unknown fields.");
+  }
+  return Object.fromEntries(allowedKeys.map((key) => [key, record[key]]));
+}
+
+function plainRecord(value: unknown): Readonly<Record<string, unknown>> {
+  if (!isPlainObject(value)) throw new TypeError("Projection object is invalid.");
+  return value;
+}
+
+function isPlainObject(value: unknown): value is Readonly<Record<string, unknown>> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value) as unknown;
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isDenseArray(value: unknown, maxLength: number): value is readonly unknown[] {
+  if (!Array.isArray(value) || value.length > maxLength) return false;
+  for (let index = 0; index < value.length; index += 1) {
+    if (!Object.hasOwn(value, index)) return false;
+  }
+  return true;
+}
+
+function boundedString(value: unknown, maxLength: number = APPLICATION_SESSION_RUN_LIMITS.maxIdentifierLength): string {
+  if (typeof value !== "string" || value.length === 0 || value.length > maxLength) {
+    throw new TypeError("String is invalid.");
+  }
+  return value;
+}
+
+function optionalBoundedString(value: unknown, maxLength: number): string | undefined {
+  return value === undefined ? undefined : boundedString(value, maxLength);
+}
+
+function integer(value: unknown, min: number, max: number): number {
+  if (!Number.isSafeInteger(value) || (value as number) < min || (value as number) > max) {
+    throw new TypeError("Integer is invalid.");
+  }
+  return value as number;
+}
+
+function optionalInteger(value: unknown, min: number, max: number): number | undefined {
+  return value === undefined ? undefined : integer(value, min, max);
+}
+
+function enumString<const TValues extends readonly string[]>(value: unknown, values: TValues): TValues[number] {
+  if (typeof value !== "string" || !values.includes(value)) throw new TypeError("Enum value is invalid.");
+  return value as TValues[number];
+}

--- a/src/main/cli-runtime.ts
+++ b/src/main/cli-runtime.ts
@@ -22,11 +22,17 @@ import type {
   ApplicationSessionMessageAccessValidator,
   ApplicationSessionMessageOperations,
 } from "../shared/application-session-message-model.js";
+import type {
+  ApplicationSessionRunAccessValidationInput,
+  ApplicationSessionRunAccessValidator,
+  ApplicationSessionRunOperations,
+} from "../shared/application-session-run-model.js";
 import { resolveApplicationDataRoot, resolveWithMateDatabasePathFromRoot } from "./application-data-path.js";
 import { createApplicationRunOperations } from "./application-run-service.js";
 import { createApplicationRunOutputOperations } from "./application-run-output-service.js";
 import { createApplicationSessionOperations } from "./application-session-service.js";
 import { createApplicationSessionMessageOperations } from "./application-session-message-service.js";
+import { createApplicationSessionRunOperations } from "./application-session-run-service.js";
 import { PersistenceWorkerClient } from "./persistence-worker-client.js";
 import { LocalSessionFilesCleanup } from "./session-files-cleanup.js";
 
@@ -41,6 +47,7 @@ export type CliRuntimeControl = Readonly<{ timeoutMs?: number; signal?: AbortSig
 export type CliRuntime = Readonly<{
   operations: ApplicationSessionOperations<LocalCliAuthorization>;
   messageOperations: ApplicationSessionMessageOperations<LocalCliAuthorization>;
+  sessionRunOperations: ApplicationSessionRunOperations<LocalCliAuthorization>;
   runOperations: ApplicationRunOperations<LocalCliAuthorization>;
   runOutputOperations: ApplicationRunOutputOperations<LocalCliAuthorization>;
   authorization: LocalCliAuthorization;
@@ -68,6 +75,7 @@ export async function startCliRuntime(control: CliRuntimeControl = {}): Promise<
     return {
       operations: createApplicationSessionOperations(client, { access, sessionFiles, snapshotAuthorization }),
       messageOperations: createApplicationSessionMessageOperations(client, { access, snapshotAuthorization }),
+      sessionRunOperations: createApplicationSessionRunOperations(client, { access, snapshotAuthorization }),
       runOperations: createApplicationRunOperations(client, { access, snapshotAuthorization }),
       runOutputOperations: createApplicationRunOutputOperations(client, { access, snapshotAuthorization }),
       authorization: localCliAuthorization,
@@ -114,7 +122,8 @@ class LocalCliAccessValidator
     ApplicationAccessValidator<LocalCliAuthorization>,
     ApplicationRunAccessValidator<LocalCliAuthorization>,
     ApplicationRunOutputAccessValidator<LocalCliAuthorization>,
-    ApplicationSessionMessageAccessValidator<LocalCliAuthorization>
+    ApplicationSessionMessageAccessValidator<LocalCliAuthorization>,
+    ApplicationSessionRunAccessValidator<LocalCliAuthorization>
 {
   async validateWorkspace(
     input: Extract<ApplicationAccessValidationInput<LocalCliAuthorization>, Readonly<{ operation: "create" }>>,
@@ -153,7 +162,8 @@ class LocalCliAccessValidator
       | ApplicationAccessValidationInput<LocalCliAuthorization>
       | ApplicationRunAccessValidationInput<LocalCliAuthorization>
       | ApplicationRunOutputAccessValidationInput<LocalCliAuthorization>
-      | ApplicationSessionMessageAccessValidationInput<LocalCliAuthorization>,
+      | ApplicationSessionMessageAccessValidationInput<LocalCliAuthorization>
+      | ApplicationSessionRunAccessValidationInput<LocalCliAuthorization>,
   ): Promise<ApplicationAccessDecision> {
     return isLocalCliAuthorization(input.context.authorization) ? { allowed: true } : authorizationInvalid();
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,5 @@
 export type { ApplicationSessionOperations } from "../shared/application-service-model.js";
 export type { ApplicationSessionMessageOperations } from "../shared/application-session-message-model.js";
+export type { ApplicationSessionRunOperations } from "../shared/application-session-run-model.js";
 export type { ApplicationRunOperations } from "../shared/application-run-model.js";
 export type { ApplicationRunOutputOperations } from "../shared/application-run-output-model.js";

--- a/src/main/repository-read-client.ts
+++ b/src/main/repository-read-client.ts
@@ -10,6 +10,7 @@ import {
   type RecoveryProjection,
   type RunDetail,
   type RunEventPage,
+  type RunHistoryListItem,
   type RunInputDeliveryRecoveryItem,
   type RunOutputListItem,
   type RunOutputItemDetail,
@@ -87,6 +88,13 @@ export class RepositoryReadClient {
 
   messageContentChunk(input: MessageContentChunkRequest, options?: RequestOptions): Promise<MessageContentChunkResult> {
     return this.worker.request(REPOSITORY_READ_OPERATIONS.messageContentChunk, "read", input, options);
+  }
+
+  runsPage(
+    input: Readonly<{ sessionId: string; workspaceKey: string; cursor?: string; limit?: number }>,
+    options?: RequestOptions,
+  ): Promise<Page<RunHistoryListItem> & Readonly<{ sessionId: string; workspaceKey: string }>> {
+    return this.worker.request(REPOSITORY_READ_OPERATIONS.runsPage, "read", input, options);
   }
 
   runEventsPage(

--- a/src/persistence-worker/repository-read-model.ts
+++ b/src/persistence-worker/repository-read-model.ts
@@ -39,6 +39,26 @@ export const REPOSITORY_PAGE_SQL = {
     WHERE s.id = ? AND s.workspace_key = ?
     ORDER BY m.ordinal ASC
   `,
+  runs: `
+    SELECT CASE WHEN r.id IS NULL THEN 1 ELSE 0 END AS scope_only,
+           r.id AS run_id, r.session_id, r.ordinal, r.initiating_message_id,
+           r.final_assistant_message_id, r.retry_of_run_id, r.phase,
+           r.failure_origin, r.error_summary, r.cancel_requested_at, r.cancel_acknowledged_at,
+           r.created_at, r.started_at, r.terminal_at, r.updated_at,
+           s.workspace_key
+    FROM sessions s
+    LEFT JOIN (
+      SELECT id, session_id, ordinal, initiating_message_id, final_assistant_message_id,
+             retry_of_run_id, phase, failure_origin, error_summary,
+             cancel_requested_at, cancel_acknowledged_at,
+             created_at, started_at, terminal_at, updated_at
+      FROM runs
+      WHERE session_id = ? AND ordinal > ?
+      ORDER BY ordinal ASC LIMIT ?
+    ) r ON r.session_id = s.id
+    WHERE s.id = ? AND s.workspace_key = ?
+    ORDER BY r.ordinal ASC
+  `,
   runEvents: `
     SELECT e.id, e.run_id, e.ordinal, e.event_code, e.subject_type, e.subject_id, e.summary, e.created_at
     FROM run_events e
@@ -181,6 +201,7 @@ export function createRepositoryReadOperations(database: DatabaseSync): Readonly
     ],
     [REPOSITORY_READ_OPERATIONS.sessionGet, read((payload) => ({ result: sessionGet(database, payload) }))],
     [REPOSITORY_READ_OPERATIONS.messagesPage, read((payload) => ({ result: messagesPage(database, payload) }))],
+    [REPOSITORY_READ_OPERATIONS.runsPage, read((payload) => ({ result: runsPage(database, payload) }))],
     [REPOSITORY_READ_OPERATIONS.runGet, read((payload) => ({ result: runGet(database, payload) }))],
     [REPOSITORY_READ_OPERATIONS.runEventsPage, read((payload) => ({ result: runEventsPage(database, payload) }))],
     [REPOSITORY_READ_OPERATIONS.runOutputCounts, read((payload) => ({ result: runOutputCounts(database, payload) }))],
@@ -442,6 +463,49 @@ function messagesPage(database: DatabaseSync, payload: Readonly<Record<string, u
     contentState: row.inline_content === null ? "chunked" : "inline",
     ...(row.inline_content === null ? {} : { contentBlocks: JSON.parse(row.inline_content) as unknown }),
     createdAt: row.created_at,
+  }));
+}
+
+function runsPage(database: DatabaseSync, payload: Readonly<Record<string, unknown>>): unknown {
+  const scope = readSessionScope(payload, ["sessionId", "workspaceKey", "cursor", "limit"]);
+  const limit = readLimit(payload.limit, REPOSITORY_READ_LIMITS.runs);
+  const cursorScope = scopeDigest(scope);
+  const afterOrdinal = decodeOrdinalCursor(payload.cursor, "runs", cursorScope);
+  const queryRows = database
+    .prepare(REPOSITORY_PAGE_SQL.runs)
+    .all(
+      scope.sessionId,
+      afterOrdinal,
+      limit + 1,
+      scope.sessionId,
+      scope.workspaceKey,
+    ) as unknown as readonly RunHistoryQueryRow[];
+  if (queryRows.length === 0) throw notFound();
+  let rows: readonly RunHistoryRow[];
+  if (queryRows[0]?.scope_only === 1) {
+    if (queryRows.length !== 1) throw persistenceContractViolation();
+    rows = [];
+  } else {
+    if (queryRows.some((row) => row.scope_only !== 0)) throw persistenceContractViolation();
+    rows = queryRows as unknown as readonly RunHistoryRow[];
+  }
+  const page = splitPage(rows, limit);
+  return ordinalPage(scope, page, "runs", cursorScope, (row) => ({
+    runId: row.run_id,
+    sessionId: row.session_id,
+    ordinal: row.ordinal,
+    initiatingMessageId: row.initiating_message_id,
+    ...(row.final_assistant_message_id === null ? {} : { finalAssistantMessageId: row.final_assistant_message_id }),
+    ...(row.retry_of_run_id === null ? {} : { retryOfRunId: row.retry_of_run_id }),
+    phase: row.phase,
+    ...(row.failure_origin === null ? {} : { failureOrigin: row.failure_origin }),
+    ...(row.error_summary === null ? {} : { errorSummary: row.error_summary }),
+    ...(row.cancel_requested_at === null ? {} : { cancelRequestedAt: row.cancel_requested_at }),
+    ...(row.cancel_acknowledged_at === null ? {} : { cancelAcknowledgedAt: row.cancel_acknowledged_at }),
+    createdAt: row.created_at,
+    ...(row.started_at === null ? {} : { startedAt: row.started_at }),
+    ...(row.terminal_at === null ? {} : { terminalAt: row.terminal_at }),
+    updatedAt: row.updated_at,
   }));
 }
 
@@ -1225,6 +1289,25 @@ type MessageRow = Readonly<{
   workspace_key: string;
 }>;
 type MessageQueryRow = Readonly<Record<string, unknown>> & Readonly<{ scope_only: number }>;
+type RunHistoryRow = Readonly<{
+  run_id: string;
+  session_id: string;
+  ordinal: number;
+  initiating_message_id: string;
+  final_assistant_message_id: string | null;
+  retry_of_run_id: string | null;
+  phase: string;
+  failure_origin: string | null;
+  error_summary: string | null;
+  cancel_requested_at: number | null;
+  cancel_acknowledged_at: number | null;
+  created_at: number;
+  started_at: number | null;
+  terminal_at: number | null;
+  updated_at: number;
+  workspace_key: string;
+}>;
+type RunHistoryQueryRow = Readonly<Record<string, unknown>> & Readonly<{ scope_only: number }>;
 type SessionPageRow = Readonly<{
   id: string;
   title: string;

--- a/src/shared/application-session-run-model.ts
+++ b/src/shared/application-session-run-model.ts
@@ -1,0 +1,115 @@
+import type {
+  ApplicationAccessDecision,
+  ApplicationOperationOptions,
+  ApplicationOperationResponse,
+  ApplicationSessionOperationContext,
+} from "./application-service-model.js";
+import type {
+  ApplicationRunCancellationSummary,
+  ApplicationRunFailureSummary,
+  ApplicationRunPhase,
+} from "./application-run-model.js";
+import { REPOSITORY_READ_LIMITS } from "./repository-read-model.js";
+
+export const APPLICATION_SESSION_RUN_LIMITS = {
+  maxIdentifierLength: 1_024,
+  maxCursorLength: 2_048,
+  maxSummaryLength: 4_096,
+  runsDefaultItems: REPOSITORY_READ_LIMITS.runs.default,
+  runsMaxItems: REPOSITORY_READ_LIMITS.runs.max,
+} as const;
+
+type ApplicationSessionRunItemBase = Readonly<{
+  runId: string;
+  ordinal: number;
+  initiatingMessageId: string;
+  finalAssistantMessageId?: string;
+  retryOfRunId?: string;
+  createdAt: number;
+  startedAt?: number;
+  updatedAt: number;
+}>;
+
+type ApplicationSessionRunNonTerminalItem = ApplicationSessionRunItemBase &
+  Readonly<{
+    phase: Exclude<ApplicationRunPhase, "canceling" | "completed" | "failed" | "canceled" | "interrupted">;
+    terminalAt?: never;
+    failure?: never;
+    cancellation?: never;
+    finalAssistantMessageId?: never;
+  }>;
+
+type ApplicationSessionRunCancelingItem = ApplicationSessionRunItemBase &
+  Readonly<{
+    phase: "canceling";
+    terminalAt?: never;
+    failure?: never;
+    cancellation?: ApplicationRunCancellationSummary;
+    finalAssistantMessageId?: never;
+  }>;
+
+type ApplicationSessionRunCompletedItem = ApplicationSessionRunItemBase &
+  Readonly<{
+    phase: "completed";
+    terminalAt: number;
+    failure?: never;
+    cancellation?: never;
+  }>;
+
+type ApplicationSessionRunFailedItem = ApplicationSessionRunItemBase &
+  Readonly<{
+    phase: "failed" | "interrupted";
+    terminalAt: number;
+    failure: ApplicationRunFailureSummary;
+    cancellation?: ApplicationRunCancellationSummary;
+    finalAssistantMessageId?: never;
+  }>;
+
+type ApplicationSessionRunCanceledItem = ApplicationSessionRunItemBase &
+  Readonly<{
+    phase: "canceled";
+    terminalAt: number;
+    failure?: never;
+    cancellation?: ApplicationRunCancellationSummary;
+    finalAssistantMessageId?: never;
+  }>;
+
+export type ApplicationSessionRunItem =
+  | ApplicationSessionRunNonTerminalItem
+  | ApplicationSessionRunCancelingItem
+  | ApplicationSessionRunCompletedItem
+  | ApplicationSessionRunFailedItem
+  | ApplicationSessionRunCanceledItem;
+
+export type ApplicationSessionRunPage = Readonly<{
+  sessionId: string;
+  items: readonly ApplicationSessionRunItem[];
+  nextCursor?: string;
+}>;
+
+export type ApplicationSessionRunsRequest<TAuthorizationContext> = Readonly<{
+  context: ApplicationSessionOperationContext<TAuthorizationContext>;
+  sessionId: string;
+  cursor?: string;
+  limit?: number;
+}>;
+
+export type ApplicationSessionRunAccessValidationInput<TAuthorizationContext> = Readonly<{
+  operation: "runs";
+  access: "read";
+  context: ApplicationSessionOperationContext<TAuthorizationContext>;
+  target: Readonly<{ kind: "session_runs"; sessionId: string }>;
+}>;
+
+export interface ApplicationSessionRunAccessValidator<TAuthorizationContext> {
+  authorize(
+    input: ApplicationSessionRunAccessValidationInput<TAuthorizationContext>,
+  ): Promise<ApplicationAccessDecision>;
+}
+
+export interface ApplicationSessionRunOperations<TAuthorizationContext> {
+  runs(
+    request: ApplicationSessionRunsRequest<TAuthorizationContext>,
+    options?: ApplicationOperationOptions,
+  ): Promise<ApplicationOperationResponse<ApplicationSessionRunPage, "read">>;
+}

--- a/src/shared/repository-read-model.ts
+++ b/src/shared/repository-read-model.ts
@@ -9,6 +9,7 @@ export const REPOSITORY_READ_OPERATIONS = {
   sessionDirectoriesChunk: "repository.session.directories-chunk",
   messagesPage: "repository.messages.page",
   messageContentChunk: "repository.message.content-chunk",
+  runsPage: "repository.runs.page",
   runEventsPage: "repository.run.events.page",
   runGet: "repository.run.get",
   runSnapshotChunk: "repository.run.snapshot-chunk",
@@ -33,6 +34,7 @@ export const REPOSITORY_READ_LIMITS = {
   sessions: { default: 25, max: 100 },
   localRepositories: { default: 25, max: 100 },
   messages: { default: 50, max: 100 },
+  runs: { default: 50, max: 100 },
   events: { default: 100, max: 200 },
   outputs: { default: 100, max: 200 },
   runInputDeliveries: { default: 100, max: 200 },
@@ -151,6 +153,24 @@ export type RunDetail = Readonly<{
   terminalAt?: number;
   updatedAt: number;
   version: number;
+}>;
+
+export type RunHistoryListItem = Readonly<{
+  runId: string;
+  sessionId: string;
+  ordinal: number;
+  initiatingMessageId: string;
+  finalAssistantMessageId?: string;
+  retryOfRunId?: string;
+  phase: string;
+  failureOrigin?: string;
+  errorSummary?: string;
+  cancelRequestedAt?: number;
+  cancelAcknowledgedAt?: number;
+  createdAt: number;
+  startedAt?: number;
+  terminalAt?: number;
+  updatedAt: number;
 }>;
 
 export type RunOutputPayloadMetadata = Readonly<{

--- a/test/application-run-service.test.ts
+++ b/test/application-run-service.test.ts
@@ -75,6 +75,15 @@ test("Run status accepts canceled persistence without cancel timestamps and expo
   }
 });
 
+test("Run status shares the history cancellation invariant for phases that cannot expose cancellation", async () => {
+  for (const phase of ["queued", "starting", "active", "finalizing", "completed"] as const) {
+    const service = createService({
+      reads: reads({ run: { ...repositoryRun(phase), cancelRequestedAt: 2 } }),
+    });
+    assert.deepEqual(await service.status(request()), internalReadFailure());
+  }
+});
+
 test("Run status accepts the full persisted failure summary bound", async () => {
   const summary = "x".repeat(4_096);
   const service = createService({

--- a/test/application-session-run-service.test.ts
+++ b/test/application-session-run-service.test.ts
@@ -1,0 +1,411 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ApplicationSessionRunService,
+  type ApplicationSessionRunServiceOptions,
+} from "../src/main/application-session-run-service.js";
+import { PersistenceClientError } from "../src/main/persistence-worker-client.js";
+import {
+  APPLICATION_SESSION_RUN_LIMITS,
+  type ApplicationSessionRunAccessValidator,
+} from "../src/shared/application-session-run-model.js";
+
+type Authorization = Readonly<{ principal: "owner" }>;
+type Reads = ApplicationSessionRunServiceOptions<Authorization>["reads"];
+type RunPageProjection = Awaited<ReturnType<Reads["runsPage"]>>;
+
+test("Run history validates the complete request before authorization or persistence", async () => {
+  let authorizationCalls = 0;
+  let repositoryCalls = 0;
+  const service = createService({
+    access: {
+      async authorize() {
+        authorizationCalls += 1;
+        return { allowed: true };
+      },
+    },
+    reads: reads({
+      sessionGet: async () => {
+        repositoryCalls += 1;
+        return sessionProjection();
+      },
+      runsPage: async () => {
+        repositoryCalls += 1;
+        return pageProjection();
+      },
+    }),
+  });
+  const invalid = [
+    { ...runsRequest(), sessionId: "" },
+    { ...runsRequest(), cursor: "x".repeat(APPLICATION_SESSION_RUN_LIMITS.maxCursorLength + 1) },
+    { ...runsRequest(), limit: 0 },
+    { ...runsRequest(), limit: APPLICATION_SESSION_RUN_LIMITS.runsMaxItems + 1 },
+    { ...runsRequest(), unexpected: true },
+    { ...runsRequest(), context: { authorization: { principal: "other" } } },
+  ];
+
+  for (const request of invalid) {
+    const response = await service.runs(request as never);
+    assertFailure(response, "request", "request_invalid", "not_attempted");
+  }
+  assert.equal(authorizationCalls, 0);
+  assert.equal(repositoryCalls, 0);
+});
+
+test("Run history denial uses the exact Session target and prevents every Repository call", async () => {
+  const calls: unknown[] = [];
+  const service = createService({
+    access: {
+      async authorize(input) {
+        calls.push(input);
+        return {
+          allowed: false,
+          error: { code: "forbidden", message: "secret policy", retryable: false },
+        };
+      },
+    },
+    reads: reads({
+      sessionGet: async () => {
+        throw new Error("must not read");
+      },
+      runsPage: async () => {
+        throw new Error("must not read");
+      },
+    }),
+  });
+
+  const response = await service.runs(runsRequest());
+  assertFailure(response, "access", "forbidden", "not_attempted");
+  assert.equal(JSON.stringify(response).includes("secret policy"), false);
+  assert.deepEqual(calls, [
+    {
+      operation: "runs",
+      access: "read",
+      context: { authorization: { principal: "owner" } },
+      target: { kind: "session_runs", sessionId: "session-1" },
+    },
+  ]);
+});
+
+test("Run history resolves a closed Session scope, applies the default, and projects every phase", async () => {
+  const calls: unknown[] = [];
+  const rawItems = runPhaseProjections();
+  const service = createService({
+    access: {
+      async authorize(input) {
+        calls.push({ operation: "authorize", input });
+        return { allowed: true };
+      },
+    },
+    reads: reads({
+      sessionGet: async (input, options) => {
+        calls.push({ operation: "sessionGet", input, signal: options?.signal instanceof AbortSignal });
+        return sessionProjection("closed");
+      },
+      runsPage: async (input, options) => {
+        calls.push({ operation: "runsPage", input, signal: options?.signal instanceof AbortSignal });
+        return pageProjection(rawItems, "cursor-2");
+      },
+    }),
+  });
+
+  const response = await service.runs(runsRequest());
+  assert.equal(response.overallStatus, "success");
+  if (response.overallStatus !== "success") return;
+  assert.equal(response.value.sessionId, "session-1");
+  assert.equal(response.value.items.length, 9);
+  assert.deepEqual(
+    response.value.items.map((item) => item.phase),
+    ["queued", "starting", "active", "canceling", "finalizing", "completed", "failed", "interrupted", "canceled"],
+  );
+  assert.equal(
+    response.value.items[5]?.phase === "completed" && response.value.items[5].finalAssistantMessageId,
+    undefined,
+  );
+  assert.equal("liveActivity" in (response.value.items[2] ?? {}), false);
+  assert.equal("sessionId" in (response.value.items[0] ?? {}), false);
+  assert.equal(response.value.nextCursor, "cursor-2");
+  assert.deepEqual(calls[1], {
+    operation: "sessionGet",
+    input: { sessionId: "session-1" },
+    signal: true,
+  });
+  assert.deepEqual(calls[2], {
+    operation: "runsPage",
+    input: {
+      sessionId: "session-1",
+      workspaceKey: "workspace",
+      limit: APPLICATION_SESSION_RUN_LIMITS.runsDefaultItems,
+    },
+    signal: true,
+  });
+
+  (rawItems[0] as { phase: string }).phase = "completed";
+  assert.equal(response.value.items[0]?.phase, "queued");
+});
+
+test("Run history accepts exact 1, 50, and 100 limits and forwards cursor without widening scope", async () => {
+  for (const limit of [1, 50, APPLICATION_SESSION_RUN_LIMITS.runsMaxItems]) {
+    let observed: unknown;
+    const service = createService({
+      reads: reads({
+        runsPage: async (input) => {
+          observed = input;
+          return pageProjection([]);
+        },
+      }),
+    });
+    const response = await service.runs({ ...runsRequest(), cursor: "cursor-1", limit });
+    assert.equal(response.overallStatus, "success");
+    assert.deepEqual(observed, {
+      sessionId: "session-1",
+      workspaceKey: "workspace",
+      cursor: "cursor-1",
+      limit,
+    });
+  }
+});
+
+test("Run history exposes bounded omissions as partial success with ordinal progress", async () => {
+  const service = createService({
+    reads: reads({
+      runsPage: async () =>
+        pageProjection(
+          [{ omitted: true, reason: "response_size_limit", ordinal: 1 }, runProjection({ runId: "run-2", ordinal: 2 })],
+          "cursor-2",
+        ),
+    }),
+  });
+
+  const response = await service.runs(runsRequest());
+  assert.equal(response.overallStatus, "partial_success");
+  if (response.overallStatus !== "partial_success") return;
+  assert.deepEqual(
+    response.value.items.map((item) => item.runId),
+    ["run-2"],
+  );
+  assert.deepEqual(response.issues, [
+    {
+      kind: "omission",
+      code: "response_size_limit",
+      message: "Run was omitted because the response size limit was reached.",
+      ordinal: 1,
+    },
+  ]);
+  assert.equal(response.value.nextCursor, "cursor-2");
+});
+
+test("Run history rejects scope drift, forbidden fields, phase tuple drift, ordering, and cursor stalls", async () => {
+  const invalidPages: unknown[] = [
+    pageProjection([], undefined, { sessionId: "session-other" }),
+    pageProjection([], undefined, { workspaceKey: "other" }),
+    { ...pageProjection(), unexpected: true },
+    pageProjection([{ ...runProjection(), version: 1 }]),
+    pageProjection([runProjection({ sessionId: "session-other" })]),
+    pageProjection([
+      runProjection({ phase: "active", terminalAt: undefined }),
+      runProjection({ runId: "run-2", ordinal: 1 }),
+    ]),
+    pageProjection([runProjection({ phase: "active", terminalAt: undefined, cancelRequestedAt: 1 })]),
+    pageProjection([
+      runProjection({ phase: "active", terminalAt: undefined, finalAssistantMessageId: "message-final" }),
+    ]),
+    pageProjection([runProjection({ phase: "completed", failureOrigin: "provider" })]),
+    pageProjection([runProjection({ phase: "failed", failureOrigin: undefined })]),
+    pageProjection([{ omitted: true, reason: "response_size_limit" }]),
+    pageProjection(
+      Array.from({ length: 2 }, (_, index) => runProjection({ runId: `run-${index}`, ordinal: index + 1 })),
+    ),
+  ];
+
+  for (const [index, page] of invalidPages.entries()) {
+    const service = createService({ reads: reads({ runsPage: async () => page as RunPageProjection }) });
+    const request = index === invalidPages.length - 1 ? { ...runsRequest(), limit: 1 } : runsRequest();
+    const response = await service.runs(request);
+    assertFailure(response, "application", "internal_error", "failed");
+  }
+
+  const stalled = createService({
+    reads: reads({ runsPage: async () => pageProjection([runProjection()], "cursor-1") }),
+  });
+  assertFailure(
+    await stalled.runs({ ...runsRequest(), cursor: "cursor-1" }),
+    "application",
+    "internal_error",
+    "failed",
+  );
+});
+
+test("Run history maps Repository not_found and aborts timeout and cancellation after persistence starts", async () => {
+  const notFound = createService({
+    reads: reads({
+      sessionGet: async () => {
+        throw new PersistenceClientError({
+          code: "not_found",
+          message: "secret path",
+          retryable: false,
+          effect: "none",
+        });
+      },
+    }),
+  });
+  const missing = await notFound.runs(runsRequest());
+  assertFailure(missing, "domain", "not_found", "rejected");
+  assert.equal(JSON.stringify(missing).includes("secret path"), false);
+
+  let timeoutAborted = false;
+  const timeoutService = createService({
+    reads: reads({
+      runsPage: async (_input, options) =>
+        pendingUntilAbort(options?.signal, () => {
+          timeoutAborted = true;
+        }),
+    }),
+  });
+  const timeout = await timeoutService.runs(runsRequest(), { timeoutMs: 5 });
+  assertFailure(timeout, "persistence", "persistence_timeout", "failed");
+  assert.equal(timeoutAborted, true);
+
+  let cancelAborted = false;
+  let markStarted!: () => void;
+  const started = new Promise<void>((resolve) => {
+    markStarted = resolve;
+  });
+  const cancelService = createService({
+    reads: reads({
+      runsPage: async (_input, options) => {
+        markStarted();
+        return pendingUntilAbort(options?.signal, () => {
+          cancelAborted = true;
+        });
+      },
+    }),
+  });
+  const controller = new AbortController();
+  const pending = cancelService.runs(runsRequest(), { signal: controller.signal });
+  await started;
+  controller.abort();
+  const canceled = await pending;
+  assertFailure(canceled, "persistence", "persistence_canceled", "failed");
+  assert.equal(cancelAborted, true);
+});
+
+function createService(
+  overrides: Partial<ApplicationSessionRunServiceOptions<Authorization>> = {},
+): ApplicationSessionRunService<Authorization> {
+  return new ApplicationSessionRunService({
+    reads: overrides.reads ?? reads(),
+    access: overrides.access ?? allowAccess(),
+    snapshotAuthorization(value) {
+      if (typeof value !== "object" || value === null || (value as Authorization).principal !== "owner") {
+        throw new TypeError("invalid authorization");
+      }
+      return { principal: "owner" };
+    },
+  });
+}
+
+function allowAccess(): ApplicationSessionRunAccessValidator<Authorization> {
+  return {
+    async authorize() {
+      return { allowed: true };
+    },
+  };
+}
+
+function reads(overrides: Partial<Reads> = {}): Reads {
+  return {
+    sessionGet: overrides.sessionGet ?? (async () => sessionProjection()),
+    runsPage: overrides.runsPage ?? (async () => pageProjection()),
+  };
+}
+
+function runsRequest() {
+  return { context: { authorization: { principal: "owner" as const } }, sessionId: "session-1" };
+}
+
+function sessionProjection(lifecycleStatus: "active" | "archived" | "closed" = "active") {
+  return {
+    session: { id: "session-1", workspaceKey: "workspace", lifecycleStatus },
+    execution: { state: "not_started" },
+  } as never;
+}
+
+function pageProjection(
+  items: readonly unknown[] = [runProjection()],
+  nextCursor?: string,
+  overrides: Readonly<Record<string, unknown>> = {},
+): RunPageProjection {
+  return {
+    sessionId: "session-1",
+    workspaceKey: "workspace",
+    items,
+    ...(nextCursor === undefined ? {} : { nextCursor }),
+    ...overrides,
+  } as RunPageProjection;
+}
+
+function runProjection(overrides: Readonly<Record<string, unknown>> = {}) {
+  return {
+    runId: "run-1",
+    sessionId: "session-1",
+    ordinal: 1,
+    initiatingMessageId: "message-1",
+    phase: "completed",
+    createdAt: 1,
+    startedAt: 2,
+    terminalAt: 3,
+    updatedAt: 3,
+    ...overrides,
+  };
+}
+
+function runPhaseProjections(): Record<string, unknown>[] {
+  return [
+    runProjection({ runId: "run-1", ordinal: 1, phase: "queued", startedAt: undefined, terminalAt: undefined }),
+    runProjection({ runId: "run-2", ordinal: 2, phase: "starting", terminalAt: undefined }),
+    runProjection({ runId: "run-3", ordinal: 3, phase: "active", terminalAt: undefined }),
+    runProjection({ runId: "run-4", ordinal: 4, phase: "canceling", terminalAt: undefined, cancelRequestedAt: 4 }),
+    runProjection({ runId: "run-5", ordinal: 5, phase: "finalizing", terminalAt: undefined }),
+    runProjection({ runId: "run-6", ordinal: 6, finalAssistantMessageId: undefined }),
+    runProjection({
+      runId: "run-7",
+      ordinal: 7,
+      phase: "failed",
+      failureOrigin: "provider",
+      errorSummary: "failed",
+      cancelRequestedAt: 6,
+      cancelAcknowledgedAt: 7,
+    }),
+    runProjection({ runId: "run-8", ordinal: 8, phase: "interrupted", failureOrigin: "transport" }),
+    runProjection({ runId: "run-9", ordinal: 9, phase: "canceled", cancelRequestedAt: 8 }),
+  ];
+}
+
+function assertFailure(
+  response: Readonly<Record<string, unknown>>,
+  kind: string,
+  code: string,
+  persistenceStatus: string,
+): void {
+  assert.equal(response.overallStatus, "failure");
+  const error = response.error as Readonly<Record<string, unknown>>;
+  const persistence = response.persistence as Readonly<Record<string, unknown>>;
+  assert.equal(error.kind, kind);
+  assert.equal(error.code, code);
+  assert.equal(persistence.status, persistenceStatus);
+}
+
+function pendingUntilAbort<TValue>(signal: AbortSignal | undefined, onAbort: () => void): Promise<TValue> {
+  return new Promise((_resolve, reject) => {
+    signal?.addEventListener(
+      "abort",
+      () => {
+        onAbort();
+        reject(signal.reason);
+      },
+      { once: true },
+    );
+  });
+}

--- a/test/cli-contract.test.ts
+++ b/test/cli-contract.test.ts
@@ -56,6 +56,11 @@ const commands = {
     sessionId: "session-1",
     limit: 50,
   },
+  runs: {
+    identity: { namespace: "session", operation: "runs" },
+    sessionId: "session-1",
+    limit: 50,
+  },
   "message-content-chunk": {
     identity: { namespace: "session", operation: "message-content-chunk" },
     sessionId: "session-1",

--- a/test/cli-lifecycle.test.ts
+++ b/test/cli-lifecycle.test.ts
@@ -14,6 +14,7 @@ import type {
   ApplicationRunOutputOperations,
   ApplicationSessionMessageOperations,
   ApplicationSessionOperations,
+  ApplicationSessionRunOperations,
 } from "../src/main/index.js";
 import { resolveWithMateDatabasePath } from "../src/main/cli-runtime.js";
 
@@ -22,6 +23,7 @@ type Operations = ApplicationSessionOperations<Authorization>;
 type RunOperations = ApplicationRunOperations<Authorization>;
 type RunOutputOperations = ApplicationRunOutputOperations<Authorization>;
 type MessageOperations = ApplicationSessionMessageOperations<Authorization>;
+type SessionRunOperations = ApplicationSessionRunOperations<Authorization>;
 
 const authorization: Authorization = { transport: "test" };
 const readArgv = ["session", "read", "--session-id", "session-1"] as const;
@@ -213,6 +215,43 @@ test("Session Message completion writes one JSON object and performs one clean s
   assert.equal(result.exitCode, CLI_EXIT_CODES.success);
   assert.equal((output.command as Readonly<Record<string, unknown>>).operation, "messages");
   assert.equal(messageCalls, 1);
+  assert.equal(shutdowns, 1);
+});
+
+test("Session Run history completion writes one JSON object and performs one clean shutdown", async () => {
+  let runHistoryCalls = 0;
+  let shutdowns = 0;
+  const sessionRunOperations = unsupportedSessionRunOperations({
+    runs: async () => {
+      runHistoryCalls += 1;
+      return {
+        overallStatus: "success",
+        value: { sessionId: "session-1", items: [] },
+        persistence: { status: "read", effect: "none" },
+      };
+    },
+  });
+  const result = await runCliLifecycle(["session", "runs", "--session-id", "session-1"], {
+    version: CLI_VERSION,
+    startRuntime: async () =>
+      runtime(
+        successfulOperations(),
+        async () => {
+          shutdowns += 1;
+          return { checkpoint: "completed" };
+        },
+        unsupportedRunOperations(),
+        unsupportedRunOutputOperations(),
+        unsupportedMessageOperations(),
+        sessionRunOperations,
+      ),
+  });
+
+  const output = oneJsonObject(result.stdout);
+  assert.equal(result.stderr, "");
+  assert.equal(result.exitCode, CLI_EXIT_CODES.success);
+  assert.equal((output.command as Readonly<Record<string, unknown>>).operation, "runs");
+  assert.equal(runHistoryCalls, 1);
   assert.equal(shutdowns, 1);
 });
 
@@ -854,8 +893,17 @@ function runtime(
   runOperations: RunOperations = unsupportedRunOperations(),
   runOutputOperations: RunOutputOperations = unsupportedRunOutputOperations(),
   messageOperations: MessageOperations = unsupportedMessageOperations(),
+  sessionRunOperations: SessionRunOperations = unsupportedSessionRunOperations(),
 ) {
-  return { operations, messageOperations, runOperations, runOutputOperations, authorization, shutdown } as const;
+  return {
+    operations,
+    messageOperations,
+    sessionRunOperations,
+    runOperations,
+    runOutputOperations,
+    authorization,
+    shutdown,
+  } as const;
 }
 
 function unsupportedMessageOperations(overrides: Partial<MessageOperations> = {}): MessageOperations {
@@ -866,6 +914,13 @@ function unsupportedMessageOperations(overrides: Partial<MessageOperations> = {}
     messages: overrides.messages ?? unsupported,
     messageContentChunk: overrides.messageContentChunk ?? unsupported,
   };
+}
+
+function unsupportedSessionRunOperations(overrides: Partial<SessionRunOperations> = {}): SessionRunOperations {
+  const unsupported = async (): Promise<never> => {
+    throw new Error("unexpected Session Run operation");
+  };
+  return { runs: overrides.runs ?? unsupported };
 }
 
 function unsupportedRunOperations(overrides: Partial<RunOperations> = {}): RunOperations {

--- a/test/cli-session-dispatch.test.ts
+++ b/test/cli-session-dispatch.test.ts
@@ -4,11 +4,16 @@ import test from "node:test";
 
 import { CLI_EXIT_CODES, CLI_SCHEMA_VERSION } from "../src/cli/contract.js";
 import { runCliWithSessionOperations } from "../src/cli/invocation.js";
-import type { ApplicationSessionMessageOperations, ApplicationSessionOperations } from "../src/main/index.js";
+import type {
+  ApplicationSessionMessageOperations,
+  ApplicationSessionOperations,
+  ApplicationSessionRunOperations,
+} from "../src/main/index.js";
 
 type Authorization = Readonly<{ principal: string }>;
 type Operations = ApplicationSessionOperations<Authorization>;
 type MessageOperations = ApplicationSessionMessageOperations<Authorization>;
+type SessionRunOperations = ApplicationSessionRunOperations<Authorization>;
 type OperationName = keyof Operations;
 type Call = Readonly<{ operation: OperationName; request: unknown; options: unknown }>;
 
@@ -388,7 +393,13 @@ test("help, version, and argv failures have stable output without invoking opera
 });
 
 function dependencies(operations: Operations) {
-  return { version: "0.1.0", operations, messageOperations: unsupportedMessageOperations(), authorization } as const;
+  return {
+    version: "0.1.0",
+    operations,
+    messageOperations: unsupportedMessageOperations(),
+    sessionRunOperations: unsupportedSessionRunOperations(),
+    authorization,
+  } as const;
 }
 
 function unsupportedMessageOperations(): MessageOperations {
@@ -396,6 +407,14 @@ function unsupportedMessageOperations(): MessageOperations {
     throw new Error("unexpected Message operation");
   };
   return { messages: unsupported, messageContentChunk: unsupported };
+}
+
+function unsupportedSessionRunOperations(): SessionRunOperations {
+  return {
+    async runs(): Promise<never> {
+      throw new Error("unexpected Session Run operation");
+    },
+  };
 }
 
 function recordingOperations(

--- a/test/cli-session-message-contract.test.ts
+++ b/test/cli-session-message-contract.test.ts
@@ -5,10 +5,15 @@ import { CLI_EXIT_CODES, CLI_SESSION_MESSAGE_LIMITS, type CliValidatedSessionCom
 import { helpText } from "../src/cli/help.js";
 import { parseCliArgv } from "../src/cli/parser.js";
 import { dispatchCliSessionCommand } from "../src/cli/session-dispatch.js";
-import type { ApplicationSessionMessageOperations, ApplicationSessionOperations } from "../src/main/index.js";
+import type {
+  ApplicationSessionMessageOperations,
+  ApplicationSessionOperations,
+  ApplicationSessionRunOperations,
+} from "../src/main/index.js";
 
 type Authorization = Readonly<{ principal: "local-user" }>;
 type MessageOperations = ApplicationSessionMessageOperations<Authorization>;
+type SessionRunOperations = ApplicationSessionRunOperations<Authorization>;
 
 const authorization: Authorization = { principal: "local-user" };
 
@@ -257,6 +262,42 @@ test("Message page dispatch propagates authorization and strictly projects inlin
     });
     assert.equal(JSON.stringify(result.output).includes("workspaceKey"), false);
   }
+});
+
+test("Message omission-only partial pages preserve a progressing cursor", async () => {
+  const command = parsedCommand([
+    "session",
+    "messages",
+    "--session-id",
+    "session-1",
+    "--cursor",
+    "cursor-1",
+    "--limit",
+    "1",
+  ]);
+  const result = await dispatchCliSessionCommand(
+    command,
+    dependencies(
+      messageOperationsFixture({
+        messages: async () => ({
+          overallStatus: "partial_success",
+          value: { sessionId: "session-1", items: [], nextCursor: "cursor-2" },
+          issues: [
+            {
+              kind: "omission",
+              code: "response_size_limit",
+              message: "Message was omitted because the response size limit was reached.",
+              ordinal: 1,
+            },
+          ],
+          persistence: { status: "read", effect: "none" },
+        }),
+      }),
+    ),
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(result.exitCode, CLI_EXIT_CODES.partialSuccess);
 });
 
 test("Message content chunk dispatch emits base64 for actual bytes and preserves EOF coupling", async () => {
@@ -509,7 +550,20 @@ function parsedCommand(argv: readonly string[]): CliValidatedSessionCommand {
 }
 
 function dependencies(messageOperations: MessageOperations) {
-  return { operations: unsupportedSessionOperations(), messageOperations, authorization } as const;
+  return {
+    operations: unsupportedSessionOperations(),
+    messageOperations,
+    sessionRunOperations: unsupportedSessionRunOperations(),
+    authorization,
+  } as const;
+}
+
+function unsupportedSessionRunOperations(): SessionRunOperations {
+  return {
+    async runs(): Promise<never> {
+      throw new Error("unexpected Session Run operation");
+    },
+  };
 }
 
 function messageOperationsFixture(overrides: Partial<MessageOperations>): MessageOperations {

--- a/test/cli-session-run-contract.test.ts
+++ b/test/cli-session-run-contract.test.ts
@@ -1,0 +1,334 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { projectCliOperationOutput, serializeCliStructuredOutput } from "../src/cli/application-response.js";
+import { CLI_EXIT_CODES, CLI_SESSION_RUN_LIMITS, type CliValidatedSessionCommand } from "../src/cli/contract.js";
+import { helpText } from "../src/cli/help.js";
+import { parseCliArgv } from "../src/cli/parser.js";
+import { dispatchCliSessionCommand } from "../src/cli/session-dispatch.js";
+import type {
+  ApplicationSessionMessageOperations,
+  ApplicationSessionOperations,
+  ApplicationSessionRunOperations,
+} from "../src/main/index.js";
+
+type Authorization = Readonly<{ principal: "local-user" }>;
+type SessionRunOperations = ApplicationSessionRunOperations<Authorization>;
+
+const authorization: Authorization = { principal: "local-user" };
+
+test("Session Run parser accepts the complete grammar and Repository-derived boundaries", () => {
+  assert.deepEqual(
+    parseCliArgv([
+      "session",
+      "runs",
+      "--session-id",
+      "session-1",
+      "--cursor",
+      "opaque-1",
+      "--limit",
+      "100",
+      "--timeout-ms",
+      "5000",
+    ]),
+    {
+      kind: "command",
+      command: {
+        identity: { namespace: "session", operation: "runs" },
+        sessionId: "session-1",
+        cursor: "opaque-1",
+        limit: 100,
+        timeoutMs: 5000,
+      },
+    },
+  );
+  assert.deepEqual(parseCliArgv(["session", "runs", "--session-id", "session-1"]), {
+    kind: "command",
+    command: {
+      identity: { namespace: "session", operation: "runs" },
+      sessionId: "session-1",
+      limit: CLI_SESSION_RUN_LIMITS.runsDefaultItems,
+    },
+  });
+  for (const limit of ["1", "50", "100"]) {
+    const parsed = parseCliArgv(["session", "runs", "--session-id", "session-1", "--limit", limit]);
+    assert.equal(parsed.kind, "command");
+  }
+  assert.match(
+    helpText({ kind: "operation", command: { namespace: "session", operation: "runs" } }),
+    /^Usage: withmate session runs/u,
+  );
+  assert.match(helpText({ kind: "session" }), /runs\s+Read a bounded persisted Run history page/u);
+});
+
+test("Session Run parser rejects missing, duplicate, unknown, and out-of-range options", () => {
+  const invalid = [
+    ["session", "runs"],
+    ["session", "runs", "--session-id", "session-1", "--limit", "0"],
+    ["session", "runs", "--session-id", "session-1", "--limit", "101"],
+    ["session", "runs", "--session-id", "session-1", "--timeout-ms", "0"],
+    ["session", "runs", "--session-id", "session-1", "--cursor", "x".repeat(2_049)],
+    ["session", "runs", "--session-id", "session-1", "--session-id", "session-2"],
+    ["session", "runs", "--session-id", "session-1", "--unknown", "x"],
+  ];
+  for (const argv of invalid) {
+    const parsed = parseCliArgv(argv);
+    assert.equal(parsed.kind, "usage_failure");
+    if (parsed.kind === "usage_failure") assert.equal(parsed.exitCode, CLI_EXIT_CODES.usageInvalid);
+  }
+});
+
+test("Session Run dispatch sends the exact Application request and emits one strict JSON object", async () => {
+  const calls: unknown[] = [];
+  const operations: SessionRunOperations = {
+    async runs(request, options) {
+      calls.push({ request, options });
+      return success({ sessionId: "session-1", items: runItems(), nextCursor: "cursor-2" }) as never;
+    },
+  };
+  const command = parsedCommand([
+    "session",
+    "runs",
+    "--session-id",
+    "session-1",
+    "--cursor",
+    "cursor-1",
+    "--limit",
+    "50",
+    "--timeout-ms",
+    "5000",
+  ]);
+  const result = await dispatchCliSessionCommand(command, dependencies(operations));
+  assert.equal(result.ok, true);
+  assert.equal(result.exitCode, CLI_EXIT_CODES.success);
+  assert.deepEqual(calls, [
+    {
+      request: {
+        context: { authorization },
+        sessionId: "session-1",
+        cursor: "cursor-1",
+        limit: 50,
+      },
+      options: { timeoutMs: 5000 },
+    },
+  ]);
+  if (!result.ok) return;
+  const line = serializeCliStructuredOutput(result.output);
+  assert.equal(line.endsWith("\n"), true);
+  assert.equal(line.slice(0, -1).includes("\n"), false);
+  const output = JSON.parse(line) as Readonly<Record<string, unknown>>;
+  const applicationResponse = output.applicationResponse as Readonly<Record<string, unknown>>;
+  const value = applicationResponse.value as Readonly<Record<string, unknown>>;
+  const items = value.items as readonly Readonly<Record<string, unknown>>[];
+  assert.deepEqual(
+    items.map((item) => item.phase),
+    ["queued", "starting", "active", "canceling", "finalizing", "completed", "failed", "interrupted", "canceled"],
+  );
+  assert.equal(JSON.stringify(output).includes("liveActivity"), false);
+  assert.equal(JSON.stringify(output).includes("workspace"), false);
+});
+
+test("Session Run projection rejects every forbidden field and invalid phase tuple as runtime failure", () => {
+  const command = parsedCommand(["session", "runs", "--session-id", "session-1"]);
+  const invalid = [
+    { ...success(runPage()), unexpected: true },
+    {
+      ...success(runPage()),
+      persistence: { status: "read", effect: "none", workspaceKey: "secret" },
+    },
+    success({ ...runPage(), workspaceKey: "secret" }),
+    success(runPage([{ ...runItem(), version: 1 }])),
+    success(runPage([{ ...runItem(), liveActivity: null }])),
+    success(runPage([runItem({ phase: "active", terminalAt: undefined, finalAssistantMessageId: "message-2" })])),
+    success(runPage([runItem({ phase: "completed", cancellation: { requestedAt: 1 } })])),
+    success(runPage([runItem({ phase: "failed", failure: undefined })])),
+    success(runPage([runItem({ phase: "active", terminalAt: undefined, failure: { origin: "provider" } })])),
+    success(runPage([runItem({ runId: "run-2", ordinal: 2 }), runItem({ ordinal: 1 })])),
+    success({ ...runPage([]), nextCursor: "cursor" }),
+    success({ ...runPage(), nextCursor: "cursor-1" }),
+    success(runPage([{ ...runItem({ phase: "failed" }), failure: { origin: "provider", raw: true } }])),
+    success(runPage([{ ...runItem({ phase: "canceled" }), cancellation: { requestedAt: 1, raw: true } }])),
+    {
+      overallStatus: "failure",
+      error: { kind: "domain", code: "not_found", message: "missing", retryable: false, workspaceKey: "secret" },
+      persistence: { status: "rejected", effect: "none" },
+    },
+    {
+      overallStatus: "failure",
+      error: {
+        kind: "domain",
+        code: "capacity_exceeded",
+        message: "not a Run history error",
+        retryable: true,
+        details: { scope: "application", current: 1, limit: 1 },
+      },
+      persistence: { status: "rejected", effect: "none" },
+    },
+  ];
+  for (const response of invalid) {
+    const projection = projectCliOperationOutput(
+      { ...command, cursor: "cursor-1" } as CliValidatedSessionCommand,
+      response,
+    );
+    assert.equal(projection.ok, false);
+    assert.equal(projection.exitCode, CLI_EXIT_CODES.runtimeFailure);
+    assert.equal(projection.output.kind, "runtime_failure");
+    if (projection.output.kind === "runtime_failure") {
+      assert.equal(projection.output.error.code, "malformed_application_response");
+    }
+  }
+});
+
+test("Session Run partial success requires exact ordinal omissions within the command limit", () => {
+  const command = parsedCommand(["session", "runs", "--session-id", "session-1", "--limit", "2"]);
+  const valid = projectCliOperationOutput(command, {
+    overallStatus: "partial_success",
+    value: runPage([runItem({ runId: "run-2", ordinal: 2 })], "cursor-2"),
+    issues: [omission(1)],
+    persistence: { status: "read", effect: "none" },
+  });
+  assert.equal(valid.ok, true);
+  assert.equal(valid.exitCode, CLI_EXIT_CODES.partialSuccess);
+
+  const omissionOnly = projectCliOperationOutput(command, {
+    overallStatus: "partial_success",
+    value: runPage([], "cursor-1"),
+    issues: [omission(1)],
+    persistence: { status: "read", effect: "none" },
+  });
+  assert.equal(omissionOnly.ok, true);
+  assert.equal(omissionOnly.exitCode, CLI_EXIT_CODES.partialSuccess);
+
+  const invalid = [
+    [runItem({ runId: "run-1", ordinal: 1 }), omission(1)],
+    [runItem({ runId: "run-2", ordinal: 2 }), { ...omission(1), raw: true }],
+    [runItem({ runId: "run-2", ordinal: 2 }), { ...omission(1), ordinal: undefined }],
+    [runItem({ runId: "run-2", ordinal: 2 }), omission(1), omission(3)],
+  ];
+  for (const [item, ...issues] of invalid) {
+    const projection = projectCliOperationOutput(command, {
+      overallStatus: "partial_success",
+      value: runPage([item], "cursor-2"),
+      issues,
+      persistence: { status: "read", effect: "none" },
+    });
+    assert.equal(projection.ok, false);
+  }
+});
+
+test("Session Run failures preserve the existing access, domain, timeout, and cancel exit mapping", () => {
+  const command = parsedCommand(["session", "runs", "--session-id", "session-1"]);
+  const cases = [
+    [failure("access", "forbidden", "not_attempted", false), CLI_EXIT_CODES.accessRejected],
+    [failure("domain", "not_found", "rejected", false), CLI_EXIT_CODES.domainRejected],
+    [failure("operation", "operation_timeout", "not_attempted", true), CLI_EXIT_CODES.timeout],
+    [failure("operation", "operation_canceled", "not_attempted", false), CLI_EXIT_CODES.canceled],
+  ] as const;
+  for (const [response, exitCode] of cases) {
+    const projection = projectCliOperationOutput(command, response);
+    assert.equal(projection.ok, true);
+    assert.equal(projection.exitCode, exitCode);
+  }
+});
+
+function parsedCommand(argv: readonly string[]): CliValidatedSessionCommand {
+  const parsed = parseCliArgv(argv);
+  assert.equal(parsed.kind, "command");
+  if (parsed.kind !== "command" || parsed.command.identity.namespace !== "session") assert.fail("expected command");
+  return parsed.command as CliValidatedSessionCommand;
+}
+
+function dependencies(sessionRunOperations: SessionRunOperations) {
+  return {
+    operations: unsupportedSessionOperations(),
+    messageOperations: unsupportedMessageOperations(),
+    sessionRunOperations,
+    authorization,
+  } as const;
+}
+
+function unsupportedSessionOperations(): ApplicationSessionOperations<Authorization> {
+  const unsupported = async (): Promise<never> => {
+    throw new Error("unexpected Session operation");
+  };
+  return {
+    create: unsupported,
+    updateTitle: unsupported,
+    list: unsupported,
+    listLocalRepositories: unsupported,
+    read: unsupported,
+    readDirectoriesChunk: unsupported,
+    archive: unsupported,
+    unarchive: unsupported,
+    close: unsupported,
+    delete: unsupported,
+  };
+}
+
+function unsupportedMessageOperations(): ApplicationSessionMessageOperations<Authorization> {
+  const unsupported = async (): Promise<never> => {
+    throw new Error("unexpected Message operation");
+  };
+  return { messages: unsupported, messageContentChunk: unsupported };
+}
+
+function success(value: unknown) {
+  return { overallStatus: "success", value, persistence: { status: "read", effect: "none" } } as const;
+}
+
+function runPage(items: readonly unknown[] = [runItem()], nextCursor?: string) {
+  return { sessionId: "session-1", items, ...(nextCursor === undefined ? {} : { nextCursor }) };
+}
+
+function runItem(overrides: Readonly<Record<string, unknown>> = {}) {
+  return Object.fromEntries(
+    Object.entries({
+      runId: "run-1",
+      ordinal: 1,
+      initiatingMessageId: "message-1",
+      phase: "completed",
+      createdAt: 1,
+      startedAt: 2,
+      terminalAt: 3,
+      updatedAt: 3,
+      ...overrides,
+    }).filter(([, value]) => value !== undefined),
+  );
+}
+
+function runItems() {
+  return [
+    runItem({ runId: "run-1", ordinal: 1, phase: "queued", startedAt: undefined, terminalAt: undefined }),
+    runItem({ runId: "run-2", ordinal: 2, phase: "starting", terminalAt: undefined }),
+    runItem({ runId: "run-3", ordinal: 3, phase: "active", terminalAt: undefined }),
+    runItem({
+      runId: "run-4",
+      ordinal: 4,
+      phase: "canceling",
+      terminalAt: undefined,
+      cancellation: { requestedAt: 4 },
+    }),
+    runItem({ runId: "run-5", ordinal: 5, phase: "finalizing", terminalAt: undefined }),
+    runItem({ runId: "run-6", ordinal: 6, finalAssistantMessageId: undefined }),
+    runItem({ runId: "run-7", ordinal: 7, phase: "failed", failure: { origin: "provider", summary: "failed" } }),
+    runItem({ runId: "run-8", ordinal: 8, phase: "interrupted", failure: { origin: "transport" } }),
+    runItem({ runId: "run-9", ordinal: 9, phase: "canceled", cancellation: { requestedAt: 8 } }),
+  ];
+}
+
+function omission(ordinal: number) {
+  return {
+    kind: "omission",
+    code: "response_size_limit",
+    message: "Run was omitted because the response size limit was reached.",
+    ordinal,
+  } as const;
+}
+
+function failure(kind: "access" | "domain" | "operation", code: string, status: string, retryable: boolean) {
+  return {
+    overallStatus: "failure",
+    error: { kind, code, message: "failure", retryable },
+    persistence: { status, effect: "none" },
+  };
+}

--- a/test/public-application-service-api.test.ts
+++ b/test/public-application-service-api.test.ts
@@ -2,7 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import * as publicApi from "../src/main/index.js";
-import type { ApplicationSessionMessageOperations, ApplicationSessionOperations } from "../src/main/index.js";
+import type {
+  ApplicationSessionMessageOperations,
+  ApplicationSessionOperations,
+  ApplicationSessionRunOperations,
+} from "../src/main/index.js";
 import type {
   ApplicationSessionMessageContentChunk,
   ApplicationSessionMessageItem,
@@ -19,6 +23,7 @@ import {
   type ApplicationSessionListItem,
   type ApplicationSessionReadResult,
 } from "../src/shared/application-service-model.js";
+import type { ApplicationSessionRunItem } from "../src/shared/application-session-run-model.js";
 import type { RepositoryCommandErrorCode, SessionLifecycleStatus } from "../src/shared/repository-write-model.js";
 
 type Equal<TLeft, TRight> = (<T>() => T extends TLeft ? 1 : 2) extends <T>() => T extends TRight ? 1 : 2 ? true : false;
@@ -34,6 +39,8 @@ type Operations = ApplicationSessionOperations<Authorization>;
 type MessageOperations = ApplicationSessionMessageOperations<Authorization>;
 type MessagePageResponse = Awaited<ReturnType<MessageOperations["messages"]>>;
 type MessageChunkResponse = Awaited<ReturnType<MessageOperations["messageContentChunk"]>>;
+type SessionRunOperations = ApplicationSessionRunOperations<Authorization>;
+type SessionRunPageResponse = Awaited<ReturnType<SessionRunOperations["runs"]>>;
 type CreateResponse = Awaited<ReturnType<Operations["create"]>>;
 type ListResponse = Awaited<ReturnType<Operations["list"]>>;
 type DirectoriesChunkResponse = Awaited<ReturnType<Operations["readDirectoriesChunk"]>>;
@@ -87,6 +94,36 @@ void invalidChunkedMessage;
 void invalidChunkedMessageVariable;
 void invalidEofMessageChunk;
 void invalidProgressMessageChunk;
+
+const runHistoryItemBase = {
+  runId: "run-1",
+  ordinal: 1,
+  initiatingMessageId: "message-1",
+  createdAt: 1,
+  updatedAt: 2,
+};
+// @ts-expect-error non-completed Run history items cannot expose a final Assistant Message
+const invalidActiveRunHistoryItem: ApplicationSessionRunItem = {
+  ...runHistoryItemBase,
+  phase: "active",
+  finalAssistantMessageId: "message-2",
+};
+// @ts-expect-error failed Run history items require a public failure summary
+const invalidFailedRunHistoryItem: ApplicationSessionRunItem = {
+  ...runHistoryItemBase,
+  phase: "failed",
+  terminalAt: 2,
+};
+// @ts-expect-error completed Run history items cannot expose cancellation state
+const invalidCompletedRunHistoryItem: ApplicationSessionRunItem = {
+  ...runHistoryItemBase,
+  phase: "completed",
+  terminalAt: 2,
+  cancellation: { requestedAt: 1 },
+};
+void invalidActiveRunHistoryItem;
+void invalidFailedRunHistoryItem;
+void invalidCompletedRunHistoryItem;
 
 const listItemBase = {
   id: "session-1",
@@ -448,6 +485,28 @@ test("public Application Service barrel exposes the transport-neutral Session Me
     Equal<EofChunk["nextOffset"], undefined>,
     Equal<ProgressChunk["nextOffset"], number>,
     Equal<ChunkValue["bytes"], ArrayBuffer>,
+  ] = [true, true, true, true, true];
+
+  assert.equal(operations, null);
+  assert.deepEqual(typeContract, [true, true, true, true, true]);
+});
+
+test("public Application Service barrel exposes the transport-neutral Session Run history contract", () => {
+  const operations = null as SessionRunOperations | null;
+  type PageValue = Extract<SessionRunPageResponse, Readonly<{ overallStatus: "success" }>>["value"];
+  type RunItem = PageValue["items"][number];
+  type Completed = Extract<RunItem, Readonly<{ phase: "completed" }>>;
+  type Failed = Extract<RunItem, Readonly<{ phase: "failed" | "interrupted" }>>;
+  type NonTerminal = Extract<RunItem, Readonly<{ phase: "queued" | "starting" | "active" | "finalizing" }>>;
+  const typeContract: readonly [
+    Equal<Completed["terminalAt"], number>,
+    Equal<Completed["finalAssistantMessageId"], string | undefined>,
+    Equal<
+      Failed["failure"]["origin"],
+      "provider" | "transport" | "process" | "application" | "persistence" | "unknown"
+    >,
+    Equal<NonTerminal["terminalAt"], undefined>,
+    Equal<"liveActivity" extends keyof RunItem ? true : false, false>,
   ] = [true, true, true, true, true];
 
   assert.equal(operations, null);

--- a/test/public-repository-api.test.ts
+++ b/test/public-repository-api.test.ts
@@ -10,6 +10,7 @@ import type {
   ApplicationRunOutputOperations,
   ApplicationSessionMessageOperations,
   ApplicationSessionOperations,
+  ApplicationSessionRunOperations,
 } from "../src/main/index.js";
 
 type Authorization = Readonly<{ principalId: string }>;
@@ -17,6 +18,7 @@ type SessionListInput = Parameters<ApplicationSessionOperations<Authorization>["
 type RunStatusInput = Parameters<ApplicationRunOperations<Authorization>["status"]>[0];
 type RunOutputCountsInput = Parameters<ApplicationRunOutputOperations<Authorization>["outputCounts"]>[0];
 type MessageChunkInput = Parameters<ApplicationSessionMessageOperations<Authorization>["messageContentChunk"]>[0];
+type SessionRunsInput = Parameters<ApplicationSessionRunOperations<Authorization>["runs"]>[0];
 
 test("public Main barrel exposes only the transport-neutral Application contract", () => {
   const sourcePath = new URL("../src/main/index.ts", import.meta.url);
@@ -33,10 +35,12 @@ test("public Main barrel exposes only the transport-neutral Application contract
   const statusInput = null as RunStatusInput | null;
   const outputCountsInput = null as RunOutputCountsInput | null;
   const messageChunkInput = null as MessageChunkInput | null;
+  const sessionRunsInput = null as SessionRunsInput | null;
 
   assert.deepEqual(exportedModules, [
     "../shared/application-service-model.js",
     "../shared/application-session-message-model.js",
+    "../shared/application-session-run-model.js",
     "../shared/application-run-model.js",
     "../shared/application-run-output-model.js",
   ]);
@@ -45,4 +49,5 @@ test("public Main barrel exposes only the transport-neutral Application contract
   assert.equal(statusInput, null);
   assert.equal(outputCountsInput, null);
   assert.equal(messageChunkInput, null);
+  assert.equal(sessionRunsInput, null);
 });

--- a/test/repository-read-model.test.ts
+++ b/test/repository-read-model.test.ts
@@ -258,6 +258,249 @@ repositoryTest("Message page keeps one SQL snapshot when its Session is deleted 
   });
 });
 
+repositoryTest("Run history is Session-scoped, keyset paged, and projects only durable public headers", () => {
+  withDatabase((database) => {
+    insertSession(database, "session-empty", 1);
+    insertSession(database, "session-1", 1);
+    insertSession(database, "session-2", 1);
+    insertMessage(database, "message-1", "session-1", 1, "[]");
+    insertMessage(database, "message-2", "session-1", 2, "[]");
+    insertMessage(database, "message-3", "session-1", 3, "[]");
+    insertMessage(database, "message-4", "session-1", 4, "[]");
+    insertHistoryRun(database, {
+      id: "run-1",
+      sessionId: "session-1",
+      ordinal: 1,
+      initiatingMessageId: "message-1",
+      finalAssistantMessageId: "message-2",
+      phase: "completed",
+      timestamp: 10,
+    });
+    insertHistoryRun(database, {
+      id: "run-2",
+      sessionId: "session-1",
+      ordinal: 3,
+      initiatingMessageId: "message-3",
+      retryOfRunId: "run-1",
+      phase: "failed",
+      failureOrigin: "provider",
+      errorSummary: "bounded failure",
+      timestamp: 20,
+    });
+    const operation = operationFor(database, "repository.runs.page");
+
+    const empty = operation({ sessionId: "session-empty", workspaceKey: "workspace" }) as PageResult;
+    assert.deepEqual(empty, { sessionId: "session-empty", workspaceKey: "workspace", items: [] });
+
+    const first = operation({ sessionId: "session-1", workspaceKey: "workspace", limit: 1 }) as PageResult;
+    assert.deepEqual(first.items, [
+      {
+        runId: "run-1",
+        sessionId: "session-1",
+        ordinal: 1,
+        initiatingMessageId: "message-1",
+        finalAssistantMessageId: "message-2",
+        phase: "completed",
+        createdAt: 10,
+        startedAt: 10,
+        terminalAt: 10,
+        updatedAt: 10,
+      },
+    ]);
+    assert.equal(typeof first.nextCursor, "string");
+    assert.equal(JSON.stringify(first).includes("secret snapshot"), false);
+    assert.equal(JSON.stringify(first).includes("secret-provider-code"), false);
+    assert.equal(JSON.stringify(first).includes("externalSideEffectState"), false);
+    assert.equal(JSON.stringify(first).includes("version"), false);
+
+    insertHistoryRun(database, {
+      id: "run-3",
+      sessionId: "session-1",
+      ordinal: 5,
+      initiatingMessageId: "message-4",
+      phase: "canceled",
+      cancelRequestedAt: 29,
+      cancelAcknowledgedAt: 30,
+      timestamp: 30,
+    });
+    const second = operation({
+      sessionId: "session-1",
+      workspaceKey: "workspace",
+      cursor: first.nextCursor,
+      limit: 10,
+    }) as PageResult;
+    assert.deepEqual(
+      second.items.map((item) => item.runId),
+      ["run-2", "run-3"],
+    );
+    assert.equal(second.nextCursor, undefined);
+
+    assert.throws(
+      () => operation({ sessionId: "session-empty", workspaceKey: "workspace", cursor: first.nextCursor }),
+      (error: unknown) => error instanceof RepositoryReadError && error.code === "cursor_invalid",
+    );
+    assert.throws(
+      () => operation({ sessionId: "session-1", workspaceKey: "other", cursor: first.nextCursor }),
+      (error: unknown) => error instanceof RepositoryReadError && error.code === "cursor_invalid",
+    );
+    for (const request of [
+      { sessionId: "session-1", workspaceKey: "other" },
+      { sessionId: "missing", workspaceKey: "workspace" },
+    ]) {
+      assert.throws(
+        () => operation(request),
+        (error: unknown) => error instanceof RepositoryReadError && error.code === "not_found",
+      );
+    }
+    for (const request of [
+      { sessionId: "session-1", workspaceKey: "workspace", limit: 0 },
+      { sessionId: "session-1", workspaceKey: "workspace", limit: 101 },
+      { sessionId: "session-1", workspaceKey: "workspace", unexpected: true },
+    ]) {
+      assert.throws(
+        () => operation(request),
+        (error: unknown) => error instanceof RepositoryReadError && error.code === "request_invalid",
+      );
+    }
+  });
+});
+
+repositoryTest("Run history preserves every non-terminal header shape without terminal details", () => {
+  for (const phase of ["queued", "starting", "active", "canceling", "finalizing"] as const) {
+    withDatabase((database) => {
+      insertSession(database, `session-${phase}`, 1);
+      insertMessage(database, `message-${phase}`, `session-${phase}`, 1, "[]");
+      insertHistoryRun(database, {
+        id: `run-${phase}`,
+        sessionId: `session-${phase}`,
+        ordinal: 1,
+        initiatingMessageId: `message-${phase}`,
+        phase,
+        ...(phase === "canceling" ? { cancelRequestedAt: 2 } : {}),
+        timestamp: 1,
+      });
+
+      const page = operationFor(
+        database,
+        "repository.runs.page",
+      )({
+        sessionId: `session-${phase}`,
+        workspaceKey: "workspace",
+      }) as PageResult;
+      assert.deepEqual(page.items, [
+        {
+          runId: `run-${phase}`,
+          sessionId: `session-${phase}`,
+          ordinal: 1,
+          initiatingMessageId: `message-${phase}`,
+          phase,
+          ...(phase === "canceling" ? { cancelRequestedAt: 2 } : {}),
+          createdAt: 1,
+          startedAt: 1,
+          updatedAt: 1,
+        },
+      ]);
+    });
+  }
+});
+
+repositoryTest("Run history applies default 50 and accepts the exact 50 and 100 item limits", () => {
+  withDatabase((database) => {
+    insertSession(database, "session-1", 1);
+    const queriedLimits: number[] = [];
+    const observedDatabase = new Proxy(database, {
+      get(target, property) {
+        if (property === "prepare") {
+          return (sql: string) => {
+            const statement = target.prepare(sql);
+            if (sql !== REPOSITORY_PAGE_SQL.runs) return statement;
+            return new Proxy(statement, {
+              get(statementTarget, statementProperty) {
+                if (statementProperty === "all") {
+                  return (...parameters: Parameters<typeof statementTarget.all>) => {
+                    queriedLimits.push(parameters[2] as number);
+                    return statementTarget.all(...parameters);
+                  };
+                }
+                const value = Reflect.get(statementTarget, statementProperty, statementTarget) as unknown;
+                return typeof value === "function" ? value.bind(statementTarget) : value;
+              },
+            });
+          };
+        }
+        const value = Reflect.get(target, property, target) as unknown;
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+    const operation = operationFor(observedDatabase, "repository.runs.page");
+
+    operation({ sessionId: "session-1", workspaceKey: "workspace" });
+    operation({ sessionId: "session-1", workspaceKey: "workspace", limit: 50 });
+    operation({ sessionId: "session-1", workspaceKey: "workspace", limit: 100 });
+    assert.deepEqual(queriedLimits, [51, 51, 101]);
+  });
+});
+
+repositoryTest("Run history resolves scope and page in one SQL statement with bounded omission progress", () => {
+  withDatabase((database) => {
+    insertSession(database, "session-1", 1);
+    insertMessage(database, "message-1", "session-1", 1, "[]");
+    insertMessage(database, "message-2", "session-1", 2, "[]");
+    insertHistoryRun(database, {
+      id: "run-large",
+      sessionId: "session-1",
+      ordinal: 1,
+      initiatingMessageId: "message-1",
+      phase: "failed",
+      failureOrigin: "provider",
+      errorSummary: "x".repeat(200 * 1024),
+      timestamp: 1,
+    });
+    insertHistoryRun(database, {
+      id: "run-next",
+      sessionId: "session-1",
+      ordinal: 2,
+      initiatingMessageId: "message-2",
+      phase: "completed",
+      timestamp: 2,
+    });
+    const preparedSql: string[] = [];
+    const observedDatabase = new Proxy(database, {
+      get(target, property) {
+        if (property === "prepare") {
+          return (sql: string) => {
+            preparedSql.push(sql);
+            return target.prepare(sql);
+          };
+        }
+        const value = Reflect.get(target, property, target) as unknown;
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+    const operation = operationFor(observedDatabase, "repository.runs.page");
+
+    preparedSql.length = 0;
+    const first = operation({ sessionId: "session-1", workspaceKey: "workspace", limit: 1 }) as PageResult;
+    assert.deepEqual(first.items, [{ omitted: true, reason: "response_size_limit", ordinal: 1 }]);
+    assert.equal(typeof first.nextCursor, "string");
+    assert.ok(Buffer.byteLength(JSON.stringify(first)) <= 192 * 1024);
+    assert.deepEqual(preparedSql, [REPOSITORY_PAGE_SQL.runs]);
+
+    preparedSql.length = 0;
+    const next = operation({
+      sessionId: "session-1",
+      workspaceKey: "workspace",
+      cursor: first.nextCursor,
+      limit: 1,
+    }) as PageResult;
+    assert.deepEqual(
+      next.items.map((item) => item.runId),
+      ["run-next"],
+    );
+    assert.deepEqual(preparedSql, [REPOSITORY_PAGE_SQL.runs]);
+  });
+});
+
 repositoryTest("Run output cursors are scoped to the workspace, Session, Run, and optional category", () => {
   withDatabase((database) => {
     insertSession(database, "session-1", 1);
@@ -786,6 +1029,13 @@ repositoryTest("RunEvent continuation is usable when the initial page is empty",
 
 repositoryTest("representative ordinal queries use covering indexes and never scan payloads", () => {
   withDatabase((database) => {
+    const runPlan = database
+      .prepare(`EXPLAIN QUERY PLAN ${REPOSITORY_PAGE_SQL.runs}`)
+      .all("s", 0, 10, "s", "w") as unknown as readonly Readonly<{ detail: string }>[];
+    const runDetails = runPlan.map((row) => row.detail).join("\n");
+    assert.match(runDetails, /runs_session_ordinal_uq/u);
+    assert.doesNotMatch(runDetails, /USE TEMP B-TREE FOR ORDER BY/u);
+
     const plans = [
       database.prepare(`EXPLAIN QUERY PLAN ${REPOSITORY_SESSION_PAGE_SQL.all}`).all(null, null, null, null, 10),
       database
@@ -1168,6 +1418,64 @@ function insertRun(
   `,
     )
     .run(id, sessionId, messageId, phase, timestamp, timestamp, phase === "completed" ? timestamp : null, timestamp);
+}
+
+function insertHistoryRun(
+  database: DatabaseSync,
+  run: Readonly<{
+    id: string;
+    sessionId: string;
+    ordinal: number;
+    initiatingMessageId: string;
+    finalAssistantMessageId?: string;
+    retryOfRunId?: string;
+    phase:
+      | "queued"
+      | "starting"
+      | "active"
+      | "canceling"
+      | "finalizing"
+      | "completed"
+      | "failed"
+      | "canceled"
+      | "interrupted";
+    failureOrigin?: string;
+    errorSummary?: string;
+    cancelRequestedAt?: number;
+    cancelAcknowledgedAt?: number;
+    timestamp: number;
+  }>,
+): void {
+  database
+    .prepare(
+      `
+    INSERT INTO runs (
+      id, session_id, ordinal, initiating_message_id, final_assistant_message_id, retry_of_run_id,
+      phase, execution_snapshot_json, failure_origin, provider_error_code, error_summary,
+      cancel_requested_at, cancel_acknowledged_at, external_side_effect_state,
+      created_at, started_at, terminal_at, updated_at, version
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'present', ?, ?, ?, ?, 7)
+  `,
+    )
+    .run(
+      run.id,
+      run.sessionId,
+      run.ordinal,
+      run.initiatingMessageId,
+      run.finalAssistantMessageId ?? null,
+      run.retryOfRunId ?? null,
+      run.phase,
+      JSON.stringify({ marker: "secret snapshot" }),
+      run.failureOrigin ?? null,
+      "secret-provider-code",
+      run.errorSummary ?? null,
+      run.cancelRequestedAt ?? null,
+      run.cancelAcknowledgedAt ?? null,
+      run.timestamp,
+      run.timestamp,
+      ["completed", "failed", "canceled", "interrupted"].includes(run.phase) ? run.timestamp : null,
+      run.timestamp,
+    );
 }
 
 type PageResult = Readonly<{


### PR DESCRIPTION
## 概要

Sessionに属する永続Run historyを、Application ServiceとCLIからbounded pageとして参照できるようにします。

- RepositoryへSession / Workspace scope付きの `repository.runs.page` を追加
- `ApplicationSessionRunOperations.runs` とphase-specific public modelを追加
- 既存Run statusと永続phase / failure / cancellation / timestamp projectionを共有
- `withmate session runs --session-id ...` のparser、help、dispatch、strict JSON projectionを追加
- 実DB process smokeとCP2 worklogを更新

## 目的と影響

Session Message timelineからRun historyを経由し、既存のRun status、events、output操作へProvider非依存で辿れるようになります。

Run historyはordinal ascendingのopaque keyset cursorを使い、default 50 / maximum 100、192 KiB response budget、ordinal付きomissionで有界化しています。Applicationは `session_runs` targetを認可後にinternal Workspace scopeを解決し、Repository境界でもSession / Workspace owner tupleを再検証します。

execution snapshot、Provider error code、terminal event受信時刻、external side effect state、version、Workspace key、live activityはpublic historyへ公開しません。Run mutation、supplemental input、child control、schema変更は含みません。

## 実行可能な契約

- valid empty Sessionとwrong / missing scopeの区別
- Session / Workspaceに結び付くcursorと別Sessionへの流用拒否
- ordinal keyset pagination、欠番、append continuation、byte-budget omission後の進行
- 1 SQL statementと `runs_session_ordinal_uq`、header-only SELECT、N+1 / payload hydrateなし
- 全9 phaseのterminal / failure / cancellation組とcompleted時のoptional final assistant Message
- historyと既存Run statusのpersisted field整合
- CLI response envelope、nested persistence / error、item projectionのstrict validation
- timeout / SIGINT / exactly-once shutdown / single stdout JSONの維持

## 検証

- `npm run check:runtime`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test` — 459件成功、SQLite schema validator成功
- `npm run build`
- `npm run smoke:cli-session`
- `npm run smoke:cli-run`
- `npm run smoke:compiled-persistence`
- `git diff --check`
- Slice A / B / Cのtargeted reviewと統合complete-diff review — 未解決blockingなし

## 後続

Session Run history sliceは完了しますが、CP2全体は引き続き進行中です。CP2完了判定は後続の `test/cp02-control-plane-gate` で行います。