### PR TITLE
fix(memory): Memory CLI配布とSkillを同期する

### DIFF
--- a/docs/design/v6-memory-foundation.md
+++ b/docs/design/v6-memory-foundation.md
@@ -845,10 +845,10 @@ search監査は件数・latency・strategy程度に抑え、private query全文�
 - current実装では、Settingsで解決できるprovider skill rootへ起動時と設定保存後に`withmate-memory`を同期する。provider skill root未設定時はskipする。
 - WithMateが管理する場合はmanaged marker / versionを持つ。current実装では`.withmate-managed-skill.json`を持つ`withmate-memory`だけをapp version単位で更新する。
 - user-created同名Skillを無断上書きしない。
-- packaged CLI pathまたはshimをSkillが利用できるようにする。current実装ではWindowsのproviderへ同期するmanaged Skillは自己完結した`SKILL.md`とmanaged markerだけを持ち、CLI実体はinstalled app側のpackaged resourceをPATH shim経由で呼ぶ。Windowsではinstall rootの`withmate-memory.cmd`に加え、user PATH既定の`Microsoft\WindowsApps\withmate-memory.cmd` aliasをinstallerが作成する。installerはuser `Path` registry値を直接編集しない。macOS / LinuxではSettings > Diagnosticsから`~/.local/bin/withmate-memory` shimをinstall / uninstallできる。`~/.local/bin`がapp processの`PATH`に含まれてshimがusableな場合、providerへ同期するmanaged Skillは`SKILL.md`とmanaged markerだけになる。
+- packaged CLI pathまたはshimをSkillが利用できるようにする。packaged CLI helperはbuild時に`scripts/withmate-memory.ts`から生成し、canonical CLIと別実装として保守しない。current実装ではWindowsのproviderへ同期するmanaged Skillは`SKILL.md`、`reference/`、managed markerを持ち、`bin/`は省略してinstalled app側のpackaged resourceをPATH shim経由で呼ぶ。Windowsではinstall rootの`withmate-memory.cmd`に加え、user PATH既定の`Microsoft\WindowsApps\withmate-memory.cmd` aliasをinstallerが作成する。installerはuser `Path` registry値を直接編集しない。macOS / LinuxではSettings > Diagnosticsから`~/.local/bin/withmate-memory` shimをinstall / uninstallできる。`~/.local/bin`がapp processの`PATH`に含まれてshimがusableな場合も、providerへ同期するmanaged Skillは`SKILL.md`、`reference/`、managed markerを持ち、`bin/`だけを省略する。
 - Skill updateとapp versionの互換範囲を定義する。
 - Skill本文はCLI command、JSON schema、error recovery、when-to-use / when-not-to-useを説明する。
-- CLIそのもののreferenceはsource bundleの`reference/`配下にも残す。Windowsまたはusable PATH shimがあるproviderへ配布される`SKILL.md`だけで基本のCLI利用、JSON shape、error handlingが完結する。macOS / Linuxでshim未導入または`PATH`外の場合は、source bundleの`reference/`と`bin/`を同期対象に含め、`node bin/withmate-memory.mjs` fallbackを維持する。
+- CLIそのもののreferenceはsource bundleの`reference/`配下に残し、すべてのmanaged Skillへ同期する。`SKILL.md`は基本のCLI利用と判断基準を持ち、完全なrequest / response shape、file operation、error recoveryは`reference/`で補う。macOS / Linuxでshim未導入または`PATH`外の場合は`bin/`も同期対象に含め、`node bin/withmate-memory.mjs` fallbackを維持する。
 - Skill本体はMemoryを使うタイミング、search / get / append / forget / tagsの判断基準、inactive entryの扱いを説明する。
 - Skill本文やreferenceにはruntime secret、runtime discovery file pathを記載しない。
 - Settings Diagnosticsは、必要なproviderのuser-level instruction fileへ手動で貼り付けるためのprovider instruction sampleを表示し、clipboard copyできる。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "6.3.10",
+  "version": "6.3.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "6.3.10",
+      "version": "6.3.11",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "6.3.10",
+  "version": "6.3.11",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",
@@ -8,8 +8,9 @@
     "dev": "vite",
     "icon:generate": "node --import tsx scripts/generate-app-icon.ts",
     "stage:provider-binaries": "node --import tsx scripts/stage-provider-binaries.ts",
+    "build:memory-cli": "tsx scripts/build-withmate-memory-cli.ts",
     "build:renderer": "vite build",
-    "build:electron": "tsc -p tsconfig.electron.json",
+    "build:electron": "npm run build:memory-cli && tsc -p tsconfig.electron.json",
     "build": "npm run build:renderer && npm run build:electron",
     "electron:dev": "npm run build:electron && tsx scripts/run-electron-dev.ts",
     "electron:start": "npm run build && electron dist-electron/src-electron/main.js",

--- a/resources/skills/withmate-memory/SKILL.md
+++ b/resources/skills/withmate-memory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: withmate-memory
-description: Search, append, inspect, and forget WithMate V6 Memory through the installed WithMate Memory CLI when durable project context or cross-session Character continuity, including explicit relationship preferences, conversational distance, recurring topics, and memorable exchanges, could affect the task or conversation. After a command, test, build, tool, or environment failure, use it only when stored failure patterns, constraints, or workarounds could change the next action; do not trigger on a non-zero exit alone or for a deterministic correction supported by current evidence.
+description: Perform lightweight Memory reflection before every user-facing final response, and search, append, inspect, or forget WithMate V6 Memory through the installed CLI when concrete reusable project context or cross-session Character continuity is relevant. Reflection does not require CLI work when no candidate exists. After a command, test, build, tool, or environment failure, use stored Memory only when a known pattern, constraint, or workaround could change the next action.
 ---
 
 # WithMate Memory
@@ -19,9 +19,9 @@ Use Memory before making a durable project or character-sensitive decision when 
 
 Use Memory after an unexpected command, test, build, tool invocation, or environment check failure only when a known failure pattern, tooling trap, environment constraint, or workaround could affect the next action.
 
-A non-zero exit code alone is not a Memory trigger. Skip Memory search when current evidence fully explains the failure and determines a safe corrected action.
+A non-zero exit code alone is not a Memory trigger. Skip recall search when current evidence fully explains the failure and determines a safe corrected action.
 
-Do not search Memory on every turn. Skip it for trivial local edits or conversations where the current files and user message fully determine the answer.
+Do not run recall search on every turn. Skip recall for trivial local edits or conversations where the current files and user message fully determine the answer. The end-of-turn reflection below still applies to every user-facing turn.
 
 ## Principles
 
@@ -33,30 +33,63 @@ Do not search Memory on every turn. Skip it for trivial local edits or conversat
 - Keep unfinished state, unexecuted validation, and the next action in a handoff rather than Memory.
 - Search before relying on remembered project or Character decisions.
 - Use `get-entry` only for search hits whose exact body matters.
-- Append only future-useful decisions, constraints, conventions, preferences, context, or Character observations that will matter across sessions.
+- Append only decisions, constraints, conventions, preferences, context, or Character observations that could make later related work or conversation a little easier or more natural.
 - Correct or forget entries only when the user asks to remove, correct, or stop using remembered information.
 - Treat missing or unavailable Memory as non-blocking unless the user explicitly made Memory access the task.
+
+## Recall Search
+
+Use recall search only when stored context could affect the current task or make the current conversation naturally continue from a past one. Run it at the point the context is needed, with an explicit target. Do not turn end-of-turn reflection into routine recall.
+
+Treat routine search and read as background recall. Search results support the current task; they do not replace current repository sources of truth or the current user message. Inspect exact entry bodies only when the wording or rationale matters.
 
 ## Character Memory
 
 Treat Character Memory as an observation record for natural conversation continuity across sessions, not as a person profile or proof of facts.
 
-Save explicit relationship preferences, conversational distance, recurring topics, and memorable exchanges when they are likely to improve a future conversation. Preferred names, light inside jokes, interaction styles, and topics the user wants to continue are also candidates. The user does not need to say `remember` when the content is explicit, within the current conversation's scope, and clearly reusable across sessions.
+Treat explicit relationship preferences, conversational distance, preferred names, interaction styles, topics the user wants to continue, light inside jokes, shared episodes, and concrete reactions as candidates when they could make a later related conversation more natural.
 
-Do not save every conversation, temporary emotions, one-off acknowledgements, routine small talk, raw transcripts, or details with no likely future value. Keep explicit user statements separate from agent inference. Write observations as attributed context such as "The user said they prefer..." rather than converting them into unqualified facts.
+Do not require repeated mentions or an unusually memorable event. One explicit statement or one shared episode can be enough, and the user does not need to say `remember`, when the future conversational benefit is concrete and the content is within the current conversation's scope. Read-only requests and casual conversations can produce Character candidates under the same rule.
+
+Do not save every conversation, generic turn summaries, temporary emotions, one-off acknowledgements, routine small talk, raw transcripts, or details with no concrete future value. Keep explicit user statements separate from agent inference. Write observations as attributed context such as "The user said they prefer..." rather than converting them into unqualified facts.
 
 Do not infer romance, exclusivity, real-world relationships, attributes, or feelings from stored interactions. The current user message and current Character Definition take precedence over Memory. Never use Memory to overwrite or amend the Character Definition.
 
 Search Character Memory when the user asks about the past, or when a prior relationship preference, ongoing topic, or conversation episode could naturally improve the current response. Do not perform Character recall on every turn. If no relevant hit exists, do not invent one. If old Memory conflicts with the current user message, follow the current message and use the correction or forget flow when the user asks to change future behavior.
 
+## End-of-Turn Memory Reflection
+
+Before every user-facing final response, review the current turn and recent conversation for concrete Memory candidates. Reflection is required on every user-facing turn; Memory search and append are conditional.
+
+Apply these lenses independently:
+
+- **Project lens:** Look for repository-specific background, decisions, constraints, conventions, working preferences, reliable investigation results, workarounds, environment-specific context, or pointers to repository sources of truth that would make later work start, decisions, investigation, or explanation a little faster. Use a project target for repository-specific context and user-global only for provider-independent preferences or constraints.
+- **Character lens:** Look for relationship or conversational distance preferences, interaction style, preferred names, continuing topics, light inside jokes, shared episodes, or concrete reactions that would make a later related conversation a little more natural. Use character or character+project according to whether the context is project-specific.
+
+Keep repository-owned current state, expected behavior, contracts, and decision rationale in repository sources of truth. A project Memory entry may point to that source and preserve only useful non-source-of-truth context.
+
+If neither lens produces a concrete candidate, stop the reflection without searching or appending. Candidate absence is normal. Never append a generic summary of the turn.
+
+For each concrete candidate:
+
+1. Select its explicit project, user-global, character, or character+project target.
+2. Run an append preflight search against that target only to check for an existing duplicate or a possible correction.
+3. Inspect an exact hit only when needed to decide duplication, contradiction, correction, or supersession.
+4. Skip append when an existing active entry already expresses the candidate. If an active entry conflicts with the candidate, follow the current user message for this turn and do not append, change, supersede, or forget Memory unless the user explicitly requests a durable correction.
+5. Append only when the candidate passes Append Safety.
+
+Keep Project and Character candidates in separate entries when their targets differ. Candidates for the same target and one searchable topic may be combined into one concise entry.
+
+Recall search and append preflight search serve different purposes: recall informs the current task or response and remains optional; append preflight runs only after reflection finds a concrete candidate.
+
 ## Workflow
 
-1. Search first with an explicit target.
-2. Inspect only relevant hits with `get-entry` when exact wording or rationale matters.
-3. Use retrieved Memory as supporting context, not as a replacement for reading current repo files and source-of-truth docs.
-4. After a failure, diagnose it from current evidence first. Search Memory before retrying when the cause or safe next action remains uncertain, the same failure signature recurs, or the next attempt changes scope, subsystem, strategy, permissions, or environment assumptions. Skip search for a deterministic correction supported by current evidence.
-5. Append only future-useful facts, decisions, preferences, or attributed Character observations that pass Append Safety. Keep title and preview short, body precise, and tags reusable.
-6. If a failure reveals a reusable pattern or reliable workaround that is likely to matter in future sessions, append a concise Memory entry describing the failure signature, likely cause, and next-time guidance.
+1. Read current repository sources of truth and the current user message before relying on Memory.
+2. Use Recall Search with an explicit target only when stored context could affect the current task or conversation.
+3. After a failure, diagnose it from current evidence first. Search Memory before retrying when the cause or safe next action remains uncertain, the same failure signature recurs, or the next attempt changes scope, subsystem, strategy, permissions, or environment assumptions. Skip search for a deterministic correction supported by current evidence.
+4. Before the user-facing final response, perform End-of-Turn Memory Reflection.
+5. For each concrete candidate, run append preflight against its explicit target and append only if it is neither already represented nor in conflict with active Memory and passes Append Safety. Keep title and preview short, body precise, and tags reusable.
+6. If a failure reveals a reusable pattern or reliable workaround that is likely to matter in future sessions, treat it as a Project lens candidate with the failure signature, likely cause, and next-time guidance.
 7. Correct or forget entries when the user explicitly requests removal, correction, privacy cleanup, or no-longer-use semantics.
 8. If Memory is unavailable, continue the task unless Memory access itself is the requested task.
 
@@ -78,15 +111,16 @@ Prefer natural wording such as "Based on the previous decision..." or "For next 
 
 Before append, check:
 
-- Is this expected to matter in future sessions?
+- Would this make a later related task, decision, explanation, or conversation a little easier or more natural?
 - Is it a decision, constraint, convention, preference, reusable context, or explicit Character observation rather than transient progress?
-- If the user did not say `remember`, is the content nevertheless explicit, in scope, and clearly useful for future project work or conversation continuity?
+- If the user did not say `remember`, is the content nevertheless explicit, in scope, and concretely useful for future project work or conversation continuity?
 - Does the entry attribute what the user actually said and avoid converting an agent inference into a fact?
 - Does it avoid secrets, tokens, private paths, raw logs, large diffs, and speculative claims?
 - Is the target explicit and correct?
+- Does it avoid creating a second active entry that conflicts with existing Memory?
 - Would a future agent understand the entry from title, preview, body, and tags alone?
 
-Do not append all conversation by default. Require explicit user intent before saving an inference, saving content outside the current task or conversation scope, or changing an existing Memory entry.
+Do not append all conversation by default. Require explicit user intent before saving an inference, saving content outside the current task or conversation scope, changing an existing Memory entry, or appending a conflicting replacement.
 
 When correcting a previous entry, inspect the exact entry, then append a replacement with `supersedes` instead of creating ambiguous duplicates when possible. Use `forget` when the user explicitly requests removal rather than replacement. Keep the same semantic target unless the user is also correcting the scope.
 
@@ -98,12 +132,15 @@ Run the installed command with an explicit target:
 withmate-memory --help
 withmate-memory status
 withmate-memory characters
+withmate-memory file-usage --largest --limit 20
 withmate-memory schema
 withmate-memory validate --command append --stdin
 withmate-memory search --project <absolute-repo-path> --query "delivery cleanup" --tag delivery-cleanup
 withmate-memory search --project <absolute-repo-path> --tags topic:delivery-cleanup,topic:relaygraph
 withmate-memory search --file memory-search.json
 withmate-memory get-entry --file memory-get-entry.json
+withmate-memory get-file --project <absolute-repo-path> --object-id <object-id> --output <absolute-output-path>
+withmate-memory export-files --project <absolute-repo-path> --entry-id <entry-id> --output-dir <absolute-output-directory>
 withmate-memory list-tags --file memory-list-tags.json
 withmate-memory append --file memory-entry.json
 withmate-memory forget --file forget-request.json
@@ -114,6 +151,8 @@ Commands write one JSON object to stdout, except `--help`, `-h`, and `help`, whi
 For commands that require a request body, prefer `--stdin` or `--file <path>`. Inline `--json` is supported, but it is shell-sensitive. On Windows PowerShell or `.cmd` wrappers, double quotes inside JSON can be consumed before the CLI receives the argument. If `--json` fails with invalid JSON or a CLI usage error, pipe the request through `--stdin`, or write it to a temporary JSON file and retry with `--file`.
 
 If `withmate-memory` is not found and `bin/withmate-memory.mjs` exists in this skill directory, replace `withmate-memory` with `node bin/withmate-memory.mjs` in the commands above.
+
+Read [reference/cli.md](reference/cli.md) before attaching or exporting files, or when complete request and failure details matter.
 
 PowerShell example:
 
@@ -157,13 +196,18 @@ withmate-memory validate --command append --stdin
   "targets": [
     { "owner": "project", "project": { "type": "path", "path": "<absolute-repo-path>" }, "scope": "project" }
   ],
-  "query": "approval mode"
+  "query": "approval mode",
+  "kinds": ["decision", "constraint"],
+  "limit": 20,
+  "cursor": "<nextCursor-from-prior-response>"
 }
 ```
 
 Search supports natural-language terms across title, preview, body, and tags. Hyphenated and spaced tag words such as `delivery-cleanup` and `delivery cleanup` are treated as related candidates. Shorthand `--tag <tag>` defaults to `topic:<tag>`, and `--tags` accepts comma-separated `<type>:<tag>` values.
 
 Search results may include `match` on each hit with matched fields and a short snippet. `match.fields` can report body matches, but snippets are limited to tags, title, and preview; use `get-entry` when the exact body matters. When no entries match, the response may include `relatedTags`.
+
+Omit `cursor` on the first request. If a response has `nextCursor` and the needed entry or append-preflight duplicate has not been resolved, repeat the same search options with that cursor before concluding that no relevant entry exists.
 
 For provider-independent user preferences, conventions, constraints, or other cross-project context, use an explicit user-global target:
 
@@ -209,9 +253,19 @@ For provider-independent user preferences, conventions, constraints, or other cr
   "body": "Durable details for future sessions.",
   "preview": "Short preview.",
   "tags": [{ "type": "topic", "value": "release" }],
+  "supersedes": ["optional-replaced-entry-id"],
+  "files": [
+    {
+      "path": "<absolute-readable-file-path>",
+      "role": "evidence",
+      "summary": "Why this file is retained."
+    }
+  ],
   "idempotencyKey": "optional-stable-key"
 }
 ```
+
+`supersedes` is an array of entry IDs. Use it only for an explicitly authorized correction. `files` is optional; each file needs an absolute path and non-empty summary. Valid roles are `evidence`, `source`, `snapshot`, `artifact`, `reference`, and `other`; `displayName` and `contentType` are optional.
 
 `forget`:
 
@@ -225,14 +279,44 @@ For provider-independent user preferences, conventions, constraints, or other cr
 }
 ```
 
+Choose a stable `idempotencyKey` before the first `append` or `forget` attempt. After a timeout or response loss, retry the unchanged request with the same key. Use a new key when the request body changes.
+
+### Protected Files
+
+`file-usage` is read-only and requires no target. Use `--largest --limit <n>` to include the largest active entry candidates. It returns aggregate metadata, not file paths or decrypted content.
+
+`get-file` exports one object to an explicit absolute output path:
+
+```json
+{
+  "schemaVersion": "withmate-memory-v1",
+  "target": { "owner": "project", "project": { "type": "path", "path": "<absolute-repo-path>" }, "scope": "project" },
+  "objectId": "<object-id>",
+  "outputPath": "<absolute-output-path>"
+}
+```
+
+`export-files` exports every file attached to one entry into an explicit absolute directory:
+
+```json
+{
+  "schemaVersion": "withmate-memory-v1",
+  "target": { "owner": "project", "project": { "type": "path", "path": "<absolute-repo-path>" }, "scope": "project" },
+  "entryId": "<entry-id>",
+  "outputDirectoryPath": "<absolute-output-directory>"
+}
+```
+
+Do not attach secrets or files outside the user's authorized scope. File append is atomic with entry creation: quota, import, or persistence failure must not be treated as a text-only success. Export verifies the explicit target and never overwrites an existing output file. `append`, `get-file`, and `export-files` may run for up to 300 seconds by default; do not assume a timeout means that a mutation had no effect.
+
 ### Exit Codes
 
 | Code | Meaning |
 | --- | --- |
 | `0` | Success |
-| `1` | Usage or validation error |
+| `1` | CLI usage or argument error |
 | `2` | WithMate Memory API is not running or could not be discovered |
-| `3` | Runtime API returned a non-success JSON response |
+| `3` | Local request validation failed, or the runtime API returned a non-success JSON response |
 | `4` | Transport failure |
 
 ## Target Selection

--- a/resources/skills/withmate-memory/bin/withmate-memory.mjs
+++ b/resources/skills/withmate-memory/bin/withmate-memory.mjs
@@ -1,43 +1,815 @@
-#!/usr/bin/env node
+// Generated from scripts/withmate-memory.ts. Do not edit directly.
 import { createHmac, randomBytes } from "node:crypto";
 import { readFile } from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-
-const schemaVersion = "withmate-memory-v1";
-const discoverySchemaVersion = "withmate-memory-discovery-v1";
-const discoveryFileName = "memory-v6-api.json";
-const apiSecretHeader = "x-withmate-memory-api-secret";
-const entryKinds = [
-  "decision",
-  "constraint",
-  "convention",
-  "context",
-  "deferred",
-  "preference",
-  "relationship",
-  "boundary",
-  "note",
+import { pathToFileURL } from "node:url";
+import { tmpdir } from "node:os";
+//#region src/memory-v6/memory-contract.ts
+var MEMORY_V6_SCHEMA_VERSION = "withmate-memory-v1";
+var MEMORY_ENTRY_KINDS = [
+	"decision",
+	"constraint",
+	"convention",
+	"context",
+	"deferred",
+	"preference",
+	"relationship",
+	"boundary",
+	"note"
 ];
-const forgetReasons = ["user_request", "incorrect", "outdated", "privacy", "other"];
-
-const exitCodes = {
-  ok: 0,
-  usage: 1,
-  notRunning: 2,
-  apiError: 3,
-  transportError: 4,
+var MEMORY_APPEND_FILE_ROLES = [
+	"evidence",
+	"source",
+	"snapshot",
+	"artifact",
+	"reference",
+	"other"
+];
+var MEMORY_FORGET_REASONS = [
+	"user_request",
+	"incorrect",
+	"outdated",
+	"privacy",
+	"other"
+];
+//#endregion
+//#region src/memory-v6/memory-discovery.ts
+var WITHMATE_MEMORY_DISCOVERY_SCHEMA_VERSION = "withmate-memory-discovery-v1";
+var WITHMATE_MEMORY_DISCOVERY_FILE_NAME = "memory-v6-api.json";
+function isLoopbackHostname(hostname) {
+	const normalized = hostname.toLowerCase();
+	if (normalized === "localhost" || normalized === "::1" || normalized === "[::1]") return true;
+	const ipv4Parts = normalized.split(".");
+	return ipv4Parts.length === 4 && ipv4Parts[0] === "127" && ipv4Parts.every((part) => /^\d+$/.test(part) && Number(part) <= 255);
+}
+function normalizeWithMateMemoryApiBaseUrl(value) {
+	const trimmed = value.trim();
+	if (!trimmed) return null;
+	try {
+		const url = new URL(trimmed);
+		if (url.protocol !== "http:" || !isLoopbackHostname(url.hostname)) return null;
+		url.pathname = url.pathname.replace(/\/+$/, "");
+		url.search = "";
+		url.hash = "";
+		return url.toString().replace(/\/$/, "");
+	} catch {
+		return null;
+	}
+}
+function resolveDefaultWithMateMemoryRuntimeDirectory(env = process.env) {
+	const runtimeDirectoryPath = env.WITHMATE_MEMORY_RUNTIME_DIR?.trim();
+	if (runtimeDirectoryPath) return path.resolve(runtimeDirectoryPath);
+	const ownerSegment = typeof process.getuid === "function" ? `uid-${process.getuid()}` : "local-user";
+	return path.join(tmpdir(), "withmate-memory", ownerSegment);
+}
+function resolveDefaultWithMateMemoryDiscoveryFilePath(env = process.env) {
+	return path.join(resolveDefaultWithMateMemoryRuntimeDirectory(env), WITHMATE_MEMORY_DISCOVERY_FILE_NAME);
+}
+//#endregion
+//#region src/memory-v6/memory-response-contract.ts
+function createMemoryErrorResponse(error) {
+	return {
+		schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+		error
+	};
+}
+//#endregion
+//#region src/memory-v6/memory-validation.ts
+var MEMORY_ENTRY_KIND_SET = new Set(MEMORY_ENTRY_KINDS);
+var MEMORY_APPEND_FILE_ROLE_SET = new Set(MEMORY_APPEND_FILE_ROLES);
+var MEMORY_FORGET_REASON_SET = new Set(MEMORY_FORGET_REASONS);
+var SEARCH_REQUEST_KEYS = /* @__PURE__ */ new Set([
+	"schemaVersion",
+	"targets",
+	"query",
+	"kinds",
+	"tags",
+	"limit",
+	"cursor"
+]);
+var GET_ENTRY_REQUEST_KEYS = /* @__PURE__ */ new Set([
+	"schemaVersion",
+	"entryId",
+	"target"
+]);
+var GET_FILE_REQUEST_KEYS = /* @__PURE__ */ new Set([
+	"schemaVersion",
+	"target",
+	"objectId",
+	"outputPath"
+]);
+var EXPORT_FILES_REQUEST_KEYS = /* @__PURE__ */ new Set([
+	"schemaVersion",
+	"target",
+	"entryId",
+	"outputDirectoryPath"
+]);
+var LIST_TAGS_REQUEST_KEYS = /* @__PURE__ */ new Set(["schemaVersion", "targets"]);
+var APPEND_REQUEST_KEYS = /* @__PURE__ */ new Set([
+	"schemaVersion",
+	"target",
+	"kind",
+	"title",
+	"body",
+	"preview",
+	"tags",
+	"supersedes",
+	"files",
+	"sourceMessageId",
+	"idempotencyKey"
+]);
+var FORGET_REQUEST_KEYS = /* @__PURE__ */ new Set([
+	"schemaVersion",
+	"target",
+	"entryIds",
+	"reason",
+	"sourceMessageId",
+	"idempotencyKey"
+]);
+var PROJECT_TARGET_ID_KEYS = /* @__PURE__ */ new Set(["type", "id"]);
+var PROJECT_TARGET_PATH_KEYS = /* @__PURE__ */ new Set(["type", "path"]);
+var CHARACTER_TARGET_ID_KEYS = /* @__PURE__ */ new Set(["type", "id"]);
+var MEMORY_TAG_KEYS = /* @__PURE__ */ new Set(["type", "value"]);
+var APPEND_FILE_KEYS = /* @__PURE__ */ new Set([
+	"path",
+	"summary",
+	"role",
+	"displayName",
+	"contentType"
+]);
+var PROJECT_PROJECT_TARGET_KEYS = /* @__PURE__ */ new Set([
+	"owner",
+	"scope",
+	"project"
+]);
+var CHARACTER_CHARACTER_TARGET_KEYS = /* @__PURE__ */ new Set([
+	"owner",
+	"scope",
+	"character"
+]);
+var CHARACTER_PROJECT_TARGET_KEYS = /* @__PURE__ */ new Set([
+	"owner",
+	"scope",
+	"character",
+	"project"
+]);
+var USER_GLOBAL_TARGET_KEYS = /* @__PURE__ */ new Set(["owner", "scope"]);
+var MAX_SEARCH_QUERY_LENGTH = 500;
+var MAX_TITLE_LENGTH = 160;
+var MAX_PREVIEW_LENGTH = 280;
+var MAX_BODY_LENGTH = 8e3;
+var MAX_TAG_TYPE_LENGTH = 48;
+var MAX_TAG_VALUE_LENGTH = 96;
+var MAX_ID_LENGTH = 200;
+var MAX_CURSOR_LENGTH = 500;
+var MAX_LIMIT = 50;
+var MAX_TAGS = 20;
+var MAX_SUPERSEDES = 20;
+var MAX_APPEND_FILES = 10;
+var MAX_FILE_PATH_LENGTH = 1e3;
+var MAX_OBJECT_ID_LENGTH = 64;
+var MAX_FILE_SUMMARY_LENGTH = 500;
+var MAX_FILE_DISPLAY_NAME_LENGTH = 255;
+var MAX_FILE_CONTENT_TYPE_LENGTH = 120;
+var MAX_FORGET_ENTRY_IDS = 50;
+var MAX_TARGETS = 5;
+function error(code, message, field) {
+	return {
+		ok: false,
+		error: field ? {
+			code,
+			message,
+			field
+		} : {
+			code,
+			message
+		}
+	};
+}
+function isRecord(value) {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function rejectUnknownKeys(value, allowedKeys, field) {
+	for (const key of Object.keys(value)) if (!allowedKeys.has(key)) return error("MEMORY_UNKNOWN_FIELD", `Unknown field: ${field}.${key}`, `${field}.${key}`);
+	return {
+		ok: true,
+		value: void 0
+	};
+}
+function hasUnpairedSurrogate(value) {
+	for (let index = 0; index < value.length; index += 1) {
+		const code = value.charCodeAt(index);
+		if (code >= 55296 && code <= 56319) {
+			const next = value.charCodeAt(index + 1);
+			if (!(next >= 56320 && next <= 57343)) return true;
+			index += 1;
+			continue;
+		}
+		if (code >= 56320 && code <= 57343) return true;
+	}
+	return false;
+}
+function canonicalizeMemoryTagPart(value) {
+	return value.normalize("NFC").toLowerCase();
+}
+function normalizeText(value, field, options) {
+	if (typeof value !== "string") {
+		if (options.required === false && value === void 0) return {
+			ok: true,
+			value: ""
+		};
+		return error("MEMORY_INVALID_FIELD", `${field} must be a string.`, field);
+	}
+	if (value.includes("\0")) return error("MEMORY_INVALID_FIELD", `${field} must not contain null bytes.`, field);
+	if (hasUnpairedSurrogate(value)) return error("MEMORY_INVALID_FIELD", `${field} must be well-formed Unicode.`, field);
+	const normalized = value.trim();
+	if (options.required !== false && normalized.length === 0) return error("MEMORY_INVALID_FIELD", `${field} must not be empty.`, field);
+	if (normalized.length > options.maxLength) return error("MEMORY_FIELD_TOO_LARGE", `${field} is too long.`, field);
+	return {
+		ok: true,
+		value: normalized
+	};
+}
+function normalizeAbsolutePath(value, field) {
+	const normalized = normalizeText(value, field, { maxLength: MAX_FILE_PATH_LENGTH });
+	if (!normalized.ok) return normalized;
+	if (!isAbsolutePathLike(normalized.value)) return error("MEMORY_INVALID_FIELD", `${field} must be an absolute path.`, field);
+	return normalized;
+}
+function isAbsolutePathLike(value) {
+	return value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value) || /^\\\\/.test(value);
+}
+function normalizeOptionalText(value, field, maxLength = MAX_ID_LENGTH) {
+	if (value === void 0) return {
+		ok: true,
+		value: void 0
+	};
+	const normalized = normalizeText(value, field, { maxLength });
+	if (!normalized.ok) return normalized;
+	return {
+		ok: true,
+		value: normalized.value
+	};
+}
+function validateSchemaVersion(value) {
+	if (value.schemaVersion !== "withmate-memory-v1") return error("MEMORY_INVALID_SCHEMA_VERSION", "Unsupported memory schemaVersion.", "schemaVersion");
+	return {
+		ok: true,
+		value: void 0
+	};
+}
+function normalizeStringArray(value, field, options) {
+	if (value === void 0) return {
+		ok: true,
+		value: void 0
+	};
+	if (!Array.isArray(value)) return error("MEMORY_INVALID_FIELD", `${field} must be an array.`, field);
+	if (value.length > options.maxItems) return error("MEMORY_FIELD_TOO_LARGE", `${field} has too many items.`, field);
+	const normalized = [];
+	const seen = /* @__PURE__ */ new Set();
+	for (let index = 0; index < value.length; index += 1) {
+		const item = normalizeText(value[index], `${field}[${index}]`, { maxLength: options.maxLength });
+		if (!item.ok) return item;
+		if (seen.has(item.value)) continue;
+		seen.add(item.value);
+		normalized.push(item.value);
+	}
+	return {
+		ok: true,
+		value: normalized
+	};
+}
+function validateMemoryKind(value, field) {
+	if (typeof value !== "string" || !MEMORY_ENTRY_KIND_SET.has(value)) return error("MEMORY_INVALID_FIELD", `${field} must be a valid memory kind.`, field);
+	return {
+		ok: true,
+		value
+	};
+}
+function validateAppendFileRole(value, field) {
+	if (value === void 0) return {
+		ok: true,
+		value: void 0
+	};
+	if (typeof value !== "string" || !MEMORY_APPEND_FILE_ROLE_SET.has(value)) return error("MEMORY_INVALID_FIELD", `${field} must be a valid file role.`, field);
+	return {
+		ok: true,
+		value
+	};
+}
+function normalizeAppendFiles(value) {
+	if (value === void 0) return {
+		ok: true,
+		value: void 0
+	};
+	if (!Array.isArray(value)) return error("MEMORY_INVALID_FIELD", "files must be an array.", "files");
+	if (value.length === 0) return {
+		ok: true,
+		value: void 0
+	};
+	if (value.length > MAX_APPEND_FILES) return error("MEMORY_FIELD_TOO_LARGE", `files supports at most ${MAX_APPEND_FILES} items.`, "files");
+	const normalized = [];
+	for (let index = 0; index < value.length; index += 1) {
+		const file = value[index];
+		const field = `files[${index}]`;
+		if (!isRecord(file)) return error("MEMORY_INVALID_FIELD", `${field} must be an object.`, field);
+		const unknownKeys = rejectUnknownKeys(file, APPEND_FILE_KEYS, field);
+		if (!unknownKeys.ok) return unknownKeys;
+		const filePath = normalizeAbsolutePath(file.path, `${field}.path`);
+		if (!filePath.ok) return filePath;
+		const summary = normalizeText(file.summary, `${field}.summary`, { maxLength: MAX_FILE_SUMMARY_LENGTH });
+		if (!summary.ok) return summary;
+		const role = validateAppendFileRole(file.role, `${field}.role`);
+		if (!role.ok) return role;
+		const displayName = normalizeOptionalText(file.displayName, `${field}.displayName`, MAX_FILE_DISPLAY_NAME_LENGTH);
+		if (!displayName.ok) return displayName;
+		const contentType = normalizeOptionalText(file.contentType, `${field}.contentType`, MAX_FILE_CONTENT_TYPE_LENGTH);
+		if (!contentType.ok) return contentType;
+		normalized.push({
+			path: filePath.value,
+			summary: summary.value,
+			...role.value !== void 0 ? { role: role.value } : {},
+			...displayName.value !== void 0 ? { displayName: displayName.value } : {},
+			...contentType.value !== void 0 ? { contentType: contentType.value } : {}
+		});
+	}
+	return {
+		ok: true,
+		value: normalized
+	};
+}
+function normalizeProjectTarget(value, field) {
+	if (!isRecord(value)) return error("MEMORY_INVALID_FIELD", `${field} must be an object.`, field);
+	if (value.type === "id") {
+		const unknownKeys = rejectUnknownKeys(value, PROJECT_TARGET_ID_KEYS, field);
+		if (!unknownKeys.ok) return unknownKeys;
+		const id = normalizeText(value.id, `${field}.id`, { maxLength: MAX_ID_LENGTH });
+		return id.ok ? {
+			ok: true,
+			value: {
+				type: "id",
+				id: id.value
+			}
+		} : id;
+	}
+	if (value.type === "path") {
+		const unknownKeys = rejectUnknownKeys(value, PROJECT_TARGET_PATH_KEYS, field);
+		if (!unknownKeys.ok) return unknownKeys;
+		const projectPath = normalizeText(value.path, `${field}.path`, { maxLength: 1e3 });
+		return projectPath.ok ? {
+			ok: true,
+			value: {
+				type: "path",
+				path: projectPath.value
+			}
+		} : projectPath;
+	}
+	return error("MEMORY_INVALID_FIELD", `${field}.type must be id or path.`, `${field}.type`);
+}
+function normalizeCharacterTarget(value, field) {
+	if (!isRecord(value)) return error("MEMORY_INVALID_FIELD", `${field} must be an object.`, field);
+	if (value.type === "id") {
+		const unknownKeys = rejectUnknownKeys(value, CHARACTER_TARGET_ID_KEYS, field);
+		if (!unknownKeys.ok) return unknownKeys;
+		const id = normalizeText(value.id, `${field}.id`, { maxLength: MAX_ID_LENGTH });
+		return id.ok ? {
+			ok: true,
+			value: {
+				type: "id",
+				id: id.value
+			}
+		} : id;
+	}
+	return error("MEMORY_INVALID_FIELD", `${field}.type must be id.`, `${field}.type`);
+}
+function normalizeMemoryTarget(value, field) {
+	if (!isRecord(value)) return error("MEMORY_INVALID_FIELD", `${field} must be an object.`, field);
+	if (value.owner === "user" && value.scope === "global") {
+		const unknownKeys = rejectUnknownKeys(value, USER_GLOBAL_TARGET_KEYS, field);
+		if (!unknownKeys.ok) return unknownKeys;
+		return {
+			ok: true,
+			value: {
+				owner: "user",
+				scope: "global"
+			}
+		};
+	}
+	if (value.owner === "project" && value.scope === "project") {
+		const unknownKeys = rejectUnknownKeys(value, PROJECT_PROJECT_TARGET_KEYS, field);
+		if (!unknownKeys.ok) return unknownKeys;
+		const project = normalizeProjectTarget(value.project, `${field}.project`);
+		return project.ok ? {
+			ok: true,
+			value: {
+				owner: "project",
+				scope: "project",
+				project: project.value
+			}
+		} : project;
+	}
+	if (value.owner === "character" && value.scope === "character") {
+		const unknownKeys = rejectUnknownKeys(value, CHARACTER_CHARACTER_TARGET_KEYS, field);
+		if (!unknownKeys.ok) return unknownKeys;
+		const character = normalizeCharacterTarget(value.character, `${field}.character`);
+		return character.ok ? {
+			ok: true,
+			value: {
+				owner: "character",
+				scope: "character",
+				character: character.value
+			}
+		} : character;
+	}
+	if (value.owner === "character" && value.scope === "project") {
+		const unknownKeys = rejectUnknownKeys(value, CHARACTER_PROJECT_TARGET_KEYS, field);
+		if (!unknownKeys.ok) return unknownKeys;
+		const character = normalizeCharacterTarget(value.character, `${field}.character`);
+		if (!character.ok) return character;
+		const project = normalizeProjectTarget(value.project, `${field}.project`);
+		return project.ok ? {
+			ok: true,
+			value: {
+				owner: "character",
+				scope: "project",
+				character: character.value,
+				project: project.value
+			}
+		} : project;
+	}
+	return error("MEMORY_INVALID_TARGET", "Unsupported memory owner / scope combination.", field);
+}
+function normalizeTargets(value) {
+	if (!Array.isArray(value) || value.length === 0) return error("MEMORY_TARGET_REQUIRED", "At least one memory target is required.", "targets");
+	if (value.length > MAX_TARGETS) return error("MEMORY_FIELD_TOO_LARGE", `targets supports at most ${MAX_TARGETS} items.`, "targets");
+	const normalized = [];
+	const seen = /* @__PURE__ */ new Set();
+	for (let index = 0; index < value.length; index += 1) {
+		const target = normalizeMemoryTarget(value[index], `targets[${index}]`);
+		if (!target.ok) return target;
+		const key = JSON.stringify(target.value);
+		if (seen.has(key)) return error("MEMORY_DUPLICATE_TARGET", "targets must not contain duplicates.", `targets[${index}]`);
+		seen.add(key);
+		normalized.push(target.value);
+	}
+	return {
+		ok: true,
+		value: normalized
+	};
+}
+function normalizeTags(value, field = "tags", options = {}) {
+	if (value === void 0) {
+		if (options.required) return error("MEMORY_INVALID_FIELD", `${field} is required.`, field);
+		return {
+			ok: true,
+			value: []
+		};
+	}
+	if (!Array.isArray(value)) return error("MEMORY_INVALID_FIELD", `${field} must be an array.`, field);
+	if (value.length > MAX_TAGS) return error("MEMORY_FIELD_TOO_LARGE", `${field} has too many items.`, field);
+	const normalized = [];
+	const seen = /* @__PURE__ */ new Set();
+	for (let index = 0; index < value.length; index += 1) {
+		const tag = value[index];
+		if (!isRecord(tag)) return error("MEMORY_INVALID_FIELD", `${field}[${index}] must be an object.`, `${field}[${index}]`);
+		const unknownKeys = rejectUnknownKeys(tag, MEMORY_TAG_KEYS, `${field}[${index}]`);
+		if (!unknownKeys.ok) return unknownKeys;
+		const type = normalizeText(tag.type, `${field}[${index}].type`, { maxLength: MAX_TAG_TYPE_LENGTH });
+		if (!type.ok) return type;
+		const tagValue = normalizeText(tag.value, `${field}[${index}].value`, { maxLength: MAX_TAG_VALUE_LENGTH });
+		if (!tagValue.ok) return tagValue;
+		const canonicalType = canonicalizeMemoryTagPart(type.value);
+		const canonicalValue = canonicalizeMemoryTagPart(tagValue.value);
+		const key = `${canonicalType}\0${canonicalValue}`;
+		if (seen.has(key)) continue;
+		seen.add(key);
+		normalized.push({
+			type: type.value,
+			value: tagValue.value,
+			canonicalType,
+			canonicalValue
+		});
+	}
+	return {
+		ok: true,
+		value: normalized
+	};
+}
+function normalizeKinds(value) {
+	if (value === void 0) return {
+		ok: true,
+		value: void 0
+	};
+	if (!Array.isArray(value)) return error("MEMORY_INVALID_FIELD", "kinds must be an array.", "kinds");
+	if (value.length > MEMORY_ENTRY_KINDS.length) return error("MEMORY_FIELD_TOO_LARGE", "kinds has too many items.", "kinds");
+	const normalized = [];
+	const seen = /* @__PURE__ */ new Set();
+	for (let index = 0; index < value.length; index += 1) {
+		const kind = validateMemoryKind(value[index], `kinds[${index}]`);
+		if (!kind.ok) return kind;
+		if (seen.has(kind.value)) continue;
+		seen.add(kind.value);
+		normalized.push(kind.value);
+	}
+	return {
+		ok: true,
+		value: normalized.length > 0 ? normalized : void 0
+	};
+}
+function validateMemorySearchRequest(value) {
+	if (!isRecord(value)) return error("MEMORY_INVALID_REQUEST", "Search request must be an object.");
+	const unknownKeys = rejectUnknownKeys(value, SEARCH_REQUEST_KEYS, "request");
+	if (!unknownKeys.ok) return unknownKeys;
+	const schema = validateSchemaVersion(value);
+	if (!schema.ok) return schema;
+	const targets = normalizeTargets(value.targets);
+	if (!targets.ok) return targets;
+	const query = normalizeText(value.query, "query", { maxLength: MAX_SEARCH_QUERY_LENGTH });
+	if (!query.ok) return query;
+	const kinds = normalizeKinds(value.kinds);
+	if (!kinds.ok) return kinds;
+	const tags = normalizeTags(value.tags);
+	if (!tags.ok) return tags;
+	const cursor = normalizeOptionalText(value.cursor, "cursor", MAX_CURSOR_LENGTH);
+	if (!cursor.ok) return cursor;
+	let limit;
+	if (value.limit !== void 0) {
+		if (typeof value.limit !== "number" || !Number.isInteger(value.limit) || value.limit < 1 || value.limit > MAX_LIMIT) return error("MEMORY_INVALID_FIELD", `limit must be an integer from 1 to ${MAX_LIMIT}.`, "limit");
+		limit = value.limit;
+	}
+	return {
+		ok: true,
+		value: {
+			schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+			targets: targets.value,
+			query: query.value,
+			...kinds.value ? { kinds: kinds.value } : {},
+			...tags.value.length > 0 ? { tags: tags.value } : {},
+			...limit !== void 0 ? { limit } : {},
+			...cursor.value !== void 0 ? { cursor: cursor.value } : {}
+		}
+	};
+}
+function validateMemoryGetEntryRequest(value) {
+	if (!isRecord(value)) return error("MEMORY_INVALID_REQUEST", "Get entry request must be an object.");
+	const unknownKeys = rejectUnknownKeys(value, GET_ENTRY_REQUEST_KEYS, "request");
+	if (!unknownKeys.ok) return unknownKeys;
+	const schema = validateSchemaVersion(value);
+	if (!schema.ok) return schema;
+	const entryId = normalizeText(value.entryId, "entryId", { maxLength: MAX_ID_LENGTH });
+	if (!entryId.ok) return entryId;
+	const target = normalizeMemoryTarget(value.target, "target");
+	if (!target.ok) return target;
+	return {
+		ok: true,
+		value: {
+			schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+			entryId: entryId.value,
+			target: target.value
+		}
+	};
+}
+function validateMemoryGetFileRequest(value) {
+	if (!isRecord(value)) return error("MEMORY_INVALID_REQUEST", "Get file request must be an object.");
+	const unknownKeys = rejectUnknownKeys(value, GET_FILE_REQUEST_KEYS, "request");
+	if (!unknownKeys.ok) return unknownKeys;
+	const schema = validateSchemaVersion(value);
+	if (!schema.ok) return schema;
+	const target = normalizeMemoryTarget(value.target, "target");
+	if (!target.ok) return target;
+	const objectId = normalizeText(value.objectId, "objectId", { maxLength: MAX_OBJECT_ID_LENGTH });
+	if (!objectId.ok) return objectId;
+	const outputPath = normalizeAbsolutePath(value.outputPath, "outputPath");
+	if (!outputPath.ok) return outputPath;
+	return {
+		ok: true,
+		value: {
+			schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+			target: target.value,
+			objectId: objectId.value,
+			outputPath: outputPath.value
+		}
+	};
+}
+function validateMemoryExportFilesRequest(value) {
+	if (!isRecord(value)) return error("MEMORY_INVALID_REQUEST", "Export files request must be an object.");
+	const unknownKeys = rejectUnknownKeys(value, EXPORT_FILES_REQUEST_KEYS, "request");
+	if (!unknownKeys.ok) return unknownKeys;
+	const schema = validateSchemaVersion(value);
+	if (!schema.ok) return schema;
+	const target = normalizeMemoryTarget(value.target, "target");
+	if (!target.ok) return target;
+	const entryId = normalizeText(value.entryId, "entryId", { maxLength: MAX_ID_LENGTH });
+	if (!entryId.ok) return entryId;
+	const outputDirectoryPath = normalizeAbsolutePath(value.outputDirectoryPath, "outputDirectoryPath");
+	if (!outputDirectoryPath.ok) return outputDirectoryPath;
+	return {
+		ok: true,
+		value: {
+			schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+			target: target.value,
+			entryId: entryId.value,
+			outputDirectoryPath: outputDirectoryPath.value
+		}
+	};
+}
+function validateMemoryListTagsRequest(value) {
+	if (!isRecord(value)) return error("MEMORY_INVALID_REQUEST", "List tags request must be an object.");
+	const unknownKeys = rejectUnknownKeys(value, LIST_TAGS_REQUEST_KEYS, "request");
+	if (!unknownKeys.ok) return unknownKeys;
+	const schema = validateSchemaVersion(value);
+	if (!schema.ok) return schema;
+	const targets = normalizeTargets(value.targets);
+	if (!targets.ok) return targets;
+	return {
+		ok: true,
+		value: {
+			schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+			targets: targets.value
+		}
+	};
+}
+function validateMemoryAppendRequest(value) {
+	if (!isRecord(value)) return error("MEMORY_INVALID_REQUEST", "Append request must be an object.");
+	const unknownKeys = rejectUnknownKeys(value, APPEND_REQUEST_KEYS, "request");
+	if (!unknownKeys.ok) return unknownKeys;
+	const schema = validateSchemaVersion(value);
+	if (!schema.ok) return schema;
+	const target = normalizeMemoryTarget(value.target, "target");
+	if (!target.ok) return target;
+	const kind = validateMemoryKind(value.kind, "kind");
+	if (!kind.ok) return kind;
+	const title = normalizeText(value.title, "title", { maxLength: MAX_TITLE_LENGTH });
+	if (!title.ok) return title;
+	const body = normalizeText(value.body, "body", { maxLength: MAX_BODY_LENGTH });
+	if (!body.ok) return body;
+	const preview = normalizeText(value.preview, "preview", { maxLength: MAX_PREVIEW_LENGTH });
+	if (!preview.ok) return preview;
+	const tags = normalizeTags(value.tags, "tags", { required: true });
+	if (!tags.ok) return tags;
+	const supersedes = normalizeStringArray(value.supersedes, "supersedes", {
+		maxItems: MAX_SUPERSEDES,
+		maxLength: MAX_ID_LENGTH
+	});
+	if (!supersedes.ok) return supersedes;
+	const files = normalizeAppendFiles(value.files);
+	if (!files.ok) return files;
+	const sourceMessageId = normalizeOptionalText(value.sourceMessageId, "sourceMessageId");
+	if (!sourceMessageId.ok) return sourceMessageId;
+	const idempotencyKey = normalizeOptionalText(value.idempotencyKey, "idempotencyKey");
+	if (!idempotencyKey.ok) return idempotencyKey;
+	return {
+		ok: true,
+		value: {
+			schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+			target: target.value,
+			kind: kind.value,
+			title: title.value,
+			body: body.value,
+			preview: preview.value,
+			tags: tags.value,
+			...supersedes.value && supersedes.value.length > 0 ? { supersedes: supersedes.value } : {},
+			...files.value && files.value.length > 0 ? { files: files.value } : {},
+			...sourceMessageId.value !== void 0 ? { sourceMessageId: sourceMessageId.value } : {},
+			...idempotencyKey.value !== void 0 ? { idempotencyKey: idempotencyKey.value } : {}
+		}
+	};
+}
+function validateMemoryForgetRequest(value) {
+	if (!isRecord(value)) return error("MEMORY_INVALID_REQUEST", "Forget request must be an object.");
+	const unknownKeys = rejectUnknownKeys(value, FORGET_REQUEST_KEYS, "request");
+	if (!unknownKeys.ok) return unknownKeys;
+	const schema = validateSchemaVersion(value);
+	if (!schema.ok) return schema;
+	const target = normalizeMemoryTarget(value.target, "target");
+	if (!target.ok) return target;
+	const entryIds = normalizeStringArray(value.entryIds, "entryIds", {
+		maxItems: MAX_FORGET_ENTRY_IDS,
+		maxLength: MAX_ID_LENGTH
+	});
+	if (!entryIds.ok) return entryIds;
+	if (!entryIds.value || entryIds.value.length === 0) return error("MEMORY_INVALID_FIELD", "entryIds must not be empty.", "entryIds");
+	if (value.reason !== void 0 && (typeof value.reason !== "string" || !MEMORY_FORGET_REASON_SET.has(value.reason))) return error("MEMORY_INVALID_FIELD", "reason must be a valid forget reason.", "reason");
+	const sourceMessageId = normalizeOptionalText(value.sourceMessageId, "sourceMessageId");
+	if (!sourceMessageId.ok) return sourceMessageId;
+	const idempotencyKey = normalizeOptionalText(value.idempotencyKey, "idempotencyKey");
+	if (!idempotencyKey.ok) return idempotencyKey;
+	return {
+		ok: true,
+		value: {
+			schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+			target: target.value,
+			entryIds: entryIds.value,
+			...value.reason !== void 0 ? { reason: value.reason } : {},
+			...sourceMessageId.value !== void 0 ? { sourceMessageId: sourceMessageId.value } : {},
+			...idempotencyKey.value !== void 0 ? { idempotencyKey: idempotencyKey.value } : {}
+		}
+	};
+}
+//#endregion
+//#region scripts/withmate-memory.ts
+var WITHMATE_MEMORY_CLI_EXIT_CODES = {
+	ok: 0,
+	usage: 1,
+	notRunning: 2,
+	apiError: 3,
+	transportError: 4
 };
-
-const helpText = `Usage:
+var routeByCommand = {
+	status: {
+		method: "GET",
+		path: "/v1/status"
+	},
+	characters: {
+		method: "GET",
+		path: "/v1/characters"
+	},
+	file_usage: {
+		method: "GET",
+		path: "/v1/file_usage"
+	},
+	search: {
+		method: "POST",
+		path: "/v1/search"
+	},
+	get_entry: {
+		method: "POST",
+		path: "/v1/get_entry"
+	},
+	get_file: {
+		method: "POST",
+		path: "/v1/get_file"
+	},
+	export_files: {
+		method: "POST",
+		path: "/v1/export_files"
+	},
+	list_tags: {
+		method: "POST",
+		path: "/v1/list_tags"
+	},
+	append: {
+		method: "POST",
+		path: "/v1/append"
+	},
+	forget: {
+		method: "POST",
+		path: "/v1/forget"
+	}
+};
+function buildRoutePath(request) {
+	const route = routeByCommand[request.command];
+	if (request.command !== "file_usage" || !request.body || typeof request.body !== "object") return route.path;
+	const body = request.body;
+	const query = new URLSearchParams();
+	if (body.largest === true) query.set("largest", "1");
+	if (typeof body.limit === "number") query.set("limit", String(body.limit));
+	const queryString = query.toString();
+	return queryString ? `${route.path}?${queryString}` : route.path;
+}
+var DEFAULT_REQUEST_TIMEOUT_MS = 1e4;
+var DEFAULT_FILE_OPERATION_REQUEST_TIMEOUT_MS = 3e5;
+var WITHMATE_MEMORY_API_SECRET_HEADER = "x-withmate-memory-api-secret";
+var FILE_OPERATION_COMMANDS = /* @__PURE__ */ new Set([
+	"append",
+	"get_file",
+	"export_files"
+]);
+var commandAliases = /* @__PURE__ */ new Map([
+	["help", "help"],
+	["status", "status"],
+	["characters", "characters"],
+	["list-characters", "characters"],
+	["list_characters", "characters"],
+	["file-usage", "file_usage"],
+	["file_usage", "file_usage"],
+	["search", "search"],
+	["get-entry", "get_entry"],
+	["get_entry", "get_entry"],
+	["get-file", "get_file"],
+	["get_file", "get_file"],
+	["export-files", "export_files"],
+	["export_files", "export_files"],
+	["list-tags", "list_tags"],
+	["list_tags", "list_tags"],
+	["append", "append"],
+	["forget", "forget"],
+	["schema", "schema"],
+	["capabilities", "schema"],
+	["validate", "validate"]
+]);
+var WITHMATE_MEMORY_CLI_HELP = `Usage:
   withmate-memory <command> [options]
 
 Commands:
   help
   status
   characters
+  file-usage
   search
   get-entry
+  get-file
+  export-files
   list-tags
   append
   forget
@@ -57,6 +829,10 @@ Shorthand options:
   --tag <tag>
   --tags <tags>
   --entry-id <id>
+  --object-id <id>
+  --output <path>
+  --output-dir <path>
+  --largest
   --limit <n>
 
 Connection options:
@@ -64,1032 +840,586 @@ Connection options:
   --discovery-file <path>
 
 Validation:
-  validate --command <search|get-entry|list-tags|append|forget>
+  validate --command <search|get-entry|get-file|export-files|list-tags|append|forget>
 
 Examples:
   withmate-memory status
   withmate-memory characters
+  withmate-memory file-usage
+  withmate-memory file-usage --largest --limit 10
   withmate-memory search --project C:\\path\\to\\repo --query "release workflow"
+  withmate-memory get-file --project C:\\path\\to\\repo --object-id <id> --output C:\\path\\to\\file.bin
+  withmate-memory export-files --project C:\\path\\to\\repo --entry-id <id> --output-dir C:\\path\\to\\exports
   withmate-memory validate --command append --stdin
   withmate-memory schema
 `;
-
-const commands = new Map([
-  ["help", { name: "help", local: true, defaultBody: {} }],
-  ["status", { name: "status", method: "GET", path: "/v1/status", defaultBody: {} }],
-  ["characters", { name: "characters", method: "GET", path: "/v1/characters", defaultBody: {} }],
-  ["list-characters", { name: "characters", method: "GET", path: "/v1/characters", defaultBody: {} }],
-  ["list_characters", { name: "characters", method: "GET", path: "/v1/characters", defaultBody: {} }],
-  ["search", { name: "search", method: "POST", path: "/v1/search", defaultBody: {} }],
-  ["get-entry", { name: "get_entry", method: "POST", path: "/v1/get_entry", defaultBody: {} }],
-  ["get_entry", { name: "get_entry", method: "POST", path: "/v1/get_entry", defaultBody: {} }],
-  ["list-tags", { name: "list_tags", method: "POST", path: "/v1/list_tags", defaultBody: {} }],
-  ["list_tags", { name: "list_tags", method: "POST", path: "/v1/list_tags", defaultBody: {} }],
-  ["append", { name: "append", method: "POST", path: "/v1/append", defaultBody: {} }],
-  ["forget", { name: "forget", method: "POST", path: "/v1/forget", defaultBody: {} }],
-  ["schema", { name: "schema", local: true, defaultBody: {} }],
-  ["capabilities", { name: "schema", local: true, defaultBody: {} }],
-  ["validate", { name: "validate", local: true, defaultBody: {} }],
+var validatableCommands = /* @__PURE__ */ new Set([
+	"search",
+	"get_entry",
+	"get_file",
+	"export_files",
+	"list_tags",
+	"append",
+	"forget"
 ]);
-const validatableCommands = new Set(["search", "get_entry", "list_tags", "append", "forget"]);
-
-function memoryError(code, message) {
-  return { schemaVersion, error: { code, message } };
+function usageError(message) {
+	return createMemoryErrorResponse({
+		code: "WITHMATE_MEMORY_CLI_USAGE",
+		message
+	});
 }
-
-function usage(message) {
-  return memoryError("WITHMATE_MEMORY_CLI_USAGE", message);
+function notRunningError() {
+	return createMemoryErrorResponse({
+		code: "WITHMATE_NOT_RUNNING",
+		message: "WithMate Memory API is not running or could not be discovered."
+	});
 }
-
-function notRunning() {
-  return memoryError("WITHMATE_NOT_RUNNING", "WithMate Memory API is not running or could not be discovered.");
+function requestTimeoutError(command, timeoutMs) {
+	return createMemoryErrorResponse({
+		code: "WITHMATE_MEMORY_REQUEST_TIMEOUT",
+		message: `WithMate Memory API request timed out after ${timeoutMs}ms.`,
+		field: command
+	});
 }
-
-function normalizeLoopbackUrl(rawUrl) {
-  try {
-    const url = new URL(rawUrl);
-    if (url.protocol !== "http:") {
-      return null;
-    }
-    if (url.hostname !== "127.0.0.1" && url.hostname !== "::1" && url.hostname !== "localhost") {
-      return null;
-    }
-    url.pathname = url.pathname.replace(/\/+$/, "");
-    url.search = "";
-    url.hash = "";
-    return url.toString().replace(/\/$/, "");
-  } catch {
-    return null;
-  }
+function transportError(message) {
+	return createMemoryErrorResponse({
+		code: "WITHMATE_MEMORY_TRANSPORT_ERROR",
+		message
+	});
 }
-
-function defaultRuntimeDirectory() {
-  const ownerSegment = typeof process.getuid === "function" ? `uid-${process.getuid()}` : "local-user";
-  return path.join(os.tmpdir(), "withmate-memory", ownerSegment);
+function isAbortError(error) {
+	return error instanceof DOMException && error.name === "AbortError";
 }
-
-async function readDiscovery(options) {
-  if (options.apiUrl !== undefined) {
-    const baseUrl = normalizeLoopbackUrl(options.apiUrl);
-    if (!baseUrl) {
-      throw usage("--api-url must be a valid loopback HTTP URL.");
-    }
-    return {
-      baseUrl,
-      apiSecret: process.env.WITHMATE_MEMORY_API_SECRET?.trim() || undefined,
-      runtimeInstanceId: process.env.WITHMATE_MEMORY_RUNTIME_INSTANCE_ID?.trim() || undefined,
-    };
-  }
-
-  const envUrl = process.env.WITHMATE_MEMORY_API_URL?.trim();
-  if (envUrl) {
-    const baseUrl = normalizeLoopbackUrl(envUrl);
-    if (!baseUrl) {
-      throw usage("WITHMATE_MEMORY_API_URL must be a valid loopback HTTP URL.");
-    }
-    return {
-      baseUrl,
-      apiSecret: process.env.WITHMATE_MEMORY_API_SECRET?.trim() || undefined,
-      runtimeInstanceId: process.env.WITHMATE_MEMORY_RUNTIME_INSTANCE_ID?.trim() || undefined,
-    };
-  }
-
-  const discoveryPath = options.discoveryFilePath
-    || process.env.WITHMATE_MEMORY_DISCOVERY_FILE?.trim()
-    || path.join(process.env.WITHMATE_MEMORY_RUNTIME_DIR?.trim() || defaultRuntimeDirectory(), discoveryFileName);
-  try {
-    const document = JSON.parse(await readFile(discoveryPath, "utf8"));
-    if (document.schemaVersion !== discoverySchemaVersion || typeof document.baseUrl !== "string") {
-      return null;
-    }
-    const baseUrl = normalizeLoopbackUrl(document.baseUrl);
-    if (!baseUrl) {
-      return null;
-    }
-    return {
-      baseUrl,
-      apiSecret: typeof document.apiSecret === "string" ? document.apiSecret.trim() || undefined : undefined,
-      runtimeInstanceId: typeof document.runtimeInstanceId === "string" ? document.runtimeInstanceId.trim() || undefined : undefined,
-    };
-  } catch {
-    return null;
-  }
+function resolveRuntimeRequestTimeoutMs(command, deps = {}) {
+	if (deps.requestTimeoutMs !== void 0) return deps.requestTimeoutMs;
+	if (FILE_OPERATION_COMMANDS.has(command)) return deps.fileOperationRequestTimeoutMs ?? 3e5;
+	return DEFAULT_REQUEST_TIMEOUT_MS;
 }
-
-async function parseArgs(argv) {
-  const [rawCommand, ...rest] = argv;
-  if (!rawCommand || rawCommand === "--help" || rawCommand === "-h") {
-    return { route: { name: "help", local: true, defaultBody: {} }, body: {} };
-  }
-  const route = rawCommand ? commands.get(rawCommand) : undefined;
-  if (!route) {
-    throw usage("Usage: withmate-memory <help|status|characters|search|get-entry|list-tags|append|forget|schema|validate> [--json <json> | --file <path> | @file | --stdin] [--command <command>] [--project <absolute-path> | --project-id <id>] [--query <text>] [--tag <tag> | --tags <tags>] [--entry-id <id>] [--limit <n>] [--api-url <url>] [--discovery-file <path>]");
-  }
-  if (route.name === "help" || rest.includes("--help") || rest.includes("-h")) {
-    return { route: { name: "help", local: true, defaultBody: {} }, body: {} };
-  }
-
-  let jsonInput = null;
-  let filePath = null;
-  let stdinRequested = false;
-  let apiUrl;
-  let discoveryFilePath;
-  let validateCommand;
-  let projectPath;
-  let projectId;
-  let query;
-  const tagOptions = [];
-  let entryId;
-  let limit;
-  for (let index = 0; index < rest.length; index += 1) {
-    const arg = rest[index];
-    if (arg === "--json") {
-      jsonInput = requireOptionValue(rest, ++index, arg);
-    } else if (arg === "--file") {
-      filePath = requireOptionValue(rest, ++index, arg);
-    } else if (arg === "--stdin") {
-      stdinRequested = true;
-    } else if (arg.startsWith("@") && arg.length > 1) {
-      filePath = arg.slice(1);
-    } else if (arg === "--api-url") {
-      apiUrl = requireOptionValue(rest, ++index, arg);
-    } else if (arg === "--discovery-file") {
-      discoveryFilePath = requireOptionValue(rest, ++index, arg);
-    } else if (arg === "--command") {
-      validateCommand = normalizeValidatableCommand(requireOptionValue(rest, ++index, arg));
-      if (!validateCommand) {
-        throw usage(`--command must be one of: ${Array.from(validatableCommands).join(", ")}.`);
-      }
-    } else if (arg === "--project") {
-      projectPath = requireOptionValue(rest, ++index, arg);
-    } else if (arg === "--project-id") {
-      projectId = requireOptionValue(rest, ++index, arg);
-    } else if (arg === "--query") {
-      query = requireOptionValue(rest, ++index, arg);
-    } else if (arg === "--tag") {
-      tagOptions.push(requireOptionValue(rest, ++index, arg));
-    } else if (arg === "--tags") {
-      tagOptions.push(...parseTagsOption(requireOptionValue(rest, ++index, arg)));
-    } else if (arg === "--entry-id") {
-      entryId = requireOptionValue(rest, ++index, arg);
-    } else if (arg === "--limit") {
-      limit = parseLimit(requireOptionValue(rest, ++index, arg));
-    } else {
-      throw usage(`Unknown option: ${arg}`);
-    }
-  }
-  const bodyInputCount = [jsonInput !== null, filePath !== null, stdinRequested].filter(Boolean).length;
-  if (bodyInputCount > 1) {
-    throw usage("--json, --file, @file, and --stdin cannot be used together.");
-  }
-  if ([Boolean(projectPath), Boolean(projectId)].filter(Boolean).length > 1) {
-    throw usage("--project and --project-id cannot be used together.");
-  }
-  if (route.name === "validate" && !validateCommand) {
-    throw usage("validate requires --command <search|get-entry|list-tags|append|forget>.");
-  }
-
-  let body = route.defaultBody;
-  if (route.method === "POST" || route.name === "validate") {
-    if (jsonInput !== null) {
-      body = parseJson(jsonInput);
-    } else if (filePath !== null) {
-      body = parseJson(await readFile(filePath, "utf8"));
-    } else if (stdinRequested) {
-      body = parseJson(await readStdin(process.stdin));
-    } else if (hasShorthandOptions({ projectPath, projectId, query, tags: tagOptions, entryId, limit })) {
-      body = buildShorthandBody(route.name, { projectPath, projectId, query, tags: tagOptions, entryId, limit });
-    }
-  }
-  return { route, body, apiUrl, discoveryFilePath, validateCommand };
+function readEnvSecret(env) {
+	const value = env.WITHMATE_MEMORY_API_SECRET?.trim();
+	return value ? value : void 0;
 }
-
-function normalizeValidatableCommand(value) {
-  const command = commands.get(value)?.name;
-  return validatableCommands.has(command) ? command : undefined;
+function readEnvRuntimeInstanceId(env) {
+	const value = env.WITHMATE_MEMORY_RUNTIME_INSTANCE_ID?.trim();
+	return value ? value : void 0;
 }
-
-function parseLimit(value) {
-  const limit = Number(value);
-  if (!Number.isInteger(limit) || limit < 1) {
-    throw usage("--limit must be a positive integer.");
-  }
-  return limit;
-}
-
-function parseTagsOption(value) {
-  return value
-    .split(",")
-    .map((item) => item.trim())
-    .filter(Boolean);
-}
-
-function normalizeCliTagOptions(values) {
-  const tags = [];
-  const seen = new Set();
-  for (const rawValue of values) {
-    const trimmed = rawValue.trim();
-    if (!trimmed) {
-      continue;
-    }
-    const separatorIndex = trimmed.indexOf(":");
-    const type = separatorIndex > 0 ? trimmed.slice(0, separatorIndex).trim() : "topic";
-    const value = separatorIndex > 0 ? trimmed.slice(separatorIndex + 1).trim() : trimmed;
-    if (!type || !value) {
-      throw usage("--tag and --tags values must be <tag> or <type>:<tag>.");
-    }
-    const key = `${type.normalize("NFC").toLowerCase()}\0${value.normalize("NFC").toLowerCase()}`;
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    tags.push({ type, value });
-  }
-  return tags;
-}
-
-function hasShorthandOptions(options) {
-  return Boolean(options.projectPath || options.projectId || options.query || (options.tags && options.tags.length > 0) || options.entryId || options.limit !== undefined);
-}
-
-function isAbsoluteCliPath(value) {
-  return path.isAbsolute(value) || path.win32.isAbsolute(value);
-}
-
-function normalizeCliProjectPath(value) {
-  if (!isAbsoluteCliPath(value)) {
-    throw usage("--project requires an absolute path.");
-  }
-  return path.win32.isAbsolute(value)
-    ? path.win32.normalize(value).replace(/\\/g, "/")
-    : path.resolve(value);
-}
-
-function buildProjectTarget(options) {
-  if (options.projectId) {
-    return { owner: "project", scope: "project", project: { type: "id", id: options.projectId } };
-  }
-  if (options.projectPath) {
-    return { owner: "project", scope: "project", project: { type: "path", path: normalizeCliProjectPath(options.projectPath) } };
-  }
-  return null;
-}
-
-function buildShorthandBody(command, options) {
-  const target = buildProjectTarget(options);
-  if (command === "search") {
-    if (!target) {
-      throw usage("search shorthand requires --project <absolute-path> or --project-id <id>.");
-    }
-    const tags = normalizeCliTagOptions(options.tags || []);
-    const query = options.query || tags.map((tag) => tag.value).join(" ");
-    if (!query) {
-      throw usage("search shorthand requires --query <text> or --tag <tag>.");
-    }
-    return {
-      schemaVersion,
-      targets: [target],
-      query,
-      ...(tags.length > 0 ? { tags } : {}),
-      ...(options.limit !== undefined ? { limit: options.limit } : {}),
-    };
-  }
-  if (command === "list_tags") {
-    if (!target) {
-      throw usage("list-tags shorthand requires --project <absolute-path> or --project-id <id>.");
-    }
-    return { schemaVersion, targets: [target] };
-  }
-  if (command === "get_entry") {
-    if (!options.entryId) {
-      throw usage("get-entry shorthand requires --entry-id <id>.");
-    }
-    if (!target) {
-      throw usage("get-entry shorthand requires --project <absolute-path> or --project-id <id>.");
-    }
-    return {
-      schemaVersion,
-      entryId: options.entryId,
-      target,
-    };
-  }
-  throw usage(`${command} does not support shorthand options. Use --json, --file, @file, or --stdin.`);
-}
-
 async function readStdin(stdin) {
-  const chunks = [];
-  for await (const chunk of stdin) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-  }
-  return Buffer.concat(chunks).toString("utf8");
+	const chunks = [];
+	for await (const chunk of stdin) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+	return Buffer.concat(chunks).toString("utf8");
 }
-
+async function parseJsonInput(input) {
+	const trimmed = input.trim();
+	if (!trimmed) return {};
+	try {
+		return JSON.parse(trimmed);
+	} catch {
+		throw usageError("Request JSON must be valid JSON. If shell quoting changed the JSON, retry with --file <path> or --stdin.");
+	}
+}
+function normalizeCommandName(value) {
+	return commandAliases.get(value);
+}
+function normalizeValidatableCommand(value) {
+	const command = normalizeCommandName(value);
+	if (command && validatableCommands.has(command)) return command;
+}
+async function discoverWithMateMemoryApi(options = {}) {
+	const env = options.env ?? process.env;
+	if (options.apiUrl !== void 0) {
+		const explicitUrl = normalizeWithMateMemoryApiBaseUrl(options.apiUrl);
+		if (!explicitUrl) throw usageError("--api-url must be a valid loopback HTTP URL.");
+		return {
+			baseUrl: explicitUrl,
+			...readEnvSecret(env) ? { apiSecret: readEnvSecret(env) } : {},
+			...readEnvRuntimeInstanceId(env) ? { runtimeInstanceId: readEnvRuntimeInstanceId(env) } : {}
+		};
+	}
+	const rawEnvUrl = env.WITHMATE_MEMORY_API_URL?.trim();
+	if (rawEnvUrl) {
+		const envUrl = normalizeWithMateMemoryApiBaseUrl(rawEnvUrl);
+		if (!envUrl) throw usageError("WITHMATE_MEMORY_API_URL must be a valid loopback HTTP URL.");
+		return {
+			baseUrl: envUrl,
+			...readEnvSecret(env) ? { apiSecret: readEnvSecret(env) } : {},
+			...readEnvRuntimeInstanceId(env) ? { runtimeInstanceId: readEnvRuntimeInstanceId(env) } : {}
+		};
+	}
+	const envDiscoveryFilePath = env.WITHMATE_MEMORY_DISCOVERY_FILE?.trim();
+	const discoveryFilePath = options.discoveryFilePath ?? (envDiscoveryFilePath || resolveDefaultWithMateMemoryDiscoveryFilePath(env));
+	const read = options.readFile ?? readFile;
+	try {
+		const document = JSON.parse(await read(discoveryFilePath, "utf8"));
+		if (document.schemaVersion !== "withmate-memory-discovery-v1" || typeof document.baseUrl !== "string") return null;
+		const baseUrl = normalizeWithMateMemoryApiBaseUrl(document.baseUrl);
+		if (!baseUrl) return null;
+		return {
+			baseUrl,
+			...typeof document.apiSecret === "string" && document.apiSecret.trim() ? { apiSecret: document.apiSecret.trim() } : {},
+			...typeof document.runtimeInstanceId === "string" && document.runtimeInstanceId.trim() ? { runtimeInstanceId: document.runtimeInstanceId.trim() } : {}
+		};
+	} catch {
+		return null;
+	}
+}
+async function parseWithMateMemoryCliArgs(args, deps = {}) {
+	const [rawCommand, ...rest] = args;
+	if (!rawCommand || rawCommand === "--help" || rawCommand === "-h") return {
+		command: "help",
+		body: {}
+	};
+	const command = rawCommand ? commandAliases.get(rawCommand) : void 0;
+	if (!command) throw usageError("Usage: withmate-memory <help|status|characters|file-usage|search|get-entry|get-file|export-files|list-tags|append|forget|schema|validate> [--json <json> | --file <path> | @file | --stdin] [--command <command>] [--project <absolute-path> | --project-id <id>] [--query <text>] [--tag <tag> | --tags <tags>] [--entry-id <id>] [--object-id <id>] [--output <path>] [--output-dir <path>] [--limit <n>] [--api-url <url>] [--discovery-file <path>]");
+	if (command === "help" || rest.includes("--help") || rest.includes("-h")) return {
+		command: "help",
+		body: {}
+	};
+	let jsonInput = null;
+	let filePath = null;
+	let stdinRequested = false;
+	let apiUrl;
+	let discoveryFilePath;
+	let validateCommand;
+	let projectPath;
+	let projectId;
+	let query;
+	const tagOptions = [];
+	let entryId;
+	let objectId;
+	let outputPath;
+	let outputDirectoryPath;
+	let largest = false;
+	let limit;
+	for (let index = 0; index < rest.length; index += 1) {
+		const arg = rest[index];
+		if (arg === "--json") jsonInput = requireOptionValue(rest, ++index, arg);
+		else if (arg === "--file") filePath = requireOptionValue(rest, ++index, arg);
+		else if (arg === "--stdin") stdinRequested = true;
+		else if (arg.startsWith("@") && arg.length > 1) filePath = arg.slice(1);
+		else if (arg === "--api-url") apiUrl = requireOptionValue(rest, ++index, arg);
+		else if (arg === "--discovery-file") discoveryFilePath = requireOptionValue(rest, ++index, arg);
+		else if (arg === "--command") {
+			validateCommand = normalizeValidatableCommand(requireOptionValue(rest, ++index, arg));
+			if (!validateCommand) throw usageError(`--command must be one of: ${Array.from(validatableCommands).join(", ")}.`);
+		} else if (arg === "--project") projectPath = requireOptionValue(rest, ++index, arg);
+		else if (arg === "--project-id") projectId = requireOptionValue(rest, ++index, arg);
+		else if (arg === "--query") query = requireOptionValue(rest, ++index, arg);
+		else if (arg === "--tag") tagOptions.push(requireOptionValue(rest, ++index, arg));
+		else if (arg === "--tags") tagOptions.push(...parseTagsOption(requireOptionValue(rest, ++index, arg)));
+		else if (arg === "--entry-id") entryId = requireOptionValue(rest, ++index, arg);
+		else if (arg === "--object-id") objectId = requireOptionValue(rest, ++index, arg);
+		else if (arg === "--output") outputPath = requireOptionValue(rest, ++index, arg);
+		else if (arg === "--output-dir") outputDirectoryPath = requireOptionValue(rest, ++index, arg);
+		else if (arg === "--largest") largest = true;
+		else if (arg === "--limit") limit = parseLimitOption(requireOptionValue(rest, ++index, arg));
+		else throw usageError(`Unknown option: ${arg}`);
+	}
+	if ([
+		jsonInput !== null,
+		filePath !== null,
+		stdinRequested
+	].filter(Boolean).length > 1) throw usageError("--json, --file, @file, and --stdin cannot be used together.");
+	if ([Boolean(projectPath), Boolean(projectId)].filter(Boolean).length > 1) throw usageError("--project and --project-id cannot be used together.");
+	if (command === "validate" && !validateCommand) throw usageError("validate requires --command <search|get-entry|get-file|export-files|list-tags|append|forget>.");
+	let body = {};
+	if (command === "file_usage") {
+		if (jsonInput !== null || filePath !== null || stdinRequested) throw usageError("file-usage does not accept JSON body input. Use --largest and --limit.");
+		if (hasShorthandOptions({
+			projectPath,
+			projectId,
+			query,
+			tags: tagOptions,
+			entryId,
+			objectId,
+			outputPath,
+			outputDirectoryPath,
+			largest,
+			limit
+		})) body = buildShorthandBody(command, {
+			projectPath,
+			projectId,
+			query,
+			tags: tagOptions,
+			entryId,
+			objectId,
+			outputPath,
+			outputDirectoryPath,
+			largest,
+			limit
+		});
+	} else if (command !== "status" && command !== "characters" && command !== "schema") {
+		if (jsonInput !== null) body = await parseJsonInput(jsonInput);
+		else if (filePath !== null) body = await parseJsonInput(await (deps.readFile ?? readFile)(filePath, "utf8"));
+		else if (stdinRequested) body = await parseJsonInput(await readStdin(deps.stdin ?? process.stdin));
+		else if (hasShorthandOptions({
+			projectPath,
+			projectId,
+			query,
+			tags: tagOptions,
+			entryId,
+			objectId,
+			outputPath,
+			outputDirectoryPath,
+			largest,
+			limit
+		})) body = buildShorthandBody(command, {
+			projectPath,
+			projectId,
+			query,
+			tags: tagOptions,
+			entryId,
+			objectId,
+			outputPath,
+			outputDirectoryPath,
+			largest,
+			limit
+		});
+		else if (deps.stdin && !deps.stdin.isTTY) body = await parseJsonInput(await readStdin(deps.stdin));
+	}
+	return {
+		command,
+		body: normalizeProjectPathTargets(body),
+		...validateCommand ? { validateCommand } : {},
+		...apiUrl ? { apiUrl } : {},
+		...discoveryFilePath ? { discoveryFilePath } : {}
+	};
+}
+function parseLimitOption(value) {
+	const limit = Number(value);
+	if (!Number.isInteger(limit) || limit < 1) throw usageError("--limit must be a positive integer.");
+	return limit;
+}
+function parseTagsOption(value) {
+	return value.split(",").map((item) => item.trim()).filter(Boolean);
+}
+function normalizeCliTagOptions(values) {
+	const tags = [];
+	const seen = /* @__PURE__ */ new Set();
+	for (const rawValue of values) {
+		const trimmed = rawValue.trim();
+		if (!trimmed) continue;
+		const separatorIndex = trimmed.indexOf(":");
+		const type = separatorIndex > 0 ? trimmed.slice(0, separatorIndex).trim() : "topic";
+		const value = separatorIndex > 0 ? trimmed.slice(separatorIndex + 1).trim() : trimmed;
+		if (!type || !value) throw usageError("--tag and --tags values must be <tag> or <type>:<tag>.");
+		const key = `${type.normalize("NFC").toLowerCase()}\0${value.normalize("NFC").toLowerCase()}`;
+		if (seen.has(key)) continue;
+		seen.add(key);
+		tags.push({
+			type,
+			value
+		});
+	}
+	return tags;
+}
+function hasShorthandOptions(options) {
+	return Boolean(options.projectPath || options.projectId || options.query || options.tags && options.tags.length > 0 || options.entryId || options.objectId || options.outputPath || options.outputDirectoryPath || options.largest || options.limit !== void 0);
+}
+function isAbsoluteCliPath(value) {
+	return path.isAbsolute(value) || path.win32.isAbsolute(value);
+}
+function normalizeCliProjectPath(value) {
+	if (!isAbsoluteCliPath(value)) throw usageError("--project requires an absolute path.");
+	return path.win32.isAbsolute(value) ? path.win32.normalize(value).replace(/\\/g, "/") : path.resolve(value);
+}
+function normalizeCliOutputPath(value) {
+	if (!isAbsoluteCliPath(value)) throw usageError("--output requires an absolute path.");
+	return path.win32.isAbsolute(value) ? path.win32.normalize(value) : path.resolve(value);
+}
+function normalizeCliOutputDirectoryPath(value) {
+	if (!isAbsoluteCliPath(value)) throw usageError("--output-dir requires an absolute path.");
+	return path.win32.isAbsolute(value) ? path.win32.normalize(value) : path.resolve(value);
+}
+function buildProjectTarget(options) {
+	if (options.projectId) return {
+		owner: "project",
+		scope: "project",
+		project: {
+			type: "id",
+			id: options.projectId
+		}
+	};
+	if (options.projectPath) return {
+		owner: "project",
+		scope: "project",
+		project: {
+			type: "path",
+			path: normalizeCliProjectPath(options.projectPath)
+		}
+	};
+	return null;
+}
+function buildShorthandBody(command, options) {
+	if (command === "validate") throw usageError("validate shorthand options are not supported. Use --json, --file, @file, or --stdin.");
+	const target = buildProjectTarget(options);
+	if (command === "file_usage") {
+		if (target || options.query || options.tags && options.tags.length > 0 || options.entryId || options.objectId || options.outputPath || options.outputDirectoryPath) throw usageError("file-usage shorthand only supports --largest and --limit.");
+		if (options.limit !== void 0 && !options.largest) throw usageError("file-usage --limit requires --largest.");
+		return {
+			...options.largest ? { largest: true } : {},
+			...options.limit !== void 0 ? { limit: options.limit } : {}
+		};
+	}
+	if (command === "search") {
+		if (!target) throw usageError("search shorthand requires --project <absolute-path> or --project-id <id>.");
+		const tags = normalizeCliTagOptions(options.tags ?? []);
+		const query = options.query ?? tags.map((tag) => tag.value).join(" ");
+		if (!query) throw usageError("search shorthand requires --query <text> or --tag <tag>.");
+		return {
+			schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+			targets: [target],
+			query,
+			...tags.length > 0 ? { tags } : {},
+			...options.limit !== void 0 ? { limit: options.limit } : {}
+		};
+	}
+	if (command === "list_tags") {
+		if (!target) throw usageError("list-tags shorthand requires --project <absolute-path> or --project-id <id>.");
+		return {
+			schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+			targets: [target]
+		};
+	}
+	if (command === "get_entry") {
+		if (!options.entryId) throw usageError("get-entry shorthand requires --entry-id <id>.");
+		if (!target) throw usageError("get-entry shorthand requires --project <absolute-path> or --project-id <id>.");
+		return {
+			schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+			entryId: options.entryId,
+			target
+		};
+	}
+	if (command === "get_file") {
+		if (!options.objectId) throw usageError("get-file shorthand requires --object-id <id>.");
+		if (!options.outputPath) throw usageError("get-file shorthand requires --output <absolute-path>.");
+		if (!target) throw usageError("get-file shorthand requires --project <absolute-path> or --project-id <id>.");
+		return {
+			schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+			target,
+			objectId: options.objectId,
+			outputPath: normalizeCliOutputPath(options.outputPath)
+		};
+	}
+	if (command === "export_files") {
+		if (!options.entryId) throw usageError("export-files shorthand requires --entry-id <id>.");
+		if (!options.outputDirectoryPath) throw usageError("export-files shorthand requires --output-dir <absolute-path>.");
+		if (!target) throw usageError("export-files shorthand requires --project <absolute-path> or --project-id <id>.");
+		return {
+			schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+			target,
+			entryId: options.entryId,
+			outputDirectoryPath: normalizeCliOutputDirectoryPath(options.outputDirectoryPath)
+		};
+	}
+	throw usageError(`${command} does not support shorthand options. Use --json, --file, @file, or --stdin.`);
+}
 function normalizeProjectPathTargets(value) {
-  if (Array.isArray(value)) {
-    return value.map((item) => normalizeProjectPathTargets(item));
-  }
-  if (!value || typeof value !== "object") {
-    return value;
-  }
-
-  const normalized = {};
-  for (const [key, item] of Object.entries(value)) {
-    normalized[key] = normalizeProjectPathTargets(item);
-  }
-
-  if (value.type === "path" && typeof value.path === "string") {
-    normalized.path = normalizeCliProjectPath(value.path);
-  }
-  return normalized;
+	if (Array.isArray(value)) return value.map((item) => normalizeProjectPathTargets(item));
+	if (!value || typeof value !== "object") return value;
+	const record = value;
+	const normalized = {};
+	for (const [key, item] of Object.entries(record)) normalized[key] = normalizeProjectPathTargets(item);
+	if (record.type === "path" && typeof record.path === "string") normalized.path = normalizeCliProjectPath(record.path);
+	return normalized;
 }
-
 function requireOptionValue(args, index, option) {
-  const value = args[index];
-  if (!value || value.startsWith("--")) {
-    throw usage(`${option} requires a value.`);
-  }
-  return value;
+	const value = args[index];
+	if (!value || value.startsWith("--")) throw usageError(`${option} requires a value.`);
+	return value;
 }
-
-function parseJson(raw) {
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return {};
-  }
-  try {
-    return JSON.parse(trimmed);
-  } catch {
-    throw usage("Request JSON must be valid JSON. If shell quoting changed the JSON, retry with --file <path> or --stdin.");
-  }
-}
-
 function buildSchemaResponse() {
-  return {
-    schemaVersion,
-    entryKinds,
-    forgetReasons,
-    commands: ["help", "status", "characters", "search", "get-entry", "list-tags", "append", "forget", "schema", "validate"],
-    requestBodyInputs: ["--json", "--file", "@file", "--stdin"],
-    targetSelectors: [
-      {
-        owner: "project",
-        scope: "project",
-        requiredFields: ["project"],
-        projectTypes: ["id", "path"],
-      },
-      {
-        owner: "character",
-        scope: "character",
-        requiredFields: ["character"],
-        characterTypes: ["id"],
-      },
-      {
-        owner: "character",
-        scope: "project",
-        requiredFields: ["character", "project"],
-        characterTypes: ["id"],
-        projectTypes: ["id", "path"],
-      },
-      {
-        owner: "user",
-        scope: "global",
-        requiredFields: [],
-      },
-    ],
-  };
+	return {
+		schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+		entryKinds: [...MEMORY_ENTRY_KINDS],
+		forgetReasons: [...MEMORY_FORGET_REASONS],
+		commands: [
+			"help",
+			"status",
+			"characters",
+			"file-usage",
+			"search",
+			"get-entry",
+			"get-file",
+			"export-files",
+			"list-tags",
+			"append",
+			"forget",
+			"schema",
+			"validate"
+		],
+		requestBodyInputs: [
+			"--json",
+			"--file",
+			"@file",
+			"--stdin"
+		],
+		targetSelectors: [
+			{
+				owner: "project",
+				scope: "project",
+				requiredFields: ["project"],
+				projectTypes: ["id", "path"]
+			},
+			{
+				owner: "character",
+				scope: "character",
+				requiredFields: ["character"],
+				characterTypes: ["id"]
+			},
+			{
+				owner: "character",
+				scope: "project",
+				requiredFields: ["character", "project"],
+				characterTypes: ["id"],
+				projectTypes: ["id", "path"]
+			},
+			{
+				owner: "user",
+				scope: "global",
+				requiredFields: []
+			}
+		]
+	};
 }
-
-const entryKindSet = new Set(entryKinds);
-const forgetReasonSet = new Set(forgetReasons);
-const searchRequestKeys = new Set(["schemaVersion", "targets", "query", "kinds", "tags", "limit", "cursor"]);
-const getEntryRequestKeys = new Set(["schemaVersion", "entryId", "target"]);
-const listTagsRequestKeys = new Set(["schemaVersion", "targets"]);
-const appendRequestKeys = new Set([
-  "schemaVersion",
-  "target",
-  "kind",
-  "title",
-  "body",
-  "preview",
-  "tags",
-  "supersedes",
-  "sourceMessageId",
-  "idempotencyKey",
-]);
-const forgetRequestKeys = new Set(["schemaVersion", "target", "entryIds", "reason", "sourceMessageId", "idempotencyKey"]);
-const projectTargetIdKeys = new Set(["type", "id"]);
-const projectTargetPathKeys = new Set(["type", "path"]);
-const characterTargetIdKeys = new Set(["type", "id"]);
-const memoryTagKeys = new Set(["type", "value"]);
-const projectProjectTargetKeys = new Set(["owner", "scope", "project"]);
-const characterCharacterTargetKeys = new Set(["owner", "scope", "character"]);
-const characterProjectTargetKeys = new Set(["owner", "scope", "character", "project"]);
-const userGlobalTargetKeys = new Set(["owner", "scope"]);
-
-const maxSearchQueryLength = 500;
-const maxTitleLength = 160;
-const maxPreviewLength = 280;
-const maxBodyLength = 8_000;
-const maxTagTypeLength = 48;
-const maxTagValueLength = 96;
-const maxIdLength = 200;
-const maxCursorLength = 500;
-const maxLimit = 50;
-const maxTags = 20;
-const maxSupersedes = 20;
-const maxForgetEntryIds = 50;
-const maxTargets = 5;
-
-function isRecord(value) {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+function validateMemoryCliRequestBody(command, body) {
+	if (command === "search") return validateMemorySearchRequest(body);
+	if (command === "get_entry") return validateMemoryGetEntryRequest(body);
+	if (command === "get_file") return validateMemoryGetFileRequest(body);
+	if (command === "export_files") return validateMemoryExportFilesRequest(body);
+	if (command === "list_tags") return validateMemoryListTagsRequest(body);
+	if (command === "append") return validateMemoryAppendRequest(body);
+	return validateMemoryForgetRequest(body);
 }
-
-function validationError(code, message, field) {
-  return { ok: false, error: field ? { code, message, field } : { code, message } };
-}
-
-function rejectUnknownKeys(value, allowedKeys, field) {
-  for (const key of Object.keys(value)) {
-    if (!allowedKeys.has(key)) {
-      return validationError("MEMORY_UNKNOWN_FIELD", `Unknown field: ${field}.${key}`, `${field}.${key}`);
-    }
-  }
-  return { ok: true, value: undefined };
-}
-
-function hasUnpairedSurrogate(value) {
-  for (let index = 0; index < value.length; index += 1) {
-    const code = value.charCodeAt(index);
-    if (code >= 0xd800 && code <= 0xdbff) {
-      const next = value.charCodeAt(index + 1);
-      if (!(next >= 0xdc00 && next <= 0xdfff)) {
-        return true;
-      }
-      index += 1;
-      continue;
-    }
-    if (code >= 0xdc00 && code <= 0xdfff) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function normalizeText(value, field, options) {
-  if (typeof value !== "string") {
-    if (options.required === false && value === undefined) {
-      return { ok: true, value: "" };
-    }
-    return validationError("MEMORY_INVALID_FIELD", `${field} must be a string.`, field);
-  }
-  if (value.includes("\0")) {
-    return validationError("MEMORY_INVALID_FIELD", `${field} must not contain null bytes.`, field);
-  }
-  if (hasUnpairedSurrogate(value)) {
-    return validationError("MEMORY_INVALID_FIELD", `${field} must be well-formed Unicode.`, field);
-  }
-  const normalized = value.trim();
-  if (options.required !== false && normalized.length === 0) {
-    return validationError("MEMORY_INVALID_FIELD", `${field} must not be empty.`, field);
-  }
-  if (normalized.length > options.maxLength) {
-    return validationError("MEMORY_FIELD_TOO_LARGE", `${field} is too long.`, field);
-  }
-  return { ok: true, value: normalized };
-}
-
-function normalizeOptionalText(value, field, maxLength = maxIdLength) {
-  if (value === undefined) {
-    return { ok: true, value: undefined };
-  }
-  return normalizeText(value, field, { maxLength });
-}
-
-function validateSchemaVersion(value) {
-  if (value.schemaVersion !== schemaVersion) {
-    return validationError("MEMORY_INVALID_SCHEMA_VERSION", "Unsupported memory schemaVersion.", "schemaVersion");
-  }
-  return { ok: true, value: undefined };
-}
-
-function normalizeStringArray(value, field, options) {
-  if (value === undefined) {
-    return { ok: true, value: undefined };
-  }
-  if (!Array.isArray(value)) {
-    return validationError("MEMORY_INVALID_FIELD", `${field} must be an array.`, field);
-  }
-  if (value.length > options.maxItems) {
-    return validationError("MEMORY_FIELD_TOO_LARGE", `${field} has too many items.`, field);
-  }
-  const normalized = [];
-  const seen = new Set();
-  for (let index = 0; index < value.length; index += 1) {
-    const item = normalizeText(value[index], `${field}[${index}]`, { maxLength: options.maxLength });
-    if (!item.ok) {
-      return item;
-    }
-    if (seen.has(item.value)) {
-      continue;
-    }
-    seen.add(item.value);
-    normalized.push(item.value);
-  }
-  return { ok: true, value: normalized };
-}
-
-function validateMemoryKind(value, field) {
-  if (typeof value !== "string" || !entryKindSet.has(value)) {
-    return validationError("MEMORY_INVALID_FIELD", `${field} must be a valid memory kind.`, field);
-  }
-  return { ok: true, value };
-}
-
-function normalizeProjectTarget(value, field) {
-  if (!isRecord(value)) {
-    return validationError("MEMORY_INVALID_FIELD", `${field} must be an object.`, field);
-  }
-  if (value.type === "id") {
-    const unknownKeys = rejectUnknownKeys(value, projectTargetIdKeys, field);
-    if (!unknownKeys.ok) {
-      return unknownKeys;
-    }
-    const id = normalizeText(value.id, `${field}.id`, { maxLength: maxIdLength });
-    return id.ok ? { ok: true, value: { type: "id", id: id.value } } : id;
-  }
-  if (value.type === "path") {
-    const unknownKeys = rejectUnknownKeys(value, projectTargetPathKeys, field);
-    if (!unknownKeys.ok) {
-      return unknownKeys;
-    }
-    const projectPath = normalizeText(value.path, `${field}.path`, { maxLength: 1_000 });
-    return projectPath.ok ? { ok: true, value: { type: "path", path: projectPath.value } } : projectPath;
-  }
-  return validationError("MEMORY_INVALID_FIELD", `${field}.type must be id or path.`, `${field}.type`);
-}
-
-function normalizeCharacterTarget(value, field) {
-  if (!isRecord(value)) {
-    return validationError("MEMORY_INVALID_FIELD", `${field} must be an object.`, field);
-  }
-  if (value.type === "id") {
-    const unknownKeys = rejectUnknownKeys(value, characterTargetIdKeys, field);
-    if (!unknownKeys.ok) {
-      return unknownKeys;
-    }
-    const id = normalizeText(value.id, `${field}.id`, { maxLength: maxIdLength });
-    return id.ok ? { ok: true, value: { type: "id", id: id.value } } : id;
-  }
-  return validationError("MEMORY_INVALID_FIELD", `${field}.type must be id.`, `${field}.type`);
-}
-
-function normalizeMemoryTarget(value, field) {
-  if (!isRecord(value)) {
-    return validationError("MEMORY_INVALID_FIELD", `${field} must be an object.`, field);
-  }
-  if (value.owner === "user" && value.scope === "global") {
-    const unknownKeys = rejectUnknownKeys(value, userGlobalTargetKeys, field);
-    if (!unknownKeys.ok) {
-      return unknownKeys;
-    }
-    return { ok: true, value: { owner: "user", scope: "global" } };
-  }
-  if (value.owner === "project" && value.scope === "project") {
-    const unknownKeys = rejectUnknownKeys(value, projectProjectTargetKeys, field);
-    if (!unknownKeys.ok) {
-      return unknownKeys;
-    }
-    const project = normalizeProjectTarget(value.project, `${field}.project`);
-    return project.ok ? { ok: true, value: { owner: "project", scope: "project", project: project.value } } : project;
-  }
-  if (value.owner === "character" && value.scope === "character") {
-    const unknownKeys = rejectUnknownKeys(value, characterCharacterTargetKeys, field);
-    if (!unknownKeys.ok) {
-      return unknownKeys;
-    }
-    const character = normalizeCharacterTarget(value.character, `${field}.character`);
-    return character.ok ? { ok: true, value: { owner: "character", scope: "character", character: character.value } } : character;
-  }
-  if (value.owner === "character" && value.scope === "project") {
-    const unknownKeys = rejectUnknownKeys(value, characterProjectTargetKeys, field);
-    if (!unknownKeys.ok) {
-      return unknownKeys;
-    }
-    const character = normalizeCharacterTarget(value.character, `${field}.character`);
-    if (!character.ok) {
-      return character;
-    }
-    const project = normalizeProjectTarget(value.project, `${field}.project`);
-    return project.ok
-      ? { ok: true, value: { owner: "character", scope: "project", character: character.value, project: project.value } }
-      : project;
-  }
-  return validationError("MEMORY_INVALID_TARGET", "Unsupported memory owner / scope combination.", field);
-}
-
-function normalizeTargets(value) {
-  if (!Array.isArray(value) || value.length === 0) {
-    return validationError("MEMORY_TARGET_REQUIRED", "At least one memory target is required.", "targets");
-  }
-  if (value.length > maxTargets) {
-    return validationError("MEMORY_FIELD_TOO_LARGE", `targets supports at most ${maxTargets} items.`, "targets");
-  }
-  const normalized = [];
-  const seen = new Set();
-  for (let index = 0; index < value.length; index += 1) {
-    const target = normalizeMemoryTarget(value[index], `targets[${index}]`);
-    if (!target.ok) {
-      return target;
-    }
-    const key = JSON.stringify(target.value);
-    if (seen.has(key)) {
-      return validationError("MEMORY_DUPLICATE_TARGET", "targets must not contain duplicates.", `targets[${index}]`);
-    }
-    seen.add(key);
-    normalized.push(target.value);
-  }
-  return { ok: true, value: normalized };
-}
-
-function normalizeTags(value, field = "tags", options = {}) {
-  if (value === undefined) {
-    if (options.required) {
-      return validationError("MEMORY_INVALID_FIELD", `${field} is required.`, field);
-    }
-    return { ok: true, value: [] };
-  }
-  if (!Array.isArray(value)) {
-    return validationError("MEMORY_INVALID_FIELD", `${field} must be an array.`, field);
-  }
-  if (value.length > maxTags) {
-    return validationError("MEMORY_FIELD_TOO_LARGE", `${field} has too many items.`, field);
-  }
-  const normalized = [];
-  const seen = new Set();
-  for (let index = 0; index < value.length; index += 1) {
-    const tag = value[index];
-    if (!isRecord(tag)) {
-      return validationError("MEMORY_INVALID_FIELD", `${field}[${index}] must be an object.`, `${field}[${index}]`);
-    }
-    const unknownKeys = rejectUnknownKeys(tag, memoryTagKeys, `${field}[${index}]`);
-    if (!unknownKeys.ok) {
-      return unknownKeys;
-    }
-    const type = normalizeText(tag.type, `${field}[${index}].type`, { maxLength: maxTagTypeLength });
-    if (!type.ok) {
-      return type;
-    }
-    const tagValue = normalizeText(tag.value, `${field}[${index}].value`, { maxLength: maxTagValueLength });
-    if (!tagValue.ok) {
-      return tagValue;
-    }
-    const canonicalType = type.value.normalize("NFC").toLowerCase();
-    const canonicalValue = tagValue.value.normalize("NFC").toLowerCase();
-    const key = `${canonicalType}\0${canonicalValue}`;
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    normalized.push({ type: type.value, value: tagValue.value, canonicalType, canonicalValue });
-  }
-  return { ok: true, value: normalized };
-}
-
-function normalizeKinds(value) {
-  if (value === undefined) {
-    return { ok: true, value: undefined };
-  }
-  if (!Array.isArray(value)) {
-    return validationError("MEMORY_INVALID_FIELD", "kinds must be an array.", "kinds");
-  }
-  if (value.length > entryKinds.length) {
-    return validationError("MEMORY_FIELD_TOO_LARGE", "kinds has too many items.", "kinds");
-  }
-  const normalized = [];
-  const seen = new Set();
-  for (let index = 0; index < value.length; index += 1) {
-    const kind = validateMemoryKind(value[index], `kinds[${index}]`);
-    if (!kind.ok) {
-      return kind;
-    }
-    if (seen.has(kind.value)) {
-      continue;
-    }
-    seen.add(kind.value);
-    normalized.push(kind.value);
-  }
-  return { ok: true, value: normalized.length > 0 ? normalized : undefined };
-}
-
-function validateRequest(command, body) {
-  if (!isRecord(body)) {
-    const label = command === "get_entry" ? "Get entry"
-      : command === "list_tags" ? "List tags"
-        : command[0].toUpperCase() + command.slice(1);
-    return validationError("MEMORY_INVALID_REQUEST", `${label} request must be an object.`);
-  }
-  if (command === "search") {
-    const unknownKeys = rejectUnknownKeys(body, searchRequestKeys, "request");
-    if (!unknownKeys.ok) {
-      return unknownKeys;
-    }
-    const schema = validateSchemaVersion(body);
-    if (!schema.ok) {
-      return schema;
-    }
-    const targets = normalizeTargets(body.targets);
-    if (!targets.ok) {
-      return targets;
-    }
-    const query = normalizeText(body.query, "query", { maxLength: maxSearchQueryLength });
-    if (!query.ok) {
-      return query;
-    }
-    const kinds = normalizeKinds(body.kinds);
-    if (!kinds.ok) {
-      return kinds;
-    }
-    const tags = normalizeTags(body.tags);
-    if (!tags.ok) {
-      return tags;
-    }
-    const cursor = normalizeOptionalText(body.cursor, "cursor", maxCursorLength);
-    if (!cursor.ok) {
-      return cursor;
-    }
-    let limit;
-    if (body.limit !== undefined) {
-      if (typeof body.limit !== "number" || !Number.isInteger(body.limit) || body.limit < 1 || body.limit > maxLimit) {
-        return validationError("MEMORY_INVALID_FIELD", `limit must be an integer from 1 to ${maxLimit}.`, "limit");
-      }
-      limit = body.limit;
-    }
-    return {
-      ok: true,
-      value: {
-        schemaVersion,
-        targets: targets.value,
-        query: query.value,
-        ...(kinds.value ? { kinds: kinds.value } : {}),
-        ...(tags.value.length > 0 ? { tags: tags.value } : {}),
-        ...(limit !== undefined ? { limit } : {}),
-        ...(cursor.value !== undefined ? { cursor: cursor.value } : {}),
-      },
-    };
-  }
-  if (command === "get_entry") {
-    const unknownKeys = rejectUnknownKeys(body, getEntryRequestKeys, "request");
-    if (!unknownKeys.ok) {
-      return unknownKeys;
-    }
-    const schema = validateSchemaVersion(body);
-    if (!schema.ok) {
-      return schema;
-    }
-    const entryId = normalizeText(body.entryId, "entryId", { maxLength: maxIdLength });
-    if (!entryId.ok) {
-      return entryId;
-    }
-    const target = normalizeMemoryTarget(body.target, "target");
-    if (!target.ok) {
-      return target;
-    }
-    return {
-      ok: true,
-      value: {
-        schemaVersion,
-        entryId: entryId.value,
-        target: target.value,
-      },
-    };
-  }
-  if (command === "list_tags") {
-    const unknownKeys = rejectUnknownKeys(body, listTagsRequestKeys, "request");
-    if (!unknownKeys.ok) {
-      return unknownKeys;
-    }
-    const schema = validateSchemaVersion(body);
-    if (!schema.ok) {
-      return schema;
-    }
-    const targets = normalizeTargets(body.targets);
-    if (!targets.ok) {
-      return targets;
-    }
-    return { ok: true, value: { schemaVersion, targets: targets.value } };
-  }
-  if (command === "append") {
-    const unknownKeys = rejectUnknownKeys(body, appendRequestKeys, "request");
-    if (!unknownKeys.ok) {
-      return unknownKeys;
-    }
-    const schema = validateSchemaVersion(body);
-    if (!schema.ok) {
-      return schema;
-    }
-    const target = normalizeMemoryTarget(body.target, "target");
-    if (!target.ok) {
-      return target;
-    }
-    const kind = validateMemoryKind(body.kind, "kind");
-    if (!kind.ok) {
-      return kind;
-    }
-    const title = normalizeText(body.title, "title", { maxLength: maxTitleLength });
-    if (!title.ok) {
-      return title;
-    }
-    const requestBody = normalizeText(body.body, "body", { maxLength: maxBodyLength });
-    if (!requestBody.ok) {
-      return requestBody;
-    }
-    const preview = normalizeText(body.preview, "preview", { maxLength: maxPreviewLength });
-    if (!preview.ok) {
-      return preview;
-    }
-    const tags = normalizeTags(body.tags, "tags", { required: true });
-    if (!tags.ok) {
-      return tags;
-    }
-    const supersedes = normalizeStringArray(body.supersedes, "supersedes", { maxItems: maxSupersedes, maxLength: maxIdLength });
-    if (!supersedes.ok) {
-      return supersedes;
-    }
-    const sourceMessageId = normalizeOptionalText(body.sourceMessageId, "sourceMessageId");
-    if (!sourceMessageId.ok) {
-      return sourceMessageId;
-    }
-    const idempotencyKey = normalizeOptionalText(body.idempotencyKey, "idempotencyKey");
-    if (!idempotencyKey.ok) {
-      return idempotencyKey;
-    }
-    return {
-      ok: true,
-      value: {
-        schemaVersion,
-        target: target.value,
-        kind: kind.value,
-        title: title.value,
-        body: requestBody.value,
-        preview: preview.value,
-        tags: tags.value,
-        ...(supersedes.value && supersedes.value.length > 0 ? { supersedes: supersedes.value } : {}),
-        ...(sourceMessageId.value !== undefined ? { sourceMessageId: sourceMessageId.value } : {}),
-        ...(idempotencyKey.value !== undefined ? { idempotencyKey: idempotencyKey.value } : {}),
-      },
-    };
-  }
-  const unknownKeys = rejectUnknownKeys(body, forgetRequestKeys, "request");
-  if (!unknownKeys.ok) {
-    return unknownKeys;
-  }
-  const schema = validateSchemaVersion(body);
-  if (!schema.ok) {
-    return schema;
-  }
-  const target = normalizeMemoryTarget(body.target, "target");
-  if (!target.ok) {
-    return target;
-  }
-  const entryIds = normalizeStringArray(body.entryIds, "entryIds", { maxItems: maxForgetEntryIds, maxLength: maxIdLength });
-  if (!entryIds.ok) {
-    return entryIds;
-  }
-  if (!entryIds.value || entryIds.value.length === 0) {
-    return validationError("MEMORY_INVALID_FIELD", "entryIds must not be empty.", "entryIds");
-  }
-  if (body.reason !== undefined && (typeof body.reason !== "string" || !forgetReasonSet.has(body.reason))) {
-    return validationError("MEMORY_INVALID_FIELD", "reason must be a valid forget reason.", "reason");
-  }
-  const sourceMessageId = normalizeOptionalText(body.sourceMessageId, "sourceMessageId");
-  if (!sourceMessageId.ok) {
-    return sourceMessageId;
-  }
-  const idempotencyKey = normalizeOptionalText(body.idempotencyKey, "idempotencyKey");
-  if (!idempotencyKey.ok) {
-    return idempotencyKey;
-  }
-  return {
-    ok: true,
-    value: {
-      schemaVersion,
-      target: target.value,
-      entryIds: entryIds.value,
-      ...(body.reason !== undefined ? { reason: body.reason } : {}),
-      ...(sourceMessageId.value !== undefined ? { sourceMessageId: sourceMessageId.value } : {}),
-      ...(idempotencyKey.value !== undefined ? { idempotencyKey: idempotencyKey.value } : {}),
-    }
-  };
-}
-
 function buildValidateResponse(command, body) {
-  const result = validateRequest(command, body);
-  if (!result.ok) {
-    return { exitCode: exitCodes.apiError, response: { schemaVersion, error: result.error } };
-  }
-  return {
-    exitCode: exitCodes.ok,
-    response: { schemaVersion, valid: true, command, value: result.value },
-  };
+	const validation = validateMemoryCliRequestBody(command, body);
+	if (!validation.ok) return {
+		exitCode: WITHMATE_MEMORY_CLI_EXIT_CODES.apiError,
+		response: createMemoryErrorResponse(validation.error)
+	};
+	return {
+		exitCode: WITHMATE_MEMORY_CLI_EXIT_CODES.ok,
+		response: {
+			schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+			valid: true,
+			command,
+			value: validation.value
+		}
+	};
 }
-
 async function readJsonResponse(response) {
-  const text = await response.text();
-  if (!text.trim()) {
-    return {};
-  }
-  try {
-    return JSON.parse(text);
-  } catch {
-    throw memoryError("WITHMATE_MEMORY_TRANSPORT_ERROR", "Memory API returned a non-JSON response.");
-  }
+	const text = await response.text();
+	if (!text.trim()) return {};
+	try {
+		return JSON.parse(text);
+	} catch {
+		throw transportError("Memory API returned a non-JSON response.");
+	}
 }
-
-async function verifyRuntime(connection, signal) {
-  if (!connection.apiSecret || !connection.runtimeInstanceId) {
-    return false;
-  }
-  const nonce = randomBytes(16).toString("base64url");
-  const response = await fetch(`${connection.baseUrl}/v1/status?nonce=${encodeURIComponent(nonce)}`, {
-    method: "GET",
-    redirect: "error",
-    signal,
-  });
-  if (!response.ok) {
-    return false;
-  }
-  const status = await readJsonResponse(response);
-  const expected = createHmac("sha256", connection.apiSecret).update(nonce, "utf8").digest("base64url");
-  return status.runtimeInstanceId === connection.runtimeInstanceId
-    && status.challenge?.nonce === nonce
-    && status.challenge?.hmacSha256 === expected;
+function createStatusChallenge(apiSecret, nonce) {
+	return createHmac("sha256", apiSecret).update(nonce, "utf8").digest("base64url");
 }
-
-async function main() {
-  try {
-    const request = await parseArgs(process.argv.slice(2));
-    if (request.route.name === "help") {
-      console.log(helpText.trimEnd());
-      return exitCodes.ok;
-    }
-    if (request.route.name === "schema") {
-      console.log(JSON.stringify(buildSchemaResponse()));
-      return exitCodes.ok;
-    }
-    if (request.route.name === "validate") {
-      const result = buildValidateResponse(request.validateCommand, normalizeProjectPathTargets(request.body));
-      console.log(JSON.stringify(result.response));
-      return result.exitCode;
-    }
-
-    const connection = await readDiscovery(request);
-    if (!connection) {
-      console.log(JSON.stringify(notRunning()));
-      return exitCodes.notRunning;
-    }
-
-    const abortController = new AbortController();
-    const timeout = setTimeout(() => abortController.abort(), 10_000);
-    try {
-      try {
-        if (!await verifyRuntime(connection, abortController.signal)) {
-          console.log(JSON.stringify(notRunning()));
-          return exitCodes.notRunning;
-        }
-        const headers = {};
-        if (request.route.method === "POST") {
-          headers["Content-Type"] = "application/json";
-        }
-        if (connection.apiSecret) {
-          headers[apiSecretHeader] = connection.apiSecret;
-        }
-        const response = await fetch(`${connection.baseUrl}${request.route.path}`, {
-          method: request.route.method,
-          headers,
-          body: request.route.method === "POST" ? JSON.stringify(normalizeProjectPathTargets(request.body)) : undefined,
-          redirect: "error",
-          signal: abortController.signal,
-        });
-        console.log(JSON.stringify(await readJsonResponse(response)));
-        return response.ok ? exitCodes.ok : exitCodes.apiError;
-      } catch (error) {
-        if (error && typeof error === "object" && "error" in error) {
-          throw error;
-        }
-        console.log(JSON.stringify(notRunning()));
-        return exitCodes.notRunning;
-      }
-    } finally {
-      clearTimeout(timeout);
-    }
-  } catch (error) {
-    if (error && typeof error === "object" && "error" in error) {
-      console.log(JSON.stringify(error));
-      return error.error?.code === "WITHMATE_MEMORY_CLI_USAGE" ? exitCodes.usage : exitCodes.transportError;
-    }
-    console.log(JSON.stringify(memoryError("WITHMATE_MEMORY_TRANSPORT_ERROR", error instanceof Error ? error.message : "Memory CLI request failed.")));
-    return exitCodes.transportError;
-  }
+function hasVerifiableRuntimeIdentity(connection) {
+	return Boolean(connection.apiSecret?.trim() && connection.runtimeInstanceId?.trim());
 }
-
-process.exitCode = await main();
+async function verifyRuntimeIdentity(connection, fetchImpl, signal) {
+	if (!hasVerifiableRuntimeIdentity(connection)) return false;
+	const nonce = randomBytes(16).toString("base64url");
+	const response = await fetchImpl(`${connection.baseUrl}/v1/status?nonce=${encodeURIComponent(nonce)}`, {
+		method: "GET",
+		redirect: "error",
+		signal
+	});
+	if (!response.ok) return false;
+	const status = await readJsonResponse(response);
+	return status.runtimeInstanceId === connection.runtimeInstanceId && status.challenge?.nonce === nonce && status.challenge.hmacSha256 === createStatusChallenge(connection.apiSecret, nonce);
+}
+async function runWithMateMemoryCli(args, deps = {}) {
+	const stdout = deps.stdout ?? process.stdout;
+	const stderr = deps.stderr ?? process.stderr;
+	const fetchImpl = deps.fetch ?? fetch;
+	try {
+		const request = await parseWithMateMemoryCliArgs(args, deps);
+		if (request.command === "help") {
+			stdout.write(WITHMATE_MEMORY_CLI_HELP);
+			return WITHMATE_MEMORY_CLI_EXIT_CODES.ok;
+		}
+		if (request.command === "schema") {
+			stdout.write(`${JSON.stringify(buildSchemaResponse())}\n`);
+			return WITHMATE_MEMORY_CLI_EXIT_CODES.ok;
+		}
+		if (request.command === "validate") {
+			const result = buildValidateResponse(request.validateCommand, request.body);
+			stdout.write(`${JSON.stringify(result.response)}\n`);
+			return result.exitCode;
+		}
+		const connection = await discoverWithMateMemoryApi({
+			env: deps.env,
+			apiUrl: request.apiUrl,
+			discoveryFilePath: request.discoveryFilePath,
+			readFile: deps.readFile
+		});
+		if (!connection) {
+			stdout.write(`${JSON.stringify(notRunningError())}\n`);
+			return WITHMATE_MEMORY_CLI_EXIT_CODES.notRunning;
+		}
+		try {
+			const verifyAbortController = new AbortController();
+			const verifyTimeout = setTimeout(() => verifyAbortController.abort(), deps.requestTimeoutMs ?? 1e4);
+			try {
+				if (!await verifyRuntimeIdentity(connection, fetchImpl, verifyAbortController.signal)) {
+					stdout.write(`${JSON.stringify(notRunningError())}\n`);
+					return WITHMATE_MEMORY_CLI_EXIT_CODES.notRunning;
+				}
+			} finally {
+				clearTimeout(verifyTimeout);
+			}
+		} catch (error) {
+			if (isMemoryErrorResponse(error)) throw error;
+			stdout.write(`${JSON.stringify(notRunningError())}\n`);
+			return WITHMATE_MEMORY_CLI_EXIT_CODES.notRunning;
+		}
+		const route = routeByCommand[request.command];
+		let response;
+		let responseJson;
+		const operationTimeoutMs = resolveRuntimeRequestTimeoutMs(request.command, deps);
+		const abortController = new AbortController();
+		const requestTimeout = setTimeout(() => abortController.abort(), operationTimeoutMs);
+		try {
+			const headers = {};
+			if (route.method === "POST") headers["Content-Type"] = "application/json";
+			if (connection.apiSecret) headers[WITHMATE_MEMORY_API_SECRET_HEADER] = connection.apiSecret;
+			response = await fetchImpl(`${connection.baseUrl}${buildRoutePath(request)}`, {
+				method: route.method,
+				headers: Object.keys(headers).length > 0 ? headers : void 0,
+				body: route.method === "POST" ? JSON.stringify(request.body) : void 0,
+				redirect: "error",
+				signal: abortController.signal
+			});
+			responseJson = await readJsonResponse(response);
+		} catch (error) {
+			if (isMemoryErrorResponse(error)) throw error;
+			if (isAbortError(error)) {
+				stdout.write(`${JSON.stringify(requestTimeoutError(request.command, operationTimeoutMs))}\n`);
+				return WITHMATE_MEMORY_CLI_EXIT_CODES.apiError;
+			}
+			stdout.write(`${JSON.stringify(notRunningError())}\n`);
+			return WITHMATE_MEMORY_CLI_EXIT_CODES.notRunning;
+		} finally {
+			clearTimeout(requestTimeout);
+		}
+		stdout.write(`${JSON.stringify(responseJson)}\n`);
+		return response.ok ? WITHMATE_MEMORY_CLI_EXIT_CODES.ok : WITHMATE_MEMORY_CLI_EXIT_CODES.apiError;
+	} catch (error) {
+		const response = isMemoryErrorResponse(error) ? error : transportError(error instanceof Error ? error.message : "Memory CLI request failed.");
+		stdout.write(`${JSON.stringify(response)}\n`);
+		if (!isMemoryErrorResponse(error)) stderr.write("withmate-memory transport failed\n");
+		if (!isMemoryErrorResponse(error)) return WITHMATE_MEMORY_CLI_EXIT_CODES.transportError;
+		return error.error.code === "WITHMATE_MEMORY_CLI_USAGE" ? WITHMATE_MEMORY_CLI_EXIT_CODES.usage : WITHMATE_MEMORY_CLI_EXIT_CODES.transportError;
+	}
+}
+function isMemoryErrorResponse(value) {
+	return typeof value === "object" && value !== null && "error" in value;
+}
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) process.exitCode = await runWithMateMemoryCli(process.argv.slice(2));
+//#endregion
+export { DEFAULT_FILE_OPERATION_REQUEST_TIMEOUT_MS, DEFAULT_REQUEST_TIMEOUT_MS, WITHMATE_MEMORY_CLI_EXIT_CODES, WITHMATE_MEMORY_DISCOVERY_FILE_NAME, WITHMATE_MEMORY_DISCOVERY_SCHEMA_VERSION, discoverWithMateMemoryApi, parseWithMateMemoryCliArgs, resolveRuntimeRequestTimeoutMs, runWithMateMemoryCli };

--- a/resources/skills/withmate-memory/reference/cli.md
+++ b/resources/skills/withmate-memory/reference/cli.md
@@ -16,6 +16,12 @@ On Windows, the installer places `withmate-memory.cmd` in the WithMate install d
 
 When a managed skill includes `bin/withmate-memory.mjs` and no `withmate-memory` command is available on `PATH`, use `node bin/withmate-memory.mjs <command>` as a temporary fallback.
 
+## Contents
+
+- [Commands](#commands)
+- [Exit Codes](#exit-codes)
+- [Notes](#notes)
+
 ## Commands
 
 ### help
@@ -61,6 +67,15 @@ withmate-memory characters
 
 Returns active Character catalog entries so callers can choose an explicit Character ID. It does not return Character definition or notes body.
 
+### file-usage
+
+```bash
+withmate-memory file-usage
+withmate-memory file-usage --largest --limit 20
+```
+
+Returns WithMate-wide Protected Object quota and usage metadata. `--largest` includes the largest active Memory entry candidates and `--limit` bounds that list. It does not return source paths, object-store paths, keys, hashes, or decrypted content.
+
 ### search
 
 ```bash
@@ -77,12 +92,19 @@ Request shape:
   "targets": [
     { "owner": "project", "project": { "type": "path", "path": "<absolute-repo-path>" }, "scope": "project" }
   ],
-  "query": "approval mode"
+  "query": "approval mode",
+  "kinds": ["decision", "constraint"],
+  "limit": 20,
+  "cursor": "<nextCursor-from-prior-response>"
 }
 ```
 
 Search returns active entry previews only. Use `get-entry` when the exact body matters.
 Search uses natural-language terms across title, preview, body, and tags. Hyphenated and spaced tag words such as `delivery-cleanup` and `delivery cleanup` are treated as related candidates. Shorthand `--tag <tag>` defaults to `topic:<tag>`, and `--tags` accepts comma-separated `<type>:<tag>` values. Search results may include matched fields and a short snippet; body matches may be reported in `match.fields`, but snippets are limited to tags, title, and preview. 0-result responses may include related tag candidates.
+
+The response contains results in `items[]` and may contain `relatedTags[]` and `nextCursor`. Each result uses `id` as its entry ID and may include attached-object metadata in `files[]`.
+
+`kinds`, `limit`, and `cursor` are optional. Omit `cursor` on the first page. When a response includes `nextCursor`, repeat the same target, query, kinds, tags, and limit with that cursor. Continue pagination when an exhaustive append-preflight or requested lookup has not found a conclusive match.
 
 For provider-independent user preferences, conventions, constraints, or other cross-project context, use an explicit user-global target:
 
@@ -113,6 +135,49 @@ Request shape:
 ```
 
 `get-entry` must include `target`, using a project target, character target, character-project target, or `{ "owner": "user", "scope": "global" }`.
+The response contains the full Memory in `entry`. Attached-object metadata, when present, is in `entry.files[]`; use each item's `objectId` with `get-file`.
+
+### get-file
+
+```bash
+withmate-memory get-file --project <absolute-repo-path> --object-id <object-id> --output <absolute-output-path>
+withmate-memory get-file --file memory-get-file.json
+```
+
+Request shape:
+
+```json
+{
+  "schemaVersion": "withmate-memory-v1",
+  "target": { "owner": "project", "project": { "type": "path", "path": "<absolute-repo-path>" }, "scope": "project" },
+  "objectId": "<object-id>",
+  "outputPath": "<absolute-output-path>"
+}
+```
+
+Exports one attached object after target validation. The output path must be absolute, and an existing file is never overwritten.
+The response confirms `objectId`, `entryId`, `outputPath`, `bytesWritten`, `contentType`, and `displayName`.
+
+### export-files
+
+```bash
+withmate-memory export-files --project <absolute-repo-path> --entry-id <entry-id> --output-dir <absolute-output-directory>
+withmate-memory export-files --file memory-export-files.json
+```
+
+Request shape:
+
+```json
+{
+  "schemaVersion": "withmate-memory-v1",
+  "target": { "owner": "project", "project": { "type": "path", "path": "<absolute-repo-path>" }, "scope": "project" },
+  "entryId": "<entry-id>",
+  "outputDirectoryPath": "<absolute-output-directory>"
+}
+```
+
+Creates the output directory when needed and exports all files attached to the entry with safe object-prefixed names. Existing output files are never overwritten.
+The response confirms `entryId`, `outputDirectoryPath`, `exportedCount`, and one result per object in `files[]`.
 
 ### list-tags
 
@@ -148,9 +213,23 @@ Input shape:
   "body": "Durable details for future sessions.",
   "preview": "Short preview.",
   "tags": [{ "type": "topic", "value": "release" }],
+  "supersedes": ["optional-replaced-entry-id"],
+  "files": [
+    {
+      "path": "<absolute-readable-file-path>",
+      "role": "evidence",
+      "summary": "Why this file is retained.",
+      "displayName": "optional-name.txt",
+      "contentType": "text/plain"
+    }
+  ],
   "idempotencyKey": "optional-stable-key"
 }
 ```
+
+`supersedes` is an array of entry IDs. `files` is optional. Each `files[]` item requires an absolute readable file path and a non-empty summary. `role` is optional and accepts `evidence`, `source`, `snapshot`, `artifact`, `reference`, or `other`; `displayName` and `contentType` are optional metadata.
+
+Do not attach secrets or files outside the user's authorized scope. Input paths are used for import and are not exposed in agent-facing Memory responses. File append is atomic with entry creation: quota, import, metadata, or idempotency failure must not be interpreted as a successful text-only append.
 
 ### forget
 
@@ -170,14 +249,16 @@ Input shape:
 }
 ```
 
+For `append` and `forget`, choose a stable idempotency key before the first attempt. If a timeout or response loss leaves the result ambiguous, retry the unchanged request with the same key. A changed request body requires a new key.
+
 ## Exit Codes
 
 | Code | Meaning |
 | --- | --- |
 | `0` | Success |
-| `1` | Usage or validation error |
+| `1` | CLI usage or argument error |
 | `2` | WithMate Memory API is not running or could not be discovered |
-| `3` | Runtime API returned a non-success JSON response |
+| `3` | Local request validation failed, or the runtime API returned a non-success JSON response |
 | `4` | Transport failure |
 
 ## Notes
@@ -189,5 +270,6 @@ Input shape:
 - Character targets use explicit IDs, for example `{ "owner": "character", "character": { "type": "id", "id": "<character-id>" }, "scope": "character" }`. If the ID is unknown, run `withmate-memory characters` first.
 - User-global Memory is visible across projects and providers. Store only user-level preferences, conventions, constraints, or other cross-project context there; do not store secrets, tokens, or project-specific private details.
 - Append is idempotent when an idempotency key is supplied.
+- `append`, `get-file`, and `export-files` use a longer 300-second operation timeout by default. A mutation timeout is ambiguous; do not assume it proves that no write occurred.
 - Forget hides entries from normal search and skill results.
 - Memory failures should not fail unrelated coding work.

--- a/scripts/build-withmate-memory-cli.ts
+++ b/scripts/build-withmate-memory-cli.ts
@@ -1,0 +1,49 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { build } from "vite";
+
+const repositoryRootPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const canonicalCliEntryPath = path.join(repositoryRootPath, "scripts", "withmate-memory.ts");
+const defaultOutputDirectoryPath = path.join(
+  repositoryRootPath,
+  "resources",
+  "skills",
+  "withmate-memory",
+  "bin",
+);
+
+export const BUNDLED_MEMORY_CLI_FILE_NAME = "withmate-memory.mjs";
+
+export async function buildWithMateMemoryCli(
+  outputDirectoryPath = defaultOutputDirectoryPath,
+): Promise<string> {
+  const resolvedOutputDirectoryPath = path.resolve(outputDirectoryPath);
+  await mkdir(resolvedOutputDirectoryPath, { recursive: true });
+  await build({
+    configFile: false,
+    logLevel: "error",
+    build: {
+      ssr: canonicalCliEntryPath,
+      outDir: resolvedOutputDirectoryPath,
+      emptyOutDir: false,
+      copyPublicDir: false,
+      target: "node20",
+      minify: false,
+      sourcemap: false,
+      rollupOptions: {
+        output: {
+          banner: "// Generated from scripts/withmate-memory.ts. Do not edit directly.",
+          codeSplitting: false,
+          entryFileNames: BUNDLED_MEMORY_CLI_FILE_NAME,
+        },
+      },
+    },
+  });
+  return path.join(resolvedOutputDirectoryPath, BUNDLED_MEMORY_CLI_FILE_NAME);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await buildWithMateMemoryCli();
+}

--- a/scripts/tests/managed-memory-skill-service.test.ts
+++ b/scripts/tests/managed-memory-skill-service.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFile } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import { createHmac } from "node:crypto";
 import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
@@ -17,6 +17,10 @@ import {
   WITHMATE_MEMORY_DISCOVERY_FILE_NAME,
   WITHMATE_MEMORY_DISCOVERY_SCHEMA_VERSION,
 } from "../../src/memory-v6/memory-discovery.js";
+import {
+  BUNDLED_MEMORY_CLI_FILE_NAME,
+  buildWithMateMemoryCli,
+} from "../build-withmate-memory-cli.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -51,8 +55,12 @@ async function pathExists(targetPath: string): Promise<boolean> {
   }
 }
 
+function normalizeLineEndings(value: string): string {
+  return value.replace(/\r\n/g, "\n");
+}
+
 describe("ManagedMemorySkillService", () => {
-  it("設定済み provider skill root に Skill.md と managed marker だけを install する", async () => {
+  it("設定済み provider skill root に Skill documentation と managed marker を install する", async () => {
     const bundlePath = await createBundle();
     const rootPath = await mkdtemp(path.join(tmpdir(), "withmate-memory-skill-root-"));
     try {
@@ -79,7 +87,7 @@ describe("ManagedMemorySkillService", () => {
       assert.equal(await readFile(path.join(skillPath, "SKILL.md"), "utf8"), await readFile(path.join(bundlePath, "SKILL.md"), "utf8"));
       assert.match(await readFile(path.join(skillPath, ".withmate-managed-skill.json"), "utf8"), /"managedBy": "WithMate"/);
       assert.equal(await pathExists(path.join(skillPath, "bin")), false);
-      assert.equal(await pathExists(path.join(skillPath, "reference")), false);
+      assert.equal(await readFile(path.join(skillPath, "reference", "cli.md"), "utf8"), "# CLI\n");
     } finally {
       await rm(bundlePath, { recursive: true, force: true });
       await rm(rootPath, { recursive: true, force: true });
@@ -175,6 +183,7 @@ describe("ManagedMemorySkillService", () => {
       assert.equal(result?.status, "updated");
       assert.equal(await pathExists(path.join(skillPath, "bin")), false);
       assert.equal(await readFile(path.join(skillPath, "SKILL.md"), "utf8"), await readFile(path.join(bundlePath, "SKILL.md"), "utf8"));
+      assert.equal(await readFile(path.join(skillPath, "reference", "cli.md"), "utf8"), "# CLI\n");
     } finally {
       await rm(bundlePath, { recursive: true, force: true });
       await rm(rootPath, { recursive: true, force: true });
@@ -211,6 +220,42 @@ describe("ManagedMemorySkillService", () => {
 
       assert.equal(result?.status, "updated");
       assert.equal(installedSkill, "updated bundle\n");
+    } finally {
+      await rm(bundlePath, { recursive: true, force: true });
+      await rm(rootPath, { recursive: true, force: true });
+    }
+  });
+
+  it("同じ app version でも reference 内容が変われば managed skill を更新する", async () => {
+    const bundlePath = await createBundle();
+    const rootPath = await mkdtemp(path.join(tmpdir(), "withmate-memory-skill-root-"));
+    try {
+      const settings = createDefaultAppSettings();
+      settings.codingProviderSettings.codex = {
+        enabled: true,
+        apiKey: "",
+        skillRootPath: rootPath,
+        skillRelativePath: "skills",
+        instructionRelativePath: "",
+      };
+      const service = new ManagedMemorySkillService({
+        bundledSkillPath: bundlePath,
+        getAppSettings: () => settings,
+        getAppVersion: () => "5.0.0-test",
+        platform: "win32",
+      });
+
+      assert.equal((await service.syncConfiguredProviderSkills())[0]?.status, "installed");
+      await writeFile(path.join(bundlePath, "reference", "cli.md"), "# Updated CLI\n", "utf8");
+
+      const result = (await service.syncConfiguredProviderSkills())[0];
+      const installedReference = await readFile(
+        path.join(rootPath, "skills", WITHMATE_MEMORY_SKILL_NAME, "reference", "cli.md"),
+        "utf8",
+      );
+
+      assert.equal(result?.status, "updated");
+      assert.equal(installedReference, "# Updated CLI\n");
     } finally {
       await rm(bundlePath, { recursive: true, force: true });
       await rm(rootPath, { recursive: true, force: true });
@@ -305,7 +350,7 @@ describe("ManagedMemorySkillService", () => {
     }
   });
 
-  it("macOS でも PATH shim が利用可能なら Skill.md と managed marker だけを同期する", async () => {
+  it("macOS でも PATH shim が利用可能なら Skill documentation と managed marker を同期する", async () => {
     const bundlePath = await createBundle();
     const rootPath = await mkdtemp(path.join(tmpdir(), "withmate-memory-skill-root-"));
     try {
@@ -331,7 +376,7 @@ describe("ManagedMemorySkillService", () => {
       assert.equal(result?.status, "installed");
       assert.equal(await pathExists(path.join(skillPath, "SKILL.md")), true);
       assert.equal(await pathExists(path.join(skillPath, "bin", "withmate-memory.mjs")), false);
-      assert.equal(await pathExists(path.join(skillPath, "reference", "cli.md")), false);
+      assert.equal(await readFile(path.join(skillPath, "reference", "cli.md"), "utf8"), "# CLI\n");
     } finally {
       await rm(bundlePath, { recursive: true, force: true });
       await rm(rootPath, { recursive: true, force: true });
@@ -342,14 +387,29 @@ describe("ManagedMemorySkillService", () => {
 describe("withmate-memory bundled helper", () => {
   const helperPath = path.resolve("resources", "skills", WITHMATE_MEMORY_SKILL_NAME, "bin", "withmate-memory.mjs");
 
-  it("runtime が生成する既定 discovery path で status できる", async () => {
+  it("canonical CLI source から生成された current artifact である", async () => {
+    const outputDirectoryPath = await mkdtemp(path.join(tmpdir(), "withmate-memory-cli-build-"));
+    try {
+      await buildWithMateMemoryCli(outputDirectoryPath);
+      assert.equal(
+        normalizeLineEndings(await readFile(path.join(outputDirectoryPath, BUNDLED_MEMORY_CLI_FILE_NAME), "utf8")),
+        normalizeLineEndings(await readFile(helperPath, "utf8")),
+      );
+    } finally {
+      await rm(outputDirectoryPath, { recursive: true, force: true });
+    }
+  });
+
+  it("runtime directory の discovery path で status できる", async () => {
     const tempRootPath = await mkdtemp(path.join(tmpdir(), "withmate-memory-runtime-root-"));
     const ownerSegment = typeof process.getuid === "function" ? `uid-${process.getuid()}` : "local-user";
     const runtimeDirectoryPath = path.join(tempRootPath, "withmate-memory", ownerSegment);
     const apiSecret = "test-secret";
     const runtimeInstanceId = "runtime-from-discovery";
+    const requestedPaths: string[] = [];
     const server = createServer((request, response) => {
       const url = new URL(request.url ?? "/", "http://127.0.0.1");
+      requestedPaths.push(`${request.method ?? "UNKNOWN"} ${url.pathname}${url.search}`);
       if (request.method === "GET" && url.pathname === "/v1/status") {
         const nonce = url.searchParams.get("nonce") ?? "";
         response.setHeader("Content-Type", "application/json");
@@ -389,13 +449,12 @@ describe("withmate-memory bundled helper", () => {
       const { stdout } = await execFileAsync(process.execPath, [helperPath, "status"], {
         env: {
           ...process.env,
-          TMP: tempRootPath,
-          TEMP: tempRootPath,
-          TMPDIR: tempRootPath,
-          WITHMATE_MEMORY_RUNTIME_DIR: "",
+          WITHMATE_MEMORY_RUNTIME_DIR: runtimeDirectoryPath,
           WITHMATE_MEMORY_DISCOVERY_FILE: "",
           WITHMATE_MEMORY_API_URL: "",
         },
+      }).catch((error: unknown) => {
+        throw new Error(`Bundled helper requests: ${JSON.stringify(requestedPaths)}`, { cause: error });
       });
 
       assert.equal(JSON.parse(stdout).runtimeInstanceId, runtimeInstanceId);
@@ -451,9 +510,54 @@ describe("withmate-memory bundled helper", () => {
     });
 
     const schema = JSON.parse(stdout);
+    assert.deepEqual(schema.commands, [
+      "help",
+      "status",
+      "characters",
+      "file-usage",
+      "search",
+      "get-entry",
+      "get-file",
+      "export-files",
+      "list-tags",
+      "append",
+      "forget",
+      "schema",
+      "validate",
+    ]);
     assert.deepEqual(schema.requestBodyInputs, ["--json", "--file", "@file", "--stdin"]);
     assert(schema.entryKinds.includes("decision"));
     assert(schema.forgetReasons.includes("user_request"));
+  });
+
+  it("--stdin は standalone helper の process stdin から request body を読む", () => {
+    const request = JSON.stringify({
+      schemaVersion: "withmate-memory-v1",
+      targets: [
+        { owner: "project", scope: "project", project: { type: "id", id: "project-a" } },
+      ],
+      query: "release",
+      kinds: ["decision"],
+      limit: 20,
+      cursor: "cursor-a",
+    });
+    const stdout = execFileSync(process.execPath, [
+      helperPath,
+      "validate",
+      "--command",
+      "search",
+      "--stdin",
+    ], {
+      env: process.env,
+      input: request,
+      encoding: "utf8",
+    });
+
+    const response = JSON.parse(stdout);
+    assert.equal(response.valid, true);
+    assert.deepEqual(response.value.kinds, ["decision"]);
+    assert.equal(response.value.limit, 20);
+    assert.equal(response.value.cursor, "cursor-a");
   });
 
   it("validate は helper 単体で request を検証する", async () => {
@@ -612,6 +716,42 @@ describe("withmate-memory bundled helper", () => {
       canonicalValue: "release",
     }]);
     assert.deepEqual(response.value.supersedes, ["entry-a"]);
+  });
+
+  it("validate は helper 側でも protected object 付き append を受け付ける", async () => {
+    const filePath = path.resolve("artifact.bin");
+    const request = JSON.stringify({
+      schemaVersion: "withmate-memory-v1",
+      target: { owner: "project", scope: "project", project: { type: "id", id: "project-a" } },
+      kind: "context",
+      title: "Artifact",
+      body: "Artifact context.",
+      preview: "Artifact preview.",
+      tags: [],
+      files: [{
+        path: filePath,
+        role: "artifact",
+        summary: "Generated artifact.",
+      }],
+    });
+    const { stdout } = await execFileAsync(process.execPath, [
+      helperPath,
+      "validate",
+      "--command",
+      "append",
+      "--json",
+      request,
+    ], {
+      env: process.env,
+    });
+
+    const response = JSON.parse(stdout);
+    assert.equal(response.valid, true);
+    assert.deepEqual(response.value.files, [{
+      path: filePath,
+      role: "artifact",
+      summary: "Generated artifact.",
+    }]);
   });
 
   it("read shorthand は helper でも request body を組み立てる", async () => {

--- a/scripts/tests/withmate-memory-cli.test.ts
+++ b/scripts/tests/withmate-memory-cli.test.ts
@@ -168,7 +168,10 @@ describe("withmate-memory CLI", () => {
 
       assert.deepEqual(
         await discoverWithMateMemoryApi({
-          env: { WITHMATE_MEMORY_RUNTIME_DIR: tempDirectory },
+          env: {
+            WITHMATE_MEMORY_RUNTIME_DIR: tempDirectory,
+            WITHMATE_MEMORY_DISCOVERY_FILE: " ",
+          },
         }),
         { baseUrl: "http://127.0.0.1:4567" },
       );

--- a/scripts/withmate-memory.ts
+++ b/scripts/withmate-memory.ts
@@ -337,9 +337,9 @@ export async function discoverWithMateMemoryApi(
     };
   }
 
+  const envDiscoveryFilePath = env.WITHMATE_MEMORY_DISCOVERY_FILE?.trim();
   const discoveryFilePath = options.discoveryFilePath
-    ?? env.WITHMATE_MEMORY_DISCOVERY_FILE?.trim()
-    ?? resolveDefaultWithMateMemoryDiscoveryFilePath(env);
+    ?? (envDiscoveryFilePath || resolveDefaultWithMateMemoryDiscoveryFilePath(env));
   const read = options.readFile ?? readFile;
 
   try {
@@ -472,10 +472,7 @@ export async function parseWithMateMemoryCliArgs(
     } else if (filePath !== null) {
       body = await parseJsonInput(await (deps.readFile ?? readFile)(filePath, "utf8"));
     } else if (stdinRequested) {
-      if (!deps.stdin) {
-        throw usageError("--stdin requires stdin.");
-      }
-      body = await parseJsonInput(await readStdin(deps.stdin));
+      body = await parseJsonInput(await readStdin(deps.stdin ?? process.stdin));
     } else if (hasShorthandOptions({ projectPath, projectId, query, tags: tagOptions, entryId, objectId, outputPath, outputDirectoryPath, largest, limit })) {
       body = buildShorthandBody(command, { projectPath, projectId, query, tags: tagOptions, entryId, objectId, outputPath, outputDirectoryPath, largest, limit });
     } else if (deps.stdin && !deps.stdin.isTTY) {

--- a/src-electron/managed-memory-skill-service.ts
+++ b/src-electron/managed-memory-skill-service.ts
@@ -80,7 +80,8 @@ export class ManagedMemorySkillService {
 
       await mkdir(resolvedSkillRootPath, { recursive: true });
 
-      const nextMarker = await this.buildMarker();
+      const syncSkillDocumentationOnly = await this.shouldSyncSkillMarkdownOnly();
+      const nextMarker = await this.buildMarker(syncSkillDocumentationOnly);
       if (marker && marker.bundleVersion === nextMarker.bundleVersion) {
         if (
           marker.bundleDigest === nextMarker.bundleDigest
@@ -100,13 +101,8 @@ export class ManagedMemorySkillService {
         `.${WITHMATE_MEMORY_SKILL_NAME}-${process.pid}-${Date.now()}.tmp`,
       );
       await rm(tempPath, { recursive: true, force: true });
-      if (await this.shouldSyncSkillMarkdownOnly()) {
-        await mkdir(tempPath, { recursive: true });
-        await writeFile(
-          path.join(tempPath, MANAGED_SKILL_FILE_NAME),
-          await readFile(path.join(this.deps.bundledSkillPath, MANAGED_SKILL_FILE_NAME), "utf8"),
-          "utf8",
-        );
+      if (syncSkillDocumentationOnly) {
+        await copyManagedSkillDocumentation(this.deps.bundledSkillPath, tempPath);
       } else {
         await cp(this.deps.bundledSkillPath, tempPath, { recursive: true });
       }
@@ -131,13 +127,13 @@ export class ManagedMemorySkillService {
     }
   }
 
-  private async buildMarker(): Promise<ManagedSkillMarker> {
+  private async buildMarker(syncSkillDocumentationOnly: boolean): Promise<ManagedSkillMarker> {
     return {
       markerVersion: MANAGED_MARKER_VERSION,
       managedBy: "WithMate",
       skillName: WITHMATE_MEMORY_SKILL_NAME,
       bundleVersion: this.deps.getAppVersion(),
-      bundleDigest: await this.shouldSyncSkillMarkdownOnly()
+      bundleDigest: syncSkillDocumentationOnly
         ? await digestManagedSkillSource(this.deps.bundledSkillPath)
         : await digestDirectory(this.deps.bundledSkillPath),
     };
@@ -192,11 +188,32 @@ export class ManagedMemorySkillService {
 
 async function digestManagedSkillSource(rootPath: string): Promise<string> {
   const hash = createHash("sha256");
-  hash.update(MANAGED_SKILL_FILE_NAME);
-  hash.update("\0");
-  hash.update(await readFile(path.join(rootPath, MANAGED_SKILL_FILE_NAME)));
-  hash.update("\0");
+  const sourcePaths = [
+    path.join(rootPath, MANAGED_SKILL_FILE_NAME),
+    ...await listFiles(path.join(rootPath, "reference")),
+  ];
+  for (const filePath of sourcePaths) {
+    const relativePath = path.relative(rootPath, filePath).replace(/\\/g, "/");
+    hash.update(relativePath);
+    hash.update("\0");
+    hash.update(await readFile(filePath));
+    hash.update("\0");
+  }
   return hash.digest("hex");
+}
+
+async function copyManagedSkillDocumentation(sourcePath: string, destinationPath: string): Promise<void> {
+  await mkdir(destinationPath, { recursive: true });
+  await writeFile(
+    path.join(destinationPath, MANAGED_SKILL_FILE_NAME),
+    await readFile(path.join(sourcePath, MANAGED_SKILL_FILE_NAME), "utf8"),
+    "utf8",
+  );
+  await cp(
+    path.join(sourcePath, "reference"),
+    path.join(destinationPath, "reference"),
+    { recursive: true },
+  );
 }
 
 async function digestDirectory(rootPath: string, excludedRelativePaths: ReadonlySet<string> = new Set()): Promise<string> {


### PR DESCRIPTION
## 概要

- アプリバージョンを `6.3.11` へ更新
- `scripts/withmate-memory.ts` を正本として、配布用 `withmate-memory.mjs` をbuild時に生成
- managed Memory Skillへ `SKILL.md` と `reference/` を同期し、PATH shim利用時は `bin/` のみ省略
- Memory Skillへ全user-facing turnの終了時reflection、Project/Character lens、条件付きappend preflightを追加
- 最新CLIのpagination、Protected Files、response shape、冪等性、exit codeをSkill referenceへ反映

## 背景

インストール処理とPATH shimは想定どおり同梱helperを参照していましたが、そのhelperがcanonical CLIとは別に手動管理されていたため、追加済みコマンドやvalidationが配布物へ反映されない状態になっていました。

## 変更内容

- canonical CLIからstandalone helperを生成するbuild scriptを追加し、Electron buildへ組み込み
- 生成artifactとcanonical CLIの一致、13コマンド、standalone stdin、Protected Files validationをテスト
- blankなdiscovery file環境変数とstandalone `--stdin`の処理を修正
- managed Skillのdocumentation同期・digest・同一version更新検知を修正
- Skill Distribution設計とCLI referenceを現在の配布契約に更新

## 影響

- 通常のbuild、開発起動、配布package作成でMemory CLI helperが自動更新されます。
- Windowsおよび利用可能なPOSIX shim経由でも、managed Skillから詳細なCLI referenceを参照できます。
- Memoryの検索・追記を毎ターン必須にはせず、最終応答前のreflectionで具体的な候補が見つかった場合だけappend preflightを行います。

## 検証

- targeted CLI / managed Skill tests: 65件成功
- `npm test`: 1845件成功、1件skip、失敗0
- `npm run typecheck`: 成功
- `npm run build`: 成功
- `npm run dist:dir`: 成功
- unpacked appのversion `6.3.11`、packaged helper一致、Skill reference同梱、`withmate-memory.cmd schema`の13コマンドを確認
- Skill quick validation: 成功
- `git diff --check`: 成功
- initial full-diff review、targeted re-review、fresh-context closure reviewで未解決blockingなし

## 未実施

- macOS/Linux実パッケージ上のshim smoke
- NSIS installerの実インストール確認
