### PR TITLE
SessionFolderをworkspaceとして新規Sessionを起動できるようにする

### DIFF
--- a/docs/adr/005-session-folder-workspace-launch.md
+++ b/docs/adr/005-session-folder-workspace-launch.md
@@ -1,0 +1,53 @@
+# 005 SessionFolder Workspace Launch
+
+- 状態: Accepted
+- 日付: 2026-07-26
+
+## Context
+
+New Session は既存 directory の選択を必須としていた。一方、作業対象がまだ存在しない Session では、WithMate が管理する `session-files/{sessionId}` をそのまま workspace として開始したい。
+
+SessionFolder の path は Session ID に依存する。renderer で仮 path や仮 ID を作ると、Main Process が所有する app data path、directory 作成、Session 永続化の境界が分散する。
+
+## Decision
+
+- New Session dialog の Agent Mode では `Browse` と `SessionFolder` を排他的な workspace 選択として扱う
+- Companion Mode では `SessionFolder` を表示せず、Agent Mode で選択済みの場合は mode 切替時に選択を解除する
+- `SessionFolder` の選択時は renderer に path を持たせず、作成方法だけを launch request として Main Process へ渡す
+- Main Process は launch request を許可済み field から再構築し、renderer 由来の Session ID や旧 workspace field を永続化へ渡さない
+- Main Process は directory / SessionFolder / 内部 create の Session ID を同じ UUID ベースの発行境界で所有する
+- Session の新規永続化は update 用 upsert と分け、ID の一意制約を使う insert-only operation で原子的に衝突を拒否する
+- `Start New Session` 時に Main Process が次の順序で処理する
+  1. Session ID を発行する
+  2. `session-files/{sessionId}` を新規 directory として排他的に作成する
+  3. 作成した absolute path を `workspacePath`、`SessionFolder` を `workspaceLabel` として Session を永続化する
+  4. renderer は作成済み Session ID で Session Window を開く
+- directory 作成に失敗した場合は Session を永続化しない
+- 同じ ID の Session record または SessionFolder が存在する場合は、既存データを再利用または上書きせず作成を失敗させる
+- Session 永続化の呼び出し後に失敗した場合は、永続化済み Session の workspace を誤って削除しないよう、その場では directory を削除しない
+- Session record を削除しても、その Session 自身の `session-files/{sessionId}` を workspace としていた場合は directory と内容を保持する
+- SessionFolder workspace の判定は filesystem の path 比較規則に合わせ、Windows では大文字小文字を区別しない
+- bulk 削除では削除前の stored Session summary で未読込 Session も分類し、通常の directory workspace に対する既存 cleanup を維持する
+
+## Alternatives
+
+- SessionFolder 選択時に directory を作成する: dialog を閉じた場合に未使用 directory が残るため採用しない
+- renderer で仮 ID と path を作る: app data path と ID 発行の所有者が renderer へ漏れるため採用しない
+- Session を先に永続化してから directory を作成する: directory 作成失敗時に実在しない workspace を持つ Session が残るため採用しない
+- create 前の存在確認だけで ID 衝突を判定する: 並行 create が同じ ID を確認して通過できるため採用しない
+- Session record の削除と同時に SessionFolder workspace も削除する: 作業成果物を不可逆に失うため採用しない
+- Settings で任意の workspace root を設定する: 今回は既存の SessionFolder を workspace として再利用すれば要件を満たすため採用しない
+
+## Consequences
+
+### Positive
+
+- button 選択だけでは filesystem に副作用が起きない
+- 永続 Session の `workspacePath` は作成時点から実在する
+- 既存の SessionFolder の terminal、attachment、provider access の経路を workspace として再利用できる
+
+### Negative
+
+- Session 永続化処理が post-commit failure を返した場合、未参照の SessionFolder が残る可能性がある
+- Session record を削除した SessionFolder workspace は自動 cleanup されず、directory が残る
+- Session 作成 IPC は concrete directory と managed SessionFolder の discriminated request を扱う

--- a/docs/design/desktop-ui.md
+++ b/docs/design/desktop-ui.md
@@ -103,7 +103,7 @@ Electron デスクトップアプリとして、`Home Window` / `Character Edito
     - text color = WCAG AA の contrast ratio を満たす dark / light 候補から自動決定
 - `New Session` dialog
   - session title 入力
-  - workspace picker
+  - Agent Mode の workspace は既存 directory を選ぶ `Browse` と、WithMate 管理下の directory を開始時に作る `SessionFolder` から選ぶ
   - enabled provider の選択
   - Character selector で default Character を初期選択する。Character が 0 件の場合は neutral fallback を使う
   - approval mode は provider-neutral 3 mode を前提にし、default は `safety`

--- a/docs/design/refactor-roadmap.md
+++ b/docs/design/refactor-roadmap.md
@@ -432,7 +432,7 @@ current の first slice では、上の 4 点を `SessionRuntimeService` とし�
 - `home-launch-state`
   - 完了
   - launch dialog の open / close / reset ルール
-  - `CreateSessionInput` の組み立て
+  - `CreateSessionRequest` の組み立て
 - `home-character-projection`
   - 完了
   - Characters 右ペインの filtered list

--- a/docs/design/session-launch-ui.md
+++ b/docs/design/session-launch-ui.md
@@ -120,6 +120,7 @@ React モックでは次の形がよい。
   - workspace path
   - session title
   - browse ボタン
+  - SessionFolder ボタン
   - provider / character
   - start action
 
@@ -128,6 +129,7 @@ React モックでは次の形がよい。
 - 現在の Home UI では上部バーに `New Session` を置いている
 - `Launch Panel` 自体は modal dialog で維持できる
 - `Browse` は Electron 実行時に OS の directory picker を開く
+- Agent Mode の `SessionFolder` は path を事前確定せず、WithMate 管理下の SessionFolder を workspace にする選択として扱う
 - title は空文字で開き、入力必須
 - provider は launch dialog 内で chip 選択し、enabled provider が 0 件なら start できない
 - `Character` は card で切り替える
@@ -146,15 +148,14 @@ React モックでは次の形がよい。
 - session 作成直後の UI 表示も `自動実行 / 安全寄り / プロバイダー判断` の provider-neutral wording に揃える
 - `provider` は session 作成時に明示保存する
 - `Start New Session` を押すと、入力した title を持つ新規 session record を作って `Session Window` を開く
+- Main Process は directory / SessionFolder のどちらでも Session ID を発行し、ID 衝突時に既存 record を上書きしない
+- `SessionFolder` 選択時は `session-files/{sessionId}` を新規 directory として作成してから、その path を `workspacePath` として session record を保存する
 - 最初の依頼は Launch Dialog ではなく `Session Window` のメインチャットから入力する
 
 ## Future Direction
 
-- 将来的にはアプリ設定で `workspace root directory` を持てるようにし、その配下へ UUID ディレクトリを自動作成して空 workspace から session を起動できるようにする
-- この方式は `既存ディレクトリを選ぶ` 導線とは別扱いにし、`New Session` dialog の別 action か `Settings` 由来の launch preset として扱う
+- SessionFolder の orphan cleanup が必要になった場合は、永続 Session から参照されない directory だけを対象にした maintenance として追加する
 
 ## Next Step
 
 - `Home Window` 内で `Recent Sessions` と視線競合しない配置に調整する
-- `Start New Session` 後に `Session Window` を開く lifecycle を実装設計へ落とす
-- 将来は OS directory dialog と empty workspace 自動生成を並立させる

--- a/docs/design/session-local-files.md
+++ b/docs/design/session-local-files.md
@@ -13,6 +13,7 @@ WithMate の Session ごとに、repo へ入れない一時資料を置ける ma
 - この機能は provider 内部の session-state や log directory を使わない
 - 保存先は WithMate app data 配下の managed directory とする
 - session local files は user-managed additional directories ではなく、runtime が常に暗黙許可する directory として扱う
+- New Session で `SessionFolder` を選んだ場合は、この managed directory 自体を Session の `workspacePath` として扱う
 - prompt 本文には保存済み file path の reference だけを入れ、file 内容の常設 inline 展開はしない
 - V5 preview では legacy MateTalk runtime / window を current runtime として提供しない。本文中の MateTalk 記述は stale `mate-talk-*` directory cleanup などの legacy compatibility として扱う
 
@@ -25,6 +26,8 @@ session-files/{sessionId}/
 ```
 
 `sessionId` は path segment として安全な文字だけへ正規化する。既存 ID は UUID 形式だが、将来の prefix 付き ID でも directory traversal を起こさないことを優先する。
+
+New Session の `SessionFolder` 選択は directory を作成しない。`Start New Session` 時に Main Process が Session ID を発行し、同じ ID の既存 directory を再利用しない排他的な作成を行った後、その absolute path を持つ Session を永続化する。
 
 ## Access Contract
 
@@ -40,6 +43,7 @@ Session local files directory は次の経路で常に effective allowed directo
 DB の `allowedAdditionalDirectories` へは保存しない。
 これはユーザーが明示追加した external directory と、WithMate が管理する session-local directory を分けるためである。
 UI の `Dirs {N}` はユーザー追加分だけを数え、session local files は数に含めない。
+`SessionFolder` を workspace にした Session では、同じ directory を additional directory として重複追加しない。
 
 ## Composer UI
 
@@ -85,8 +89,10 @@ composer は戻り値を既存の `@path` reference 挿入処理へ渡す。
 
 ## Cleanup
 
-Session 削除時の cleanup は session ID 単位で directory を削除する。
+通常の external workspace を使う Session では、Session 削除時に session ID 単位で local files directory を削除する。
 削除に失敗しても session 削除自体は失敗させず、best-effort cleanup として扱う。
+Session 自身の local files directory を workspace としている場合は、Session record を削除しても directory と内容を保持する。
+bulk 削除では削除前に storage の Session summary を取得し、未読込 Session も workspace の種別を判定する。
 legacy MateTalk は永続 session record を持たないため、window ごとの一時 session ID を使っていた。
 `mate-talk-*` の session files directory は使い捨て扱いとし、次回起動時に stale directory を削除する。
 
@@ -97,3 +103,7 @@ legacy MateTalk は永続 session record を持たないため、window ごと�
 - preview で session local files が outside workspace attachment として認識される
 - Codex / Copilot runtime に session local files directory が additional directory として渡る
 - `Dirs {N}` は session local files を数えない
+- `SessionFolder` 選択だけでは directory が作成されず、開始時に作成済み path が `workspacePath` として保存される
+- SessionFolder の作成に失敗した場合は Session が保存されない
+- 同じ ID の SessionFolder または Session record が存在しても、既存内容を再利用または上書きしない
+- SessionFolder workspace の Session record を削除しても directory と内容が残る

--- a/docs/manual-test-checklist.md
+++ b/docs/manual-test-checklist.md
@@ -63,6 +63,8 @@ npm run electron:start
 | MT-013 | New Session 起動 | Home の `New Session` を押す | launch dialog が開く |
 | MT-013A | New Session dialog keyboard | `New Session` dialog を開き、初期 focus、`Tab` / `Shift+Tab`、`Escape`、provider chip の矢印キーを試す | open 時に title input へ focus が入り、focus は dialog 内で循環する。`Escape` で閉じ、provider chip は矢印キーで切り替えられる |
 | MT-014 | New Session 作成 | title、workspace、provider、Character を選び `Start New Session` を押す | 選択した Character snapshot を使って Session Window が開き、Home の session 一覧に追加され、選んだ provider で session が作られ、approval 初期値は `安全寄り` になる。Character が 0 件の場合は neutral fallback を使う |
+| MT-014B | New Session SessionFolder | `New Session` で `SessionFolder` を選び、title、provider、Character を指定して `Start New Session` を押す | 選択時点では path の指定を求められない。開始後は WithMate の `session-files/{sessionId}` が作成され、その absolute path を workspace にした Session Window が開く |
+| MT-014C | SessionFolder workspace retention | `SessionFolder` で作成した Session の workspace にファイルを置き、その Session を削除する | Session record は削除されるが、workspace directory と中のファイルは残る |
 | MT-014A | New Session provider availability | `Coding Agent Providers` で一部 provider を無効化した後に `New Session` を開く | launch dialog の provider 候補には enabled provider だけが出る。0 件なら empty state が出て `Start New Session` は disabled のままになる |
 | MT-015 | Session 実行 | Session Window の textarea に入力して送信する | user message が追加され、pending と live activity が表示される |
 | MT-015A | Copilot basic turn | provider を `GitHub Copilot` にした session を作成し、text-only の prompt を 1 回送る | assistant response が返り、Session が `idle` へ戻る。添付なしなら Codex と同じ Session UI で 1 turn 完了できる |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "6.3.11",
+  "version": "6.3.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "6.3.11",
+      "version": "6.3.12",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "6.3.11",
+  "version": "6.3.12",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/scripts/tests/additional-directories.test.ts
+++ b/scripts/tests/additional-directories.test.ts
@@ -7,6 +7,7 @@ import { describe, it } from "node:test";
 import { buildNewSession } from "../../src/app-state.js";
 import { DEFAULT_APPROVAL_MODE } from "../../src/approval-mode.js";
 import {
+  areDirectoryPathsEquivalent,
   isPathWithinDirectory,
   normalizeAllowedAdditionalDirectories,
 } from "../../src-electron/additional-directories.js";
@@ -33,6 +34,17 @@ function createSession(workspacePath: string, allowedAdditionalDirectories: stri
 }
 
 describe("additional directories", () => {
+  it("Windows path は大文字小文字が異なっても同じ directory として比較する", () => {
+    assert.equal(
+      areDirectoryPathsEquivalent(
+        "C:\\Data\\WithMate\\session-files\\launch-1",
+        "c:\\data\\withmate\\session-files\\launch-1",
+        "win32",
+      ),
+      true,
+    );
+  });
+
   it("workspace 内 path を除外しつつ重複と入れ子を正規化できる", () => {
     const workspacePath = path.resolve("C:/repo");
     const normalized = normalizeAllowedAdditionalDirectories(workspacePath, [

--- a/scripts/tests/home-components.test.tsx
+++ b/scripts/tests/home-components.test.tsx
@@ -523,7 +523,8 @@ describe("HomeLaunchDialog", () => {
       open={true}
       mode={mode}
       title="demo"
-      workspace={null}
+      workspaceSelected={false}
+      sessionFolderSelected={false}
       launchWorkspacePathLabel="workspace"
       enabledLaunchProviders={[{ id: "codex", label: "Codex" }]}
       selectedLaunchProviderId="codex"
@@ -538,6 +539,7 @@ describe("HomeLaunchDialog", () => {
       onSelectMode={noOp}
       onChangeTitle={noOp}
       onBrowseWorkspace={noOp}
+      onSelectSessionFolder={noOp}
       onSelectProvider={noOp}
       onSelectCharacter={noOp}
       onSelectRandomCharacter={noOp}
@@ -555,6 +557,7 @@ describe("HomeLaunchDialog", () => {
     assert.ok(html.includes("ランダム"));
     assert.ok(html.indexOf("ランダム") < html.indexOf("Mia"));
     assert.ok(html.includes("最近使っていないCharacterを優先"));
+    assert.ok(html.indexOf("Browse") < html.indexOf("SessionFolder"));
   });
 
   it("random選択時は一覧先頭のランダムcardだけを選択状態にする", () => {
@@ -575,6 +578,7 @@ describe("HomeLaunchDialog", () => {
 
     assert.ok(html.includes("Character"));
     assert.ok(html.includes("Mia"));
+    assert.ok(!html.includes("SessionFolder"));
   });
 
   it("Character 0 件なら neutral fallback を表示する", () => {

--- a/scripts/tests/home-launch-actions.test.ts
+++ b/scripts/tests/home-launch-actions.test.ts
@@ -7,6 +7,7 @@ import { startHomeLaunch } from "../../src/home/home-launch-actions.js";
 import {
   createClosedLaunchDraft,
   setLaunchWorkspaceFromPath,
+  setLaunchWorkspaceToSessionFolder,
   type HomeLaunchDraft,
 } from "../../src/home/home-launch-state.js";
 import type { MateProfile } from "../../src/mate/mate-state.js";
@@ -231,6 +232,27 @@ describe("home-launch-actions", () => {
     assert.deepEqual(harness.startingStates, [true, false]);
     assert.equal(harness.closeCount, 1);
     assert.deepEqual(harness.sessionSummaries, ["session-1"]);
+    assert.deepEqual(harness.openedSessions, ["session-1"]);
+  });
+
+  it("SessionFolder 選択時は未確定 path の request で session を作成する", async () => {
+    let capturedWorkspace: unknown = null;
+    const harness = createStartHomeLaunchHarness({
+      draft: {
+        ...setLaunchWorkspaceToSessionFolder(createReadyDraft()),
+      },
+      createSession: async (input) => {
+        capturedWorkspace = input.workspace;
+        return createSessionSummary({
+          workspaceLabel: "SessionFolder",
+          workspacePath: "C:/WithMate/session-files/session-1",
+        });
+      },
+    });
+
+    await startHomeLaunch(harness.input);
+
+    assert.deepEqual(capturedWorkspace, { kind: "session-folder" });
     assert.deepEqual(harness.openedSessions, ["session-1"]);
   });
 

--- a/scripts/tests/home-launch-handlers.test.ts
+++ b/scripts/tests/home-launch-handlers.test.ts
@@ -84,5 +84,12 @@ describe("home-launch-handlers", () => {
 
     handlers.onSelectLaunchCharacter("new-default");
     assert.equal(draft.characterSelectionMode, "specific");
+
+    handlers.onSelectSessionFolder();
+    assert.deepEqual(draft.workspace, { kind: "session-folder" });
+
+    handlers.onChangeMode("companion");
+    assert.equal(draft.mode, "companion");
+    assert.equal(draft.workspace, null);
   });
 });

--- a/scripts/tests/home-launch-projection.test.ts
+++ b/scripts/tests/home-launch-projection.test.ts
@@ -116,6 +116,37 @@ describe("home-launch-projection", () => {
     assert.equal(enabledOnlyCodex.canStartSession, true);
   });
 
+  it("SessionFolder 選択時は未確定 path の代わりに選択状態を投影する", () => {
+    const projection = buildHomeLaunchProjection({
+      launchProviderId: "codex",
+      launchTitle: "task",
+      launchWorkspace: { kind: "session-folder" },
+      characterEntries: createCharacters(),
+      appSettings: createDefaultAppSettings(),
+      modelCatalog: createCatalog(),
+    });
+
+    assert.equal(projection.launchWorkspacePathLabel, "SessionFolder");
+    assert.equal(projection.sessionFolderSelected, true);
+    assert.equal(projection.workspaceSelected, true);
+    assert.equal(projection.canStartSession, true);
+  });
+
+  it("Companion Mode では SessionFolder 選択を開始可能として投影しない", () => {
+    const projection = buildHomeLaunchProjection({
+      launchProviderId: "codex",
+      launchMode: "companion",
+      launchTitle: "task",
+      launchWorkspace: { kind: "session-folder" },
+      characterEntries: createCharacters(),
+      appSettings: createDefaultAppSettings(),
+      modelCatalog: createCatalog(),
+    });
+
+    assert.equal(projection.sessionFolderSelected, true);
+    assert.equal(projection.canStartSession, false);
+  });
+
   it("random character選択時は固定Characterを選択状態にしない", () => {
     const projection = buildHomeLaunchProjection({
       launchProviderId: "codex",

--- a/scripts/tests/home-launch-state.test.ts
+++ b/scripts/tests/home-launch-state.test.ts
@@ -8,7 +8,7 @@ import type { SessionSummary } from "../../src/app-state.js";
 import type { CharacterCatalogEntry } from "../../src/character/character-catalog.js";
 import {
   buildCreateCompanionSessionInputFromLaunchDraft,
-  buildCreateSessionInputFromLaunchDraft,
+  buildCreateSessionRequestFromLaunchDraft,
   closeLaunchDraft,
   createClosedLaunchDraft,
   openLaunchDraft,
@@ -17,6 +17,7 @@ import {
   resolveLaunchValidationMessage,
   selectWeightedRandomLaunchCharacterId,
   setLaunchWorkspaceFromPath,
+  setLaunchWorkspaceToSessionFolder,
   updateLaunchDraftForCharacterSelection,
   updateLaunchDraftForProviderSelection,
   updateLaunchDraftForRandomCharacterSelection,
@@ -297,8 +298,8 @@ describe("home-launch-state", () => {
     );
   });
 
-  it("launch draft から session input を組み立てる", () => {
-    const input = buildCreateSessionInputFromLaunchDraft({
+  it("launch draft から directory workspace の session request を組み立てる", () => {
+    const input = buildCreateSessionRequestFromLaunchDraft({
       draft: {
         ...createClosedLaunchDraft(),
         open: true,
@@ -336,9 +337,12 @@ describe("home-launch-state", () => {
     assert.deepEqual(input, {
       provider: "codex",
       taskTitle: "task",
-      workspaceLabel: "demo",
-      workspacePath: "F:/work/demo",
-      branch: "main",
+      workspace: {
+        kind: "directory",
+        label: "demo",
+        path: "F:/work/demo",
+        branch: "main",
+      },
       characterId: "mia",
       character: "Mia",
       characterIconPath: "icon.png",
@@ -354,7 +358,7 @@ describe("home-launch-state", () => {
   });
 
   it("Mate 未作成でも neutral character で session input を組み立てる", () => {
-    const input = buildCreateSessionInputFromLaunchDraft({
+    const input = buildCreateSessionRequestFromLaunchDraft({
       draft: {
         ...createClosedLaunchDraft(),
         open: true,
@@ -377,7 +381,7 @@ describe("home-launch-state", () => {
   });
 
   it("archived Character が draft に残っていても active Character で session input を組み立てる", () => {
-    const input = buildCreateSessionInputFromLaunchDraft({
+    const input = buildCreateSessionRequestFromLaunchDraft({
       draft: {
         ...createClosedLaunchDraft(),
         open: true,
@@ -528,7 +532,7 @@ describe("home-launch-state", () => {
   });
 
   it("launch 条件が欠けている時は session input を返さない", () => {
-    const input = buildCreateSessionInputFromLaunchDraft({
+    const input = buildCreateSessionRequestFromLaunchDraft({
       draft: createClosedLaunchDraft(),
       mateProfile: null,
       selectedProviderId: "codex",
@@ -536,5 +540,33 @@ describe("home-launch-state", () => {
     });
 
     assert.equal(input, null);
+  });
+
+  it("SessionFolder 選択は path を確定せず session request に保持する", () => {
+    const draft = {
+      ...setLaunchWorkspaceToSessionFolder(createClosedLaunchDraft()),
+      open: true,
+      title: "task",
+      providerId: "codex",
+    };
+
+    assert.equal(
+      resolveLaunchValidationMessage({
+        draft,
+        mateState: "active",
+        mateProfile: null,
+        selectedProviderId: "codex",
+      }),
+      "",
+    );
+    assert.deepEqual(
+      buildCreateSessionRequestFromLaunchDraft({
+        draft,
+        mateProfile: null,
+        selectedProviderId: "codex",
+        approvalMode: DEFAULT_APPROVAL_MODE,
+      })?.workspace,
+      { kind: "session-folder" },
+    );
   });
 });

--- a/scripts/tests/main-session-command-facade.test.ts
+++ b/scripts/tests/main-session-command-facade.test.ts
@@ -3,10 +3,28 @@ import test from "node:test";
 
 import { MainSessionCommandFacade } from "../../src-electron/main-session-command-facade.js";
 
+function createSessionRequest(workspace: Record<string, unknown>): Record<string, unknown> {
+  return {
+    provider: "codex",
+    taskTitle: "test task",
+    workspace,
+    characterId: "character-1",
+    character: "Character",
+    characterIconPath: "",
+    characterThemeColors: {
+      main: "#112233",
+      sub: "#445566",
+    },
+    approvalMode: "untrusted",
+  };
+}
+
 test("MainSessionCommandFacade は create/update/delete/cancel を各 service に委譲する", async () => {
   const calls: string[] = [];
   const facade = new MainSessionCommandFacade({
     getSession: () => null,
+    getSessions: () => [{ id: "s-1", workspacePath: "C:/work/repo" } as never],
+    getStoredSessionSummaries: () => [],
     getSessionPersistenceService: () =>
       ({
         createSession(input) {
@@ -44,18 +62,34 @@ test("MainSessionCommandFacade は create/update/delete/cancel を各 service �
     getProviderQuotaTelemetry: () => null,
     isProviderQuotaTelemetryStale: () => false,
     refreshProviderQuotaTelemetry: async () => null,
+    createSessionId: () => "launch-test",
+    createSessionFilesDirectory: () => "C:/session-files/launch-test",
+    isSessionFilesWorkspace: () => false,
     async cleanupSessionFilesDirectory(sessionId) {
       calls.push(`cleanup-files:${sessionId}`);
     },
   });
 
-  facade.createSession({ id: "s-1" } as never);
+  await facade.createSession({
+    taskTitle: "test",
+    workspaceLabel: "repo",
+    workspacePath: "C:/work/repo",
+    branch: "main",
+    characterId: "character-1",
+    character: "Character",
+    characterIconPath: "",
+    characterThemeColors: {
+      main: "#112233",
+      sub: "#445566",
+    },
+    approvalMode: "untrusted",
+  });
   facade.updateSession({ id: "s-1" } as never);
   await facade.deleteSession("s-1");
   facade.cancelSessionRun("s-1");
 
   assert.deepEqual(calls, [
-    "create:s-1",
+    "create:launch-test",
     "update:s-1",
     "delete:s-1",
     "cleanup-files:s-1",
@@ -63,10 +97,241 @@ test("MainSessionCommandFacade は create/update/delete/cancel を各 service �
   ]);
 });
 
+test("MainSessionCommandFacade は SessionFolder を作成してから同じ ID の session を永続化する", async () => {
+  const calls: string[] = [];
+  let persistedInput: Record<string, unknown> | null = null;
+  const facade = new MainSessionCommandFacade({
+    getSession: () => null,
+    getSessions: () => [],
+    getStoredSessionSummaries: () => [],
+    getSessionPersistenceService: () =>
+      ({
+        createSession(input) {
+          calls.push(`persist:${input.id}`);
+          persistedInput = input as unknown as Record<string, unknown>;
+          return input as never;
+        },
+      }) as never,
+    getSessionRuntimeService: () => ({} as never),
+    getProviderQuotaTelemetry: () => null,
+    isProviderQuotaTelemetryStale: () => false,
+    refreshProviderQuotaTelemetry: async () => null,
+    createSessionId: () => {
+      calls.push("issue-id");
+      return "launch-managed";
+    },
+    createSessionFilesDirectory: (sessionId) => {
+      calls.push(`mkdir:${sessionId}`);
+      return "C:/WithMate/session-files/launch-managed";
+    },
+    isSessionFilesWorkspace: () => false,
+  });
+
+  await facade.createSessionFromRequest(createSessionRequest({ kind: "session-folder" }) as never);
+
+  assert.deepEqual(calls, [
+    "issue-id",
+    "mkdir:launch-managed",
+    "persist:launch-managed",
+  ]);
+  assert.deepEqual(
+    {
+      id: persistedInput?.id,
+      workspaceLabel: persistedInput?.workspaceLabel,
+      workspacePath: persistedInput?.workspacePath,
+      branch: persistedInput?.branch,
+      workspace: persistedInput?.workspace,
+    },
+    {
+      id: "launch-managed",
+      workspaceLabel: "SessionFolder",
+      workspacePath: "C:/WithMate/session-files/launch-managed",
+      branch: "",
+      workspace: undefined,
+    },
+  );
+});
+
+test("MainSessionCommandFacade は Browse で選んだ directory をそのまま session に使う", async () => {
+  let persistedInput: Record<string, unknown> | null = null;
+  const facade = new MainSessionCommandFacade({
+    getSession: () => null,
+    getSessions: () => [],
+    getStoredSessionSummaries: () => [],
+    getSessionPersistenceService: () =>
+      ({
+        createSession(input) {
+          persistedInput = input as unknown as Record<string, unknown>;
+          return input as never;
+        },
+      }) as never,
+    getSessionRuntimeService: () => ({} as never),
+    getProviderQuotaTelemetry: () => null,
+    isProviderQuotaTelemetryStale: () => false,
+    refreshProviderQuotaTelemetry: async () => null,
+    createSessionId: () => "launch-directory",
+    createSessionFilesDirectory: () => {
+      throw new Error("directory workspace では SessionFolder を作成しない");
+    },
+    isSessionFilesWorkspace: () => false,
+  });
+
+  await facade.createSessionFromRequest(
+    createSessionRequest({
+      kind: "directory",
+      label: "repo",
+      path: "C:/work/repo",
+      branch: "main",
+    }) as never,
+  );
+
+  assert.deepEqual(
+    {
+      id: persistedInput?.id,
+      workspaceLabel: persistedInput?.workspaceLabel,
+      workspacePath: persistedInput?.workspacePath,
+      branch: persistedInput?.branch,
+    },
+    {
+      id: "launch-directory",
+      workspaceLabel: "repo",
+      workspacePath: "C:/work/repo",
+      branch: "main",
+    },
+  );
+});
+
+test("MainSessionCommandFacade は IPC payload の余分な session ID と legacy workspace fields を無視する", async () => {
+  let persistedInput: Record<string, unknown> | null = null;
+  const facade = new MainSessionCommandFacade({
+    getSession: () => null,
+    getSessions: () => [],
+    getStoredSessionSummaries: () => [],
+    getSessionPersistenceService: () =>
+      ({
+        createSession(input) {
+          persistedInput = input as unknown as Record<string, unknown>;
+          return input as never;
+        },
+      }) as never,
+    getSessionRuntimeService: () => ({} as never),
+    getProviderQuotaTelemetry: () => null,
+    isProviderQuotaTelemetryStale: () => false,
+    refreshProviderQuotaTelemetry: async () => null,
+    createSessionId: () => {
+      return "launch-directory";
+    },
+    createSessionFilesDirectory: () => {
+      throw new Error("directory workspace では SessionFolder を作成しない");
+    },
+    isSessionFilesWorkspace: () => false,
+  });
+  const request = {
+    ...createSessionRequest({
+      kind: "directory",
+      label: "repo",
+      path: "C:/work/repo",
+      branch: "main",
+    }),
+    id: "existing-session",
+    workspaceLabel: "forged",
+    workspacePath: "C:/forged",
+    branch: "forged",
+  };
+
+  await facade.createSessionFromRequest(request as never);
+
+  assert.deepEqual(
+    {
+      id: persistedInput?.id,
+      workspaceLabel: persistedInput?.workspaceLabel,
+      workspacePath: persistedInput?.workspacePath,
+      branch: persistedInput?.branch,
+    },
+    {
+      id: "launch-directory",
+      workspaceLabel: "repo",
+      workspacePath: "C:/work/repo",
+      branch: "main",
+    },
+  );
+});
+
+test("MainSessionCommandFacade は SessionFolder 作成失敗時に session を永続化しない", async () => {
+  let persistCount = 0;
+  const facade = new MainSessionCommandFacade({
+    getSession: () => null,
+    getSessions: () => [],
+    getStoredSessionSummaries: () => [],
+    getSessionPersistenceService: () =>
+      ({
+        createSession(input) {
+          persistCount += 1;
+          return input as never;
+        },
+      }) as never,
+    getSessionRuntimeService: () => ({} as never),
+    getProviderQuotaTelemetry: () => null,
+    isProviderQuotaTelemetryStale: () => false,
+    refreshProviderQuotaTelemetry: async () => null,
+    createSessionId: () => "launch-managed",
+    createSessionFilesDirectory: () => {
+      throw new Error("mkdir failed");
+    },
+    isSessionFilesWorkspace: () => false,
+  });
+
+  await assert.rejects(
+    facade.createSessionFromRequest(createSessionRequest({ kind: "session-folder" }) as never),
+    /mkdir failed/,
+  );
+  assert.equal(persistCount, 0);
+});
+
+test("MainSessionCommandFacade は session 永続化失敗後に作成済み SessionFolder を削除しない", async () => {
+  const calls: string[] = [];
+  const facade = new MainSessionCommandFacade({
+    getSession: () => null,
+    getSessions: () => [],
+    getStoredSessionSummaries: () => [],
+    getSessionPersistenceService: () =>
+      ({
+        createSession() {
+          calls.push("persist");
+          throw new Error("persist failed after commit");
+        },
+      }) as never,
+    getSessionRuntimeService: () => ({} as never),
+    getProviderQuotaTelemetry: () => null,
+    isProviderQuotaTelemetryStale: () => false,
+    refreshProviderQuotaTelemetry: async () => null,
+    createSessionId: () => {
+      calls.push("issue-id");
+      return "launch-managed";
+    },
+    createSessionFilesDirectory: () => {
+      calls.push("mkdir");
+      return "C:/WithMate/session-files/launch-managed";
+    },
+    isSessionFilesWorkspace: () => false,
+    async cleanupSessionFilesDirectory() {
+      calls.push("cleanup");
+    },
+  });
+
+  await assert.rejects(
+    facade.createSessionFromRequest(createSessionRequest({ kind: "session-folder" }) as never),
+    /persist failed after commit/,
+  );
+  assert.deepEqual(calls, ["issue-id", "mkdir", "persist"]);
+});
+
 test("MainSessionCommandFacade は cutoff delete の削除済み session だけ cleanup する", async () => {
   const calls: string[] = [];
   const facade = new MainSessionCommandFacade({
     getSession: () => null,
+    getSessions: () => [{ id: "s-old", workspacePath: "C:/work/repo" } as never],
+    getStoredSessionSummaries: () => [],
     getSessionPersistenceService: () =>
       ({
         deleteSessionsLastActiveBefore(cutoff) {
@@ -83,6 +348,9 @@ test("MainSessionCommandFacade は cutoff delete の削除済み session だけ 
     getProviderQuotaTelemetry: () => null,
     isProviderQuotaTelemetryStale: () => false,
     refreshProviderQuotaTelemetry: async () => null,
+    createSessionId: () => "launch-test",
+    createSessionFilesDirectory: () => "C:/session-files/launch-test",
+    isSessionFilesWorkspace: () => false,
     async cleanupSessionFilesDirectory(sessionId) {
       calls.push(`cleanup-files:${sessionId}`);
     },
@@ -98,10 +366,71 @@ test("MainSessionCommandFacade は cutoff delete の削除済み session だけ 
   ]);
 });
 
+test("MainSessionCommandFacade は cached/uncached の SessionFolder を保持し directory workspace だけ cleanup する", async () => {
+  const cleanedSessionIds: string[] = [];
+  const cachedManagedSession = {
+    id: "s-cached-managed",
+    workspacePath: "C:/WithMate/session-files/s-cached-managed",
+  } as never;
+  const cachedDirectorySession = {
+    id: "s-cached-directory",
+    workspacePath: "C:/work/cached",
+  } as never;
+  const facade = new MainSessionCommandFacade({
+    getSession: () => null,
+    getSessions: () => [cachedManagedSession, cachedDirectorySession],
+    getStoredSessionSummaries: () => [
+      cachedManagedSession,
+      cachedDirectorySession,
+      {
+        id: "s-uncached-managed",
+        workspacePath: "C:/WithMate/session-files/s-uncached-managed",
+      } as never,
+      {
+        id: "s-uncached-directory",
+        workspacePath: "C:/work/uncached",
+      } as never,
+    ],
+    getSessionPersistenceService: () =>
+      ({
+        deleteSessionsLastActiveBefore() {
+          return {
+            deletedSessionIds: [
+              "s-cached-managed",
+              "s-cached-directory",
+              "s-uncached-managed",
+              "s-uncached-directory",
+            ],
+            skippedRunningSessionIds: [],
+          };
+        },
+      }) as never,
+    getSessionRuntimeService: () => ({} as never),
+    getProviderQuotaTelemetry: () => null,
+    isProviderQuotaTelemetryStale: () => false,
+    refreshProviderQuotaTelemetry: async () => null,
+    createSessionId: () => "launch-test",
+    createSessionFilesDirectory: () => "C:/session-files/launch-test",
+    isSessionFilesWorkspace: (session) => session.id.endsWith("-managed"),
+    async cleanupSessionFilesDirectory(sessionId) {
+      cleanedSessionIds.push(sessionId);
+    },
+  });
+
+  await facade.deleteSessionsLastActiveBefore({ cutoffDate: "2026-07-01" });
+
+  assert.deepEqual(cleanedSessionIds, [
+    "s-cached-directory",
+    "s-uncached-directory",
+  ]);
+});
+
 test("MainSessionCommandFacade は実在しない cutoff delete 日付を拒否する", async () => {
   const calls: string[] = [];
   const facade = new MainSessionCommandFacade({
     getSession: () => null,
+    getSessions: () => [],
+    getStoredSessionSummaries: () => [],
     getSessionPersistenceService: () =>
       ({
         deleteSessionsLastActiveBefore() {
@@ -116,6 +445,9 @@ test("MainSessionCommandFacade は実在しない cutoff delete 日付を拒否�
     getProviderQuotaTelemetry: () => null,
     isProviderQuotaTelemetryStale: () => false,
     refreshProviderQuotaTelemetry: async () => null,
+    createSessionId: () => "launch-test",
+    createSessionFilesDirectory: () => "C:/session-files/launch-test",
+    isSessionFilesWorkspace: () => false,
     async cleanupSessionFilesDirectory(sessionId) {
       calls.push(`cleanup-files:${sessionId}`);
     },
@@ -133,6 +465,8 @@ test("MainSessionCommandFacade は stale な Copilot quota を非同期更新し
   let refreshedProviderId: string | null = null;
   const facade = new MainSessionCommandFacade({
     getSession: () => ({ id: "s-1", provider: "copilot" }) as never,
+    getSessions: () => [],
+    getStoredSessionSummaries: () => [],
     getSessionPersistenceService: () => ({} as never),
     getSessionRuntimeService: () =>
       ({
@@ -150,6 +484,9 @@ test("MainSessionCommandFacade は stale な Copilot quota を非同期更新し
       refreshedProviderId = providerId;
       return null;
     },
+    createSessionId: () => "launch-test",
+    createSessionFilesDirectory: () => "C:/session-files/launch-test",
+    isSessionFilesWorkspace: () => false,
   });
 
   const result = await facade.runSessionTurn("s-1", { userMessage: "hello" } as never);
@@ -163,6 +500,8 @@ test("MainSessionCommandFacade は non-Copilot session では quota refresh を�
   let refreshed = false;
   const facade = new MainSessionCommandFacade({
     getSession: () => ({ id: "s-1", provider: "codex" }) as never,
+    getSessions: () => [],
+    getStoredSessionSummaries: () => [],
     getSessionPersistenceService: () => ({} as never),
     getSessionRuntimeService: () =>
       ({
@@ -179,6 +518,9 @@ test("MainSessionCommandFacade は non-Copilot session では quota refresh を�
       refreshed = true;
       return null;
     },
+    createSessionId: () => "launch-test",
+    createSessionFilesDirectory: () => "C:/session-files/launch-test",
+    isSessionFilesWorkspace: () => false,
   });
 
   await facade.runSessionTurn("s-1", { userMessage: "hello" } as never);

--- a/scripts/tests/session-files.test.ts
+++ b/scripts/tests/session-files.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+import {
+  createSessionFilesDirectory,
+  resolveSessionFilesDirectory,
+} from "../../src-electron/session-files.js";
+
+describe("session files directory", () => {
+  it("createSessionFilesDirectory は既存 SessionFolder を再利用しない", async () => {
+    const userDataPath = await mkdtemp(path.join(os.tmpdir(), "withmate-session-files-"));
+    const sessionId = "launch-collision";
+    const directoryPath = resolveSessionFilesDirectory(userDataPath, sessionId);
+    const retainedFilePath = path.join(directoryPath, "result.txt");
+
+    try {
+      assert.equal(
+        await createSessionFilesDirectory(userDataPath, sessionId),
+        directoryPath,
+      );
+      await writeFile(retainedFilePath, "retained", "utf8");
+
+      await assert.rejects(
+        createSessionFilesDirectory(userDataPath, sessionId),
+        /同じ ID の SessionFolder がすでに存在するよ。/,
+      );
+      assert.equal(await readFile(retainedFilePath, "utf8"), "retained");
+    } finally {
+      await rm(userDataPath, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/tests/session-persistence-service.test.ts
+++ b/scripts/tests/session-persistence-service.test.ts
@@ -86,6 +86,7 @@ describe("SessionPersistenceService", () => {
     const snapshot = createSnapshot();
     const characterRuntimeSnapshot = createCharacterRuntimeSnapshot();
     const snapshotCharacterIds: string[] = [];
+    const storeOperations: string[] = [];
     let persistedSession: Session | null = null;
 
     const service = new SessionPersistenceService({
@@ -101,7 +102,8 @@ describe("SessionPersistenceService", () => {
       isSessionRunInFlight() {
         return false;
       },
-      upsertStoredSession(session) {
+      upsertStoredSession(session, operation) {
+        storeOperations.push(operation);
         persistedSession = session;
         storedSessions.splice(0, storedSessions.length, session);
         return session;
@@ -172,6 +174,58 @@ describe("SessionPersistenceService", () => {
     assert.equal(storedSessions[0]?.characterRuntimeSnapshot, null);
     assert.deepEqual(syncedSessionIds, [created.id]);
     assert.deepEqual(broadcastedSessionIds, [[created.id]]);
+    assert.deepEqual(storeOperations, ["create"]);
+  });
+
+  it("createSession は指定 ID が既存 Session と衝突する場合に上書きしない", async () => {
+    const existing = createSession({
+      id: "existing-session",
+      status: "running",
+      runState: "running",
+      threadId: "thread-existing",
+    });
+    let upsertCount = 0;
+    const service = new SessionPersistenceService({
+      getSessions: () => [existing],
+      setSessions() {},
+      getSession: (sessionId) => sessionId === existing.id ? existing : null,
+      getStoredSession: () => existing,
+      isSessionRunInFlight: () => true,
+      upsertStoredSession(session) {
+        upsertCount += 1;
+        return session;
+      },
+      replaceStoredSessions() {},
+      listStoredSessions: () => [existing],
+      deleteStoredSession() {},
+      getAppSettings: () => normalizeAppSettings(),
+      getModelCatalogSnapshot: () => createSnapshot(),
+      syncSessionDependencies() {},
+      clearSessionContextTelemetry() {},
+      clearSessionBackgroundActivities() {},
+      invalidateProviderSessionThread() {},
+      closeSessionWindow() {},
+      broadcastSessions() {},
+    });
+
+    await assert.rejects(
+      service.createSession({
+        id: existing.id,
+        taskTitle: "forged replacement",
+        workspaceLabel: "forged",
+        workspacePath: "C:/forged",
+        branch: "",
+        characterId: "char-a",
+        character: "A",
+        characterIconPath: "",
+        characterThemeColors: { main: "#6f8cff", sub: "#6fb8c7" },
+        approvalMode: DEFAULT_APPROVAL_MODE,
+      }),
+      /同じ ID の Session がすでに存在するよ。/,
+    );
+    assert.equal(upsertCount, 0);
+    assert.equal(existing.threadId, "thread-existing");
+    assert.equal(existing.workspacePath, "C:/workspace");
   });
 
   it("createSession は input の CharacterRuntimeSnapshot を優先して保存する", async () => {

--- a/scripts/tests/session-state.test.ts
+++ b/scripts/tests/session-state.test.ts
@@ -53,8 +53,9 @@ const CODEX_PROVIDER_CATALOG: ModelCatalogProvider = {
   ],
 };
 
-function createSession(provider: string) {
+function createSession(provider: string, id?: string) {
   return buildNewSession({
+    id,
     provider,
     taskTitle: `${provider} session`,
     workspaceLabel: "workspace",
@@ -72,8 +73,9 @@ function createSession(provider: string) {
 
 describe("session-state custom agent selection", () => {
   it("新規 session は V5 schema version で作成し、V4 以前は閲覧専用として扱う", () => {
-    const session = createSession("codex");
+    const session = createSession("codex", "launch-fixed");
 
+    assert.equal(session.id, "launch-fixed");
     assert.equal(CURRENT_SESSION_SCHEMA_VERSION, 5);
     assert.equal(session.sourceSchemaVersion, 5);
     assert.equal(isReadOnlySession(session), false);

--- a/scripts/tests/session-storage-v6.test.ts
+++ b/scripts/tests/session-storage-v6.test.ts
@@ -155,6 +155,46 @@ function listSessionTurnSummaries(dbPath: string): string[] {
 }
 
 describe("SessionStorageV6", () => {
+  it("insertSession は別 connection からの同一 ID create を拒否して既存 Session を保持する", async () => {
+    const tempDirectory = await mkdtemp(path.join(os.tmpdir(), "withmate-session-storage-v6-"));
+    const dbPath = path.join(tempDirectory, "withmate-v6.db");
+    let firstStorage: SessionStorageV6 | null = null;
+    let secondStorage: SessionStorageV6 | null = null;
+
+    try {
+      firstStorage = new SessionStorageV6(dbPath);
+      secondStorage = new SessionStorageV6(dbPath);
+      const original = buildNewSession({
+        id: "collision-session",
+        taskTitle: "first",
+        workspaceLabel: "workspace-a",
+        workspacePath: "C:/workspace-a",
+        branch: "main",
+        characterId: "char-a",
+        character: "A",
+        characterIconPath: "",
+        characterThemeColors: { main: "#6f8cff", sub: "#6fb8c7" },
+        approvalMode: DEFAULT_APPROVAL_MODE,
+      });
+
+      firstStorage.insertSession(original);
+      assert.throws(
+        () => secondStorage?.insertSession({
+          ...original,
+          taskTitle: "second",
+          workspacePath: "C:/workspace-b",
+        }),
+        /同じ ID の Session がすでに存在するよ。/,
+      );
+      assert.equal(firstStorage.getSession(original.id)?.taskTitle, "first");
+      assert.equal(firstStorage.getSession(original.id)?.workspacePath, "C:/workspace-a");
+    } finally {
+      secondStorage?.close();
+      firstStorage?.close();
+      await removeDirectoryWithRetry(tempDirectory);
+    }
+  });
+
   it("既存の artifact_body なし schema は constructor で補完する", async () => {
     const tempDirectory = await mkdtemp(path.join(os.tmpdir(), "withmate-session-storage-v6-"));
     const dbPath = path.join(tempDirectory, "withmate-v6.db");

--- a/scripts/tests/session-storage.test.ts
+++ b/scripts/tests/session-storage.test.ts
@@ -44,6 +44,31 @@ function createSession(taskTitle: string, workspaceLabel: string, characterId: s
 }
 
 describe("SessionStorage", () => {
+  it("insertSession は同一 ID create を拒否して既存 Session を保持する", async () => {
+    const tempDirectory = await mkdtemp(path.join(os.tmpdir(), "withmate-session-storage-"));
+    const dbPath = path.join(tempDirectory, "withmate.db");
+
+    try {
+      const storage = new SessionStorage(dbPath);
+      const original = createSession("first", "workspace-a", "char-a", "A");
+      storage.insertSession(original);
+
+      assert.throws(
+        () => storage.insertSession({
+          ...original,
+          taskTitle: "second",
+          workspacePath: "C:/workspace-b",
+        }),
+        /同じ ID の Session がすでに存在するよ。/,
+      );
+      assert.equal(storage.getSession(original.id)?.taskTitle, "first");
+      assert.equal(storage.getSession(original.id)?.workspacePath, original.workspacePath);
+      storage.close();
+    } finally {
+      await removeDirectoryWithRetry(tempDirectory);
+    }
+  });
+
   it("replaceSessions で一覧をまとめて置き換えられる", async () => {
     const tempDirectory = await mkdtemp(path.join(os.tmpdir(), "withmate-session-storage-"));
     const dbPath = path.join(tempDirectory, "withmate.db");

--- a/src-electron/additional-directories.ts
+++ b/src-electron/additional-directories.ts
@@ -1,8 +1,17 @@
 import path from "node:path";
 
-function normalizeForComparison(targetPath: string): string {
-  const normalized = path.resolve(targetPath).replace(/[\\/]+$/, "");
-  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+function normalizeForComparison(targetPath: string, platform: NodeJS.Platform = process.platform): string {
+  const pathApi = platform === "win32" ? path.win32 : path;
+  const normalized = pathApi.resolve(targetPath).replace(/[\\/]+$/, "");
+  return platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+export function areDirectoryPathsEquivalent(
+  leftPath: string,
+  rightPath: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return normalizeForComparison(leftPath, platform) === normalizeForComparison(rightPath, platform);
 }
 
 export function normalizeDirectoryPath(targetPath: string): string {

--- a/src-electron/character-authoring-service.ts
+++ b/src-electron/character-authoring-service.ts
@@ -23,7 +23,7 @@ const COPILOT_WORKSPACE_SKILL_ROOT = ".github/skills";
 
 type CharacterAuthoringServiceDeps = {
   bundledSkillPath: string;
-  createSession(input: CreateSessionInput): Promise<Session>;
+  createSession(input: Omit<CreateSessionInput, "id">): Promise<Session>;
   getCharacter(characterId: string): Promise<CharacterDetail | null> | CharacterDetail | null;
   getCharacterDirectory(characterId: string): string | null;
 };

--- a/src-electron/create-session-request.ts
+++ b/src-electron/create-session-request.ts
@@ -1,0 +1,145 @@
+import { APPROVAL_MODE_VALUES, type ApprovalMode } from "../src/approval-mode.js";
+import { CODEX_SANDBOX_MODE_VALUES, type CodexSandboxMode } from "../src/codex-sandbox-mode.js";
+import { normalizeCharacterRuntimeSnapshot } from "../src/character/character-runtime-snapshot.js";
+import { MODEL_REASONING_EFFORTS, type ModelReasoningEffort } from "../src/model-catalog.js";
+import type {
+  CreateSessionInput,
+  CreateSessionWorkspaceRequest,
+  SessionKind,
+} from "../src/session-state.js";
+
+type CreateSessionMetadataInput = Omit<
+  CreateSessionInput,
+  "id" | "workspaceLabel" | "workspacePath" | "branch"
+>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function requireRecord(value: unknown, fieldName: string): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error(`${fieldName} の形式が正しくないよ。`);
+  }
+  return value;
+}
+
+function requireString(value: unknown, fieldName: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`${fieldName} の形式が正しくないよ。`);
+  }
+  return value;
+}
+
+function optionalString(value: unknown, fieldName: string): string | undefined {
+  return value === undefined ? undefined : requireString(value, fieldName);
+}
+
+function optionalNumber(value: unknown, fieldName: string): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${fieldName} の形式が正しくないよ。`);
+  }
+  return value;
+}
+
+function requireEnum<T extends string>(
+  value: unknown,
+  fieldName: string,
+  allowedValues: readonly T[],
+): T {
+  const normalized = requireString(value, fieldName);
+  if (!allowedValues.includes(normalized as T)) {
+    throw new Error(`${fieldName} の値を解釈できないよ。`);
+  }
+  return normalized as T;
+}
+
+function optionalEnum<T extends string>(
+  value: unknown,
+  fieldName: string,
+  allowedValues: readonly T[],
+): T | undefined {
+  return value === undefined ? undefined : requireEnum(value, fieldName, allowedValues);
+}
+
+function optionalStringArray(value: unknown, fieldName: string): string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    throw new Error(`${fieldName} の形式が正しくないよ。`);
+  }
+  return [...value];
+}
+
+export function parseCreateSessionRequest(input: unknown): {
+  sessionInput: CreateSessionMetadataInput;
+  workspace: CreateSessionWorkspaceRequest;
+} {
+  const request = requireRecord(input, "session");
+  const theme = requireRecord(request.characterThemeColors, "characterThemeColors");
+  const runtimeSnapshot = request.characterRuntimeSnapshot === undefined || request.characterRuntimeSnapshot === null
+    ? request.characterRuntimeSnapshot
+    : normalizeCharacterRuntimeSnapshot(request.characterRuntimeSnapshot);
+  if (request.characterRuntimeSnapshot !== undefined && request.characterRuntimeSnapshot !== null && !runtimeSnapshot) {
+    throw new Error("characterRuntimeSnapshot の形式が正しくないよ。");
+  }
+
+  const workspaceInput = requireRecord(request.workspace, "workspace");
+  const workspaceKind = requireString(workspaceInput.kind, "workspace.kind");
+  let workspace: CreateSessionWorkspaceRequest;
+  if (workspaceKind === "directory") {
+    workspace = {
+      kind: "directory",
+      label: requireString(workspaceInput.label, "workspace.label"),
+      path: requireString(workspaceInput.path, "workspace.path"),
+      branch: requireString(workspaceInput.branch, "workspace.branch"),
+    };
+  } else if (workspaceKind === "session-folder") {
+    workspace = { kind: "session-folder" };
+  } else {
+    throw new Error("workspace の作成方法を解釈できないよ。");
+  }
+
+  return {
+    workspace,
+    sessionInput: {
+      provider: optionalString(request.provider, "provider"),
+      catalogRevision: optionalNumber(request.catalogRevision, "catalogRevision"),
+      taskTitle: requireString(request.taskTitle, "taskTitle"),
+      sessionKind: optionalEnum<SessionKind>(
+        request.sessionKind,
+        "sessionKind",
+        ["default", "character-authoring"],
+      ),
+      characterId: requireString(request.characterId, "characterId"),
+      character: requireString(request.character, "character"),
+      characterIconPath: requireString(request.characterIconPath, "characterIconPath"),
+      characterThemeColors: {
+        main: requireString(theme.main, "characterThemeColors.main"),
+        sub: requireString(theme.sub, "characterThemeColors.sub"),
+      },
+      characterRuntimeSnapshot: runtimeSnapshot,
+      approvalMode: requireEnum<ApprovalMode>(request.approvalMode, "approvalMode", APPROVAL_MODE_VALUES),
+      codexSandboxMode: optionalEnum<CodexSandboxMode>(
+        request.codexSandboxMode,
+        "codexSandboxMode",
+        CODEX_SANDBOX_MODE_VALUES,
+      ),
+      model: optionalString(request.model, "model"),
+      reasoningEffort: optionalEnum<ModelReasoningEffort>(
+        request.reasoningEffort,
+        "reasoningEffort",
+        MODEL_REASONING_EFFORTS,
+      ),
+      customAgentName: optionalString(request.customAgentName, "customAgentName"),
+      allowedAdditionalDirectories: optionalStringArray(
+        request.allowedAdditionalDirectories,
+        "allowedAdditionalDirectories",
+      ),
+    },
+  };
+}

--- a/src-electron/main-ipc-deps.ts
+++ b/src-electron/main-ipc-deps.ts
@@ -59,7 +59,7 @@ import type {
 import type { ModelCatalogDocument, ModelCatalogSnapshot } from "../src/model-catalog.js";
 import type { AppSettings } from "../src/provider-settings-state.js";
 import type { DiscoveredCustomAgent, DiscoveredSkill } from "../src/runtime-state.js";
-import type { CreateSessionInput, DiffPreviewPayload, MessageArtifact, Session } from "../src/session-state.js";
+import type { CreateSessionRequest, DiffPreviewPayload, MessageArtifact, Session } from "../src/session-state.js";
 import type {
   OpenPathOptions,
   DeleteSessionsLastActiveBeforeRequest,
@@ -226,7 +226,7 @@ export type MainIpcSessionRuntimeDepsArgs = {
   ): SessionBackgroundActivityState | null;
   resolveLiveApproval(sessionId: string, requestId: string, decision: LiveApprovalDecision): void;
   resolveLiveElicitation(sessionId: string, requestId: string, response: LiveElicitationResponse): void;
-  createSession(input: CreateSessionInput): Awaitable<Session>;
+  createSession(input: CreateSessionRequest): Awaitable<Session>;
   updateSession(session: Session): Awaitable<Session>;
   deleteSession(sessionId: string): Awaitable<void>;
   deleteSessionsLastActiveBefore(

--- a/src-electron/main-ipc-registration.ts
+++ b/src-electron/main-ipc-registration.ts
@@ -67,7 +67,7 @@ import type {
 import type { ModelCatalogDocument, ModelCatalogSnapshot } from "../src/model-catalog.js";
 import type { AppSettings } from "../src/provider-settings-state.js";
 import type { DiscoveredCustomAgent, DiscoveredSkill } from "../src/runtime-state.js";
-import type { CreateSessionInput, DiffPreviewPayload, MessageArtifact, Session } from "../src/session-state.js";
+import type { CreateSessionRequest, DiffPreviewPayload, MessageArtifact, Session } from "../src/session-state.js";
 import type { Awaitable } from "./persistent-store-lifecycle-service.js";
 import {
   WITHMATE_CANCEL_SESSION_RUN_CHANNEL,
@@ -304,7 +304,7 @@ export type MainIpcRegistrationDeps = {
   ): SessionBackgroundActivityState | null;
   resolveLiveApproval(sessionId: string, requestId: string, decision: LiveApprovalDecision): void;
   resolveLiveElicitation(sessionId: string, requestId: string, response: LiveElicitationResponse): void;
-  createSession(input: CreateSessionInput): Awaitable<Session>;
+  createSession(input: CreateSessionRequest): Awaitable<Session>;
   createCompanionSession(input: CreateCompanionSessionInput): Promise<CompanionSession>;
   getCompanionSession(sessionId: string): Awaitable<CompanionSession | null>;
   getCompanionMessageArtifact(sessionId: string, messageIndex: number): Awaitable<MessageArtifact | null>;
@@ -1038,7 +1038,7 @@ function registerSessionRuntimeHandlers(ipcMain: IpcHandleRegistrar, deps: MainI
       deps.resolveLiveElicitation(sessionId, requestId, response);
     },
   );
-  ipcMain.handle(WITHMATE_CREATE_SESSION_CHANNEL, (_event, input: CreateSessionInput) => deps.createSession(input));
+  ipcMain.handle(WITHMATE_CREATE_SESSION_CHANNEL, (_event, input: CreateSessionRequest) => deps.createSession(input));
   ipcMain.handle(WITHMATE_UPDATE_SESSION_CHANNEL, (_event, session: Session) => deps.updateSession(session));
   ipcMain.handle(WITHMATE_DELETE_SESSION_CHANNEL, (event, sessionId: string) => {
     assertSessionDeleteSender(event, sessionId, deps);

--- a/src-electron/main-session-command-facade.ts
+++ b/src-electron/main-session-command-facade.ts
@@ -1,5 +1,5 @@
 import type { ProviderQuotaTelemetry, RunSessionTurnRequest } from "../src/runtime-state.js";
-import type { CreateSessionInput, Session } from "../src/session-state.js";
+import type { CreateSessionInput, CreateSessionRequest, Session, SessionSummary } from "../src/session-state.js";
 import {
   resolveDeleteSessionsLastActiveBeforeCutoff,
   type DeleteSessionsLastActiveBeforeRequest,
@@ -7,22 +7,78 @@ import {
 } from "../src/withmate-window-types.js";
 import type { SessionPersistenceService } from "./session-persistence-service.js";
 import type { SessionRuntimeService } from "./session-runtime-service.js";
+import { parseCreateSessionRequest } from "./create-session-request.js";
 
 type MainSessionCommandFacadeDeps = {
   getSession(sessionId: string): Session | null;
+  getSessions(): readonly Session[];
+  getStoredSessionSummaries(): Promise<readonly SessionSummary[]> | readonly SessionSummary[];
   getSessionPersistenceService(): SessionPersistenceService;
   getSessionRuntimeService(): SessionRuntimeService;
   getProviderQuotaTelemetry(providerId: string): ProviderQuotaTelemetry | null;
   isProviderQuotaTelemetryStale(telemetry: ProviderQuotaTelemetry | null): boolean;
   refreshProviderQuotaTelemetry(providerId: string): Promise<ProviderQuotaTelemetry | null>;
+  createSessionId(): string;
+  createSessionFilesDirectory(sessionId: string): Promise<string> | string;
+  isSessionFilesWorkspace(session: Pick<Session, "id" | "workspacePath">): boolean;
   cleanupSessionFilesDirectory?(sessionId: string): Promise<void>;
 };
+
+type MainOwnedCreateSessionInput = Omit<CreateSessionInput, "id">;
 
 export class MainSessionCommandFacade {
   constructor(private readonly deps: MainSessionCommandFacadeDeps) {}
 
-  async createSession(input: CreateSessionInput): Promise<Session> {
+  async createSession(input: MainOwnedCreateSessionInput): Promise<Session> {
+    return this.persistCreatedSession({
+      ...input,
+      id: this.issueSessionId(),
+    });
+  }
+
+  async createSessionFromRequest(input: CreateSessionRequest): Promise<Session> {
+    const { workspace, sessionInput } = parseCreateSessionRequest(input);
+    if (workspace?.kind === "directory") {
+      if (!workspace.label.trim() || !workspace.path.trim()) {
+        throw new Error("workspace の情報が不足しているよ。");
+      }
+      return this.persistCreatedSession({
+        ...sessionInput,
+        id: this.issueSessionId(),
+        workspaceLabel: workspace.label,
+        workspacePath: workspace.path,
+        branch: workspace.branch,
+      });
+    }
+    if (workspace?.kind !== "session-folder") {
+      throw new Error("workspace の作成方法を解釈できないよ。");
+    }
+
+    const sessionId = this.issueSessionId();
+    const workspacePath = await this.deps.createSessionFilesDirectory(sessionId);
+    if (!workspacePath.trim()) {
+      throw new Error("SessionFolder を作成できなかったよ。");
+    }
+
+    return this.persistCreatedSession({
+      ...sessionInput,
+      id: sessionId,
+      workspaceLabel: "SessionFolder",
+      workspacePath,
+      branch: "",
+    });
+  }
+
+  private async persistCreatedSession(input: CreateSessionInput & { id: string }): Promise<Session> {
     return this.deps.getSessionPersistenceService().createSession(input);
+  }
+
+  private issueSessionId(): string {
+    const sessionId = this.deps.createSessionId().trim();
+    if (!sessionId) {
+      throw new Error("Session ID を発行できなかったよ。");
+    }
+    return sessionId;
   }
 
   async updateSession(session: Session): Promise<Session> {
@@ -30,8 +86,10 @@ export class MainSessionCommandFacade {
   }
 
   async deleteSession(sessionId: string): Promise<void> {
+    const sessionsById = new Map(this.deps.getSessions().map((session) => [session.id, session] as const));
     await this.cleanupDeletedSessions(
       await this.deps.getSessionPersistenceService().deleteSession(sessionId),
+      sessionsById,
     );
   }
 
@@ -39,8 +97,14 @@ export class MainSessionCommandFacade {
     request: DeleteSessionsLastActiveBeforeRequest | null | undefined,
   ): Promise<DeleteSessionsResult> {
     const cutoff = resolveDeleteSessionsLastActiveBeforeCutoff(request);
+    const sessionsById = new Map(
+      [
+        ...await this.deps.getStoredSessionSummaries(),
+        ...this.deps.getSessions(),
+      ].map((session) => [session.id, session] as const),
+    );
     const result = await this.deps.getSessionPersistenceService().deleteSessionsLastActiveBefore(cutoff);
-    await this.cleanupDeletedSessions(result);
+    await this.cleanupDeletedSessions(result, sessionsById);
     return result;
   }
 
@@ -60,8 +124,15 @@ export class MainSessionCommandFacade {
     return this.deps.getSessionRuntimeService().runSessionTurn(sessionId, request);
   }
 
-  private async cleanupDeletedSessions(result: DeleteSessionsResult): Promise<void> {
+  private async cleanupDeletedSessions(
+    result: DeleteSessionsResult,
+    sessionsById: ReadonlyMap<string, Pick<Session, "id" | "workspacePath">>,
+  ): Promise<void> {
     for (const sessionId of result.deletedSessionIds) {
+      const deletedSession = sessionsById.get(sessionId);
+      if (deletedSession && this.deps.isSessionFilesWorkspace(deletedSession)) {
+        continue;
+      }
       await this.deps.cleanupSessionFilesDirectory?.(sessionId);
     }
   }

--- a/src-electron/main.ts
+++ b/src-electron/main.ts
@@ -68,6 +68,7 @@ import {
 import { CodexAdapter } from "./codex-adapter.js";
 import { CopilotAdapter } from "./copilot-adapter.js";
 import { resolveComposerPreview } from "./composer-attachments.js";
+import { areDirectoryPathsEquivalent } from "./additional-directories.js";
 import { ModelCatalogStorage } from "./model-catalog-storage.js";
 import {
   buildDirectoryOpenFallbackCommand,
@@ -99,6 +100,7 @@ import {
   appendSessionFilesDirectory,
   appendSessionFilesDirectoryForSessionId,
   copyFilesToSessionFiles as copyFilesToSessionFilesStorage,
+  createSessionFilesDirectory,
   deleteSessionFilesDirectory,
   resolveSessionFilesDirectory,
   saveSessionFile,
@@ -1428,7 +1430,7 @@ function requireMainInfrastructureRegistry(): MainInfrastructureRegistry<
                 getSessionBackgroundActivity: (sessionId, kind) => getSessionBackgroundActivity(sessionId, kind),
                 resolveLiveApproval,
                 resolveLiveElicitation,
-                createSession: (input) => requireMainSessionCommandFacade().createSession(input),
+                createSession: (input) => requireMainSessionCommandFacade().createSessionFromRequest(input),
                 updateSession: (session) => requireMainSessionCommandFacade().updateSession(session),
                 deleteSession: (sessionId) => requireMainSessionCommandFacade().deleteSession(sessionId),
                 deleteSessionsLastActiveBefore: (request) =>
@@ -1485,6 +1487,7 @@ function requireSessionStorageForWrite(): SessionStorage {
 function isSessionStorageWritable(storage: SessionStorageRead): storage is SessionStorage {
   const candidate = storage as Partial<SessionStorage>;
   return (
+    typeof candidate.insertSession === "function" &&
     typeof candidate.upsertSession === "function" &&
     typeof candidate.replaceSessions === "function" &&
     typeof candidate.deleteSession === "function" &&
@@ -1577,11 +1580,21 @@ function requireMainSessionCommandFacade(): MainSessionCommandFacade {
   if (!mainSessionCommandFacade) {
     mainSessionCommandFacade = new MainSessionCommandFacade({
       getSession,
+      getSessions: () => sessions,
+      getStoredSessionSummaries: () => requireSessionStorage().listSessionSummaries(),
       getSessionPersistenceService: () => requireSessionPersistenceService(),
       getSessionRuntimeService: () => requireSessionRuntimeService(),
       getProviderQuotaTelemetry: (providerId) => getProviderQuotaTelemetry(providerId),
       isProviderQuotaTelemetryStale: (telemetry) => isProviderQuotaTelemetryStale(telemetry),
       refreshProviderQuotaTelemetry: (providerId) => refreshProviderQuotaTelemetry(providerId),
+      createSessionId: () => `launch-${crypto.randomUUID()}`,
+      createSessionFilesDirectory: (sessionId) =>
+        createSessionFilesDirectory(app.getPath("userData"), sessionId),
+      isSessionFilesWorkspace: (session) =>
+        areDirectoryPathsEquivalent(
+          session.workspacePath,
+          resolveSessionFilesDirectory(app.getPath("userData"), session.id),
+        ),
       cleanupSessionFilesDirectory,
     });
   }
@@ -2087,7 +2100,12 @@ function requireSessionPersistenceService(): SessionPersistenceService {
       getStoredSession: (sessionId) => requireSessionStorage().getSession(sessionId),
       isSessionRunInFlight,
       listRunningActiveAuxiliaryParentIds: listRunningActiveAuxiliaryParentSessionIds,
-      upsertStoredSession: (session) => requireSessionStorageForWrite().upsertSession(session),
+      upsertStoredSession: (session, operation) => {
+        const storage = requireSessionStorageForWrite();
+        return operation === "create"
+          ? storage.insertSession(session)
+          : storage.upsertSession(session);
+      },
       replaceStoredSessions: async (nextSessions) => {
         await requireSessionStorageForWrite().replaceSessions(nextSessions);
       },

--- a/src-electron/persistent-store-lifecycle-service.ts
+++ b/src-electron/persistent-store-lifecycle-service.ts
@@ -57,7 +57,7 @@ export type SessionStorageRead = AwaitableStorageMethods<
 > & Pick<SessionStorage, "close">;
 export type SessionStorageWrite = AwaitableStorageMethods<
   SessionStorage,
-  "upsertSession" | "replaceSessions" | "deleteSession" | "deleteSessions" | "clearSessions"
+  "insertSession" | "upsertSession" | "replaceSessions" | "deleteSession" | "deleteSessions" | "clearSessions"
 > & SessionStorageRead;
 
 export type AuditLogStorageRead = AwaitableStorageMethods<

--- a/src-electron/session-files.ts
+++ b/src-electron/session-files.ts
@@ -31,6 +31,21 @@ export function resolveSessionFilesDirectory(userDataPath: string, sessionId: st
   return path.join(userDataPath, SESSION_FILES_ROOT, safePathSegment(sessionId));
 }
 
+export async function createSessionFilesDirectory(userDataPath: string, sessionId: string): Promise<string> {
+  const directoryPath = resolveSessionFilesDirectory(userDataPath, sessionId);
+  await mkdir(path.dirname(directoryPath), { recursive: true });
+  try {
+    await mkdir(directoryPath);
+  } catch (error) {
+    const code = error && typeof error === "object" ? (error as { code?: unknown }).code : null;
+    if (code === "EEXIST") {
+      throw new Error("同じ ID の SessionFolder がすでに存在するよ。");
+    }
+    throw error;
+  }
+  return directoryPath;
+}
+
 export function appendSessionFilesDirectory<TSession extends { id: string; allowedAdditionalDirectories: string[] }>(
   userDataPath: string,
   session: TSession,

--- a/src-electron/session-persistence-service.ts
+++ b/src-electron/session-persistence-service.ts
@@ -22,6 +22,7 @@ import type {
   DeleteSessionsLastActiveBeforeCutoff,
   DeleteSessionsResult,
 } from "../src/withmate-window-types.js";
+import { SessionIdCollisionError } from "./session-storage-errors.js";
 
 const SESSION_RUN_STUCK_INVESTIGATION_LOG = "[investigate:session-run-stuck]";
 
@@ -39,7 +40,7 @@ export type SessionPersistenceServiceDeps = {
   getStoredSession?(sessionId: string): Awaitable<Session | null>;
   isSessionRunInFlight(sessionId: string): boolean;
   listRunningActiveAuxiliaryParentIds?(sessionIds: readonly string[]): Awaitable<ReadonlySet<string>>;
-  upsertStoredSession(session: Session): Awaitable<Session>;
+  upsertStoredSession(session: Session, operation: "create" | "upsert"): Awaitable<Session>;
   replaceStoredSessions(sessions: Session[]): Awaitable<void>;
   listStoredSessions(): Awaitable<Session[]>;
   listStoredSessionIdsLastActiveBefore?(cutoff: DeleteSessionsLastActiveBeforeCutoff): Awaitable<string[]>;
@@ -82,6 +83,17 @@ export class SessionPersistenceService {
   constructor(private readonly deps: SessionPersistenceServiceDeps) {}
 
   async createSession(input: CreateSessionInput): Promise<Session> {
+    const requestedSessionId = input.id?.trim() ?? "";
+    if (
+      requestedSessionId &&
+      (
+        this.deps.getSession(requestedSessionId) ||
+        await this.deps.getStoredSession?.(requestedSessionId)
+      )
+    ) {
+      throw new SessionIdCollisionError(requestedSessionId);
+    }
+
     const appSettings = this.deps.getAppSettings();
     const snapshot = this.deps.getModelCatalogSnapshot();
     const provider = this.resolveEnabledProviderCatalog(snapshot, appSettings, input.provider);
@@ -109,7 +121,7 @@ export class SessionPersistenceService {
         input.allowedAdditionalDirectories ?? [],
       ),
     });
-    return this.upsertSession(created);
+    return this.upsertSession(created, "create");
   }
 
   async updateSession(nextSession: Session): Promise<Session> {
@@ -234,7 +246,10 @@ export class SessionPersistenceService {
     };
   }
 
-  async upsertSession(nextSession: Session): Promise<Session> {
+  async upsertSession(
+    nextSession: Session,
+    operation: "create" | "upsert" = "upsert",
+  ): Promise<Session> {
     const startedAt = Date.now();
     const currentSession = this.deps.getSession(nextSession.id);
     if (currentSession) {
@@ -249,7 +264,7 @@ export class SessionPersistenceService {
         sessionToStore.workspacePath,
         sessionToStore.allowedAdditionalDirectories,
       ),
-    });
+    }, operation);
     const storeDurationMs = Date.now() - storeStartedAt;
     const cacheStartedAt = Date.now();
     this.syncStoredSession(stored);

--- a/src-electron/session-storage-errors.ts
+++ b/src-electron/session-storage-errors.ts
@@ -1,0 +1,6 @@
+export class SessionIdCollisionError extends Error {
+  constructor(readonly sessionId: string) {
+    super("同じ ID の Session がすでに存在するよ。");
+    this.name = "SessionIdCollisionError";
+  }
+}

--- a/src-electron/session-storage-v6.ts
+++ b/src-electron/session-storage-v6.ts
@@ -20,6 +20,7 @@ import {
 import { deleteAuditEventsForSessionTargets } from "./audit-log-storage-v6.js";
 import { ensureV6Schema } from "./database-schema-v6.js";
 import { openAppDatabase } from "./sqlite-connection.js";
+import { SessionIdCollisionError } from "./session-storage-errors.js";
 import type { DeleteSessionsLastActiveBeforeCutoff } from "../src/withmate-window-types.js";
 
 type SessionV6Row = {
@@ -206,6 +207,14 @@ export class SessionStorageV6 {
   }
 
   upsertSession(session: Session): Session {
+    return this.storeSession(session, "upsert");
+  }
+
+  insertSession(session: Session): Session {
+    return this.storeSession(session, "create");
+  }
+
+  private storeSession(session: Session, operation: "create" | "upsert"): Session {
     const normalized = normalizeSession(session);
     if (!normalized) {
       throw new Error("SessionStorageV6 に保存できない session 形式だよ。");
@@ -214,10 +223,10 @@ export class SessionStorageV6 {
     const startedAt = Date.now();
     this.db.exec("BEGIN IMMEDIATE TRANSACTION");
     try {
-      this.writeSession(normalized);
+      this.writeSession(normalized, operation);
       this.db.exec("COMMIT");
       const stored = this.getSession(normalized.id) ?? normalized;
-      logSessionRunStuckInvestigation("storage-v6.upsert-session.done", {
+      logSessionRunStuckInvestigation(`storage-v6.${operation}-session.done`, {
         sessionId: normalized.id,
         durationMs: Date.now() - startedAt,
         messageCount: normalized.messages.length,
@@ -229,7 +238,7 @@ export class SessionStorageV6 {
       return stored;
     } catch (error) {
       this.db.exec("ROLLBACK");
-      logSessionRunStuckInvestigation("storage-v6.upsert-session.failed", {
+      logSessionRunStuckInvestigation(`storage-v6.${operation}-session.failed`, {
         sessionId: normalized.id,
         durationMs: Date.now() - startedAt,
         messageCount: normalized.messages.length,
@@ -318,7 +327,7 @@ export class SessionStorageV6 {
     this.db.close();
   }
 
-  private writeSession(session: Session): void {
+  private writeSession(session: Session, operation: "create" | "upsert" = "upsert"): void {
     const startedAt = Date.now();
     const snapshot = session.characterRuntimeSnapshot;
     const runtimePolicy = {
@@ -332,7 +341,30 @@ export class SessionStorageV6 {
       characterIconPath: session.characterIconPath,
       characterThemeColors: session.characterThemeColors,
     };
-    this.db.prepare(`
+    const conflictClause = operation === "create"
+      ? "ON CONFLICT(id) DO NOTHING"
+      : `
+        ON CONFLICT(id) DO UPDATE SET
+          title = excluded.title,
+          state = excluded.state,
+          session_kind = excluded.session_kind,
+          provider_id = excluded.provider_id,
+          catalog_revision = excluded.catalog_revision,
+          model_id = excluded.model_id,
+          reasoning_effort = excluded.reasoning_effort,
+          custom_agent_name = excluded.custom_agent_name,
+          approval_mode = excluded.approval_mode,
+          codex_sandbox_mode = excluded.codex_sandbox_mode,
+          allowed_additional_directories_json = excluded.allowed_additional_directories_json,
+          runtime_policy_json = excluded.runtime_policy_json,
+          thread_id = excluded.thread_id,
+          character_id = excluded.character_id,
+          character_snapshot_json = excluded.character_snapshot_json,
+          workspace_path = excluded.workspace_path,
+          updated_at = excluded.updated_at,
+          last_active_at = excluded.last_active_at
+      `;
+    const result = this.db.prepare(`
       INSERT INTO sessions_v6 (
         id,
         title,
@@ -356,25 +388,7 @@ export class SessionStorageV6 {
         last_active_at
       )
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      ON CONFLICT(id) DO UPDATE SET
-        title = excluded.title,
-        state = excluded.state,
-        session_kind = excluded.session_kind,
-        provider_id = excluded.provider_id,
-        catalog_revision = excluded.catalog_revision,
-        model_id = excluded.model_id,
-        reasoning_effort = excluded.reasoning_effort,
-        custom_agent_name = excluded.custom_agent_name,
-        approval_mode = excluded.approval_mode,
-        codex_sandbox_mode = excluded.codex_sandbox_mode,
-        allowed_additional_directories_json = excluded.allowed_additional_directories_json,
-        runtime_policy_json = excluded.runtime_policy_json,
-        thread_id = excluded.thread_id,
-        character_id = excluded.character_id,
-        character_snapshot_json = excluded.character_snapshot_json,
-        workspace_path = excluded.workspace_path,
-        updated_at = excluded.updated_at,
-        last_active_at = excluded.last_active_at
+      ${conflictClause}
     `).run(
       session.id,
       session.taskTitle,
@@ -397,6 +411,9 @@ export class SessionStorageV6 {
       session.updatedAt,
       session.updatedAt,
     );
+    if (operation === "create" && Number(result.changes) === 0) {
+      throw new SessionIdCollisionError(session.id);
+    }
 
     const existingArtifactBodies = new Map(
       (this.db.prepare(`

--- a/src-electron/session-storage.ts
+++ b/src-electron/session-storage.ts
@@ -19,6 +19,7 @@ import {
 } from "./database-schema-v1.js";
 import { openAppDatabase } from "./sqlite-connection.js";
 import type { DeleteSessionsLastActiveBeforeCutoff } from "../src/withmate-window-types.js";
+import { SessionIdCollisionError } from "./session-storage-errors.js";
 
 type SessionRow = {
   id: string;
@@ -141,7 +142,7 @@ const GET_SESSION_SQL = `
   WHERE id = ?
 `;
 
-const UPSERT_SESSION_SQL = `
+const INSERT_SESSION_SQL = `
   INSERT INTO sessions (
     id,
     task_title,
@@ -173,6 +174,15 @@ const UPSERT_SESSION_SQL = `
     stream_json,
     last_active_at
   ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+`;
+
+const CREATE_SESSION_SQL = `
+  ${INSERT_SESSION_SQL}
+  ON CONFLICT(id) DO NOTHING
+`;
+
+const UPSERT_SESSION_SQL = `
+  ${INSERT_SESSION_SQL}
   ON CONFLICT(id) DO UPDATE SET
     task_title = excluded.task_title,
     status = excluded.status,
@@ -344,8 +354,12 @@ export class SessionStorage {
     this.ensureSchema();
   }
 
-  private writeSession(normalized: Session, lastActiveAt: number): void {
-    this.db.prepare(UPSERT_SESSION_SQL).run(
+  private writeSession(
+    normalized: Session,
+    lastActiveAt: number,
+    operation: "create" | "upsert",
+  ): void {
+    const result = this.db.prepare(operation === "create" ? CREATE_SESSION_SQL : UPSERT_SESSION_SQL).run(
       normalized.id,
       normalized.taskTitle,
       normalized.status,
@@ -376,6 +390,9 @@ export class SessionStorage {
       JSON.stringify(normalized.stream),
       lastActiveAt,
     );
+    if (operation === "create" && Number(result.changes) === 0) {
+      throw new SessionIdCollisionError(normalized.id);
+    }
   }
 
   private ensureSchema(): void {
@@ -467,7 +484,17 @@ export class SessionStorage {
       throw new Error("保存するセッション形式が不正だよ。");
     }
 
-    this.writeSession(normalized, Date.now());
+    this.writeSession(normalized, Date.now(), "upsert");
+    return cloneSessions([normalized])[0];
+  }
+
+  insertSession(session: Session): Session {
+    const normalized = normalizeSession(session);
+    if (!normalized) {
+      throw new Error("保存するセッション形式が不正だよ。");
+    }
+
+    this.writeSession(normalized, Date.now(), "create");
     return cloneSessions([normalized])[0];
   }
 
@@ -486,7 +513,7 @@ export class SessionStorage {
     try {
       this.db.exec("DELETE FROM sessions");
       normalizedSessions.forEach((session, index) => {
-        this.writeSession(session, baseLastActiveAt - index);
+        this.writeSession(session, baseLastActiveAt - index, "upsert");
       });
       this.deleteAuxiliarySessionsWithoutValidParents(normalizedSessions.map((session) => session.id));
       this.db.exec("COMMIT");

--- a/src/HomeApp.tsx
+++ b/src/HomeApp.tsx
@@ -608,6 +608,7 @@ export default function HomeApp() {
       onSelectMode: homeLaunchHandlers.onChangeMode,
       onChangeTitle: homeLaunchHandlers.onChangeTitle,
       onBrowseWorkspace: () => void homeLaunchHandlers.onBrowseWorkspace(),
+      onSelectSessionFolder: homeLaunchHandlers.onSelectSessionFolder,
       onSelectProvider: homeLaunchHandlers.onSelectLaunchProvider,
       onSelectCharacter: homeLaunchHandlers.onSelectLaunchCharacter,
       onSelectRandomCharacter: homeLaunchHandlers.onSelectRandomLaunchCharacter,

--- a/src/app-state.ts
+++ b/src/app-state.ts
@@ -14,6 +14,8 @@ export {
 } from "./session-state.js";
 export type {
   CreateSessionInput,
+  CreateSessionRequest,
+  CreateSessionWorkspaceRequest,
   DiffPreviewPayload,
   Message,
   MessageArtifact,

--- a/src/home/HomeLaunchDialog.tsx
+++ b/src/home/HomeLaunchDialog.tsx
@@ -5,7 +5,6 @@ import { LaunchDialogFooter, LaunchDialogShell } from "../launch/launch-dialog-s
 import { ProviderLaunchField } from "../launch/provider-launch-picker.js";
 import { buildCharacterThemeStyle } from "../theme-utils.js";
 import { CharacterAvatar } from "../ui-utils.js";
-import type { LaunchWorkspace } from "./home-launch-projection.js";
 import type { CharacterCatalogEntry } from "../character/character-catalog.js";
 import { DEFAULT_CHARACTER_THEME_COLORS } from "../character-state.js";
 
@@ -13,7 +12,8 @@ export type HomeLaunchDialogProps = {
   open: boolean;
   mode: "session" | "companion";
   title: string;
-  workspace: LaunchWorkspace | null;
+  workspaceSelected: boolean;
+  sessionFolderSelected: boolean;
   launchWorkspacePathLabel: string;
   enabledLaunchProviders: Array<{ id: string; label: string }>;
   selectedLaunchProviderId: string | null;
@@ -28,6 +28,7 @@ export type HomeLaunchDialogProps = {
   onSelectMode: (mode: "session" | "companion") => void;
   onChangeTitle: (value: string) => void;
   onBrowseWorkspace: () => void;
+  onSelectSessionFolder: () => void;
   onSelectProvider: (providerId: string) => void;
   onSelectCharacter: (characterId: string) => void;
   onSelectRandomCharacter: () => void;
@@ -38,7 +39,8 @@ export function HomeLaunchDialog({
   open,
   mode,
   title,
-  workspace,
+  workspaceSelected,
+  sessionFolderSelected,
   launchWorkspacePathLabel,
   enabledLaunchProviders,
   selectedLaunchProviderId,
@@ -53,6 +55,7 @@ export function HomeLaunchDialog({
   onSelectMode,
   onChangeTitle,
   onBrowseWorkspace,
+  onSelectSessionFolder,
   onSelectProvider,
   onSelectCharacter,
   onSelectRandomCharacter,
@@ -135,12 +138,22 @@ export function HomeLaunchDialog({
       </section>
 
       <section className="launch-section workspace-picker minimal">
-        <div className="section-head compact-actions">
+        <div className="section-head compact-actions workspace-picker-actions">
           <button className="browse-button" type="button" onClick={onBrowseWorkspace}>
             Browse
           </button>
+          {mode === "session" ? (
+            <button
+              className={`browse-button${sessionFolderSelected ? " active" : ""}`}
+              type="button"
+              aria-pressed={sessionFolderSelected}
+              onClick={onSelectSessionFolder}
+            >
+              SessionFolder
+            </button>
+          ) : null}
         </div>
-        <p className={`launch-path${workspace ? " selected" : ""}`}>{launchWorkspacePathLabel}</p>
+        <p className={`launch-path${workspaceSelected ? " selected" : ""}`}>{launchWorkspacePathLabel}</p>
       </section>
 
       <ProviderLaunchField

--- a/src/home/home-launch-actions.ts
+++ b/src/home/home-launch-actions.ts
@@ -3,18 +3,18 @@ import type { CharacterCatalogEntry } from "../character/character-catalog.js";
 import type { CompanionSession, CompanionSessionSummary, CreateCompanionSessionInput } from "../companion-state.js";
 import { createCompanionSessionSummary } from "../companion-state.js";
 import type { MateProfile, MateStorageState } from "../mate/mate-state.js";
-import type { CreateSessionInput, SessionSummary } from "../session-state.js";
+import type { CreateSessionRequest, SessionSummary } from "../session-state.js";
 import type { SessionSummariesLoadStatus } from "../session-summary-subscription.js";
 import { projectSessionSummary } from "../session-state.js";
 import {
   buildCreateCompanionSessionInputFromLaunchDraft,
-  buildCreateSessionInputFromLaunchDraft,
+  buildCreateSessionRequestFromLaunchDraft,
   resolveLastUsedSessionSelection,
   resolveLaunchValidationMessage,
   type HomeLaunchDraft,
 } from "./home-launch-state.js";
 
-export type HomeLaunchSessionCreator = (input: CreateSessionInput) => Promise<SessionSummary | null>;
+export type HomeLaunchSessionCreator = (input: CreateSessionRequest) => Promise<SessionSummary | null>;
 
 export type HomeLaunchCompanionSessionCreator = (input: CreateCompanionSessionInput) => Promise<CompanionSession | null>;
 
@@ -98,7 +98,7 @@ export async function startHomeLaunch(input: StartHomeLaunchInput): Promise<void
       return;
     }
 
-    const sessionInput = buildCreateSessionInputFromLaunchDraft({
+    const sessionInput = buildCreateSessionRequestFromLaunchDraft({
       draft: input.draft,
       mateProfile: input.mateProfile,
       selectedProviderId: input.selectedProviderId,

--- a/src/home/home-launch-dialog-props.ts
+++ b/src/home/home-launch-dialog-props.ts
@@ -12,6 +12,7 @@ type HomeLaunchDialogPropsInput = {
   onSelectMode: (mode: HomeLaunchDraft["mode"]) => void;
   onChangeTitle: (value: string) => void;
   onBrowseWorkspace: () => void;
+  onSelectSessionFolder: () => void;
   onSelectProvider: (providerId: string) => void;
   onSelectCharacter: (characterId: string) => void;
   onSelectRandomCharacter: () => void;
@@ -28,6 +29,7 @@ export function buildHomeLaunchDialogProps({
   onSelectMode,
   onChangeTitle,
   onBrowseWorkspace,
+  onSelectSessionFolder,
   onSelectProvider,
   onSelectCharacter,
   onSelectRandomCharacter,
@@ -37,7 +39,8 @@ export function buildHomeLaunchDialogProps({
     open: draft.open,
     mode: draft.mode,
     title: draft.title,
-    workspace: draft.workspace,
+    workspaceSelected: projection.workspaceSelected,
+    sessionFolderSelected: projection.sessionFolderSelected,
     launchWorkspacePathLabel: projection.launchWorkspacePathLabel,
     enabledLaunchProviders: projection.enabledLaunchProviders,
     selectedLaunchProviderId: projection.selectedLaunchProvider?.id ?? null,
@@ -52,6 +55,7 @@ export function buildHomeLaunchDialogProps({
     onSelectMode,
     onChangeTitle,
     onBrowseWorkspace,
+    onSelectSessionFolder,
     onSelectProvider,
     onSelectCharacter,
     onSelectRandomCharacter,

--- a/src/home/home-launch-handlers.ts
+++ b/src/home/home-launch-handlers.ts
@@ -1,6 +1,6 @@
 import type { CompanionSessionSummary } from "../companion-state.js";
 import type { CharacterCatalogEntry } from "../character/character-catalog.js";
-import type { CreateSessionInput, SessionSummary } from "../session-state.js";
+import type { CreateSessionRequest, SessionSummary } from "../session-state.js";
 import type { MateProfile, MateStorageState } from "../mate/mate-state.js";
 import type { CreateCompanionSessionInput, CompanionSession } from "../companion-state.js";
 import type { ModelCatalogProvider } from "../model-catalog.js";
@@ -11,10 +11,12 @@ import {
   openLaunchDraft,
   resolveLaunchCharacterId,
   setLaunchWorkspaceFromPath,
+  setLaunchWorkspaceToSessionFolder,
   updateLaunchDraftForCharacterSelection,
   updateLaunchDraftForProviderSelection,
   updateLaunchDraftForRandomCharacterSelection,
 } from "./home-launch-state.js";
+import { isSessionFolderLaunchWorkspace } from "./home-launch-workspace.js";
 import { startHomeLaunch } from "./home-launch-actions.js";
 
 type HomeLaunchHandlersContext = {
@@ -34,7 +36,7 @@ type HomeLaunchHandlersContext = {
   pickWorkspaceDirectory: () => Promise<string | null> | string | null;
   openSessionWindow: (sessionId: string) => Promise<void>;
   openCompanionReviewWindow: (sessionId: string) => Promise<void>;
-  createSession: (input: CreateSessionInput) => Promise<SessionSummary | null>;
+  createSession: (input: CreateSessionRequest) => Promise<SessionSummary | null>;
   createCompanionSession: (input: CreateCompanionSessionInput) => Promise<CompanionSession | null>;
   upsertSessionSummary: (summary: SessionSummary) => void;
   upsertCompanionSessionSummary: (summary: CompanionSessionSummary) => void;
@@ -42,6 +44,7 @@ type HomeLaunchHandlersContext = {
 
 export type HomeLaunchHandlers = {
   onBrowseWorkspace: () => void;
+  onSelectSessionFolder: () => void;
   onOpenLaunchDialog: () => Promise<void>;
   onCloseLaunchDialog: () => void;
   onSelectLaunchProvider: (providerId: string) => void;
@@ -136,6 +139,10 @@ export function buildHomeLaunchHandlers({
 
   return {
     onBrowseWorkspace: () => void onBrowseWorkspace(),
+    onSelectSessionFolder: () => {
+      setLaunchFeedback("");
+      setLaunchDraft((current) => setLaunchWorkspaceToSessionFolder(current));
+    },
     onOpenLaunchDialog,
     onCloseLaunchDialog,
     onSelectLaunchProvider,
@@ -149,7 +156,13 @@ export function buildHomeLaunchHandlers({
     },
     onChangeMode: (mode) => {
       setLaunchFeedback("");
-      setLaunchDraft((current) => ({ ...current, mode }));
+      setLaunchDraft((current) => ({
+        ...current,
+        mode,
+        workspace: mode === "companion" && isSessionFolderLaunchWorkspace(current.workspace)
+          ? null
+          : current.workspace,
+      }));
     },
     onChangeTitle: (value) => {
       setLaunchFeedback("");

--- a/src/home/home-launch-projection.ts
+++ b/src/home/home-launch-projection.ts
@@ -6,12 +6,13 @@ import {
   resolveLaunchCharacterId,
   type LaunchCharacterSelectionMode,
 } from "./home-launch-state.js";
+import {
+  isSessionFolderLaunchWorkspace,
+  type LaunchWorkspaceSelection,
+} from "./home-launch-workspace.js";
 
-export type LaunchWorkspace = {
-  label: string;
-  path: string;
-  branch: string;
-};
+export { inferWorkspaceFromPath } from "./home-launch-workspace.js";
+export type { LaunchWorkspace, LaunchWorkspaceSelection } from "./home-launch-workspace.js";
 
 export type HomeLaunchProjection = {
   enabledLaunchProviders: ModelCatalogProvider[];
@@ -21,20 +22,10 @@ export type HomeLaunchProjection = {
   randomCharacterSelected: boolean;
   charactersLoaded: boolean;
   launchWorkspacePathLabel: string;
+  sessionFolderSelected: boolean;
+  workspaceSelected: boolean;
   canStartSession: boolean;
 };
-
-export function inferWorkspaceFromPath(selectedPath: string): LaunchWorkspace {
-  const normalized = selectedPath.replace(/[\\/]+$/, "");
-  const segments = normalized.split(/[\\/]/).filter(Boolean);
-  const label = segments.at(-1) ?? normalized;
-
-  return {
-    label,
-    path: selectedPath,
-    branch: "",
-  };
-}
 
 export function buildHomeLaunchProjection({
   launchProviderId,
@@ -51,7 +42,7 @@ export function buildHomeLaunchProjection({
   launchProviderId: string;
   launchMode?: "session" | "companion";
   launchTitle: string;
-  launchWorkspace: LaunchWorkspace | null;
+  launchWorkspace: LaunchWorkspaceSelection | null;
   launchCharacterId?: string;
   launchCharacterSelectionMode?: LaunchCharacterSelectionMode;
   characterEntries?: readonly CharacterCatalogEntry[];
@@ -70,6 +61,7 @@ export function buildHomeLaunchProjection({
   const selectedCharacter = launchCharacterSelectionMode === "random"
     ? null
     : activeCharacterEntries.find((character) => character.id === selectedCharacterId) ?? null;
+  const sessionFolderSelected = isSessionFolderLaunchWorkspace(launchWorkspace);
 
   return {
     enabledLaunchProviders,
@@ -78,7 +70,16 @@ export function buildHomeLaunchProjection({
     selectedCharacter,
     randomCharacterSelected: launchCharacterSelectionMode === "random",
     charactersLoaded,
-    launchWorkspacePathLabel: launchWorkspace ? launchWorkspace.path : "workspace",
-    canStartSession: charactersLoaded && !!launchTitle.trim() && !!launchWorkspace && !!selectedLaunchProvider,
+    launchWorkspacePathLabel: sessionFolderSelected
+      ? "SessionFolder"
+      : launchWorkspace?.path ?? "workspace",
+    sessionFolderSelected,
+    workspaceSelected: !!launchWorkspace,
+    canStartSession:
+      charactersLoaded &&
+      !!launchTitle.trim() &&
+      !!launchWorkspace &&
+      !!selectedLaunchProvider &&
+      (launchMode !== "companion" || !sessionFolderSelected),
   };
 }

--- a/src/home/home-launch-state.ts
+++ b/src/home/home-launch-state.ts
@@ -1,10 +1,15 @@
 import { DEFAULT_APPROVAL_MODE, type ApprovalMode } from "../approval-mode.js";
-import type { CreateSessionInput, SessionSummary } from "../app-state.js";
+import type { CreateSessionInput, CreateSessionRequest, SessionSummary } from "../app-state.js";
 import { DEFAULT_CHARACTER_THEME_COLORS, type CharacterThemeColors } from "../character-state.js";
 import type { CharacterCatalogEntry } from "../character/character-catalog.js";
 import { DEFAULT_CODEX_SANDBOX_MODE, type CodexSandboxMode } from "../codex-sandbox-mode.js";
 import type { CreateCompanionSessionInput } from "../companion-state.js";
-import { inferWorkspaceFromPath, type LaunchWorkspace } from "./home-launch-projection.js";
+import {
+  inferWorkspaceFromPath,
+  isSessionFolderLaunchWorkspace,
+  resolveLaunchDirectoryWorkspace,
+  type LaunchWorkspaceSelection,
+} from "./home-launch-workspace.js";
 import {
   DEFAULT_MODEL_ID,
   DEFAULT_REASONING_EFFORT,
@@ -38,7 +43,7 @@ export type HomeLaunchDraft = {
   open: boolean;
   mode: "session" | "companion";
   title: string;
-  workspace: LaunchWorkspace | null;
+  workspace: LaunchWorkspaceSelection | null;
   providerId: string;
   characterSelectionMode: LaunchCharacterSelectionMode;
   characterId: string;
@@ -104,7 +109,8 @@ export function buildCreateCompanionSessionInputFromLaunchDraft({
   random?: () => number;
 }): CreateCompanionSessionInput | null {
   const normalizedTitle = draft.title.trim();
-  if (!normalizedTitle || !draft.workspace || !selectedProviderId) {
+  const workspace = resolveLaunchDirectoryWorkspace(draft.workspace);
+  if (!normalizedTitle || !workspace || !selectedProviderId) {
     return null;
   }
   const characterSnapshot = buildLaunchCharacterSnapshot(characterEntries, draft, sessions, random);
@@ -118,7 +124,7 @@ export function buildCreateCompanionSessionInputFromLaunchDraft({
 
   return {
     taskTitle: normalizedTitle,
-    workspacePath: draft.workspace.path,
+    workspacePath: workspace.path,
     provider: selectedProviderId,
     characterId: characterSnapshot.characterId,
     character: characterSnapshot.character,
@@ -149,6 +155,13 @@ export function setLaunchWorkspaceFromPath(draft: HomeLaunchDraft, selectedPath:
   return {
     ...draft,
     workspace: inferWorkspaceFromPath(selectedPath),
+  };
+}
+
+export function setLaunchWorkspaceToSessionFolder(draft: HomeLaunchDraft): HomeLaunchDraft {
+  return {
+    ...draft,
+    workspace: { kind: "session-folder" },
   };
 }
 
@@ -235,7 +248,7 @@ export function resolveLastUsedSessionSelection(
   };
 }
 
-export function buildCreateSessionInputFromLaunchDraft({
+export function buildCreateSessionRequestFromLaunchDraft({
   draft,
   mateProfile,
   selectedProviderId,
@@ -253,19 +266,25 @@ export function buildCreateSessionInputFromLaunchDraft({
   characterEntries?: readonly CharacterCatalogEntry[];
   sessions?: readonly CharacterUsageSessionSource[];
   random?: () => number;
-}): CreateSessionInput | null {
+}): CreateSessionRequest | null {
   const normalizedTitle = draft.title.trim();
   if (!normalizedTitle || !draft.workspace || !selectedProviderId) {
     return null;
   }
   const characterSnapshot = buildLaunchCharacterSnapshot(characterEntries, draft, sessions, random);
+  const workspace = isSessionFolderLaunchWorkspace(draft.workspace)
+    ? { kind: "session-folder" as const }
+    : {
+        kind: "directory" as const,
+        label: draft.workspace.label,
+        path: draft.workspace.path,
+        branch: draft.workspace.branch,
+      };
 
   return {
     provider: selectedProviderId,
     taskTitle: normalizedTitle,
-    workspaceLabel: draft.workspace.label,
-    workspacePath: draft.workspace.path,
-    branch: draft.workspace.branch,
+    workspace,
     characterId: characterSnapshot.characterId,
     character: characterSnapshot.character,
     characterIconPath: characterSnapshot.characterIconPath,

--- a/src/home/home-launch-workspace.ts
+++ b/src/home/home-launch-workspace.ts
@@ -1,0 +1,35 @@
+export type LaunchWorkspace = {
+  label: string;
+  path: string;
+  branch: string;
+};
+
+export type LaunchWorkspaceSelection =
+  | LaunchWorkspace
+  | {
+      kind: "session-folder";
+    };
+
+export function inferWorkspaceFromPath(selectedPath: string): LaunchWorkspace {
+  const normalized = selectedPath.replace(/[\\/]+$/, "");
+  const segments = normalized.split(/[\\/]/).filter(Boolean);
+  const label = segments.at(-1) ?? normalized;
+
+  return {
+    label,
+    path: selectedPath,
+    branch: "",
+  };
+}
+
+export function isSessionFolderLaunchWorkspace(
+  workspace: LaunchWorkspaceSelection | null,
+): workspace is { kind: "session-folder" } {
+  return !!workspace && "kind" in workspace && workspace.kind === "session-folder";
+}
+
+export function resolveLaunchDirectoryWorkspace(
+  workspace: LaunchWorkspaceSelection | null,
+): LaunchWorkspace | null {
+  return workspace && !isSessionFolderLaunchWorkspace(workspace) ? workspace : null;
+}

--- a/src/session-state.ts
+++ b/src/session-state.ts
@@ -96,6 +96,7 @@ export type DiffPreviewPayload = {
 };
 
 export type CreateSessionInput = {
+  id?: string;
   provider?: string;
   catalogRevision?: number;
   taskTitle: string;
@@ -114,6 +115,24 @@ export type CreateSessionInput = {
   reasoningEffort?: ModelReasoningEffort;
   customAgentName?: string;
   allowedAdditionalDirectories?: string[];
+};
+
+export type CreateSessionWorkspaceRequest =
+  | {
+      kind: "directory";
+      label: string;
+      path: string;
+      branch: string;
+    }
+  | {
+      kind: "session-folder";
+    };
+
+export type CreateSessionRequest = Omit<
+  CreateSessionInput,
+  "id" | "workspaceLabel" | "workspacePath" | "branch"
+> & {
+  workspace: CreateSessionWorkspaceRequest;
 };
 
 export function normalizeSessionAccessMode(value: unknown, fallback: SessionAccessMode = "active"): SessionAccessMode {
@@ -419,7 +438,7 @@ export function summarizeMessageArtifact(artifact: MessageArtifact): MessageArti
 export function buildNewSession(input: CreateSessionInput): Session {
   const normalizedTaskTitle = input.taskTitle.trim() || `${input.workspaceLabel} で新規作業を開始する`;
   return {
-    id: `launch-${Date.now()}`,
+    id: input.id?.trim() || `launch-${Date.now()}`,
     taskTitle: normalizedTaskTitle,
     status: "idle",
     updatedAt: currentTimestampLabel(),

--- a/src/styles.css
+++ b/src/styles.css
@@ -1481,6 +1481,14 @@ button:disabled {
   justify-content: flex-end;
 }
 
+.home-page .workspace-picker-actions .browse-button.active {
+  background: rgba(111, 140, 255, 0.24);
+  color: #eef4ff;
+  box-shadow:
+    inset 0 0 0 1px rgba(143, 169, 255, 0.48),
+    0 8px 18px rgba(111, 140, 255, 0.14);
+}
+
 .panel-head,
 .session-card-head,
 .session-character-row,

--- a/src/withmate-window-api.ts
+++ b/src/withmate-window-api.ts
@@ -10,7 +10,7 @@ import type {
   AppSettings,
   CharacterProfile,
   ComposerPreview,
-  CreateSessionInput,
+  CreateSessionRequest,
   DiscoveredCustomAgent,
   DiscoveredSkill,
   DiffPreviewPayload,
@@ -103,7 +103,7 @@ export type WithMateWindowSessionApi = {
   listSessionSummaries(): Promise<SessionSummary[]>;
   getSession(sessionId: string): Promise<Session | null>;
   getSessionMessageArtifact(sessionId: string, messageIndex: number): Promise<MessageArtifact | null>;
-  createSession(input: CreateSessionInput): Promise<Session>;
+  createSession(input: CreateSessionRequest): Promise<Session>;
   updateSession(session: Session): Promise<Session>;
   deleteSession(sessionId: string): Promise<void>;
   previewComposerInput(sessionId: string, userMessage: string): Promise<ComposerPreview>;


### PR DESCRIPTION
## 概要
- New SessionのAgent Modeで、既存directoryに加えてWithMate管理下のSessionFolderをworkspaceとして選択可能にする
- BrowseとSessionFolderを同じ行に配置し、SessionFolder選択時は作成までpathを確定しない
- アプリバージョンを6.3.12へ更新する

## 実装
- Main ProcessでSession ID発行、SessionFolderの排他的作成、Session永続化を順に実行
- create IPCをdiscriminated requestとして検証し、renderer由来のIDや未知fieldを除外
- Session createをinsert-only、updateをupsertとして分離し、ID衝突時の既存Session上書きを防止
- SessionFolder workspaceのSession削除時は作業内容を保持し、既存directory workspaceのcleanupを維持
- Companion ModeにはSessionFolderを追加しない

## 検証
- `npm test`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## 影響
- New SessionのAgent ModeとSession永続化境界
- 既存directory workspaceの起動フローは維持