### PR TITLE
feat(session): Windowsのターン完了通知を追加

### DIFF
--- a/docs/adr/006-windows-session-turn-notifications.md
+++ b/docs/adr/006-windows-session-turn-notifications.md
@@ -1,0 +1,64 @@
+# 006 Windows Session Turn Notifications
+
+- 状態: Accepted
+- 日付: 2026-07-29
+
+## Context
+
+Session のターン完了まで時間がかかる場合、ユーザーは WithMate 以外のアプリで作業を続ける。対象の Session Window が前面にないと、完了に気づくために WithMate を定期的に確認する必要がある。
+
+通知には Windows のネイティブ通知、アプリ内表示、独自の Windows toast XML が候補になる。通知はターン本体の成功を損なわない補助的な外部副作用として扱う必要がある。また、Session には Character icon があるが、画像形式やファイル状態によって Windows 通知へ利用できない場合がある。
+
+## Decision
+
+- 対応対象は Windows の通常 Session と Character 作成 Session とし、Companion と Auxiliary Session、macOS、Linux は対象外とする。
+- Electron の `Notification` API を使い、Windows の既定の通知音と表示時間に従う。独自 toast XML は生成しない。
+- 通知設定は既定で有効とし、App Settings から無効化できる。
+- provider の成功結果を含む Session が永続化された直後を通知契機とする。失敗、キャンセル、setup failure では通知しない。
+- 対象 Session Window 自体が focus 中の場合だけ通知を抑止する。対象 Window が表示中でも、別アプリまたは別の WithMate Window が focus 中なら通知する。
+- 通知の title は `WithMate`、body は `「Session名」のターンが完了しました` とする。
+- Character icon は `nativeImage` で読み込める場合だけ通知へ渡す。未設定、相対 path、欠損、不正、非対応形式の場合は icon を省略し、Windows が選ぶアプリアイコンへフォールバックする。
+- Session ID から安定した Windows notification ID を生成する。同一 Session の未処理通知がある場合は閉じ、プロセス再起動をまたぐ場合も Windows の Tag と Group によって新しい完了通知へ置き換える。
+- Electron の通知 instance が click を受け取れる間は、クリック時点で対象 Session が存在すれば Session Window を開き、削除済みまたは読み込み・表示に失敗した場合は Home Window を開く。
+- WithMate のプロセス終了後、または通知 instance が破棄された後に Action Center から通知をクリックした場合、Windows によるアプリ起動は許容するが、対象 Session への復帰は保証しない。
+- 通知可否の判定、icon 読み込み、通知生成、表示、click 処理の失敗は記録するが、ターン結果を失敗へ変更せず、通知の再試行もしない。
+
+実装の正本は `src-electron/session-turn-notification-service.ts` と `src-electron/session-runtime-service.ts`、設定の正本は `src/provider-settings-state.ts` と `src-electron/app-settings-storage.ts` に置く。観測可能な契約は `scripts/tests/session-turn-notification-service.test.ts`、`scripts/tests/session-runtime-service.test.ts`、設定関連 test に置く。
+
+## Alternatives
+
+### アプリ内通知だけを使う
+
+別アプリを使用中の完了通知という目的を満たさないため採用しない。
+
+### Windows toast XML を直接生成する
+
+通知の識別子や表示、プロセス再起動後の activation target を制御できるが、Windows 固有の XML、activation、画像形式への追加対応が必要になる。プロセス終了後に Action Center の過去通知から対象 Session へ戻る利用場面は限定的であり、今回の範囲では Electron 標準 API の保守性を優先する。
+
+### Character icon を通知前に対応形式へ変換する
+
+より多くの画像を表示できるが、変換処理、cache、cleanup、失敗経路が増える。icon は補助情報であり、通知本体を優先するため採用しない。
+
+### WithMate のいずれかの Window が focus 中なら通知しない
+
+別の Session や Settings を操作中に、対象 Session の完了を見落とす可能性があるため採用しない。
+
+### Audit Log の詳細更新後に通知する
+
+補助的な enrichment の遅延や timeout が通知を妨げるため採用しない。Session の成功状態が永続化された時点で通知する。
+
+## Consequences
+
+### Positive
+
+- 別アプリで作業している間も Session の完了へ気づける。
+- 対象 Session を見ている時の重複通知を避けつつ、別の WithMate Window を操作中の完了は通知できる。
+- 通知または icon の失敗が provider の成功結果や Session 永続化へ影響しない。
+- Electron 標準 API の範囲に限定し、Windows 固有実装を小さく保てる。
+
+### Negative
+
+- Windows の通知設定、集中モード、Electron の対応状況によって通知が表示されない場合がある。
+- icon を読み込めない場合は Character icon ではなくアプリアイコンになる。
+- プロセス終了後、または通知 instance の破棄後に過去通知をクリックしても、元の Session へ直接復帰できない場合がある。
+- macOS、Linux、Companion、Auxiliary Session には同じ通知機能がない。

--- a/scripts/tests/app-settings-storage.test.ts
+++ b/scripts/tests/app-settings-storage.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { describe, it } from "node:test";
 
 import {
@@ -11,6 +12,42 @@ import {
 import { AppSettingsStorage } from "../../src-electron/app-settings-storage.js";
 
 describe("AppSettingsStorage", () => {
+  it("Session turn notification setting の欠損値と不正値は既定の有効へ戻す", async () => {
+    const tempDirectory = await mkdtemp(path.join(os.tmpdir(), "withmate-app-settings-"));
+    const dbPath = path.join(tempDirectory, "withmate.db");
+
+    try {
+      const storage = new AppSettingsStorage(dbPath);
+      storage.close();
+
+      const invalidDatabase = new DatabaseSync(dbPath);
+      invalidDatabase
+        .prepare(`
+          UPDATE app_settings
+          SET setting_value = ?
+          WHERE setting_key = ?
+        `)
+        .run("invalid", "session_turn_notification_enabled");
+      invalidDatabase.close();
+
+      const invalidValueStorage = new AppSettingsStorage(dbPath);
+      assert.equal(invalidValueStorage.getSettings().sessionTurnNotificationEnabled, true);
+      invalidValueStorage.close();
+
+      const missingDatabase = new DatabaseSync(dbPath);
+      missingDatabase
+        .prepare("DELETE FROM app_settings WHERE setting_key = ?")
+        .run("session_turn_notification_enabled");
+      missingDatabase.close();
+
+      const missingValueStorage = new AppSettingsStorage(dbPath);
+      assert.equal(missingValueStorage.getSettings().sessionTurnNotificationEnabled, true);
+      missingValueStorage.close();
+    } finally {
+      await rm(tempDirectory, { recursive: true, force: true });
+    }
+  });
+
   it("coding provider settings を canonical key で保存して再読込できる", async () => {
     const tempDirectory = await mkdtemp(path.join(os.tmpdir(), "withmate-app-settings-"));
     const dbPath = path.join(tempDirectory, "withmate.db");
@@ -21,6 +58,7 @@ describe("AppSettingsStorage", () => {
         ...createDefaultAppSettings(),
         memoryGenerationEnabled: false,
         launchAtLoginEnabled: true,
+        sessionTurnNotificationEnabled: false,
         autoCollapseActionDockOnSend: false,
         memoryFileQuotaBytes: 2 * MEMORY_FILE_QUOTA_DEFAULT_BYTES,
         userMicrocopyCatalog: {
@@ -109,6 +147,7 @@ describe("AppSettingsStorage", () => {
         ...createDefaultAppSettings(),
         memoryGenerationEnabled: false,
         launchAtLoginEnabled: true,
+        sessionTurnNotificationEnabled: false,
         autoCollapseActionDockOnSend: false,
         userMicrocopyCatalog: {
           ...createDefaultAppSettings().userMicrocopyCatalog,

--- a/scripts/tests/home-components.test.tsx
+++ b/scripts/tests/home-components.test.tsx
@@ -75,6 +75,7 @@ describe("HomeSettingsContent", () => {
     deletingOldSessions: false,
     onChangeAutoCollapseActionDockOnSend: noOp,
     onChangeLaunchAtLoginEnabled: noOp,
+    onChangeSessionTurnNotificationEnabled: noOp,
     onChangeSessionCleanupCutoffDate: noOp,
     onChangeUserMicrocopySlot: noOp,
     onChangeProviderEnabled: noOp,
@@ -97,6 +98,12 @@ describe("HomeSettingsContent", () => {
   });
 
   const renderSettings = (params?: RenderSettingsParams) => renderToStaticMarkup(buildSettingsContent(params));
+
+  it("App settings に Windows の Session turn notification toggle を表示する", () => {
+    const html = renderSettings();
+
+    assert.ok(html.includes("Session のターン完了を Windows 通知で知らせる"));
+  });
 
   it("Mate Reset の危険操作は Settings に表示されない", () => {
     const html = renderSettings();

--- a/scripts/tests/home-settings-draft.test.ts
+++ b/scripts/tests/home-settings-draft.test.ts
@@ -30,6 +30,7 @@ import {
   updateMemoryExtractionTimeoutSecondsDraft,
   updateMemoryFileQuotaMegabytesDraft,
   updateMemoryGenerationEnabled,
+  updateSessionTurnNotificationEnabled,
   updateMateMemoryGenerationTriggerIntervalMinutesDraft,
   updateMateMemoryGenerationPriorityProviderDraft,
   updateMateMemoryGenerationPriorityModelDraft,
@@ -56,6 +57,7 @@ import {
   handleChangeProviderInstructionRelativePath as handleChangeProviderInstructionRelativePathAction,
   handleChangeProviderSkillRelativePath as handleChangeProviderSkillRelativePathAction,
   handleChangeProviderSkillRootPath as handleChangeProviderSkillRootPathAction,
+  handleChangeSessionTurnNotificationEnabled as handleChangeSessionTurnNotificationEnabledAction,
   handleChangeUserMicrocopySlot as handleChangeUserMicrocopySlotAction,
   handleAddMateMemoryGenerationPriority as handleAddMateMemoryGenerationPriorityAction,
   handleRemoveMateMemoryGenerationPriority as handleRemoveMateMemoryGenerationPriorityAction,
@@ -273,6 +275,14 @@ describe("home-settings-draft", () => {
     assert.equal(next.autoCollapseActionDockOnSend, false);
   });
 
+  it("Session turn notification を toggle できる", () => {
+    const draft = createDefaultAppSettings();
+
+    const next = updateSessionTurnNotificationEnabled(draft, false);
+
+    assert.equal(next.sessionTurnNotificationEnabled, false);
+  });
+
   it("memory file quota は MB 入力から bytes の draft に変換する", () => {
     const draft = createDefaultAppSettings();
 
@@ -382,6 +392,10 @@ describe("home-settings-draft", () => {
       enabled: false,
       setSettingsDraft: state.setSettingsDraft,
     });
+    handleChangeSessionTurnNotificationEnabledAction({
+      enabled: false,
+      setSettingsDraft: state.setSettingsDraft,
+    });
     handleChangeMemoryFileQuotaMegabytesAction({
       value: "2048",
       setSettingsDraft: state.setSettingsDraft,
@@ -394,6 +408,7 @@ describe("home-settings-draft", () => {
 
     assert.equal(state.draft.memoryGenerationEnabled, false);
     assert.equal(state.draft.autoCollapseActionDockOnSend, false);
+    assert.equal(state.draft.sessionTurnNotificationEnabled, false);
     assert.equal(state.draft.memoryFileQuotaBytes, 2 * MEMORY_FILE_QUOTA_DEFAULT_BYTES);
     assert.equal(state.draft.userMicrocopyCatalog["dock.status.responding"], "応答生成中\n");
   });

--- a/scripts/tests/provider-settings-state.test.ts
+++ b/scripts/tests/provider-settings-state.test.ts
@@ -22,6 +22,7 @@ describe("provider-settings-state", () => {
     assert.equal(DEFAULT_BACKGROUND_TIMEOUT_SECONDS, 180);
     assert.equal(settings.memoryExtractionProviderSettings.codex.timeoutSeconds, 180);
     assert.equal(settings.autoCollapseActionDockOnSend, true);
+    assert.equal(settings.sessionTurnNotificationEnabled, true);
     assert.equal(settings.memoryFileQuotaBytes, MEMORY_FILE_QUOTA_DEFAULT_BYTES);
   });
 
@@ -101,6 +102,12 @@ describe("provider-settings-state", () => {
     assert.equal(createDefaultAppSettings().launchAtLoginEnabled, false);
     assert.equal(normalizeAppSettings({ launchAtLoginEnabled: true }).launchAtLoginEnabled, true);
     assert.equal(normalizeAppSettings({ launchAtLoginEnabled: "true" }).launchAtLoginEnabled, false);
+  });
+
+  it("Session turn notification は default true で boolean を保持する", () => {
+    assert.equal(createDefaultAppSettings().sessionTurnNotificationEnabled, true);
+    assert.equal(normalizeAppSettings({ sessionTurnNotificationEnabled: false }).sessionTurnNotificationEnabled, false);
+    assert.equal(normalizeAppSettings({ sessionTurnNotificationEnabled: "false" }).sessionTurnNotificationEnabled, true);
   });
 
   it("memory file quota は normalize で min/max に clamp する", () => {

--- a/scripts/tests/session-runtime-service.test.ts
+++ b/scripts/tests/session-runtime-service.test.ts
@@ -202,6 +202,7 @@ describe("SessionRuntimeService", () => {
     };
     let composeSessionName = "";
     let runSessionName = "";
+    let notifiedSession: Session | null = null;
 
     const adapter: ProviderCodingAdapter = {
       composePrompt(input) {
@@ -278,6 +279,9 @@ describe("SessionRuntimeService", () => {
       broadcastLiveSessionRun() {},
       resolvePendingApprovalRequest() {},
       resolvePendingElicitationRequest() {},
+      notifySessionTurnCompleted(completedSession) {
+        notifiedSession = completedSession;
+      },
       currentTimestampLabel,
     });
 
@@ -286,6 +290,7 @@ describe("SessionRuntimeService", () => {
     assert.equal(composeSessionName, "Fresh");
     assert.equal(runSessionName, "Fresh");
     assert.equal(result.characterRuntimeSnapshot?.name, "Fresh");
+    assert.equal(notifiedSession, result);
   });
 
   it("resolveSessionCharacter 未提供でも provider turn まで進む", async () => {
@@ -1013,6 +1018,7 @@ describe("SessionRuntimeService", () => {
     const storedSessions: Session[] = [];
     const auditUpdates: UpdateAuditLogInput[] = [];
     let canceledSessionId: string | null = null;
+    let notificationCount = 0;
     const partialResult: RunSessionTurnResult = {
       threadId: null,
       assistantText: "",
@@ -1128,6 +1134,9 @@ describe("SessionRuntimeService", () => {
       broadcastLiveSessionRun() {},
       resolvePendingApprovalRequest() {},
       resolvePendingElicitationRequest() {},
+      notifySessionTurnCompleted() {
+        notificationCount += 1;
+      },
       currentTimestampLabel,
     });
 
@@ -1169,6 +1178,7 @@ describe("SessionRuntimeService", () => {
       "2",
     );
     assert.equal(canceledSessionId, baseSession.id);
+    assert.equal(notificationCount, 0);
   });
 
   it("実行中の session は in-flight として見え、完了後に解放される", async () => {
@@ -1501,6 +1511,103 @@ describe("SessionRuntimeService", () => {
     ]);
   });
 
+  it("cancel 後に provider が grace 内で成功しても完了通知しない", async () => {
+    const session = createSession();
+    let resolveProvider: ((result: RunSessionTurnResult) => void) | null = null;
+    let notificationCount = 0;
+    const adapter: ProviderCodingAdapter = {
+      composePrompt() {
+        return {
+          systemBodyText: "system",
+          inputBodyText: "input",
+          logicalPrompt: { systemText: "system", inputText: "input", composedText: "system\ninput" },
+          imagePaths: [],
+          additionalDirectories: [],
+        };
+      },
+      async getProviderQuotaTelemetry() {
+        return null;
+      },
+      invalidateSessionThread() {},
+      invalidateAllSessionThreads() {},
+      runSessionTurn() {
+        return new Promise<RunSessionTurnResult>((resolve) => {
+          resolveProvider = resolve;
+        });
+      },
+    };
+
+    const service = new SessionRuntimeService({
+      getSession() {
+        return session;
+      },
+      upsertSession(next) {
+        return next;
+      },
+      async resolveComposerPreview() {
+        return { attachments: [], errors: [] };
+      },
+      async resolveSessionCharacter() {
+        return createCharacter();
+      },
+      getAppSettings() {
+        return normalizeAppSettings({});
+      },
+      resolveProviderCatalog() {
+        return { snapshot: { revision: 1, providers: [createProviderCatalog()] }, provider: createProviderCatalog() };
+      },
+      getProviderCodingAdapter() {
+        return adapter;
+      },
+      getSessionMemory(current) {
+        return createSessionMemory(current.id);
+      },
+      resolveProjectMemoryEntriesForPrompt() {
+        return [];
+      },
+      createAuditLog(input) {
+        return createAuditLogBase(input);
+      },
+      updateAuditLog() {},
+      setLiveSessionRun() {},
+      getLiveSessionRun() {
+        return null;
+      },
+      async waitForApprovalDecision(): Promise<LiveApprovalDecision> {
+        return "approve";
+      },
+      async waitForElicitationResponse() {
+        return { action: "cancel" } as const;
+      },
+      setProviderQuotaTelemetry() {},
+      setSessionContextTelemetry() {},
+      invalidateProviderSessionThread() {},
+      scheduleProviderQuotaTelemetryRefresh() {},
+      broadcastLiveSessionRun() {},
+      resolvePendingApprovalRequest() {},
+      resolvePendingElicitationRequest() {},
+      notifySessionTurnCompleted() {
+        notificationCount += 1;
+      },
+      currentTimestampLabel,
+      providerCancelGraceMs: 1_000,
+    });
+
+    const runPromise = service.runSessionTurn(session.id, { userMessage: "お願いします" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    if (!resolveProvider) {
+      throw new Error("provider resolve が取得できていないよ。");
+    }
+
+    service.cancelRun(session.id);
+    resolveProvider(createPartialResult({ assistantText: "完了したよ。" }));
+    const result = await runPromise;
+
+    assert.equal(result.runState, "idle");
+    assert.equal(result.messages.at(-1)?.text, "完了したよ。");
+    assert.equal(notificationCount, 0);
+  });
+
   it("stale thread / session error で meaningful partial が無い時だけ thread reset 後に 1 回 retry する", async () => {
     const session = createSession({ provider: "codex", threadId: "thread-stale" });
     const storedSessions: Session[] = [];
@@ -1508,6 +1615,7 @@ describe("SessionRuntimeService", () => {
     const auditUpdates: UpdateAuditLogInput[] = [];
     const seenThreadIds: string[] = [];
     let attempt = 0;
+    let notificationCount = 0;
 
     const adapter: ProviderCodingAdapter = {
       composePrompt() {
@@ -1593,6 +1701,9 @@ describe("SessionRuntimeService", () => {
       broadcastLiveSessionRun() {},
       resolvePendingApprovalRequest() {},
       resolvePendingElicitationRequest() {},
+      notifySessionTurnCompleted() {
+        notificationCount += 1;
+      },
       currentTimestampLabel,
     });
 
@@ -1609,6 +1720,7 @@ describe("SessionRuntimeService", () => {
     assert.equal(auditUpdates.length, 3);
     assert.equal(auditUpdates[0]?.phase, "running");
     assert.equal(auditUpdates.at(-1)?.phase, "completed");
+    assert.equal(notificationCount, 1);
   });
 
   it("stale retry 後の running audit log は前回 progress の断片を引き継がない", async () => {
@@ -2561,6 +2673,7 @@ describe("SessionRuntimeService", () => {
     const session = createSession({ provider: "codex", threadId: "thread-stale" });
     const storedSessions: Session[] = [];
     const auditUpdates: UpdateAuditLogInput[] = [];
+    let notificationCount = 0;
 
     const adapter: ProviderCodingAdapter = {
       composePrompt() {
@@ -2649,6 +2762,9 @@ describe("SessionRuntimeService", () => {
       broadcastLiveSessionRun() {},
       resolvePendingApprovalRequest() {},
       resolvePendingElicitationRequest() {},
+      notifySessionTurnCompleted() {
+        notificationCount += 1;
+      },
       currentTimestampLabel,
     });
 
@@ -2662,6 +2778,7 @@ describe("SessionRuntimeService", () => {
     assert.equal(auditUpdates.at(-1)?.assistantText, "途中まで進んだよ。");
     assert.deepEqual(auditUpdates.at(-1)?.operations, [{ type: "command_execution", summary: "npm test", details: "in_progress" }]);
     assert.deepEqual(auditUpdates.at(-1)?.usage, { inputTokens: 9, cachedInputTokens: 1, outputTokens: 3 });
+    assert.equal(notificationCount, 0);
   });
 
   it("usage_limit reason は audit log と assistant fallback で通常失敗文言にしない", async () => {
@@ -3327,8 +3444,10 @@ describe("SessionRuntimeService", () => {
     ]);
   });
 
-  it("Session turn 後に Mate Memory generation hook を持たない", async () => {
+  it("Session success を保存後に通知し、通知 failure は turn を失敗させない", async () => {
     const session = createSession();
+    let persistedCompletedSession: Session | null = null;
+    let notifiedSession: Session | null = null;
     const adapter: ProviderCodingAdapter = {
       composePrompt() {
         return {
@@ -3357,6 +3476,9 @@ describe("SessionRuntimeService", () => {
         return sessionId === session.id ? session : null;
       },
       upsertSession(next) {
+        if (next.runState === "idle" && next.messages.at(-1)?.role === "assistant") {
+          persistedCompletedSession = next;
+        }
         return next;
       },
       async resolveComposerPreview() {
@@ -3402,6 +3524,10 @@ describe("SessionRuntimeService", () => {
       broadcastLiveSessionRun() {},
       resolvePendingApprovalRequest() {},
       resolvePendingElicitationRequest() {},
+      notifySessionTurnCompleted(completedSession) {
+        notifiedSession = completedSession;
+        return Promise.reject(new Error("notification failed"));
+      },
       currentTimestampLabel,
     });
 
@@ -3409,5 +3535,7 @@ describe("SessionRuntimeService", () => {
 
     assert.equal(result.runState, "idle");
     assert.equal(result.messages.at(-1)?.text, "完了したよ。");
+    assert.equal(notifiedSession, persistedCompletedSession);
+    assert.equal(notifiedSession?.messages.at(-1)?.text, "完了したよ。");
   });
 });

--- a/scripts/tests/session-turn-notification-service.test.ts
+++ b/scripts/tests/session-turn-notification-service.test.ts
@@ -1,0 +1,272 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { DEFAULT_APPROVAL_MODE } from "../../src/approval-mode.js";
+import { buildNewSession, type Session } from "../../src/session-state.js";
+import {
+  SessionTurnNotificationService,
+  type SessionTurnNotificationHandle,
+  type SessionTurnNotificationOptions,
+  type SessionTurnNotificationServiceDeps,
+} from "../../src-electron/session-turn-notification-service.js";
+
+type FakeIcon = { path: string };
+
+class FakeNotification implements SessionTurnNotificationHandle {
+  shown = false;
+  closed = false;
+  private clickListener: (() => void) | null = null;
+  private closeListener: (() => void) | null = null;
+  private failedListener: ((error: unknown) => void) | null = null;
+
+  show(): void {
+    this.shown = true;
+  }
+
+  close(): void {
+    this.closed = true;
+    this.closeListener?.();
+  }
+
+  onClick(listener: () => void): void {
+    this.clickListener = listener;
+  }
+
+  onClose(listener: () => void): void {
+    this.closeListener = listener;
+  }
+
+  onFailed(listener: (error: unknown) => void): void {
+    this.failedListener = listener;
+  }
+
+  click(): void {
+    this.clickListener?.();
+  }
+
+  fail(error: unknown): void {
+    this.failedListener?.(error);
+  }
+
+  timeout(): void {
+    this.closeListener?.();
+  }
+}
+
+function createSession(overrides?: Partial<Session>): Session {
+  return {
+    ...buildNewSession({
+      taskTitle: "通知テスト",
+      workspaceLabel: "workspace",
+      workspacePath: "C:/workspace",
+      branch: "main",
+      characterId: "character-a",
+      character: "Character A",
+      characterIconPath: "C:/characters/a.png",
+      characterThemeColors: { main: "#6f8cff", sub: "#6fb8c7" },
+      approvalMode: DEFAULT_APPROVAL_MODE,
+    }),
+    ...overrides,
+  };
+}
+
+function createHarness(overrides?: Partial<SessionTurnNotificationServiceDeps<FakeIcon>>) {
+  const session = createSession();
+  const notifications: FakeNotification[] = [];
+  const options: SessionTurnNotificationOptions<FakeIcon>[] = [];
+  const openedSessions: string[] = [];
+  let homeOpenCount = 0;
+  const warnings: Array<{ event: string; sessionId: string; error?: unknown }> = [];
+  const deps: SessionTurnNotificationServiceDeps<FakeIcon> = {
+    platform: "win32",
+    isNotificationSupported: () => true,
+    isNotificationEnabled: () => true,
+    isSessionWindowFocused: () => false,
+    loadCharacterIcon: (iconPath) => ({ path: iconPath }),
+    createNotification: (nextOptions) => {
+      const notification = new FakeNotification();
+      notifications.push(notification);
+      options.push(nextOptions);
+      return notification;
+    },
+    getSession: () => session,
+    openSessionWindow: (sessionId) => {
+      openedSessions.push(sessionId);
+    },
+    openHomeWindow: () => {
+      homeOpenCount += 1;
+    },
+    logWarning: (event, sessionId, error) => {
+      warnings.push({ event, sessionId, error });
+    },
+    ...overrides,
+  };
+
+  return {
+    session,
+    service: new SessionTurnNotificationService(deps),
+    notifications,
+    options,
+    openedSessions,
+    warnings,
+    get homeOpenCount() {
+      return homeOpenCount;
+    },
+  };
+}
+
+async function flushAsyncListeners(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+describe("SessionTurnNotificationService", () => {
+  it("Windows で設定が有効かつ対象 Session Window が非 focus ならキャラアイコン付きで通知する", () => {
+    const harness = createHarness();
+
+    assert.equal(harness.service.notifyTurnCompleted(harness.session), true);
+
+    assert.equal(harness.notifications[0]?.shown, true);
+    assert.deepEqual(harness.options[0], {
+      id: harness.options[0]?.id,
+      groupId: "WithMateSessions",
+      title: "WithMate",
+      body: "「通知テスト」のターンが完了しました",
+      icon: { path: "C:/characters/a.png" },
+    });
+    assert.match(harness.options[0]?.id ?? "", /^[0-9a-f]{64}$/);
+  });
+
+  it("Windows 以外、非対応、設定無効、対象 Session Window focus 中は通知しない", () => {
+    const cases: Array<Partial<SessionTurnNotificationServiceDeps<FakeIcon>>> = [
+      { platform: "darwin" },
+      { isNotificationSupported: () => false },
+      { isNotificationEnabled: () => false },
+      { isSessionWindowFocused: () => true },
+    ];
+
+    for (const overrides of cases) {
+      const harness = createHarness(overrides);
+      assert.equal(harness.service.notifyTurnCompleted(harness.session), false);
+      assert.equal(harness.notifications.length, 0);
+    }
+  });
+
+  it("同じ Session の新しい完了通知は前の通知を閉じて置き換える", () => {
+    const harness = createHarness();
+
+    harness.service.notifyTurnCompleted(harness.session);
+    harness.service.notifyTurnCompleted(harness.session);
+
+    assert.equal(harness.notifications.length, 2);
+    assert.equal(harness.notifications[0]?.closed, true);
+    assert.equal(harness.notifications[1]?.shown, true);
+    assert.equal(harness.options[0]?.id, harness.options[1]?.id);
+    assert.equal(harness.options[0]?.groupId, harness.options[1]?.groupId);
+
+    const otherSession = createSession({ id: "other-session" });
+    harness.service.notifyTurnCompleted(otherSession);
+    assert.notEqual(harness.options[1]?.id, harness.options[2]?.id);
+  });
+
+  it("system timeout 後も同じ Session は同じ Windows Tag と Group で置き換える", () => {
+    const harness = createHarness();
+
+    harness.service.notifyTurnCompleted(harness.session);
+    harness.notifications[0]?.timeout();
+    harness.service.notifyTurnCompleted(harness.session);
+
+    assert.equal(harness.notifications[0]?.closed, false);
+    assert.equal(harness.options[0]?.id, harness.options[1]?.id);
+    assert.equal(harness.options[0]?.groupId, harness.options[1]?.groupId);
+  });
+
+  it("キャラアイコンを読み込めなくても通知本体を表示し、show failure は呼び出し元へ投げない", () => {
+    const iconFailureHarness = createHarness({
+      loadCharacterIcon() {
+        throw new Error("invalid icon");
+      },
+    });
+
+    assert.equal(iconFailureHarness.service.notifyTurnCompleted(iconFailureHarness.session), true);
+    assert.deepEqual(iconFailureHarness.options[0], {
+      id: iconFailureHarness.options[0]?.id,
+      groupId: "WithMateSessions",
+      title: "WithMate",
+      body: "「通知テスト」のターンが完了しました",
+    });
+    assert.equal(iconFailureHarness.warnings[0]?.event, "icon-load-failed");
+
+    const showFailureHarness = createHarness({
+      createNotification() {
+        return {
+          show() {
+            throw new Error("show failed");
+          },
+          close() {},
+          onClick() {},
+          onClose() {},
+          onFailed() {},
+        };
+      },
+    });
+
+    assert.equal(showFailureHarness.service.notifyTurnCompleted(showFailureHarness.session), false);
+    assert.equal(showFailureHarness.warnings[0]?.event, "show-failed");
+  });
+
+  it("通知 click で対象 Session を開き、削除済みなら Home を開く", async () => {
+    const existingHarness = createHarness();
+    existingHarness.service.notifyTurnCompleted(existingHarness.session);
+    existingHarness.notifications[0]?.click();
+    await flushAsyncListeners();
+
+    assert.deepEqual(existingHarness.openedSessions, [existingHarness.session.id]);
+    assert.equal(existingHarness.homeOpenCount, 0);
+
+    const deletedHarness = createHarness({
+      getSession: () => null,
+    });
+    deletedHarness.service.notifyTurnCompleted(deletedHarness.session);
+    deletedHarness.notifications[0]?.click();
+    await flushAsyncListeners();
+
+    assert.deepEqual(deletedHarness.openedSessions, []);
+    assert.equal(deletedHarness.homeOpenCount, 1);
+
+    const readFailureHarness = createHarness({
+      async getSession() {
+        throw new Error("read failed");
+      },
+    });
+    readFailureHarness.service.notifyTurnCompleted(readFailureHarness.session);
+    readFailureHarness.notifications[0]?.click();
+    await flushAsyncListeners();
+
+    assert.equal(readFailureHarness.homeOpenCount, 1);
+    assert.equal(readFailureHarness.warnings[0]?.event, "target-open-failed");
+
+    const openFailureHarness = createHarness({
+      async openSessionWindow() {
+        throw new Error("open failed");
+      },
+    });
+    openFailureHarness.service.notifyTurnCompleted(openFailureHarness.session);
+    openFailureHarness.notifications[0]?.click();
+    await flushAsyncListeners();
+
+    assert.equal(openFailureHarness.homeOpenCount, 1);
+    assert.equal(openFailureHarness.warnings[0]?.event, "target-open-failed");
+  });
+
+  it("delivery failure 後は active notification から外し、次の通知時に閉じ直さない", () => {
+    const harness = createHarness();
+    harness.service.notifyTurnCompleted(harness.session);
+    harness.notifications[0]?.fail(new Error("delivery failed"));
+
+    harness.service.notifyTurnCompleted(harness.session);
+
+    assert.equal(harness.notifications[0]?.closed, false);
+    assert.equal(harness.notifications[1]?.shown, true);
+    assert.equal(harness.warnings[0]?.event, "delivery-failed");
+  });
+});

--- a/scripts/tests/settings-ui.test.ts
+++ b/scripts/tests/settings-ui.test.ts
@@ -12,6 +12,7 @@ import {
   SETTINGS_RELEASE_COMPATIBILITY_NOTE,
   SETTINGS_RESET_DATABASE_HELP,
   SETTINGS_RESET_DATABASE_LABEL,
+  SETTINGS_SESSION_TURN_NOTIFICATION_LABEL,
   buildResetDatabaseConfirmMessage,
   buildResetDatabaseSuccessMessage,
 } from "../../src/settings/settings-ui.js";
@@ -41,6 +42,10 @@ describe("Settings UI constants", () => {
     assert.equal(SETTINGS_MEMORY_FILE_QUOTA_LABEL, "Memory file quota");
     assert.match(SETTINGS_MEMORY_FILE_QUOTA_HELP, /Protected Object/);
     assert.match(SETTINGS_MEMORY_FILE_QUOTA_HELP, /file append/);
+  });
+
+  it("Session turn notification は Windows 通知だと分かる", () => {
+    assert.equal(SETTINGS_SESSION_TURN_NOTIFICATION_LABEL, "Session のターン完了を Windows 通知で知らせる");
   });
 
   it("Home Window は Settings overlay の余裕を確保する既定サイズを使う", () => {

--- a/src-electron/app-settings-storage.ts
+++ b/src-electron/app-settings-storage.ts
@@ -7,6 +7,7 @@ import { openAppDatabase } from "./sqlite-connection.js";
 const DEFAULT_APP_SETTINGS: AppSettings = createDefaultAppSettings();
 const MEMORY_GENERATION_ENABLED_KEY = "memory_generation_enabled";
 const LAUNCH_AT_LOGIN_ENABLED_KEY = "launch_at_login_enabled";
+const SESSION_TURN_NOTIFICATION_ENABLED_KEY = "session_turn_notification_enabled";
 const AUTO_COLLAPSE_ACTION_DOCK_ON_SEND_KEY = "auto_collapse_action_dock_on_send";
 const MEMORY_FILE_QUOTA_BYTES_KEY = "memory_file_quota_bytes";
 const CODING_PROVIDER_SETTINGS_KEY = "coding_provider_settings_json";
@@ -44,6 +45,17 @@ export class AppSettingsStorage {
         ON CONFLICT(setting_key) DO NOTHING
       `)
       .run(LAUNCH_AT_LOGIN_ENABLED_KEY, String(DEFAULT_APP_SETTINGS.launchAtLoginEnabled), updatedAt);
+    this.db
+      .prepare(`
+        INSERT INTO app_settings (setting_key, setting_value, updated_at)
+        VALUES (?, ?, ?)
+        ON CONFLICT(setting_key) DO NOTHING
+      `)
+      .run(
+        SESSION_TURN_NOTIFICATION_ENABLED_KEY,
+        String(DEFAULT_APP_SETTINGS.sessionTurnNotificationEnabled),
+        updatedAt,
+      );
     this.db
       .prepare(`
         INSERT INTO app_settings (setting_key, setting_value, updated_at)
@@ -120,6 +132,12 @@ export class AppSettingsStorage {
       }
       if (row.setting_key === LAUNCH_AT_LOGIN_ENABLED_KEY) {
         settings.launchAtLoginEnabled = row.setting_value === "true";
+        continue;
+      }
+      if (row.setting_key === SESSION_TURN_NOTIFICATION_ENABLED_KEY) {
+        if (row.setting_value === "true" || row.setting_value === "false") {
+          settings.sessionTurnNotificationEnabled = row.setting_value === "true";
+        }
         continue;
       }
       if (row.setting_key === AUTO_COLLAPSE_ACTION_DOCK_ON_SEND_KEY) {
@@ -211,6 +229,19 @@ export class AppSettingsStorage {
             updated_at = excluded.updated_at
         `)
         .run(LAUNCH_AT_LOGIN_ENABLED_KEY, String(normalized.launchAtLoginEnabled), updatedAt);
+      this.db
+        .prepare(`
+          INSERT INTO app_settings (setting_key, setting_value, updated_at)
+          VALUES (?, ?, ?)
+          ON CONFLICT(setting_key) DO UPDATE SET
+            setting_value = excluded.setting_value,
+            updated_at = excluded.updated_at
+        `)
+        .run(
+          SESSION_TURN_NOTIFICATION_ENABLED_KEY,
+          String(normalized.sessionTurnNotificationEnabled),
+          updatedAt,
+        );
       this.db
         .prepare(`
           INSERT INTO app_settings (setting_key, setting_value, updated_at)

--- a/src-electron/main.ts
+++ b/src-electron/main.ts
@@ -5,7 +5,21 @@ import { homedir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { app, BrowserWindow, crashReporter, dialog, ipcMain, Menu, safeStorage, screen, shell, Tray } from "electron";
+import {
+  app,
+  BrowserWindow,
+  crashReporter,
+  dialog,
+  ipcMain,
+  Menu,
+  nativeImage,
+  Notification,
+  safeStorage,
+  screen,
+  shell,
+  Tray,
+  type NativeImage,
+} from "electron";
 
 import type { RendererLogInput } from "../src/app-log-types.js";
 import { summarizeAuditLogDetailFragment } from "../src/audit-log-detail-metrics.js";
@@ -87,6 +101,7 @@ import { CompanionAuditLogStorageV3 } from "./companion-audit-log-storage-v3.js"
 import { CompanionStorage } from "./companion-storage.js";
 import { CompanionStorageV3 } from "./companion-storage-v3.js";
 import { SessionRuntimeService } from "./session-runtime-service.js";
+import { SessionTurnNotificationService } from "./session-turn-notification-service.js";
 import { SessionPersistenceService } from "./session-persistence-service.js";
 import { SessionWindowBridge } from "./session-window-bridge.js";
 import { SettingsCatalogService } from "./settings-catalog-service.js";
@@ -267,6 +282,7 @@ const hasSingleInstanceLock = app.requestSingleInstanceLock();
 ipcMain.handle(WITHMATE_GET_APP_BOOT_STATUS_CHANNEL, () => appBootStatus);
 const PROVIDER_QUOTA_STALE_TTL_MS = 5 * 60 * 1000;
 let sessionRuntimeService: SessionRuntimeService | null = null;
+let sessionTurnNotificationService: SessionTurnNotificationService<NativeImage> | null = null;
 let auxiliarySessionService: AuxiliarySessionService | null = null;
 let auxiliarySessionRuntimeService: SessionRuntimeService | null = null;
 let sessionPersistenceService: SessionPersistenceService | null = null;
@@ -1933,11 +1949,71 @@ function requireSessionRuntimeService(): SessionRuntimeService {
           requireSessionElicitationService().resolveLiveElicitation(sessionId, requestId, response);
         }
       },
+      notifySessionTurnCompleted: (session) => {
+        requireSessionTurnNotificationService().notifyTurnCompleted(session);
+      },
       currentTimestampLabel,
     });
   }
 
   return sessionRuntimeService;
+}
+
+function requireSessionTurnNotificationService(): SessionTurnNotificationService<NativeImage> {
+  if (!sessionTurnNotificationService) {
+    sessionTurnNotificationService = new SessionTurnNotificationService({
+      platform: process.platform,
+      isNotificationSupported: () => Notification.isSupported(),
+      isNotificationEnabled: () => requireAppSettingsStorage().getSettings().sessionTurnNotificationEnabled,
+      isSessionWindowFocused: (sessionId) => {
+        const sessionWindow = requireSessionWindowBridge().getWindow(sessionId);
+        return Boolean(sessionWindow && !sessionWindow.isDestroyed() && sessionWindow.isFocused());
+      },
+      loadCharacterIcon: (iconPath) => {
+        if (!path.isAbsolute(iconPath)) {
+          return null;
+        }
+
+        const icon = nativeImage.createFromPath(iconPath);
+        return icon.isEmpty() ? null : icon;
+      },
+      createNotification: (options) => {
+        const notification = new Notification(options);
+        return {
+          show: () => notification.show(),
+          close: () => notification.close(),
+          onClick: (listener) => {
+            notification.on("click", listener);
+          },
+          onClose: (listener) => {
+            notification.on("close", listener);
+          },
+          onFailed: (listener) => {
+            notification.on("failed", (_event, error) => listener(error));
+          },
+        };
+      },
+      getSession: (sessionId) => requireSessionStorage().getSession(sessionId),
+      openSessionWindow: async (sessionId) => {
+        await openSessionWindow(sessionId);
+      },
+      openHomeWindow: async () => {
+        await createHomeWindow();
+      },
+      logWarning: (event, sessionId, error) => {
+        writeAppLog({
+          level: "warn",
+          kind: `session.turn-notification.${event}`,
+          process: "main",
+          message: "Session turn notification warning",
+          data: { sessionId },
+          ...(error === undefined ? {} : { error: appLogService.errorToLogError(error) }),
+        });
+      },
+    });
+  }
+
+  return sessionTurnNotificationService;
 }
 
 function requireAuxiliarySessionRuntimeService(): SessionRuntimeService {

--- a/src-electron/session-runtime-service.ts
+++ b/src-electron/session-runtime-service.ts
@@ -87,10 +87,27 @@ export type SessionRuntimeServiceDeps = {
   resolvePendingApprovalRequest(sessionId: string, decision: LiveApprovalDecision): void;
   resolvePendingElicitationRequest(sessionId: string, response: LiveElicitationResponse): void;
   getMateState?: () => MateStorageState;
+  notifySessionTurnCompleted?: (session: Session) => Awaitable<void>;
   currentTimestampLabel?: () => string;
   providerCancelGraceMs?: number;
   auditEnrichmentGraceMs?: number;
 };
+
+function notifySessionTurnCompletedBestEffort(
+  notify: SessionRuntimeServiceDeps["notifySessionTurnCompleted"],
+  session: Session,
+): void {
+  if (!notify) {
+    return;
+  }
+
+  try {
+    void Promise.resolve(notify(session))
+      .catch((error) => console.warn("Session turn completion notification failed", error));
+  } catch (error) {
+    console.warn("Session turn completion notification failed", error);
+  }
+}
 
 async function waitForAuditEnrichment<T>(
   promise: Promise<T>,
@@ -1095,6 +1112,9 @@ export class SessionRuntimeService {
         storedStatus: storedCompletedSession.status,
       });
       activeRunningSession = storedCompletedSession;
+      if (!runAbortController.signal.aborted) {
+        notifySessionTurnCompletedBestEffort(this.deps.notifySessionTurnCompleted, storedCompletedSession);
+      }
 
       const completedAuditEntry = buildTerminalAuditEntry({
         baseEntry: runningAuditEntry,

--- a/src-electron/session-turn-notification-service.ts
+++ b/src-electron/session-turn-notification-service.ts
@@ -1,0 +1,157 @@
+import { createHash } from "node:crypto";
+
+import type { Session } from "../src/session-state.js";
+import type { Awaitable } from "./persistent-store-lifecycle-service.js";
+
+export type SessionTurnNotificationOptions<TIcon> = {
+  id: string;
+  groupId: string;
+  title: string;
+  body: string;
+  icon?: TIcon;
+};
+
+export type SessionTurnNotificationHandle = {
+  show(): void;
+  close(): void;
+  onClick(listener: () => void): void;
+  onClose(listener: () => void): void;
+  onFailed(listener: (error: unknown) => void): void;
+};
+
+export type SessionTurnNotificationServiceDeps<TIcon> = {
+  platform: NodeJS.Platform;
+  isNotificationSupported(): boolean;
+  isNotificationEnabled(): boolean;
+  isSessionWindowFocused(sessionId: string): boolean;
+  loadCharacterIcon(iconPath: string): TIcon | null;
+  createNotification(options: SessionTurnNotificationOptions<TIcon>): SessionTurnNotificationHandle;
+  getSession(sessionId: string): Awaitable<Session | null>;
+  openSessionWindow(sessionId: string): Awaitable<void>;
+  openHomeWindow(): Awaitable<void>;
+  logWarning(event: string, sessionId: string, error?: unknown): void;
+};
+
+export class SessionTurnNotificationService<TIcon> {
+  private static readonly notificationGroupId = "WithMateSessions";
+  private readonly activeNotifications = new Map<string, SessionTurnNotificationHandle>();
+
+  constructor(private readonly deps: SessionTurnNotificationServiceDeps<TIcon>) {}
+
+  notifyTurnCompleted(session: Session): boolean {
+    if (!this.isEligible(session.id)) {
+      return false;
+    }
+
+    const options: SessionTurnNotificationOptions<TIcon> = {
+      id: this.buildNotificationId(session.id),
+      groupId: SessionTurnNotificationService.notificationGroupId,
+      title: "WithMate",
+      body: `「${session.taskTitle.trim() || "Session"}」のターンが完了しました`,
+    };
+    const icon = this.loadCharacterIcon(session);
+    if (icon !== null) {
+      options.icon = icon;
+    }
+
+    this.closePreviousNotification(session.id);
+
+    let notification: SessionTurnNotificationHandle;
+    try {
+      notification = this.deps.createNotification(options);
+    } catch (error) {
+      this.deps.logWarning("create-failed", session.id, error);
+      return false;
+    }
+
+    notification.onClick(() => {
+      this.clearIfCurrent(session.id, notification);
+      void this.openNotificationTarget(session.id);
+    });
+    notification.onClose(() => {
+      this.clearIfCurrent(session.id, notification);
+    });
+    notification.onFailed((error) => {
+      this.clearIfCurrent(session.id, notification);
+      this.deps.logWarning("delivery-failed", session.id, error);
+    });
+    this.activeNotifications.set(session.id, notification);
+
+    try {
+      notification.show();
+      return true;
+    } catch (error) {
+      this.clearIfCurrent(session.id, notification);
+      this.deps.logWarning("show-failed", session.id, error);
+      return false;
+    }
+  }
+
+  private isEligible(sessionId: string): boolean {
+    try {
+      return this.deps.platform === "win32"
+        && this.deps.isNotificationSupported()
+        && this.deps.isNotificationEnabled()
+        && !this.deps.isSessionWindowFocused(sessionId);
+    } catch (error) {
+      this.deps.logWarning("eligibility-check-failed", sessionId, error);
+      return false;
+    }
+  }
+
+  private loadCharacterIcon(session: Session): TIcon | null {
+    const iconPath = session.characterIconPath.trim();
+    if (!iconPath) {
+      return null;
+    }
+
+    try {
+      return this.deps.loadCharacterIcon(iconPath);
+    } catch (error) {
+      this.deps.logWarning("icon-load-failed", session.id, error);
+      return null;
+    }
+  }
+
+  private buildNotificationId(sessionId: string): string {
+    return createHash("sha256").update(sessionId).digest("hex");
+  }
+
+  private closePreviousNotification(sessionId: string): void {
+    const previousNotification = this.activeNotifications.get(sessionId);
+    if (!previousNotification) {
+      return;
+    }
+
+    this.activeNotifications.delete(sessionId);
+    try {
+      previousNotification.close();
+    } catch (error) {
+      this.deps.logWarning("replace-close-failed", sessionId, error);
+    }
+  }
+
+  private clearIfCurrent(sessionId: string, notification: SessionTurnNotificationHandle): void {
+    if (this.activeNotifications.get(sessionId) === notification) {
+      this.activeNotifications.delete(sessionId);
+    }
+  }
+
+  private async openNotificationTarget(sessionId: string): Promise<void> {
+    try {
+      const session = await this.deps.getSession(sessionId);
+      if (session) {
+        await this.deps.openSessionWindow(sessionId);
+        return;
+      }
+    } catch (error) {
+      this.deps.logWarning("target-open-failed", sessionId, error);
+    }
+
+    try {
+      await this.deps.openHomeWindow();
+    } catch (error) {
+      this.deps.logWarning("home-open-failed", sessionId, error);
+    }
+  }
+}

--- a/src/provider-settings-state.ts
+++ b/src/provider-settings-state.ts
@@ -15,6 +15,7 @@ import {
 export type AppSettings = {
   memoryGenerationEnabled: boolean;
   launchAtLoginEnabled: boolean;
+  sessionTurnNotificationEnabled: boolean;
   autoCollapseActionDockOnSend: boolean;
   memoryFileQuotaBytes: number;
   userMicrocopyCatalog: MicrocopyCatalog;
@@ -92,6 +93,7 @@ export function createDefaultAppSettings(): AppSettings {
   return {
     memoryGenerationEnabled: true,
     launchAtLoginEnabled: false,
+    sessionTurnNotificationEnabled: true,
     autoCollapseActionDockOnSend: true,
     memoryFileQuotaBytes: MEMORY_FILE_QUOTA_DEFAULT_BYTES,
     userMicrocopyCatalog: createDefaultUserMicrocopyCatalog(),
@@ -310,6 +312,8 @@ export function normalizeAppSettings(value: unknown): AppSettings {
       typeof candidate.memoryGenerationEnabled === "boolean" ? candidate.memoryGenerationEnabled : true,
     launchAtLoginEnabled:
       typeof candidate.launchAtLoginEnabled === "boolean" ? candidate.launchAtLoginEnabled : false,
+    sessionTurnNotificationEnabled:
+      typeof candidate.sessionTurnNotificationEnabled === "boolean" ? candidate.sessionTurnNotificationEnabled : true,
     autoCollapseActionDockOnSend:
       typeof candidate.autoCollapseActionDockOnSend === "boolean" ? candidate.autoCollapseActionDockOnSend : true,
     memoryFileQuotaBytes: normalizeMemoryFileQuotaBytes(candidate.memoryFileQuotaBytes),

--- a/src/settings/SettingsContent.tsx
+++ b/src/settings/SettingsContent.tsx
@@ -30,6 +30,7 @@ import {
   SETTINGS_PROVIDER_SKILL_RELATIVE_PATH_PLACEHOLDER,
   SETTINGS_PROVIDER_ROOT_DIRECTORY_LABEL,
   SETTINGS_PROVIDER_ROOT_DIRECTORY_PLACEHOLDER,
+  SETTINGS_SESSION_TURN_NOTIFICATION_LABEL,
 } from "./settings-ui.js";
 
 export type HomeSettingsContentProps = {
@@ -44,6 +45,7 @@ export type HomeSettingsContentProps = {
   deletingOldSessions: boolean;
   onChangeAutoCollapseActionDockOnSend: (enabled: boolean) => void;
   onChangeLaunchAtLoginEnabled: (enabled: boolean) => void;
+  onChangeSessionTurnNotificationEnabled: (enabled: boolean) => void;
   onChangeMemoryFileQuotaMegabytes: (value: string) => void;
   onChangeSessionCleanupCutoffDate: (value: string) => void;
   onChangeUserMicrocopySlot: (slot: MicrocopySlot, value: string) => void;
@@ -102,6 +104,7 @@ export function HomeSettingsContent({
   deletingOldSessions,
   onChangeAutoCollapseActionDockOnSend,
   onChangeLaunchAtLoginEnabled,
+  onChangeSessionTurnNotificationEnabled,
   onChangeMemoryFileQuotaMegabytes,
   onChangeSessionCleanupCutoffDate,
   onChangeUserMicrocopySlot,
@@ -140,6 +143,14 @@ export function HomeSettingsContent({
                   type="checkbox"
                   checked={settingsDraft.launchAtLoginEnabled}
                   onChange={(event) => onChangeLaunchAtLoginEnabled(event.target.checked)}
+                />
+              </label>
+              <label className="settings-provider-toggle-row settings-section-toggle">
+                <span className="settings-provider-name">{SETTINGS_SESSION_TURN_NOTIFICATION_LABEL}</span>
+                <input
+                  type="checkbox"
+                  checked={settingsDraft.sessionTurnNotificationEnabled}
+                  onChange={(event) => onChangeSessionTurnNotificationEnabled(event.target.checked)}
                 />
               </label>
               <label className="settings-provider-toggle-row settings-section-toggle">

--- a/src/settings/settings-draft-actions.ts
+++ b/src/settings/settings-draft-actions.ts
@@ -21,6 +21,7 @@ import {
   updateMemoryExtractionTimeoutSecondsDraft,
   updateMemoryFileQuotaMegabytesDraft,
   updateMemoryGenerationEnabled,
+  updateSessionTurnNotificationEnabled,
   updateUserMicrocopySlotDraft,
 } from "./settings-draft.js";
 
@@ -84,6 +85,12 @@ export function handleChangeLaunchAtLoginEnabled(input: SettingsDraftActionInput
   enabled: boolean;
 }): void {
   input.setSettingsDraft((current) => updateLaunchAtLoginEnabled(current, input.enabled));
+}
+
+export function handleChangeSessionTurnNotificationEnabled(input: SettingsDraftActionInput & {
+  enabled: boolean;
+}): void {
+  input.setSettingsDraft((current) => updateSessionTurnNotificationEnabled(current, input.enabled));
 }
 
 export function handleChangeMemoryFileQuotaMegabytes(input: SettingsDraftActionInput & {

--- a/src/settings/settings-draft-handlers.ts
+++ b/src/settings/settings-draft-handlers.ts
@@ -9,6 +9,7 @@ import {
   handleChangeProviderEnabled,
   handleChangeProviderSkillRelativePath,
   handleChangeProviderSkillRootPath,
+  handleChangeSessionTurnNotificationEnabled,
   handleChangeUserMicrocopySlot,
 } from "./settings-draft-actions.js";
 
@@ -20,6 +21,7 @@ export type SettingsDraftHandlers = Pick<
   HomeSettingsContentBaseProps,
   | "onChangeAutoCollapseActionDockOnSend"
   | "onChangeLaunchAtLoginEnabled"
+  | "onChangeSessionTurnNotificationEnabled"
   | "onChangeMemoryFileQuotaMegabytes"
   | "onChangeUserMicrocopySlot"
   | "onChangeProviderEnabled"
@@ -37,6 +39,9 @@ export function buildSettingsDraftHandlers({
     },
     onChangeLaunchAtLoginEnabled: (enabled) => {
       handleChangeLaunchAtLoginEnabled({ enabled, setSettingsDraft });
+    },
+    onChangeSessionTurnNotificationEnabled: (enabled) => {
+      handleChangeSessionTurnNotificationEnabled({ enabled, setSettingsDraft });
     },
     onChangeMemoryFileQuotaMegabytes: (value) => {
       handleChangeMemoryFileQuotaMegabytes({ value, setSettingsDraft });

--- a/src/settings/settings-draft.ts
+++ b/src/settings/settings-draft.ts
@@ -32,6 +32,16 @@ export function updateAutoCollapseActionDockOnSend(
   };
 }
 
+export function updateSessionTurnNotificationEnabled(
+  draft: AppSettings,
+  enabled: boolean,
+): AppSettings {
+  return {
+    ...draft,
+    sessionTurnNotificationEnabled: enabled,
+  };
+}
+
 export function updateLaunchAtLoginEnabled(
   draft: AppSettings,
   enabled: boolean,

--- a/src/settings/settings-ui.ts
+++ b/src/settings/settings-ui.ts
@@ -30,6 +30,7 @@ export const SETTINGS_CODING_CREDENTIALS_FUTURE_NOTE =
 export const SETTINGS_RELEASE_COMPATIBILITY_NOTE =
   "初回リリース前のため、設定 schema の後方互換性は考慮しない。";
 export const SETTINGS_LAUNCH_AT_LOGIN_LABEL = "PC 起動時に WithMate をバックグラウンドで起動する";
+export const SETTINGS_SESSION_TURN_NOTIFICATION_LABEL = "Session のターン完了を Windows 通知で知らせる";
 export const SETTINGS_ACTION_DOCK_AUTO_CLOSE_LABEL = "送信後に Action Dock を自動で閉じる";
 export const SETTINGS_MEMORY_FILE_QUOTA_LABEL = "Memory file quota";
 export const SETTINGS_MEMORY_FILE_QUOTA_HELP =


### PR DESCRIPTION
## 概要

- Session の成功ターン保存後に Windows ネイティブ通知を表示
- 対象 Session Window がフォーカス中の場合のみ通知を抑止
- 設定画面に既定 ON の通知切り替えを追加
- キャラクターアイコンの best-effort 適用、同一 Session 通知の置換、通知クリック時の Session/Home 導線を実装
- Windows 標準 Notification API を採用する判断を ADR に記録

## 検証

- `npx tsx --test scripts/tests/session-turn-notification-service.test.ts scripts/tests/session-runtime-service.test.ts scripts/tests/app-settings-storage.test.ts`（41件成功）
- `npm test`（1874件成功、1件スキップ、失敗なし）
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## 補足

- インストール済み Windows 環境での実通知、既定音、Action Center、実キャラクターアイコンの smoke test は未実施
- WithMate process 終了後または Notification instance 破棄後の Action Center click では、対象 Session の復元を保証しない