### PR TITLE
feat(home): Companion新規作成導線を非表示にする

### DIFF
--- a/docs/design/companion-mode.md
+++ b/docs/design/companion-mode.md
@@ -78,15 +78,17 @@ UI では `apply` と `proposal` を避け、`merge`、`discard`、`changed file
 
 ## Launch Model
 
-Companion の起動導線は 3 種類とする。
+アプリ全体の再構築中は、Home の Session 起動画面に Companion の新規作成導線を表示しない。`New Session` は Agent session の作成に固定し、既存 Companion の履歴、Review UI、保存データ、runtime 実装は維持する。
 
-1. 既存 Session 起動画面の `Agent / Companion` toggle
+Companion の設計上の起動導線は次の 3 種類とする。
+
+1. 既存 Session 起動画面の `Agent / Companion` toggle（現行 UI では非表示）
 2. AgentMode の Session 画面 header の `Start Companion` / `Open in Companion` 相当ボタン
 3. CompanionList からの `New Companion`
 
 ### Session 起動画面
 
-既存 Session 起動画面に `Agent / Companion` toggle を追加する。
+現行 UI では `Agent / Companion` toggle を表示せず、Agent session の作成だけを受け付ける。Companion の新規作成を再び公開する場合は、次の既存設計を適用する。
 
 - `Agent` 選択時は既存 Agent session 起動を使う
 - `Companion` 選択時は Git repo root eligibility を確認する

--- a/docs/manual-test-checklist.md
+++ b/docs/manual-test-checklist.md
@@ -24,11 +24,11 @@ npm run electron:start
 
 | ID | 領域 | 手順 | 期待結果 |
 | --- | --- | --- | --- |
-| V5C-001 | Character 0 件 fallback | Character catalog が 0 件の状態で Home を起動し、`New Session` と Companion 起動 dialog を開く | 起動導線は SingleMate / Mate 未作成 gate に戻らず、neutral fallback の Character 表示で session / companion を開始できる |
+| V5C-001 | Character 0 件 fallback | Character catalog が 0 件の状態で Home を起動し、`New Session` を開く | 起動導線は SingleMate / Mate 未作成 gate に戻らず、neutral fallback の Character 表示で session を開始できる |
 | V5C-002 | Character A / B 登録 | Home の `Characters` から `Create Character` を押し、Character Editor Window で Character A と Character B を作成して name / description / icon / theme / `character.md` を保存する | Home の Characters list に A / B が表示され、Editor Window を開き直しても metadata と `character.md` が保持される |
 | V5C-003 | Default Character | Character Editor Window で Character B を default に設定し、Home の `New Session` を開く | Character selector の初期選択が B になり、Character name / icon / theme preview が selector と作成後の session summary に反映される |
 | V5C-004 | New Session explicit selection | `New Session` で Character A を明示選択して session を作成する | 作成された Session Window と Home summary は Character A の name / icon / theme を表示し、B へ default を戻しても既存 session の表示は A のまま残る |
-| V5C-005 | Companion explicit selection | Companion 起動で Character A / B をそれぞれ選んで companion session を作成する | Companion session summary と Companion Review UI に選択した Character の name / icon / theme が反映される |
+| V5C-005 | Existing Companion compatibility | 既存の companion session を Home の履歴から開く | Companion session summary と Companion Review UI に保存済み Character の name / icon / theme が反映される |
 | V5C-006 | Snapshot boundary | Character A で session を作成した後、Character Editor Window で Character A の `character.md` を別内容へ変更し、既存 session で 1 turn 実行する | provider prompt は session 作成時点の saved snapshot を使い、現在の catalog 内容へ置き換わらない |
 | V5C-007 | Prompt boundary | `character.md` と `character-notes.md` の両方を持つ Character で 1 turn 実行し、Audit Log の `Logical Prompt` / `Transport Payload` を確認する | `character.md` snapshot は system 側に入る。`character-notes.md`、Memory / Growth history、provider instruction sync 由来の Character 書き込みは常設注入されない |
 | V5C-008 | Markdown fence boundary | `character.md` に triple backtick と quadruple backtick の code fence を含め、session を作成して 1 turn 実行する | Character Definition Snapshot section の外側 fence が壊れず、definition 全体が 1 つの markdown block として扱われる |

--- a/scripts/tests/home-components.test.tsx
+++ b/scripts/tests/home-components.test.tsx
@@ -514,14 +514,12 @@ describe("HomeLaunchDialog", () => {
   }];
 
   const renderHomeLaunchDialog = (
-    mode: "session" | "companion",
     options = characterOptions,
     charactersLoaded = true,
     randomCharacterSelected = false,
   ) => renderToStaticMarkup(
     <HomeLaunchDialog
       open={true}
-      mode={mode}
       title="demo"
       workspaceSelected={false}
       sessionFolderSelected={false}
@@ -536,7 +534,6 @@ describe("HomeLaunchDialog", () => {
       launchFeedback=""
       launchStarting={false}
       onClose={noOp}
-      onSelectMode={noOp}
       onChangeTitle={noOp}
       onBrowseWorkspace={noOp}
       onSelectSessionFolder={noOp}
@@ -547,8 +544,18 @@ describe("HomeLaunchDialog", () => {
     />,
   );
 
-  it("session mode でダイアログに Character selector が含まれる", () => {
-    const html = renderHomeLaunchDialog("session");
+  it("新規作成導線は Session 専用で Companion Mode を表示しない", () => {
+    const html = renderHomeLaunchDialog();
+
+    assert.ok(html.includes("Start New Session"));
+    assert.ok(!html.includes("Agent Mode"));
+    assert.ok(!html.includes("Companion Mode"));
+    assert.ok(!html.includes("Start Companion"));
+    assert.ok(html.includes("SessionFolder"));
+  });
+
+  it("ダイアログに Character selector が含まれる", () => {
+    const html = renderHomeLaunchDialog();
 
     assert.ok(html.includes("Character"));
     assert.ok(html.includes("Mia"));
@@ -561,7 +568,7 @@ describe("HomeLaunchDialog", () => {
   });
 
   it("random選択時は一覧先頭のランダムcardだけを選択状態にする", () => {
-    const html = renderHomeLaunchDialog("session", characterOptions, true, true);
+    const html = renderHomeLaunchDialog(characterOptions, true, true);
 
     assert.match(
       html,
@@ -573,23 +580,15 @@ describe("HomeLaunchDialog", () => {
     );
   });
 
-  it("companion mode でも Character selector が含まれる", () => {
-    const html = renderHomeLaunchDialog("companion");
-
-    assert.ok(html.includes("Character"));
-    assert.ok(html.includes("Mia"));
-    assert.ok(!html.includes("SessionFolder"));
-  });
-
   it("Character 0 件なら neutral fallback を表示する", () => {
-    const html = renderHomeLaunchDialog("session", []);
+    const html = renderHomeLaunchDialog([]);
 
     assert.ok(html.includes("WithMate"));
     assert.ok(html.includes("Neutral"));
   });
 
   it("Character catalog 読み込み前は neutral fallback を表示しない", () => {
-    const html = renderHomeLaunchDialog("session", [], false);
+    const html = renderHomeLaunchDialog([], false);
 
     assert.ok(html.includes("読み込み中"));
     assert.ok(html.includes("Character を読み込んでるよ..."));

--- a/src/HomeApp.tsx
+++ b/src/HomeApp.tsx
@@ -364,7 +364,7 @@ export default function HomeApp() {
   const launchProjection = useMemo(
     () => buildHomeLaunchProjection({
       launchProviderId: launchDraft.providerId,
-      launchMode: launchDraft.mode,
+      launchMode: "session",
       launchTitle: launchDraft.title,
       launchWorkspace: launchDraft.workspace,
       launchCharacterId: launchDraft.characterId,
@@ -605,14 +605,13 @@ export default function HomeApp() {
       launchFeedback,
       launchStarting,
       onClose: homeLaunchHandlers.onCloseLaunchDialog,
-      onSelectMode: homeLaunchHandlers.onChangeMode,
       onChangeTitle: homeLaunchHandlers.onChangeTitle,
       onBrowseWorkspace: () => void homeLaunchHandlers.onBrowseWorkspace(),
       onSelectSessionFolder: homeLaunchHandlers.onSelectSessionFolder,
       onSelectProvider: homeLaunchHandlers.onSelectLaunchProvider,
       onSelectCharacter: homeLaunchHandlers.onSelectLaunchCharacter,
       onSelectRandomCharacter: homeLaunchHandlers.onSelectRandomLaunchCharacter,
-      onStartSession: (mode) => void homeLaunchHandlers.onStartSession(mode),
+      onStartSession: () => void homeLaunchHandlers.onStartSession("session"),
     }),
   });
 

--- a/src/home/HomeLaunchDialog.tsx
+++ b/src/home/HomeLaunchDialog.tsx
@@ -10,7 +10,6 @@ import { DEFAULT_CHARACTER_THEME_COLORS } from "../character-state.js";
 
 export type HomeLaunchDialogProps = {
   open: boolean;
-  mode: "session" | "companion";
   title: string;
   workspaceSelected: boolean;
   sessionFolderSelected: boolean;
@@ -25,19 +24,17 @@ export type HomeLaunchDialogProps = {
   launchFeedback: string;
   launchStarting: boolean;
   onClose: () => void;
-  onSelectMode: (mode: "session" | "companion") => void;
   onChangeTitle: (value: string) => void;
   onBrowseWorkspace: () => void;
   onSelectSessionFolder: () => void;
   onSelectProvider: (providerId: string) => void;
   onSelectCharacter: (characterId: string) => void;
   onSelectRandomCharacter: () => void;
-  onStartSession: (mode: "session" | "companion") => void;
+  onStartSession: () => void;
 };
 
 export function HomeLaunchDialog({
   open,
-  mode,
   title,
   workspaceSelected,
   sessionFolderSelected,
@@ -52,7 +49,6 @@ export function HomeLaunchDialog({
   launchFeedback,
   launchStarting,
   onClose,
-  onSelectMode,
   onChangeTitle,
   onBrowseWorkspace,
   onSelectSessionFolder,
@@ -80,47 +76,13 @@ export function HomeLaunchDialog({
       footer={
         <LaunchDialogFooter
           feedback={launchFeedback}
-          startButtonLabel={
-            launchStarting
-              ? "Starting..."
-              : mode === "companion"
-                  ? "Start Companion"
-                  : "Start New Session"
-          }
+          startButtonLabel={launchStarting ? "Starting..." : "Start New Session"}
           startButtonDisabled={!canStartSession || launchStarting}
           startButtonAriaDisabled={!canStartSession || launchStarting}
-          onStart={() => onStartSession(mode)}
+          onStart={onStartSession}
         />
       }
     >
-      <section className="launch-section minimal">
-        <div
-          className="choice-list launch-provider-list"
-          role="tablist"
-          aria-label="Session mode"
-          onKeyDown={(event) => {
-            focusRovingItemByKey(event, { orientation: "horizontal", activateOnFocus: true });
-          }}
-        >
-          {[
-            { value: "session" as const, label: "Agent Mode" },
-            { value: "companion" as const, label: "Companion Mode" },
-          ].map((option) => (
-            <button
-              key={option.value}
-              className={`choice-chip${mode === option.value ? " active" : ""}`}
-              type="button"
-              role="tab"
-              aria-selected={mode === option.value}
-              tabIndex={mode === option.value ? 0 : -1}
-              onClick={() => onSelectMode(option.value)}
-            >
-              {option.label}
-            </button>
-          ))}
-        </div>
-      </section>
-
       <section className="launch-section minimal">
         <div className="launch-field">
           <label className="launch-field-label" htmlFor="launch-session-title">
@@ -142,16 +104,14 @@ export function HomeLaunchDialog({
           <button className="browse-button" type="button" onClick={onBrowseWorkspace}>
             Browse
           </button>
-          {mode === "session" ? (
-            <button
-              className={`browse-button${sessionFolderSelected ? " active" : ""}`}
-              type="button"
-              aria-pressed={sessionFolderSelected}
-              onClick={onSelectSessionFolder}
-            >
-              SessionFolder
-            </button>
-          ) : null}
+          <button
+            className={`browse-button${sessionFolderSelected ? " active" : ""}`}
+            type="button"
+            aria-pressed={sessionFolderSelected}
+            onClick={onSelectSessionFolder}
+          >
+            SessionFolder
+          </button>
         </div>
         <p className={`launch-path${workspaceSelected ? " selected" : ""}`}>{launchWorkspacePathLabel}</p>
       </section>

--- a/src/home/home-launch-dialog-props.ts
+++ b/src/home/home-launch-dialog-props.ts
@@ -9,14 +9,13 @@ type HomeLaunchDialogPropsInput = {
   launchFeedback: string;
   launchStarting: boolean;
   onClose: () => void;
-  onSelectMode: (mode: HomeLaunchDraft["mode"]) => void;
   onChangeTitle: (value: string) => void;
   onBrowseWorkspace: () => void;
   onSelectSessionFolder: () => void;
   onSelectProvider: (providerId: string) => void;
   onSelectCharacter: (characterId: string) => void;
   onSelectRandomCharacter: () => void;
-  onStartSession: (mode: HomeLaunchDraft["mode"]) => void;
+  onStartSession: () => void;
 };
 
 export function buildHomeLaunchDialogProps({
@@ -26,7 +25,6 @@ export function buildHomeLaunchDialogProps({
   launchFeedback,
   launchStarting,
   onClose,
-  onSelectMode,
   onChangeTitle,
   onBrowseWorkspace,
   onSelectSessionFolder,
@@ -37,7 +35,6 @@ export function buildHomeLaunchDialogProps({
 }: HomeLaunchDialogPropsInput): HomeLaunchDialogProps {
   return {
     open: draft.open,
-    mode: draft.mode,
     title: draft.title,
     workspaceSelected: projection.workspaceSelected,
     sessionFolderSelected: projection.sessionFolderSelected,
@@ -52,7 +49,6 @@ export function buildHomeLaunchDialogProps({
     launchFeedback,
     launchStarting,
     onClose,
-    onSelectMode,
     onChangeTitle,
     onBrowseWorkspace,
     onSelectSessionFolder,


### PR DESCRIPTION
## 概要

- Home の Session 作成画面から Agent / Companion のモード選択を削除
- 新規作成時の投影と開始処理を Session に固定
- 既存 Companion の履歴、Review UI、保存データ、runtime 実装は維持
- 現行設計文書と手動テスト項目を更新

## 背景

アプリ全体の再構築中は Companion Mode の実装全体を削除せず、新規作成画面からのみ導線を非表示にする方針としたためです。

## 影響

`New Session` は常に Agent session を作成します。既存の Companion session は引き続き Home の履歴から開いて確認できます。

## 検証

- `npm exec -- tsx --test scripts/tests/home-components.test.tsx`（34件成功）
- `npm run typecheck`
- `npm run build:renderer`
- `git diff --check`

## 未実施

- Electron 上での手動表示確認
- 全テスト一括実行