### PR TITLE
feat(home): Characterのランダム選択を追加する

### DIFF
--- a/docs/adr/004-launch-character-random-selection.md
+++ b/docs/adr/004-launch-character-random-selection.md
@@ -1,0 +1,55 @@
+# 004 Launch Character Random Selection
+
+- 状態: Accepted
+- 日付: 2026-07-20
+
+## Context
+
+New Session ダイアログでは Character を固定選択できる。Character の利用機会を分散するため、選択をアプリへ任せる導線も必要になった。
+
+完全な均等抽選では、直前に使った Character が続けて選ばれる可能性を下げられない。一方、利用回数や抽選履歴を新たに永続化すると、schema と更新経路が増える。既存の通常 Session summary は最終利用日時の降順で取得できるため、永続化を変更せずに最近の利用状況を抽選へ反映できる。
+
+## Decision
+
+- New Session ダイアログの Character 一覧先頭に、ランダム選択を置く。
+- Agent と Companion のランダム開始は、active Character を共通の候補とする。
+- 通常 Session の最終利用順から Character ごとの直近位置を求め、最近使われた Character から順に `1, 2, 3, ...` の線形な重みを与える。履歴にない Character には、履歴にある候補より大きい同一の重みを与える。
+- Character 作成 Session は利用履歴に含めない。
+- 通常 Session の履歴が0件なら、active Character を均等に抽選する。active Character が0件なら、既存の neutral Character を使う。
+- 履歴の読み込み中または取得失敗時はランダム開始を拒否する。取得成功後の0件だけを均等抽選として扱う。
+- DB schema と Session summary API は変更しない。
+
+実装の正本は `src/home/home-launch-state.ts` と `src/home/home-launch-actions.ts`、観測可能な契約は `scripts/tests/home-launch-state.test.ts` と `scripts/tests/home-launch-actions.test.ts` に置く。
+
+## Alternatives
+
+### 常に均等抽選する
+
+実装は単純だが、最近使っていない Character を優先する目的を満たさない。
+
+### 最も長く使っていない Character だけから選ぶ
+
+利用機会を強く分散できるが、抽選結果が狭い候補へ固定されやすく、ランダム選択としての幅が小さくなる。
+
+### 利用回数または抽選履歴を永続化する
+
+利用傾向を細かく制御できるが、schema、migration、更新経路が必要になる。既存データで目的を満たせる今回の範囲を超える。
+
+### 開始操作のたびに履歴を再取得する
+
+最新状態を直接確認できるが、開始時の追加 I/O と失敗経路が増える。Home が購読している Session summary の取得成功状態を使えば、同じ要件を満たせる。
+
+## Consequences
+
+### Positive
+
+- 最近使っていない Character の選択確率を上げつつ、すべての active Character に選択可能性を残せる。
+- Agent と Companion で同じ抽選方針を使える。
+- 新しい永続化データと migration を追加せずに実現できる。
+- 履歴未取得を履歴0件と誤認した均等抽選を防げる。
+
+### Negative
+
+- 抽選確率は利用回数ではなく、Character ごとの直近利用順だけで決まる。
+- Session summary の読み込みに失敗している間は、固定 Character では開始できるが、ランダム選択では開始できない。
+- 複数の Home window 間で購読更新に短い遅延がある場合、その間は抽選時の重みが一致しない可能性がある。

--- a/docs/design/session-launch-ui.md
+++ b/docs/design/session-launch-ui.md
@@ -27,7 +27,7 @@ WithMate では、`Recent Sessions` が 2 の `resume` 側を担う。
 
 - 作業ディレクトリの選択
 - session title の入力
-- 現在選択中の Character の確認
+- 現在選択中の Character、またはランダム選択の確認
 - Provider の確認
 - approval mode は provider-neutral 3 mode の正本を使い、New Session の default は `safety` で初期化する
 - 新規セッション開始
@@ -132,6 +132,9 @@ React モックでは次の形がよい。
 - provider は launch dialog 内で chip 選択し、enabled provider が 0 件なら start できない
 - `Character` は card で切り替える
 - `Character` は portrait 付きカードで切り替える
+- Character一覧の先頭にランダム選択カードを置く。ランダム選択時は、通常Sessionの最終利用順を使い、最近使っていないactive Characterほど高い重みで抽選する
+- Character利用履歴がない場合はactive Characterを均等に抽選し、active Characterが0件なら既存のneutral fallbackを使う
+- Session履歴の読み込み中または取得失敗時はランダム選択で開始せず、取得成功した0件と区別する
 - `Character` には検索入力があり、`name / description` の部分一致で絞り込める
 - launch dialog 内の character card も Home と同じ theme rule を使う
   - background = character `main`
@@ -149,10 +152,6 @@ React モックでは次の形がよい。
 
 - 将来的にはアプリ設定で `workspace root directory` を持てるようにし、その配下へ UUID ディレクトリを自動作成して空 workspace から session を起動できるようにする
 - この方式は `既存ディレクトリを選ぶ` 導線とは別扱いにし、`New Session` dialog の別 action か `Settings` 由来の launch preset として扱う
-
-## Open Questions
-
-- Character は固定選択にするか、launch 時に変えられるようにするか
 
 ## Next Step
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "6.3.9",
+  "version": "6.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "6.3.9",
+      "version": "6.3.10",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "6.3.9",
+  "version": "6.3.10",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/scripts/tests/home-components.test.tsx
+++ b/scripts/tests/home-components.test.tsx
@@ -517,6 +517,7 @@ describe("HomeLaunchDialog", () => {
     mode: "session" | "companion",
     options = characterOptions,
     charactersLoaded = true,
+    randomCharacterSelected = false,
   ) => renderToStaticMarkup(
     <HomeLaunchDialog
       open={true}
@@ -527,7 +528,8 @@ describe("HomeLaunchDialog", () => {
       enabledLaunchProviders={[{ id: "codex", label: "Codex" }]}
       selectedLaunchProviderId="codex"
       characterOptions={options}
-      selectedCharacterId={options[0]?.id ?? null}
+      selectedCharacterId={randomCharacterSelected ? null : options[0]?.id ?? null}
+      randomCharacterSelected={randomCharacterSelected}
       charactersLoaded={charactersLoaded}
       canStartSession={true}
       launchFeedback=""
@@ -538,6 +540,7 @@ describe("HomeLaunchDialog", () => {
       onBrowseWorkspace={noOp}
       onSelectProvider={noOp}
       onSelectCharacter={noOp}
+      onSelectRandomCharacter={noOp}
       onStartSession={noOp}
     />,
   );
@@ -549,6 +552,22 @@ describe("HomeLaunchDialog", () => {
     assert.ok(html.includes("Mia"));
     assert.ok(html.includes("Default"));
     assert.ok(html.includes("Default character"));
+    assert.ok(html.includes("ランダム"));
+    assert.ok(html.indexOf("ランダム") < html.indexOf("Mia"));
+    assert.ok(html.includes("最近使っていないCharacterを優先"));
+  });
+
+  it("random選択時は一覧先頭のランダムcardだけを選択状態にする", () => {
+    const html = renderHomeLaunchDialog("session", characterOptions, true, true);
+
+    assert.match(
+      html,
+      /<button class="launch-character-option selected"[^>]*aria-checked="true"[^>]*>(?:(?!<\/button>).)*ランダム/s,
+    );
+    assert.doesNotMatch(
+      html,
+      /<button class="launch-character-option selected"[^>]*>(?:(?!<\/button>).)*Mia/s,
+    );
   });
 
   it("companion mode でも Character selector が含まれる", () => {

--- a/scripts/tests/home-launch-actions.test.ts
+++ b/scripts/tests/home-launch-actions.test.ts
@@ -44,18 +44,32 @@ function createReadyDraft(mode: HomeLaunchDraft["mode"] = "session"): HomeLaunch
 }
 
 function createCharacterEntries(): CharacterCatalogEntry[] {
-  return [{
-    id: "mia",
-    name: "Mia",
-    description: "Character profile",
-    iconFilePath: "character.png",
-    theme: { main: "#222222", sub: "#eeeeee" },
-    state: "active",
-    isDefault: true,
-    createdAt: "2026-01-01T00:00:00.000Z",
-    updatedAt: "2026-01-01T00:00:00.000Z",
-    archivedAt: null,
-  }];
+  return [
+    {
+      id: "mia",
+      name: "Mia",
+      description: "Character profile",
+      iconFilePath: "character.png",
+      theme: { main: "#222222", sub: "#eeeeee" },
+      state: "active",
+      isDefault: true,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      archivedAt: null,
+    },
+    {
+      id: "noa",
+      name: "Noa",
+      description: "Second character",
+      iconFilePath: "noa.png",
+      theme: { main: "#333333", sub: "#dddddd" },
+      state: "active",
+      isDefault: false,
+      createdAt: "2026-01-02T00:00:00.000Z",
+      updatedAt: "2026-01-02T00:00:00.000Z",
+      archivedAt: null,
+    },
+  ];
 }
 
 function createCompanionSession(): CompanionSession {
@@ -94,7 +108,7 @@ function createCompanionSession(): CompanionSession {
   };
 }
 
-function createSessionSummary(): SessionSummary {
+function createSessionSummary(overrides: Partial<SessionSummary> = {}): SessionSummary {
   return {
     id: "session-1",
     taskTitle: "Task",
@@ -120,6 +134,7 @@ function createSessionSummary(): SessionSummary {
     customAgentName: "",
     allowedAdditionalDirectories: [],
     threadId: "",
+    ...overrides,
   };
 }
 
@@ -150,6 +165,7 @@ function createStartHomeLaunchHarness(overrides: Partial<Parameters<typeof start
       characterEntries: createCharacterEntries(),
       selectedProviderId: "codex",
       sessions: [],
+      sessionSummariesLoadStatus: "loaded" as const,
       createSession: async () => createSessionSummary(),
       createCompanionSession: async () => createCompanionSession(),
       openSessionWindow: async (sessionId: string) => {
@@ -218,9 +234,92 @@ describe("home-launch-actions", () => {
     assert.deepEqual(harness.openedSessions, ["session-1"]);
   });
 
+  it("random選択では最近使っていないCharacterを重み付きで選んでsessionを作成する", async () => {
+    let capturedCharacterId = "";
+    const harness = createStartHomeLaunchHarness({
+      draft: {
+        ...createReadyDraft(),
+        characterSelectionMode: "random",
+      },
+      sessions: [createSessionSummary({ id: "recent-mia", characterId: "mia" })],
+      random: () => 0.4,
+      createSession: async (input) => {
+        capturedCharacterId = input.characterId;
+        return createSessionSummary();
+      },
+    });
+
+    await startHomeLaunch(harness.input);
+
+    assert.equal(capturedCharacterId, "noa");
+    assert.deepEqual(harness.openedSessions, ["session-1"]);
+  });
+
+  it("履歴の読み込み中はrandom選択のsessionを開始しない", async () => {
+    let createCount = 0;
+    const harness = createStartHomeLaunchHarness({
+      draft: {
+        ...createReadyDraft(),
+        characterSelectionMode: "random",
+      },
+      sessionSummariesLoadStatus: "loading",
+      createSession: async () => {
+        createCount += 1;
+        return createSessionSummary();
+      },
+    });
+
+    await startHomeLaunch(harness.input);
+
+    assert.equal(createCount, 0);
+    assert.deepEqual(harness.feedback, ["Session 履歴を読み込んでるよ。完了してからもう一度開始してね。"]);
+    assert.deepEqual(harness.startingStates, []);
+  });
+
+  it("履歴の読み込み失敗後はrandom選択のsessionを開始しない", async () => {
+    let createCount = 0;
+    const harness = createStartHomeLaunchHarness({
+      draft: {
+        ...createReadyDraft(),
+        characterSelectionMode: "random",
+      },
+      sessionSummariesLoadStatus: "error",
+      createSession: async () => {
+        createCount += 1;
+        return createSessionSummary();
+      },
+    });
+
+    await startHomeLaunch(harness.input);
+
+    assert.equal(createCount, 0);
+    assert.deepEqual(harness.feedback, ["Session 履歴を読み込めていないため、ランダム選択を開始できないよ。"]);
+    assert.deepEqual(harness.startingStates, []);
+  });
+
+  it("履歴の読み込み失敗後でも固定Characterのsessionは開始できる", async () => {
+    let capturedCharacterId = "";
+    const harness = createStartHomeLaunchHarness({
+      sessionSummariesLoadStatus: "error",
+      createSession: async (input) => {
+        capturedCharacterId = input.characterId;
+        return createSessionSummary();
+      },
+    });
+
+    await startHomeLaunch(harness.input);
+
+    assert.equal(capturedCharacterId, "mia");
+    assert.deepEqual(harness.openedSessions, ["session-1"]);
+  });
+
   it("Mate 未作成でも neutral character で session を作成する", async () => {
     let capturedCharacterId = "";
     const harness = createStartHomeLaunchHarness({
+      draft: {
+        ...createReadyDraft(),
+        characterSelectionMode: "random",
+      },
       mateState: "not_created",
       mateProfile: null,
       characterEntries: [],
@@ -255,6 +354,29 @@ describe("home-launch-actions", () => {
     assert.deepEqual(harness.feedback, ["Companion を開始してるよ..."]);
     assert.deepEqual(harness.startingStates, [true, false]);
     assert.equal(harness.closeCount, 1);
+    assert.deepEqual(harness.companionSummaries, ["companion-1"]);
+    assert.deepEqual(harness.openedCompanionSessions, ["companion-1"]);
+  });
+
+  it("random選択では最近使っていないCharacterを重み付きで選んでcompanionを作成する", async () => {
+    let capturedCharacterId = "";
+    const harness = createStartHomeLaunchHarness({
+      draft: {
+        ...createReadyDraft("companion"),
+        characterSelectionMode: "random",
+      },
+      requestedMode: "companion",
+      sessions: [createSessionSummary({ id: "recent-mia", characterId: "mia" })],
+      random: () => 0.4,
+      createCompanionSession: async (input) => {
+        capturedCharacterId = input.characterId;
+        return createCompanionSession();
+      },
+    });
+
+    await startHomeLaunch(harness.input);
+
+    assert.equal(capturedCharacterId, "noa");
     assert.deepEqual(harness.companionSummaries, ["companion-1"]);
     assert.deepEqual(harness.openedCompanionSessions, ["companion-1"]);
   });

--- a/scripts/tests/home-launch-handlers.test.ts
+++ b/scripts/tests/home-launch-handlers.test.ts
@@ -52,6 +52,7 @@ describe("home-launch-handlers", () => {
       characterEntries: [createCharacterEntry({ id: "old", name: "Old" })],
       selectedLaunchProviderId: "codex",
       sessions: [],
+      sessionSummariesLoadStatus: "loaded",
       refreshCharacterEntries: async () => {
         refreshCount += 1;
         return latestEntries;
@@ -75,6 +76,13 @@ describe("home-launch-handlers", () => {
     assert.equal(refreshCount, 1);
     assert.equal(draft.open, true);
     assert.equal(draft.characterId, "new-default");
+    assert.equal(draft.characterSelectionMode, "specific");
     assert.deepEqual(feedback, [""]);
+
+    handlers.onSelectRandomLaunchCharacter();
+    assert.equal(draft.characterSelectionMode, "random");
+
+    handlers.onSelectLaunchCharacter("new-default");
+    assert.equal(draft.characterSelectionMode, "specific");
   });
 });

--- a/scripts/tests/home-launch-projection.test.ts
+++ b/scripts/tests/home-launch-projection.test.ts
@@ -110,9 +110,27 @@ describe("home-launch-projection", () => {
     assert.deepEqual(enabledOnlyCodex.enabledLaunchProviders.map((provider) => provider.id), ["codex"]);
     assert.equal(enabledOnlyCodex.selectedLaunchProvider?.id, "codex");
     assert.equal(enabledOnlyCodex.selectedCharacter?.id, "noa");
+    assert.equal(enabledOnlyCodex.randomCharacterSelected, false);
     assert.deepEqual(enabledOnlyCodex.characterOptions.map((character) => character.id), ["mia", "noa"]);
     assert.equal(enabledOnlyCodex.launchWorkspacePathLabel, "F:/work/demo");
     assert.equal(enabledOnlyCodex.canStartSession, true);
+  });
+
+  it("random character選択時は固定Characterを選択状態にしない", () => {
+    const projection = buildHomeLaunchProjection({
+      launchProviderId: "codex",
+      launchTitle: "task",
+      launchWorkspace: { label: "demo", path: "F:/work/demo", branch: "" },
+      launchCharacterId: "mia",
+      launchCharacterSelectionMode: "random",
+      characterEntries: createCharacters(),
+      appSettings: createDefaultAppSettings(),
+      modelCatalog: createCatalog(),
+    });
+
+    assert.equal(projection.selectedCharacter, null);
+    assert.equal(projection.randomCharacterSelected, true);
+    assert.equal(projection.canStartSession, true);
   });
 
   it("Character catalog 読み込み前は開始不可にする", () => {

--- a/scripts/tests/home-launch-state.test.ts
+++ b/scripts/tests/home-launch-state.test.ts
@@ -15,9 +15,11 @@ import {
   resolveLastUsedSessionSelection,
   resolveLaunchCharacterId,
   resolveLaunchValidationMessage,
+  selectWeightedRandomLaunchCharacterId,
   setLaunchWorkspaceFromPath,
   updateLaunchDraftForCharacterSelection,
   updateLaunchDraftForProviderSelection,
+  updateLaunchDraftForRandomCharacterSelection,
 } from "../../src/home/home-launch-state.js";
 import type { MateProfile } from "../../src/mate/mate-state.js";
 
@@ -79,6 +81,7 @@ describe("home-launch-state", () => {
       title: "",
       workspace: null,
       providerId: "codex",
+      characterSelectionMode: "specific",
       characterId: "mia",
       model: DEFAULT_MODEL_ID,
       reasoningEffort: DEFAULT_REASONING_EFFORT,
@@ -92,6 +95,7 @@ describe("home-launch-state", () => {
       title: "",
       workspace: null,
       providerId: "",
+      characterSelectionMode: "specific",
       characterId: "",
       model: DEFAULT_MODEL_ID,
       reasoningEffort: DEFAULT_REASONING_EFFORT,
@@ -151,6 +155,17 @@ describe("home-launch-state", () => {
     const draft = updateLaunchDraftForCharacterSelection(createClosedLaunchDraft(), "mia");
 
     assert.equal(draft.characterId, "mia");
+    assert.equal(draft.characterSelectionMode, "specific");
+  });
+
+  it("random character 選択時に launch draft の選択modeを更新する", () => {
+    const draft = updateLaunchDraftForRandomCharacterSelection({
+      ...createClosedLaunchDraft(),
+      characterId: "mia",
+    });
+
+    assert.equal(draft.characterId, "mia");
+    assert.equal(draft.characterSelectionMode, "random");
   });
 
   it("character selection は既存選択、default順の先頭、空文字の順で解決する", () => {
@@ -171,6 +186,58 @@ describe("home-launch-state", () => {
     ];
 
     assert.equal(resolveLaunchCharacterId(entries, "mia"), "noa");
+  });
+
+  it("random character selection は最近使っていないactive Characterほど選択範囲を広くする", () => {
+    const entries = [
+      createCharacterEntry({ id: "mia", name: "Mia" }),
+      createCharacterEntry({ id: "noa", name: "Noa" }),
+      createCharacterEntry({ id: "yui", name: "Yui" }),
+      createCharacterEntry({ id: "archived", name: "Archived", state: "archived" }),
+    ];
+    const sessions = [
+      { characterId: "mia", sessionKind: "default" as const },
+      { characterId: "yui", sessionKind: "character-authoring" as const },
+      { characterId: "archived", sessionKind: "default" as const },
+      { characterId: "noa", sessionKind: "default" as const },
+    ];
+    const selectionCounts = new Map(entries.map((entry) => [entry.id, 0] as const));
+
+    for (let index = 0; index < 600; index += 1) {
+      const characterId = selectWeightedRandomLaunchCharacterId(
+        entries,
+        sessions,
+        () => (index + 0.5) / 600,
+      );
+      selectionCounts.set(characterId, (selectionCounts.get(characterId) ?? 0) + 1);
+    }
+
+    assert.ok((selectionCounts.get("yui") ?? 0) > (selectionCounts.get("noa") ?? 0));
+    assert.ok((selectionCounts.get("noa") ?? 0) > (selectionCounts.get("mia") ?? 0));
+    assert.equal(selectionCounts.get("archived"), 0);
+  });
+
+  it("random character selection はactive Characterがなければ空IDを返す", () => {
+    assert.equal(selectWeightedRandomLaunchCharacterId([], [], () => 0.5), "");
+  });
+
+  it("random character selection は利用履歴がなければactive Characterを均等に選ぶ", () => {
+    const entries = [
+      createCharacterEntry({ id: "mia", name: "Mia" }),
+      createCharacterEntry({ id: "noa", name: "Noa" }),
+    ];
+    const selectionCounts = new Map(entries.map((entry) => [entry.id, 0] as const));
+
+    for (let index = 0; index < 200; index += 1) {
+      const characterId = selectWeightedRandomLaunchCharacterId(
+        entries,
+        [],
+        () => (index + 0.5) / 200,
+      );
+      selectionCounts.set(characterId, (selectionCounts.get(characterId) ?? 0) + 1);
+    }
+
+    assert.deepEqual(Object.fromEntries(selectionCounts), { mia: 100, noa: 100 });
   });
 
   it("launch validation message は既存の優先順位で返す", () => {

--- a/src/HomeApp.tsx
+++ b/src/HomeApp.tsx
@@ -6,7 +6,10 @@ import {
 } from "./provider-settings-state.js";
 import { startAppSettingsSubscription } from "./app-settings-subscription.js";
 import { type SessionSummary } from "./session-state.js";
-import { startSessionSummariesSubscription } from "./session-summary-subscription.js";
+import {
+  startSessionSummariesSubscription,
+  type SessionSummariesLoadStatus,
+} from "./session-summary-subscription.js";
 import {
   type AuxiliarySessionSummary,
 } from "./auxiliary-session-state.js";
@@ -71,13 +74,22 @@ import { createHomeActiveAuxiliarySessionRefresher } from "./home/home-active-au
 
 type HomeRightPaneView = "monitor" | "characters";
 
+type HomeSessionSummariesState = {
+  status: SessionSummariesLoadStatus;
+  summaries: SessionSummary[];
+};
+
 export default function HomeApp() {
   const desktopRuntime = isDesktopRuntime();
   const homeWindowMode = useMemo(() => getHomeWindowMode(), []);
   const isMonitorWindowMode = homeWindowMode === "monitor";
   const isSettingsWindowMode = homeWindowMode === "settings";
   const isMemoryReviewWindowMode = homeWindowMode === "memory-review";
-  const [sessions, setSessions] = useState<SessionSummary[]>([]);
+  const [sessionSummariesState, setSessionSummariesState] = useState<HomeSessionSummariesState>({
+    status: "loading",
+    summaries: [],
+  });
+  const sessions = sessionSummariesState.summaries;
   const [companionSessions, setCompanionSessions] = useState<CompanionSessionSummary[]>([]);
   const [activeAuxiliarySessions, setActiveAuxiliarySessions] = useState<AuxiliarySessionSummary[]>([]);
   const [openSessionWindowIds, setOpenSessionWindowIds] = useState<string[]>([]);
@@ -137,6 +149,10 @@ export default function HomeApp() {
     }));
   };
 
+  const applyLoadedSessionSummaries = (summaries: SessionSummary[]) => {
+    setSessionSummariesState({ status: "loaded", summaries });
+  };
+
   const refreshCharacterEntries = async (
     api: NonNullable<ReturnType<typeof getWithMateApi>>,
   ): Promise<CharacterCatalogEntry[]> => {
@@ -167,6 +183,11 @@ export default function HomeApp() {
       setLaunchFeedback(error instanceof Error ? error.message : "Home の読み込みに失敗したよ。");
     };
 
+    const handleInitialSessionSummaryLoadError = (error: unknown) => {
+      setSessionSummariesState((current) => ({ ...current, status: "error" }));
+      handleInitialSummaryLoadError(error);
+    };
+
     let unsubscribeSessions: (() => void) | null = null;
     let unsubscribeCompanionSessions: (() => void) | null = null;
 
@@ -177,8 +198,8 @@ export default function HomeApp() {
 
       unsubscribeSessions = startSessionSummariesSubscription({
         api: withmateApi,
-        applySummaries: setSessions,
-        onInitialLoadError: handleInitialSummaryLoadError,
+        applySummaries: applyLoadedSessionSummaries,
+        onInitialLoadError: handleInitialSessionSummaryLoadError,
       });
       unsubscribeCompanionSessions = startCompanionSessionSummariesSubscription({
         api: withmateApi,
@@ -347,6 +368,7 @@ export default function HomeApp() {
       launchTitle: launchDraft.title,
       launchWorkspace: launchDraft.workspace,
       launchCharacterId: launchDraft.characterId,
+      launchCharacterSelectionMode: launchDraft.characterSelectionMode,
       characterEntries,
       charactersLoaded,
       appSettings,
@@ -385,6 +407,7 @@ export default function HomeApp() {
     characterEntries,
     selectedLaunchProviderId: selectedLaunchProvider?.id ?? null,
     sessions,
+    sessionSummariesLoadStatus: sessionSummariesState.status,
     refreshCharacterEntries: async () => {
       const api = getWithMateApi();
       if (!api) {
@@ -401,10 +424,13 @@ export default function HomeApp() {
     createSession: async (input) => await withWithMateApi((api) => api.createSession(input)),
     createCompanionSession: async (input) => await withWithMateApi((api) => api.createCompanionSession(input)),
     upsertSessionSummary: (summary) => {
-      setSessions((current) => [
-        summary,
-        ...current.filter((session) => session.id !== summary.id),
-      ]);
+      setSessionSummariesState((current) => ({
+        ...current,
+        summaries: [
+          summary,
+          ...current.summaries.filter((session) => session.id !== summary.id),
+        ],
+      }));
     },
     upsertCompanionSessionSummary: (summary) => {
       setCompanionSessions((current) => [
@@ -427,7 +453,7 @@ export default function HomeApp() {
     setMateCreating,
     setMateAvatarUpdating,
     setLaunchFeedback,
-    setSessions,
+    setSessions: applyLoadedSessionSummaries,
     setCompanionSessions,
   });
 
@@ -470,7 +496,7 @@ export default function HomeApp() {
       if (!api) {
         return;
       }
-      setSessions(await api.listSessionSummaries());
+      applyLoadedSessionSummaries(await api.listSessionSummaries());
     },
     onSettingsSaved: () => {
       const api = getWithMateApi();
@@ -584,6 +610,7 @@ export default function HomeApp() {
       onBrowseWorkspace: () => void homeLaunchHandlers.onBrowseWorkspace(),
       onSelectProvider: homeLaunchHandlers.onSelectLaunchProvider,
       onSelectCharacter: homeLaunchHandlers.onSelectLaunchCharacter,
+      onSelectRandomCharacter: homeLaunchHandlers.onSelectRandomLaunchCharacter,
       onStartSession: (mode) => void homeLaunchHandlers.onStartSession(mode),
     }),
   });

--- a/src/home/HomeLaunchDialog.tsx
+++ b/src/home/HomeLaunchDialog.tsx
@@ -7,6 +7,7 @@ import { buildCharacterThemeStyle } from "../theme-utils.js";
 import { CharacterAvatar } from "../ui-utils.js";
 import type { LaunchWorkspace } from "./home-launch-projection.js";
 import type { CharacterCatalogEntry } from "../character/character-catalog.js";
+import { DEFAULT_CHARACTER_THEME_COLORS } from "../character-state.js";
 
 export type HomeLaunchDialogProps = {
   open: boolean;
@@ -18,6 +19,7 @@ export type HomeLaunchDialogProps = {
   selectedLaunchProviderId: string | null;
   characterOptions: CharacterCatalogEntry[];
   selectedCharacterId: string | null;
+  randomCharacterSelected: boolean;
   charactersLoaded: boolean;
   canStartSession: boolean;
   launchFeedback: string;
@@ -28,6 +30,7 @@ export type HomeLaunchDialogProps = {
   onBrowseWorkspace: () => void;
   onSelectProvider: (providerId: string) => void;
   onSelectCharacter: (characterId: string) => void;
+  onSelectRandomCharacter: () => void;
   onStartSession: (mode: "session" | "companion") => void;
 };
 
@@ -41,6 +44,7 @@ export function HomeLaunchDialog({
   selectedLaunchProviderId,
   characterOptions,
   selectedCharacterId,
+  randomCharacterSelected,
   charactersLoaded,
   canStartSession,
   launchFeedback,
@@ -51,6 +55,7 @@ export function HomeLaunchDialog({
   onBrowseWorkspace,
   onSelectProvider,
   onSelectCharacter,
+  onSelectRandomCharacter,
   onStartSession,
 }: HomeLaunchDialogProps) {
   const titleInputRef = useRef<HTMLInputElement | null>(null);
@@ -173,6 +178,21 @@ export function HomeLaunchDialog({
                 focusRovingItemByKey(event, { orientation: "vertical", activateOnFocus: true });
               }}
             >
+              <button
+                className={`launch-character-option${randomCharacterSelected ? " selected" : ""}`}
+                type="button"
+                role="radio"
+                aria-checked={randomCharacterSelected}
+                tabIndex={randomCharacterSelected ? 0 : -1}
+                style={buildCharacterThemeStyle(DEFAULT_CHARACTER_THEME_COLORS)}
+                onClick={onSelectRandomCharacter}
+              >
+                <span className="character-avatar tiny" aria-hidden="true">R</span>
+                <span className="launch-character-copy">
+                  <strong>ランダム</strong>
+                  <span>最近使っていないCharacterを優先</span>
+                </span>
+              </button>
               {characterOptions.map((character) => (
                 <button
                   key={character.id}

--- a/src/home/home-launch-actions.ts
+++ b/src/home/home-launch-actions.ts
@@ -4,6 +4,7 @@ import type { CompanionSession, CompanionSessionSummary, CreateCompanionSessionI
 import { createCompanionSessionSummary } from "../companion-state.js";
 import type { MateProfile, MateStorageState } from "../mate/mate-state.js";
 import type { CreateSessionInput, SessionSummary } from "../session-state.js";
+import type { SessionSummariesLoadStatus } from "../session-summary-subscription.js";
 import { projectSessionSummary } from "../session-state.js";
 import {
   buildCreateCompanionSessionInputFromLaunchDraft,
@@ -26,6 +27,7 @@ export type StartHomeLaunchInput = {
   characterEntries: readonly CharacterCatalogEntry[];
   selectedProviderId: string | null;
   sessions: readonly SessionSummary[];
+  sessionSummariesLoadStatus: SessionSummariesLoadStatus;
   createSession: HomeLaunchSessionCreator;
   createCompanionSession: HomeLaunchCompanionSessionCreator;
   openSessionWindow: (sessionId: string) => Promise<void>;
@@ -35,6 +37,7 @@ export type StartHomeLaunchInput = {
   setLaunchStarting: (launchStarting: boolean) => void;
   upsertSessionSummary: (summary: SessionSummary) => void;
   upsertCompanionSessionSummary: (summary: CompanionSessionSummary) => void;
+  random?: () => number;
 };
 
 export async function startHomeLaunch(input: StartHomeLaunchInput): Promise<void> {
@@ -54,6 +57,15 @@ export async function startHomeLaunch(input: StartHomeLaunchInput): Promise<void
     return;
   }
 
+  if (input.draft.characterSelectionMode === "random" && input.sessionSummariesLoadStatus !== "loaded") {
+    input.setLaunchFeedback(
+      input.sessionSummariesLoadStatus === "loading"
+        ? "Session 履歴を読み込んでるよ。完了してからもう一度開始してね。"
+        : "Session 履歴を読み込めていないため、ランダム選択を開始できないよ。",
+    );
+    return;
+  }
+
   input.setLaunchFeedback(requestedMode === "companion" ? "Companion を開始してるよ..." : "Session を開始してるよ...");
   input.setLaunchStarting(true);
 
@@ -65,6 +77,8 @@ export async function startHomeLaunch(input: StartHomeLaunchInput): Promise<void
         mateProfile: input.mateProfile,
         selectedProviderId: input.selectedProviderId,
         characterEntries: input.characterEntries,
+        sessions: input.sessions,
+        random: input.random,
         lastUsedSelection,
       });
       if (!companionInput) {
@@ -90,6 +104,8 @@ export async function startHomeLaunch(input: StartHomeLaunchInput): Promise<void
       selectedProviderId: input.selectedProviderId,
       approvalMode: DEFAULT_APPROVAL_MODE,
       characterEntries: input.characterEntries,
+      sessions: input.sessions,
+      random: input.random,
       lastUsedSelection,
     });
     if (!sessionInput) {

--- a/src/home/home-launch-dialog-props.ts
+++ b/src/home/home-launch-dialog-props.ts
@@ -14,6 +14,7 @@ type HomeLaunchDialogPropsInput = {
   onBrowseWorkspace: () => void;
   onSelectProvider: (providerId: string) => void;
   onSelectCharacter: (characterId: string) => void;
+  onSelectRandomCharacter: () => void;
   onStartSession: (mode: HomeLaunchDraft["mode"]) => void;
 };
 
@@ -29,6 +30,7 @@ export function buildHomeLaunchDialogProps({
   onBrowseWorkspace,
   onSelectProvider,
   onSelectCharacter,
+  onSelectRandomCharacter,
   onStartSession,
 }: HomeLaunchDialogPropsInput): HomeLaunchDialogProps {
   return {
@@ -41,6 +43,7 @@ export function buildHomeLaunchDialogProps({
     selectedLaunchProviderId: projection.selectedLaunchProvider?.id ?? null,
     characterOptions: projection.characterOptions,
     selectedCharacterId: projection.selectedCharacter?.id ?? null,
+    randomCharacterSelected: projection.randomCharacterSelected,
     charactersLoaded: projection.charactersLoaded,
     canStartSession: projection.canStartSession && canUsePrimaryFeatures,
     launchFeedback,
@@ -51,6 +54,7 @@ export function buildHomeLaunchDialogProps({
     onBrowseWorkspace,
     onSelectProvider,
     onSelectCharacter,
+    onSelectRandomCharacter,
     onStartSession,
   };
 }

--- a/src/home/home-launch-handlers.ts
+++ b/src/home/home-launch-handlers.ts
@@ -4,6 +4,7 @@ import type { CreateSessionInput, SessionSummary } from "../session-state.js";
 import type { MateProfile, MateStorageState } from "../mate/mate-state.js";
 import type { CreateCompanionSessionInput, CompanionSession } from "../companion-state.js";
 import type { ModelCatalogProvider } from "../model-catalog.js";
+import type { SessionSummariesLoadStatus } from "../session-summary-subscription.js";
 import type { HomeLaunchDraft } from "./home-launch-state.js";
 import {
   closeLaunchDraft,
@@ -12,6 +13,7 @@ import {
   setLaunchWorkspaceFromPath,
   updateLaunchDraftForCharacterSelection,
   updateLaunchDraftForProviderSelection,
+  updateLaunchDraftForRandomCharacterSelection,
 } from "./home-launch-state.js";
 import { startHomeLaunch } from "./home-launch-actions.js";
 
@@ -24,6 +26,7 @@ type HomeLaunchHandlersContext = {
   characterEntries: readonly CharacterCatalogEntry[];
   selectedLaunchProviderId: string | null;
   sessions: readonly SessionSummary[];
+  sessionSummariesLoadStatus: SessionSummariesLoadStatus;
   refreshCharacterEntries: () => Promise<readonly CharacterCatalogEntry[]>;
   setLaunchFeedback: (message: string) => void;
   setLaunchStarting: (launchStarting: boolean) => void;
@@ -43,6 +46,7 @@ export type HomeLaunchHandlers = {
   onCloseLaunchDialog: () => void;
   onSelectLaunchProvider: (providerId: string) => void;
   onSelectLaunchCharacter: (characterId: string) => void;
+  onSelectRandomLaunchCharacter: () => void;
   onChangeMode: (mode: HomeLaunchDraft["mode"]) => void;
   onChangeTitle: (value: string) => void;
   onStartSession: (mode?: HomeLaunchDraft["mode"]) => void;
@@ -57,6 +61,7 @@ export function buildHomeLaunchHandlers({
   characterEntries,
   selectedLaunchProviderId,
   sessions,
+  sessionSummariesLoadStatus,
   refreshCharacterEntries,
   setLaunchFeedback,
   setLaunchStarting,
@@ -116,6 +121,7 @@ export function buildHomeLaunchHandlers({
       selectedProviderId: selectedLaunchProviderId,
       characterEntries,
       sessions,
+      sessionSummariesLoadStatus,
       createSession,
       createCompanionSession,
       openSessionWindow,
@@ -136,6 +142,10 @@ export function buildHomeLaunchHandlers({
     onSelectLaunchCharacter: (characterId) => {
       setLaunchFeedback("");
       setLaunchDraft((current) => updateLaunchDraftForCharacterSelection(current, characterId));
+    },
+    onSelectRandomLaunchCharacter: () => {
+      setLaunchFeedback("");
+      setLaunchDraft((current) => updateLaunchDraftForRandomCharacterSelection(current));
     },
     onChangeMode: (mode) => {
       setLaunchFeedback("");

--- a/src/home/home-launch-projection.ts
+++ b/src/home/home-launch-projection.ts
@@ -2,7 +2,10 @@ import type { CharacterCatalogEntry } from "../character/character-catalog.js";
 import type { ModelCatalogProvider, ModelCatalogSnapshot } from "../model-catalog.js";
 import { getProviderAppSettings, type AppSettings } from "../provider-settings-state.js";
 import { resolveSelectedLaunchProviderId } from "../launch/launch-provider-selection.js";
-import { resolveLaunchCharacterId } from "./home-launch-state.js";
+import {
+  resolveLaunchCharacterId,
+  type LaunchCharacterSelectionMode,
+} from "./home-launch-state.js";
 
 export type LaunchWorkspace = {
   label: string;
@@ -15,6 +18,7 @@ export type HomeLaunchProjection = {
   selectedLaunchProvider: ModelCatalogProvider | null;
   characterOptions: CharacterCatalogEntry[];
   selectedCharacter: CharacterCatalogEntry | null;
+  randomCharacterSelected: boolean;
   charactersLoaded: boolean;
   launchWorkspacePathLabel: string;
   canStartSession: boolean;
@@ -38,6 +42,7 @@ export function buildHomeLaunchProjection({
   launchTitle,
   launchWorkspace,
   launchCharacterId,
+  launchCharacterSelectionMode = "specific",
   characterEntries = [],
   charactersLoaded = true,
   appSettings,
@@ -48,6 +53,7 @@ export function buildHomeLaunchProjection({
   launchTitle: string;
   launchWorkspace: LaunchWorkspace | null;
   launchCharacterId?: string;
+  launchCharacterSelectionMode?: LaunchCharacterSelectionMode;
   characterEntries?: readonly CharacterCatalogEntry[];
   charactersLoaded?: boolean;
   appSettings: AppSettings;
@@ -61,14 +67,16 @@ export function buildHomeLaunchProjection({
     enabledLaunchProviders.find((provider) => provider.id === selectedLaunchProviderId) ?? null;
   const activeCharacterEntries = characterEntries.filter((character) => character.state === "active");
   const selectedCharacterId = resolveLaunchCharacterId(activeCharacterEntries, launchCharacterId);
-  const selectedCharacter =
-    activeCharacterEntries.find((character) => character.id === selectedCharacterId) ?? null;
+  const selectedCharacter = launchCharacterSelectionMode === "random"
+    ? null
+    : activeCharacterEntries.find((character) => character.id === selectedCharacterId) ?? null;
 
   return {
     enabledLaunchProviders,
     selectedLaunchProvider,
     characterOptions: [...activeCharacterEntries],
     selectedCharacter,
+    randomCharacterSelected: launchCharacterSelectionMode === "random",
     charactersLoaded,
     launchWorkspacePathLabel: launchWorkspace ? launchWorkspace.path : "workspace",
     canStartSession: charactersLoaded && !!launchTitle.trim() && !!launchWorkspace && !!selectedLaunchProvider,

--- a/src/home/home-launch-state.ts
+++ b/src/home/home-launch-state.ts
@@ -30,12 +30,17 @@ type LastUsedSessionSelectionSource = Pick<
   "provider" | "model" | "reasoningEffort" | "customAgentName"
 >;
 
+type CharacterUsageSessionSource = Pick<SessionSummary, "characterId" | "sessionKind">;
+
+export type LaunchCharacterSelectionMode = "specific" | "random";
+
 export type HomeLaunchDraft = {
   open: boolean;
   mode: "session" | "companion";
   title: string;
   workspace: LaunchWorkspace | null;
   providerId: string;
+  characterSelectionMode: LaunchCharacterSelectionMode;
   characterId: string;
   model: string;
   reasoningEffort: ModelReasoningEffort;
@@ -50,6 +55,7 @@ export function createClosedLaunchDraft(): HomeLaunchDraft {
     title: "",
     workspace: null,
     providerId: "",
+    characterSelectionMode: "specific",
     characterId: "",
     model: DEFAULT_MODEL_ID,
     reasoningEffort: DEFAULT_REASONING_EFFORT,
@@ -71,6 +77,7 @@ export function openLaunchDraft(
     title: "",
     workspace: null,
     providerId: defaultProviderId,
+    characterSelectionMode: "specific",
     characterId: defaultCharacterId,
     model: DEFAULT_MODEL_ID,
     reasoningEffort: DEFAULT_REASONING_EFFORT,
@@ -85,18 +92,22 @@ export function buildCreateCompanionSessionInputFromLaunchDraft({
   selectedProviderId,
   lastUsedSelection,
   characterEntries = [],
+  sessions = [],
+  random = Math.random,
 }: {
   draft: HomeLaunchDraft;
   mateProfile: MateProfile | null;
   selectedProviderId: string | null;
   lastUsedSelection?: Pick<CreateSessionInput, "model" | "reasoningEffort" | "customAgentName"> | null;
   characterEntries?: readonly CharacterCatalogEntry[];
+  sessions?: readonly CharacterUsageSessionSource[];
+  random?: () => number;
 }): CreateCompanionSessionInput | null {
   const normalizedTitle = draft.title.trim();
   if (!normalizedTitle || !draft.workspace || !selectedProviderId) {
     return null;
   }
-  const characterSnapshot = buildLaunchCharacterSnapshot(characterEntries, draft.characterId);
+  const characterSnapshot = buildLaunchCharacterSnapshot(characterEntries, draft, sessions, random);
 
   const companionModel = draft.mode === "companion"
     ? lastUsedSelection?.model ?? draft.model
@@ -129,6 +140,7 @@ export function closeLaunchDraft(draft: HomeLaunchDraft): HomeLaunchDraft {
     title: "",
     workspace: null,
     providerId: "",
+    characterSelectionMode: "specific",
     characterId: "",
   };
 }
@@ -165,7 +177,17 @@ export function updateLaunchDraftForCharacterSelection(
 ): HomeLaunchDraft {
   return {
     ...draft,
+    characterSelectionMode: "specific",
     characterId,
+  };
+}
+
+export function updateLaunchDraftForRandomCharacterSelection(
+  draft: HomeLaunchDraft,
+): HomeLaunchDraft {
+  return {
+    ...draft,
+    characterSelectionMode: "random",
   };
 }
 
@@ -220,6 +242,8 @@ export function buildCreateSessionInputFromLaunchDraft({
   approvalMode,
   lastUsedSelection,
   characterEntries = [],
+  sessions = [],
+  random = Math.random,
 }: {
   draft: HomeLaunchDraft;
   mateProfile: MateProfile | null;
@@ -227,12 +251,14 @@ export function buildCreateSessionInputFromLaunchDraft({
   approvalMode: ApprovalMode;
   lastUsedSelection?: Pick<CreateSessionInput, "model" | "reasoningEffort" | "customAgentName"> | null;
   characterEntries?: readonly CharacterCatalogEntry[];
+  sessions?: readonly CharacterUsageSessionSource[];
+  random?: () => number;
 }): CreateSessionInput | null {
   const normalizedTitle = draft.title.trim();
   if (!normalizedTitle || !draft.workspace || !selectedProviderId) {
     return null;
   }
-  const characterSnapshot = buildLaunchCharacterSnapshot(characterEntries, draft.characterId);
+  const characterSnapshot = buildLaunchCharacterSnapshot(characterEntries, draft, sessions, random);
 
   return {
     provider: selectedProviderId,
@@ -263,6 +289,50 @@ export function resolveLaunchCharacterId(
   return activeEntries[0]?.id ?? "";
 }
 
+export function selectWeightedRandomLaunchCharacterId(
+  entries: readonly CharacterCatalogEntry[],
+  sessionsByLastActiveDesc: readonly CharacterUsageSessionSource[],
+  random: () => number = Math.random,
+): string {
+  const activeEntries = entries.filter((entry) => entry.state === "active");
+  if (activeEntries.length === 0) {
+    return "";
+  }
+
+  const activeCharacterIds = new Set(activeEntries.map((entry) => entry.id));
+  const recencyRanks = new Map<string, number>();
+  for (const session of sessionsByLastActiveDesc) {
+    if (
+      session.sessionKind !== "default" ||
+      !activeCharacterIds.has(session.characterId) ||
+      recencyRanks.has(session.characterId)
+    ) {
+      continue;
+    }
+    recencyRanks.set(session.characterId, recencyRanks.size);
+  }
+
+  const weightedEntries = activeEntries.map((entry) => ({
+    entry,
+    weight: (recencyRanks.get(entry.id) ?? recencyRanks.size) + 1,
+  }));
+  const totalWeight = weightedEntries.reduce((total, candidate) => total + candidate.weight, 0);
+  const randomValue = random();
+  const normalizedRandomValue = Number.isFinite(randomValue)
+    ? Math.min(Math.max(randomValue, 0), 1 - Number.EPSILON)
+    : 0;
+  let remainingWeight = normalizedRandomValue * totalWeight;
+
+  for (const candidate of weightedEntries) {
+    remainingWeight -= candidate.weight;
+    if (remainingWeight < 0) {
+      return candidate.entry.id;
+    }
+  }
+
+  return weightedEntries.at(-1)?.entry.id ?? "";
+}
+
 function resolveLaunchCharacterEntry(
   entries: readonly CharacterCatalogEntry[],
   characterId: string | null | undefined,
@@ -273,8 +343,13 @@ function resolveLaunchCharacterEntry(
 
 function buildLaunchCharacterSnapshot(
   entries: readonly CharacterCatalogEntry[],
-  characterId: string | null | undefined,
+  draft: Pick<HomeLaunchDraft, "characterId" | "characterSelectionMode">,
+  sessions: readonly CharacterUsageSessionSource[],
+  random: () => number,
 ): LaunchCharacterSnapshot {
+  const characterId = draft.characterSelectionMode === "random"
+    ? selectWeightedRandomLaunchCharacterId(entries, sessions, random)
+    : draft.characterId;
   const character = resolveLaunchCharacterEntry(entries, characterId);
   if (!character) {
     return {

--- a/src/session-summary-subscription.ts
+++ b/src/session-summary-subscription.ts
@@ -1,5 +1,7 @@
 import type { SessionSummary } from "./session-state.js";
 
+export type SessionSummariesLoadStatus = "loading" | "loaded" | "error";
+
 export type SessionSummariesSubscriptionApi = {
   listSessionSummaries: () => Promise<SessionSummary[]>;
   subscribeSessionSummaries: (


### PR DESCRIPTION
## 概要

- New Session ダイアログの Character 一覧先頭にランダム選択を追加
- 通常 Session の最終利用順を使い、最近使っていない active Character ほど高い重みで抽選
- Agent と Companion の両方で同じ抽選処理を利用
- Session 履歴の未読み込み、成功0件、取得失敗を区別し、未読み込み・失敗時のランダム開始を防止
- アプリバージョンを `6.3.10` に更新

## 背景

Character の選択をアプリへ任せる導線を追加しつつ、完全な均等抽選より利用機会を分散させるためです。また、履歴ロード前や取得失敗後を履歴0件と誤認すると、既存履歴を反映できないため、ロード状態を明示的に管理します。

## 影響

- ランダム選択時は、履歴取得成功後に Session または Companion を開始します。
- 履歴取得に失敗していても、固定 Character の開始には影響しません。
- DB schema と Session summary API は変更しません。

## 検証

- `npm test`（1841 pass / 1 skip / 0 fail）
- `npm run typecheck`
- `npm run build:renderer`
- `git diff --check`

## 未実施

- Electron 実機での visual smoke
- Windows installer 作成