### PR TITLE
chore(codex): SDKを0.145.0へ更新する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.6",
-        "@openai/codex-sdk": "^0.144.3",
+        "@openai/codex-sdk": "^0.145.0",
         "@tanstack/react-virtual": "^3.14.6",
         "ignore": "^7.0.5",
         "mermaid": "^11.16.0",
@@ -1942,9 +1942,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.144.3",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.3.tgz",
-      "integrity": "sha512-8Re3wp5CdYiM7nsF4StFa5js6IT11N7srhxfvwtol7ENHDht05C+HS4e1CTmYjqkhgsUzl2R1gB27iN2pdbVnA==",
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0.tgz",
+      "integrity": "sha512-/PSPSFujjjmiyVFvG2yu/grOFhsWdokTH8t2KGWhXSo/M5n/dIDsnbsnO82/7bLtIoDuzQf7ATBUMWqPWQINlQ==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -1953,19 +1953,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.3-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.3-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.3-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.3-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.3-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.3-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.145.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.145.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.145.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.145.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.145.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.145.0-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.3-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.3-darwin-arm64.tgz",
-      "integrity": "sha512-v/yT1wqslBcwquUvUPZvAdYyiZcCBIUL+pE4ymHpbUMVduwDJBw1EjLroOhe9FkYFDHzWGyv7YEw7iIV4k+0dA==",
+      "version": "0.145.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-darwin-arm64.tgz",
+      "integrity": "sha512-h6aQ0UxnaP8mIM/9/qPAH9MNkRliJo88toq1T36IxNM2L5JSU0TFamu+MZn7YkFgDsrp0RfiI+97Tm8AVVxqtA==",
       "cpu": [
         "arm64"
       ],
@@ -1980,9 +1980,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.144.3-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.3-darwin-x64.tgz",
-      "integrity": "sha512-308U0s7AeRg3AlnxJtmJk03yRRriEplC6ceFoB3OpWh+przqt8/u6MKDVU3KHdjb+vasa0IpmDWv5VrFw3oJAw==",
+      "version": "0.145.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-darwin-x64.tgz",
+      "integrity": "sha512-FCYzVKCa9VoLtg9gVyzKpqylonfgZrfcWZN6HsXAZPeuo8CukdMqdgTUOhDn2V6h3MbqS0z6VqQVKUllN/yKhA==",
       "cpu": [
         "x64"
       ],
@@ -1997,9 +1997,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.3-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.3-linux-arm64.tgz",
-      "integrity": "sha512-mJgDUmoPMry9a7g6ywsMQ4uQko2K0uHLqzEITUJMXiNNbCRBQKS+PxDWBlSK0bF0v72uAhWRRRGvPXslwhIdyg==",
+      "version": "0.145.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-linux-arm64.tgz",
+      "integrity": "sha512-8OLcPXaAol/FOrRoDxWhIiHIFa73KRsM41EKocjRZOwiT4TcelzJWn3dHyiuSb7teWF25rrslvSPyvhULYRRCQ==",
       "cpu": [
         "arm64"
       ],
@@ -2014,9 +2014,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.144.3-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.3-linux-x64.tgz",
-      "integrity": "sha512-xtDY5sWQPbYBj2lLWZJvc0jBre0XQ7ZmN4VbSEvazbQ2X7uHhm1D/0oZ7AI+SgC/VfZrUhvxRHd43/AmXSaAzA==",
+      "version": "0.145.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-linux-x64.tgz",
+      "integrity": "sha512-u8w8LLv3DvsfrDCoswLIemZ0SoNEXyi511WsfFsSiYUazk9qMsB/NtU8N9vhAfN7mZAxLFoMex4v66JjHuZWwA==",
       "cpu": [
         "x64"
       ],
@@ -2030,12 +2030,12 @@
       }
     },
     "node_modules/@openai/codex-sdk": {
-      "version": "0.144.3",
-      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.144.3.tgz",
-      "integrity": "sha512-WPtEx38iVyksWujOwmsxnJznRR8T/YF+lAJghMhHL1xIWdJrrvZ1iafhIsw4egY5CRoRmFm2ta8NQsK4f4XDZA==",
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.145.0.tgz",
+      "integrity": "sha512-lBviqBKnomEXNpdjfDzUoz/H+VZuK75m2oR8dQSmL2zUpnklfAsTneuaSg23NOoE+vw/Qhbxp8ePy9te973yfw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openai/codex": "0.144.3"
+        "@openai/codex": "0.145.0"
       },
       "engines": {
         "node": ">=18"
@@ -2043,9 +2043,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.3-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.3-win32-arm64.tgz",
-      "integrity": "sha512-uvgBLuBX58GIq58CquhvhEmwLlH9Lc46rLmE5/CkEf1vQiCvWqVHxL28t7P9cmWGoeMuxsrIwqJgyzmRu6wZMQ==",
+      "version": "0.145.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-win32-arm64.tgz",
+      "integrity": "sha512-sub61rjEFevi1i3Zx7nAd4JM5XxoNFqMqFc5LfTo2xSI8ixHjFvEYDFDXwXOftT04n3Ht1Wh271ioUZpDiEjEg==",
       "cpu": [
         "arm64"
       ],
@@ -2060,9 +2060,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.144.3-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.3-win32-x64.tgz",
-      "integrity": "sha512-0o8LpbZuBvqcAdIqMh96pECFTtfkgMT2sP/Q2IKYUOOlSudq3ulvdDW6zARq04HhbOxSsU9TBYDkdqtDs2YcYQ==",
+      "version": "0.145.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-win32-x64.tgz",
+      "integrity": "sha512-u0h9lk094CaXRSqE34SBW2dRaQTPa6fASXqehczWH9QdsU62mBsiAgAdp6tCG4i+YzPmmhjD8FdXNnYGNmwuMg==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "type": "module",
   "dependencies": {
     "@github/copilot-sdk": "^1.0.6",
-    "@openai/codex-sdk": "^0.144.3",
+    "@openai/codex-sdk": "^0.145.0",
     "@tanstack/react-virtual": "^3.14.6",
     "ignore": "^7.0.5",
     "mermaid": "^11.16.0",

--- a/src-electron/codex-adapter.ts
+++ b/src-electron/codex-adapter.ts
@@ -257,7 +257,7 @@ export type CodexThreadSettings = {
 };
 
 function toCodexSdkThreadOptions(options: CodexThreadOptions): CodexSdkThreadOptions {
-  // Codex CLI 0.144.3 accepts max/ultra, while the TypeScript SDK union still ends at xhigh.
+  // Codex CLI accepts max/ultra, while the TypeScript SDK union still ends at xhigh.
   return {
     ...options,
     modelReasoningEffort: options.modelReasoningEffort as CodexSdkThreadOptions["modelReasoningEffort"],


### PR DESCRIPTION
## 概要

Codex SDK と同梱 Codex CLI を stable 0.145.0 系へ更新します。WithMate のアプリバージョンは 6.3.11 のままです。

## 変更内容

- `@openai/codex-sdk` を `^0.145.0` へ更新
- lockfile 内の `@openai/codex` と全 platform native package を 0.145.0 世代へ同期
- SDK の型制約に関するコメントから陳腐化する固定バージョン表記を削除

## 検証

- `npx tsx --test scripts/tests/provider-token-usage.test.ts scripts/tests/provider-binary-paths.test.ts scripts/tests/codex-adapter.test.ts`
  - 44 pass / 0 fail
- `npm run typecheck`
  - 成功
- `npm test`
  - 1845 pass / 1 skip / 0 fail
- `npm run dist:dir`
  - 成功
- packaged `codex.exe --version`
  - `codex-cli 0.145.0`
- packaged `app.asar` の manifest
  - app version `6.3.11`
  - `@openai/codex-sdk` `^0.145.0`

## 残リスク

macOS / Linux と Windows arm64 は lockfile と静的な path mapping まで確認し、各実機での staging・起動確認は実施していません。