### PR TITLE
Character icon の登録形式を PNG / JPEG に制限

### DIFF
--- a/docs/adr/008-character-icon-notification-compatible-formats.md
+++ b/docs/adr/008-character-icon-notification-compatible-formats.md
@@ -1,0 +1,59 @@
+# 008 Character Icon Notification-Compatible Formats
+
+- 状態: Accepted
+- 日付: 2026-07-30
+
+## Context
+
+Character icon は renderer の avatar 表示に加え、Windows の Session turn notification にも使用する。renderer が表示できる画像形式と Electron の `nativeImage` が全 platform で扱う画像形式は一致しない。Electron は全 platform 共通の対応形式を PNG と JPEG としているため、GIF、WebP、BMP、SVG を登録すると、UI では表示できても通知では Character icon が省略される。
+
+新規登録だけを制限する、既存画像を自動変換する、通知時に変換する、すべての形式を継続して許可する選択肢がある。既存 Character と過去 Session は icon path を保持しているため、既存ファイルの変換や削除は過去の表示を壊す可能性がある。
+
+## Decision
+
+- Character の新規作成と icon 差し替えでは、local filesystem 上の PNG、JPG、JPEG だけを受け付ける。
+- Character Editor の画像選択は Character icon 用の filter を要求する。Mate avatar と Session attachment が使用する一般画像 filter は変更しない。
+- format 制約の canonical owner は Main Process の Character storage とする。renderer の picker や手入力、IPC 呼び出しから同じ保存処理へ到達しても制約を迂回できない。
+- 既存の非対応 icon は変換、削除、metadata の消去を行わない。
+- 既存の非対応 icon と同じ参照を維持した metadata 更新は許可する。Windows filesystem path は drive path と UNC path を対象に、directory separator と大文字小文字の表記差を除いて比較する。scheme path と POSIX path は文字列が一致する場合だけ同じ参照として扱う。別の非対応 icon への差し替えは拒否する。
+- Character authoring session の icon は保存済み Character から解決する。未保存の Editor draft や IPC input に icon path を持たせない。
+- icon の欠損、破損、既存の非対応形式では、`docs/adr/006-windows-session-turn-notifications.md` のとおり通知本体を優先し、Character icon を省略して Windows が選ぶアプリアイコンへフォールバックする。
+
+## Alternatives
+
+### 既存 icon を PNG へ一括変換する
+
+GIF の animation や SVG の表現が変わり、既存 Session が保持する旧 path との整合も必要になる。今回の目的に対して migration と cleanup の負担が大きいため採用しない。
+
+### 通知時だけ PNG へ変換して cache する
+
+Character storage と別に変換、cache、cleanup、失敗処理の owner が必要になる。通知は補助的な外部副作用であり、登録時に対応形式へ限定する方が境界を小さく保てるため採用しない。
+
+### 既存の対応形式をすべて継続する
+
+新しく登録した icon でも通知に Character icon が出ない状態が残るため採用しない。
+
+### 既存の非対応 icon を解除する
+
+ユーザーが登録済みの表示を失い、過去 Session の参照も壊すため採用しない。
+
+## Consequences
+
+### Positive
+
+- 新しく登録または差し替えた Character icon は Electron の通知画像として利用可能な形式になる。
+- 既存 Character と過去 Session の icon file/path を破壊しない。
+- Character storage の保存境界で形式を強制し、picker 以外の入口からの迂回を防げる。
+- Mate avatar と Session attachment の画像選択には影響しない。
+
+### Negative
+
+- 既存の非対応 icon は、差し替えるまで通知では Character icon が表示されない。
+- 非対応 icon を持つ既存 Character には、対応形式と非対応形式が併存する。
+- 拡張子が PNG/JPG/JPEG でも、欠損または破損した画像は通知で使用できない場合がある。
+
+形式判定の正本は `src/character/character-icon.ts`、保存境界の強制は `src-electron/character-storage.ts` に置く。picker / IPC の正本は `src-electron/window-dialog-service.ts`、`src-electron/main-ipc-registration.ts`、`src-electron/preload-api.ts`、renderer の入口は `src/CharacterEditorApp.tsx` に置く。Character authoring session の icon projection は `src-electron/character-authoring-service.ts` が保存済み Character から作る。観測可能な契約は `scripts/tests/character-storage.test.ts`、`scripts/tests/character-authoring-service.test.ts`、`scripts/tests/window-dialog-service.test.ts`、`scripts/tests/main-ipc-registration.test.ts`、`scripts/tests/preload-api.test.ts`、`scripts/tests/character-editor-state.test.ts`、`scripts/tests/character-editor-app.test.tsx` に置く。
+
+外部制約:
+
+- [Electron `nativeImage` Supported Formats](https://www.electronjs.org/docs/latest/api/native-image#supported-formats)

--- a/docs/design/character-definition-format.md
+++ b/docs/design/character-definition-format.md
@@ -99,6 +99,7 @@ V5 Core 必須条件:
 - V5 Core の storage metadata は `docs/design/character-storage.md` で扱う。
 - `character-notes.md` と `icon.<ext>` は optional asset として扱う。
 - 取り込み後の managed icon file は `characters/<character-id>/icon.<ext>` に保存される。`character.md` 内の asset 参照例は authoring 時の推奨構造であり、metadata の `iconFilePath` 正本は storage service が管理する。
+- 新しく登録または差し替える icon の対応形式と既存 icon の互換性方針は `docs/adr/008-character-icon-notification-compatible-formats.md` と `docs/design/character-storage.md` に従う。
 - update workspace 用の `AGENTS.md`、instruction file、skill は V5 Core に含めない。
 
 ## `character.md` Recommended Structure

--- a/docs/design/character-storage.md
+++ b/docs/design/character-storage.md
@@ -1,7 +1,7 @@
 # Character Storage
 
 - 作成日: 2026-03-12
-- 更新日: 2026-06-15
+- 更新日: 2026-07-30
 - 対象: V5 Core の Character catalog / storage / snapshot 境界
 
 ## Goal
@@ -62,8 +62,9 @@ Character icon は保存時に Main Process が app data 配下へ materialize �
 - 外部絶対 path が指定された場合、`characters/<character-id>/icon.<ext>` へコピーする。
 - DB の `icon_file_path` は managed icon では `characters/<character-id>/icon.<ext>` の app data 相対 path を保存する。
 - API / renderer へ返す `iconFilePath` は `userData` 基準の表示可能な path に materialize する。
-- 相対 path は `userData` 基準として扱う。`data:` / `file://` などの scheme path はコピーせず、そのまま返す。
-- managed icon の許可拡張子は `png`, `jpg`, `jpeg`, `gif`, `webp`, `bmp`, `svg` とし、絶対 path から取り込む場合は regular file かつ 10 MiB 以下であることを Main Process 側で検証する。
+- 相対 path は `userData` 基準として扱う。新規作成と icon 差し替えでは scheme path を受け付けない。
+- 新規作成と icon 差し替えで受け付ける拡張子は `png`, `jpg`, `jpeg` とする。絶対 path から取り込む場合は regular file かつ 10 MiB 以下であることを Main Process 側で検証する。
+- 既存の非対応 icon は変換または削除しない。同じ icon 参照を維持した metadata 更新は許可し、Windows filesystem path は drive path と UNC path を対象に directory separator と大文字小文字の表記差を除いて比較する。scheme path と POSIX path は文字列一致のみを同一参照として扱う。別の非対応 icon への差し替えは拒否する。
 - managed icon を別拡張子へ置換した場合は、旧 `icon.<ext>` を best-effort で削除する。削除失敗は保存成功を妨げない。
 
 ## SQLite Metadata
@@ -104,6 +105,7 @@ Character icon は保存時に Main Process が app data 配下へ materialize �
 - Character 一覧、Editor preview、session / companion snapshot の avatar 表示に使う代表画像。
 - Renderer は filesystem を直接解決せず、storage service が materialize した `iconFilePath` を受け取る。
 - 外部絶対 path の取り込みは保存時にコピーし、保存後の正本は app data 配下の managed icon とする。
+- 新しく取り込む icon は PNG、JPG、JPEG に限定する。既存の非対応 icon は同じ参照を維持する限り継続して使用できる。
 
 ## Service API
 

--- a/scripts/tests/character-authoring-service.test.ts
+++ b/scripts/tests/character-authoring-service.test.ts
@@ -22,7 +22,7 @@ describe("CharacterAuthoringService", () => {
         id: "char-muse",
         name: "Muse",
         description: "作業を一緒に進める相手",
-        iconFilePath: "",
+        iconFilePath: "C:\\Characters\\Muse\\legacy.webp",
         theme: DEFAULT_CHARACTER_THEME,
         state: "active",
         isDefault: false,
@@ -47,7 +47,8 @@ describe("CharacterAuthoringService", () => {
         description: "作業を一緒に進める相手",
         definitionMarkdown: "",
         notesMarkdown: "",
-      });
+        iconFilePath: "C:\\Drafts\\unsupported.webp",
+      } as Parameters<CharacterAuthoringService["startSession"]>[0] & { iconFilePath: string });
 
       assert.equal(result.session.sessionKind, "character-authoring");
       assert.equal(createdInputs[0]?.sessionKind, "character-authoring");
@@ -57,6 +58,7 @@ describe("CharacterAuthoringService", () => {
       assert.equal(createdInputs[0]?.provider, "codex");
       assert.equal(createdInputs[0]?.model, undefined);
       assert.equal(createdInputs[0]?.reasoningEffort, undefined);
+      assert.equal(createdInputs[0]?.characterIconPath, "C:\\Characters\\Muse\\legacy.webp");
       assert.equal(result.workspacePath, path.join(tempDirectory, "characters", "char-muse"));
 
       const rootEntries = await readdir(result.workspacePath);
@@ -200,6 +202,34 @@ describe("CharacterAuthoringService", () => {
       }),
       /保存済み Character/,
     );
+  });
+
+  it("保存済み Character が見つからない場合は workspace と session を作らない", async () => {
+    let workspaceResolutionCount = 0;
+    let sessionCreationCount = 0;
+    const service = new CharacterAuthoringService({
+      bundledSkillPath: path.resolve("resources", "skills", CHARACTER_AUTHORING_SKILL_NAME),
+      getCharacter: () => null,
+      getCharacterDirectory: () => {
+        workspaceResolutionCount += 1;
+        return "C:/unexpected";
+      },
+      async createSession(input) {
+        sessionCreationCount += 1;
+        return buildNewSession(input);
+      },
+    });
+
+    await assert.rejects(
+      () => service.startSession({
+        mode: "improve",
+        characterId: "missing-character",
+        name: "Missing",
+      }),
+      /保存済み Character/,
+    );
+    assert.equal(workspaceResolutionCount, 0);
+    assert.equal(sessionCreationCount, 0);
   });
 
   it("authoring 補助ファイルと Skill directory は次回起動時に作り直す", async () => {

--- a/scripts/tests/character-editor-app.test.tsx
+++ b/scripts/tests/character-editor-app.test.tsx
@@ -83,6 +83,9 @@ test("CharacterEditorApp は Improve with Agent 押下で authoring session を�
   const previousWithMate = (globalThis.window as typeof window | undefined)?.withmate;
   const startInputs: StartCharacterAuthoringSessionInput[] = [];
   const metadataUpdates: Array<{ name: string; description: string }> = [];
+  const iconPickerCalls: Array<{ initialPath: string | null; purpose: string | undefined }> = [];
+  let selectedIconPath: string | null = "C:\\icons\\muse.webp";
+  let definitionUpdateCount = 0;
 
   Object.defineProperty(globalThis, "window", { value: dom.window, configurable: true });
   Object.defineProperty(globalThis, "document", { value: dom.window.document, configurable: true });
@@ -147,6 +150,7 @@ test("CharacterEditorApp は Improve with Agent 押下で authoring session を�
     },
     async updateCharacterDefinition(input) {
       assert.equal(input.characterId, "char-1");
+      definitionUpdateCount += 1;
       currentCharacter = {
         ...currentCharacter,
         definitionMarkdown: input.definitionMarkdown,
@@ -169,6 +173,13 @@ test("CharacterEditorApp は Improve with Agent 押下で authoring session を�
       };
       return currentCharacter;
     },
+    async pickImageFile(initialPath, purpose) {
+      iconPickerCalls.push({
+        initialPath: initialPath ?? null,
+        purpose,
+      });
+      return selectedIconPath;
+    },
   } as Partial<WithMateWindowApi> as WithMateWindowApi;
 
   try {
@@ -179,6 +190,34 @@ test("CharacterEditorApp は Improve with Agent 押下で authoring session を�
     await act(async () => {
       await Promise.resolve();
     });
+    await act(async () => {
+      findButtonByText(rootElement, "Import Image")
+        .dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+    assert.deepEqual(iconPickerCalls, [{
+      initialPath: null,
+      purpose: "character-icon",
+    }]);
+
+    await act(async () => {
+      findButtonByText(rootElement, "Save")
+        .dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+    assert.equal(definitionUpdateCount, 0);
+    assert.equal(metadataUpdates.length, 0);
+    assert.match(
+      rootElement.textContent ?? "",
+      /Character icon は png \/ jpg \/ jpeg の画像ファイルを指定してね。/,
+    );
+    selectedIconPath = "C:\\icons\\muse.png";
+    await act(async () => {
+      findButtonByText(rootElement, "Import Image")
+        .dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
     const button = findButtonByText(rootElement, "Improve with Agent");
     assert.equal(button.disabled, false);
 
@@ -207,6 +246,7 @@ test("CharacterEditorApp は Improve with Agent 押下で authoring session を�
     assert.equal(startInputs[0]?.provider, "copilot");
     assert.equal(startInputs[0]?.model, undefined);
     assert.equal(startInputs[0]?.reasoningEffort, undefined);
+    assert.equal(Object.hasOwn(startInputs[0] ?? {}, "iconFilePath"), false);
 
     currentCharacter = {
       ...currentCharacter,

--- a/scripts/tests/character-editor-state.test.ts
+++ b/scripts/tests/character-editor-state.test.ts
@@ -8,6 +8,7 @@ import {
   buildCreateCharacterInputFromDraft,
   createCharacterEditorDraftFromDetail,
   createNewCharacterEditorDraft,
+  getCharacterIconDraftValidationMessage,
   isCharacterEditorDraftDirty,
   replaceCharacterDefinitionDraft,
   shouldBlockCharacterEditorBeforeUnload,
@@ -116,6 +117,68 @@ describe("Character editor state", () => {
     assert.equal(shouldBlockCharacterEditorBeforeUnload({ dirty: true, saving: true, confirmedClose: false }), false);
     assert.equal(shouldBlockCharacterEditorBeforeUnload({ dirty: false, saving: false, confirmedClose: false }), false);
     assert.equal(shouldBlockCharacterEditorBeforeUnload({ dirty: true, saving: false, confirmedClose: true }), false);
+  });
+
+  it("新規・置換 icon は PNG/JPEG の local path に制限し、既存 icon はそのまま許可する", () => {
+    assert.equal(getCharacterIconDraftValidationMessage("", null), null);
+    assert.equal(getCharacterIconDraftValidationMessage("C:\\icons\\muse.PNG", null), null);
+    assert.equal(getCharacterIconDraftValidationMessage("/icons/muse.jpg", null), null);
+    assert.equal(getCharacterIconDraftValidationMessage("icons/muse.jpeg", null), null);
+    assert.equal(
+      getCharacterIconDraftValidationMessage("file:///icons/muse.png", null),
+      "Character icon は local file path で指定してね。",
+    );
+    assert.equal(
+      getCharacterIconDraftValidationMessage("/icons/muse.webp", null),
+      "Character icon は png / jpg / jpeg の画像ファイルを指定してね。",
+    );
+    assert.equal(
+      getCharacterIconDraftValidationMessage("  /legacy/muse.webp  ", "/legacy/muse.webp"),
+      null,
+    );
+    assert.equal(
+      getCharacterIconDraftValidationMessage(
+        "c:/characters/muse/ICON.webp",
+        "C:\\Characters\\Muse\\icon.webp",
+      ),
+      null,
+    );
+    assert.equal(
+      getCharacterIconDraftValidationMessage(
+        "//server/share/icon.webp",
+        "//Server/Share/icon.webp",
+      ),
+      null,
+    );
+    assert.equal(
+      getCharacterIconDraftValidationMessage("/legacy/Muse.webp", "/legacy/muse.webp"),
+      "Character icon は png / jpg / jpeg の画像ファイルを指定してね。",
+    );
+    assert.equal(
+      getCharacterIconDraftValidationMessage(
+        "DATA:image/webp;base64,AAAA",
+        "data:image/webp;base64,AAAA",
+      ),
+      "Character icon は local file path で指定してね。",
+    );
+    assert.equal(
+      getCharacterIconDraftValidationMessage(
+        "data:image\\webp;base64,AAAA",
+        "data:image/webp;base64,AAAA",
+      ),
+      "Character icon は local file path で指定してね。",
+    );
+    assert.equal(
+      getCharacterIconDraftValidationMessage(
+        "/legacy/muse\\icon.webp",
+        "/legacy/muse/icon.webp",
+      ),
+      "Character icon は png / jpg / jpeg の画像ファイルを指定してね。",
+    );
+    assert.equal(
+      getCharacterIconDraftValidationMessage("/legacy/other.gif", "/legacy/muse.webp"),
+      "Character icon は png / jpg / jpeg の画像ファイルを指定してね。",
+    );
   });
 
   it("create payload は default fallback を潰す setDefault false を渡さない", () => {

--- a/scripts/tests/character-storage.test.ts
+++ b/scripts/tests/character-storage.test.ts
@@ -186,24 +186,138 @@ describe("CharacterStorage", () => {
     }
   });
 
-  it("createCharacter は画像ではない絶対 icon path と大きすぎる icon を拒否する", async () => {
+  it("updateCharacterMetadata は managed icon の相対 path alias で同じファイルを削除しない", async () => {
+    const { dbPath, userDataPath, cleanup } = await createTempPaths();
+    let storage: CharacterStorage | null = null;
+
+    try {
+      storage = new CharacterStorage(dbPath, userDataPath);
+      const mia = storage.createCharacter({ name: "Mia", definitionMarkdown: validDefinition("Mia") });
+      const sourceIconPath = path.join(path.dirname(userDataPath), "source-icon.png");
+      const sourceIconContent = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x03]);
+      await writeFile(sourceIconPath, sourceIconContent);
+
+      storage.updateCharacterMetadata({
+        characterId: mia.id,
+        iconFilePath: sourceIconPath,
+      });
+      const managedIconPath = path.join(userDataPath, "characters", mia.id, "icon.png");
+
+      const updated = storage.updateCharacterMetadata({
+        characterId: mia.id,
+        iconFilePath: process.platform === "win32"
+          ? `CHARACTERS/${mia.id.toUpperCase()}/./ICON.PNG`
+          : `characters/${mia.id}/./icon.png`,
+      });
+
+      await access(updated.iconFilePath);
+      assert.equal((await readFile(managedIconPath)).equals(sourceIconContent), true);
+    } finally {
+      storage?.close();
+      await cleanup();
+    }
+  });
+
+  it("updateCharacterMetadata は iconFilePath の未指定・解除・不正な runtime 型を区別する", async () => {
+    const { dbPath, userDataPath, cleanup } = await createTempPaths();
+    let storage: CharacterStorage | null = null;
+
+    try {
+      storage = new CharacterStorage(dbPath, userDataPath);
+      const mia = storage.createCharacter({ name: "Mia", definitionMarkdown: validDefinition("Mia") });
+      const sourceIconPath = path.join(path.dirname(userDataPath), "source-icon.png");
+      const sourceIconContent = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x04]);
+      await writeFile(sourceIconPath, sourceIconContent);
+      const before = storage.updateCharacterMetadata({
+        characterId: mia.id,
+        iconFilePath: sourceIconPath,
+      });
+      const unchanged = storage.updateCharacterMetadata({
+        characterId: mia.id,
+        name: "Mia Prime",
+        iconFilePath: undefined,
+      });
+      assert.equal(unchanged.iconFilePath, before.iconFilePath);
+      assert.equal((await readFile(before.iconFilePath)).equals(sourceIconContent), true);
+
+      assert.throws(
+        () => storage.updateCharacterMetadata({
+          characterId: mia.id,
+          name: "Mutated",
+          iconFilePath: null as unknown as string,
+        }),
+        /Character icon path は文字列/,
+      );
+
+      const after = storage.getCharacter(mia.id);
+      assert.equal(after?.name, "Mia Prime");
+      assert.equal(after?.iconFilePath, before.iconFilePath);
+      assert.equal((await readFile(before.iconFilePath)).equals(sourceIconContent), true);
+
+      const cleared = storage.updateCharacterMetadata({
+        characterId: mia.id,
+        iconFilePath: "",
+      });
+      assert.equal(cleared.iconFilePath, "");
+      await assert.rejects(access(before.iconFilePath));
+    } finally {
+      storage?.close();
+      await cleanup();
+    }
+  });
+
+  it("createCharacter は PNG / JPEG 以外、画像ではない path、大きすぎる icon を拒否する", async () => {
     const { dbPath, userDataPath, cleanup } = await createTempPaths();
     let storage: CharacterStorage | null = null;
 
     try {
       storage = new CharacterStorage(dbPath, userDataPath);
       const textPath = path.join(path.dirname(userDataPath), "not-image.txt");
+      const gifPath = path.join(path.dirname(userDataPath), "legacy-icon.gif");
       const largePngPath = path.join(path.dirname(userDataPath), "large-icon.png");
       await writeFile(textPath, "not an image", "utf8");
+      await writeFile(gifPath, Buffer.from("GIF89a", "ascii"));
       await writeFile(largePngPath, Buffer.alloc((10 * 1024 * 1024) + 1));
 
+      assert.throws(
+        () => storage.createCharacter({
+          name: "Invalid Runtime Icon",
+          iconFilePath: null as unknown as string,
+          definitionMarkdown: validDefinition("Invalid Runtime Icon"),
+        }),
+        /Character icon path は文字列/,
+      );
       assert.throws(
         () => storage.createCharacter({
           name: "Text Icon",
           iconFilePath: textPath,
           definitionMarkdown: validDefinition("Text Icon"),
         }),
-        /png \/ jpg \/ jpeg \/ gif \/ webp \/ bmp \/ svg/,
+        /png \/ jpg \/ jpeg/,
+      );
+      assert.throws(
+        () => storage.createCharacter({
+          name: "GIF Icon",
+          iconFilePath: gifPath,
+          definitionMarkdown: validDefinition("GIF Icon"),
+        }),
+        /png \/ jpg \/ jpeg/,
+      );
+      assert.throws(
+        () => storage.createCharacter({
+          name: "Relative WebP Icon",
+          iconFilePath: "assets/icon.webp",
+          definitionMarkdown: validDefinition("Relative WebP Icon"),
+        }),
+        /png \/ jpg \/ jpeg/,
+      );
+      assert.throws(
+        () => storage.createCharacter({
+          name: "File URL Icon",
+          iconFilePath: "file:///C:/icons/icon.png",
+          definitionMarkdown: validDefinition("File URL Icon"),
+        }),
+        /local file path/,
       );
       assert.throws(
         () => storage.createCharacter({
@@ -213,6 +327,101 @@ describe("CharacterStorage", () => {
         }),
         /10 MiB/,
       );
+      assert.equal(storage.listCharacters({ includeArchived: true }).length, 0);
+    } finally {
+      storage?.close();
+      await cleanup();
+    }
+  });
+
+  it("updateCharacterMetadata は既存の非対応 icon を未変更で保持できるが、新しい非対応 icon への差し替えは拒否する", async () => {
+    const { dbPath, userDataPath, cleanup } = await createTempPaths();
+    let storage: CharacterStorage | null = null;
+
+    try {
+      storage = new CharacterStorage(dbPath, userDataPath);
+      const mia = storage.createCharacter({ name: "Mia", definitionMarkdown: validDefinition("Mia") });
+      const legacyIconPath = path.join(userDataPath, "characters", mia.id, "icon.webp");
+      await writeFile(legacyIconPath, Buffer.from("legacy webp"));
+
+      const db = new DatabaseSync(dbPath);
+      try {
+        db.prepare("UPDATE characters SET icon_file_path = ? WHERE id = ?")
+          .run(`characters/${mia.id}/icon.webp`, mia.id);
+      } finally {
+        db.close();
+      }
+
+      const differentlyFormattedWindowsPath = legacyIconPath
+        .replaceAll("\\", "/")
+        .replace(/^([A-Z]):/, (_match, drive: string) => `${drive.toLowerCase()}:`)
+        .replace("/characters/", "/CHARACTERS/")
+        .replace("/icon.webp", "/ICON.WEBP");
+      const updated = storage.updateCharacterMetadata({
+        characterId: mia.id,
+        name: "Mia Prime",
+        iconFilePath: process.platform === "win32"
+          ? differentlyFormattedWindowsPath
+          : legacyIconPath,
+      });
+
+      assert.equal(updated.name, "Mia Prime");
+      assert.equal(updated.iconFilePath, legacyIconPath);
+      assert.equal((await readFile(legacyIconPath, "utf8")), "legacy webp");
+
+      const replacementPath = path.join(path.dirname(userDataPath), "replacement.gif");
+      await writeFile(replacementPath, Buffer.from("GIF89a", "ascii"));
+      assert.throws(
+        () => storage.updateCharacterMetadata({
+          characterId: mia.id,
+          iconFilePath: replacementPath,
+        }),
+        /png \/ jpg \/ jpeg/,
+      );
+    } finally {
+      storage?.close();
+      await cleanup();
+    }
+  });
+
+  it("既存 icon の同一参照判定は scheme と POSIX path を Windows path として正規化しない", async () => {
+    const { dbPath, userDataPath, cleanup } = await createTempPaths();
+    let storage: CharacterStorage | null = null;
+
+    try {
+      storage = new CharacterStorage(dbPath, userDataPath);
+      const mia = storage.createCharacter({ name: "Mia", definitionMarkdown: validDefinition("Mia") });
+      const db = new DatabaseSync(dbPath);
+      try {
+        db.prepare("UPDATE characters SET icon_file_path = ? WHERE id = ?")
+          .run("data:image/webp;base64,AAAA", mia.id);
+        assert.equal(
+          storage.updateCharacterMetadata({
+            characterId: mia.id,
+            iconFilePath: "data:image/webp;base64,AAAA",
+          }).iconFilePath,
+          "data:image/webp;base64,AAAA",
+        );
+        assert.throws(
+          () => storage.updateCharacterMetadata({
+            characterId: mia.id,
+            iconFilePath: "DATA:image/webp;base64,AAAA",
+          }),
+          /local file path/,
+        );
+
+        db.prepare("UPDATE characters SET icon_file_path = ? WHERE id = ?")
+          .run("/legacy/muse/icon.webp", mia.id);
+        assert.throws(
+          () => storage.updateCharacterMetadata({
+            characterId: mia.id,
+            iconFilePath: "/legacy/muse\\icon.webp",
+          }),
+          /png \/ jpg \/ jpeg/,
+        );
+      } finally {
+        db.close();
+      }
     } finally {
       storage?.close();
       await cleanup();

--- a/scripts/tests/main-ipc-registration.test.ts
+++ b/scripts/tests/main-ipc-registration.test.ts
@@ -35,6 +35,7 @@ import {
   WITHMATE_OPEN_CHARACTER_EDITOR_WINDOW_CHANNEL,
   WITHMATE_OPEN_SESSION_CHANNEL,
   WITHMATE_OPEN_SETTINGS_WINDOW_CHANNEL,
+  WITHMATE_PICK_IMAGE_FILE_CHANNEL,
   WITHMATE_RESET_APP_DATABASE_CHANNEL,
   WITHMATE_RESOLVE_LAUNCH_CHARACTER_CHANNEL,
   WITHMATE_RUN_AUXILIARY_SESSION_TURN_CHANNEL,
@@ -177,6 +178,39 @@ test("registerMainIpcHandlers は保持する public IPC だけを登録する",
   for (const channel of removedChannels) {
     assert.equal(handlers.has(channel), false, `${channel} should not be registered`);
   }
+});
+
+test("pick-image-file IPC は Character icon purpose を伝播し、不正な purpose を拒否する", async () => {
+  const { ipcMain, handlers } = createIpcMainStub();
+  const calls: Array<{ initialPath: string | null; purpose: string }> = [];
+  const { deps } = createDeps({
+    pickImageFile: async (_targetWindow: unknown, initialPath: string | null, purpose: string) => {
+      calls.push({ initialPath, purpose });
+      return "C:/icons/a.png";
+    },
+  });
+
+  registerMainIpcHandlers(ipcMain, deps);
+  const handler = handlers.get(WITHMATE_PICK_IMAGE_FILE_CHANNEL);
+  assert.ok(handler);
+
+  assert.equal(
+    await handler({}, "C:/icons/current.webp", "character-icon"),
+    "C:/icons/a.png",
+  );
+  assert.deepEqual(calls, [{
+    initialPath: "C:/icons/current.webp",
+    purpose: "character-icon",
+  }]);
+  assert.equal(await handler({}, null), "C:/icons/a.png");
+  assert.deepEqual(calls[1], {
+    initialPath: null,
+    purpose: "general",
+  });
+  await assert.rejects(
+    async () => handler({}, null, "unsupported-purpose"),
+    /画像選択の用途が不正です/,
+  );
 });
 
 test("right pane 表示設定 IPC は boolean だけを専用更新処理へ渡す", async () => {

--- a/scripts/tests/preload-api.test.ts
+++ b/scripts/tests/preload-api.test.ts
@@ -200,6 +200,14 @@ test("createWithMateWindowApi は invoke 系 API を domain ごとに束ねる",
     channel: "withmate:pick-session-image-file",
     args: ["session-1"],
   });
+  assert.deepEqual(await api.pickImageFile("C:/icons/current.webp", "character-icon"), {
+    channel: "withmate:pick-image-file",
+    args: ["C:/icons/current.webp", "character-icon"],
+  });
+  assert.deepEqual(await api.pickImageFile(), {
+    channel: "withmate:pick-image-file",
+    args: [null, "general"],
+  });
   const pastedBuffer = new ArrayBuffer(3);
   assert.deepEqual(await api.savePastedSessionFile({
     sessionId: "session-1",

--- a/scripts/tests/window-dialog-service.test.ts
+++ b/scripts/tests/window-dialog-service.test.ts
@@ -12,7 +12,8 @@ test("WindowDialogService は directory / file / image picker の選択結果を
       if ((options as { title?: string }).title === "作業ディレクトリを選択") {
         return { canceled: false, filePaths: ["C:/workspace"] };
       }
-      if ((options as { title?: string }).title === "画像を選択") {
+      const title = (options as { title?: string }).title;
+      if (title?.includes("icon") || title === "画像を選択") {
         return { canceled: false, filePaths: ["C:/images/a.png"] };
       }
       if ((options as { properties?: string[] }).properties?.includes("multiSelections")) {
@@ -41,18 +42,27 @@ test("WindowDialogService は directory / file / image picker の選択結果を
   const file = await service.pickFile(undefined, "C:/seed.txt");
   const files = await service.pickFiles(undefined, "C:/seed.txt");
   const image = await service.pickImageFile();
+  const characterIcon = await service.pickImageFile(undefined, undefined, "character-icon");
 
   assert.equal(directory, "C:/workspace");
   assert.equal(file, "C:/file.txt");
   assert.deepEqual(files, ["C:/file-a.txt", "C:/file-b.txt"]);
   assert.equal(image, "C:/images/a.png");
+  assert.equal(characterIcon, "C:/images/a.png");
   assert.deepEqual(calls.map((entry) => (entry.options as { title?: string }).title), [
     "作業ディレクトリを選択",
     "ファイルを選択",
     "ファイルを選択",
     "画像を選択",
+    "Character icon を選択",
   ]);
   assert.deepEqual((calls[2]?.options as { properties?: string[] }).properties, ["openFile", "multiSelections"]);
+  assert.deepEqual((calls[3]?.options as { filters?: unknown }).filters, [
+    { name: "Images", extensions: ["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg"] },
+  ]);
+  assert.deepEqual((calls[4]?.options as { filters?: unknown }).filters, [
+    { name: "PNG / JPEG", extensions: ["png", "jpg", "jpeg"] },
+  ]);
 });
 
 test("WindowDialogService は model catalog import/export を file I/O と接続する", async () => {

--- a/src-electron/character-authoring-service.ts
+++ b/src-electron/character-authoring-service.ts
@@ -44,7 +44,12 @@ export class CharacterAuthoringService {
       throw new Error("Authoring session は保存済み Character でのみ開始できます。先に Character を保存してください。");
     }
 
-    const seed = await this.resolveSeed(input);
+    const character = await this.deps.getCharacter(characterId);
+    if (!character) {
+      throw new Error("Authoring session は保存済み Character でのみ開始できます。先に Character を保存してください。");
+    }
+
+    const seed = await this.resolveSeed(input, character);
     const runId = this.createRunId(seed.name);
     const workspacePath = this.deps.getCharacterDirectory(characterId);
     if (!workspacePath) {
@@ -62,7 +67,7 @@ export class CharacterAuthoringService {
       sessionKind: "character-authoring",
       characterId,
       character: seed.name,
-      characterIconPath: input.iconFilePath ?? "",
+      characterIconPath: character.iconFilePath,
       characterThemeColors: {
         main: input.theme?.main ?? DEFAULT_CHARACTER_THEME.main,
         sub: input.theme?.sub ?? DEFAULT_CHARACTER_THEME.sub,
@@ -83,16 +88,18 @@ export class CharacterAuthoringService {
     };
   }
 
-  private async resolveSeed(input: StartCharacterAuthoringSessionInput): Promise<AuthoringSeed> {
-    const character = input.characterId ? await this.deps.getCharacter(input.characterId) : null;
-    const name = this.normalizeName(input.name || character?.name || "New Character");
-    const description = (input.description ?? character?.description ?? "").trim();
+  private async resolveSeed(
+    input: StartCharacterAuthoringSessionInput,
+    character: CharacterDetail,
+  ): Promise<AuthoringSeed> {
+    const name = this.normalizeName(input.name || character.name || "New Character");
+    const description = (input.description ?? character.description).trim();
     return {
       name,
       description,
       definitionMarkdown: input.definitionMarkdown?.trim()
         ? input.definitionMarkdown
-        : character?.definitionMarkdown?.trim()
+        : character.definitionMarkdown.trim()
           ? character.definitionMarkdown
           : await this.readTemplate("character.md", {
               character_name: name,
@@ -100,7 +107,7 @@ export class CharacterAuthoringService {
             }),
       notesMarkdown: input.notesMarkdown?.trim()
         ? input.notesMarkdown
-        : character?.notesMarkdown?.trim()
+        : character.notesMarkdown.trim()
           ? character.notesMarkdown
           : await this.readTemplate("character-notes.md"),
     };

--- a/src-electron/character-storage.ts
+++ b/src-electron/character-storage.ts
@@ -22,6 +22,11 @@ import {
   type UpdateCharacterMetadataInput,
 } from "../src/character/character-catalog.js";
 import {
+  areCharacterIconPathReferencesEquivalent,
+  hasCharacterIconPathScheme,
+  validateCharacterIconRegistrationPath,
+} from "../src/character/character-icon.js";
+import {
   APP_DATABASE_V4_FILENAME,
   assertV4SchemaInitializationAllowed,
 } from "./database-schema-v4.js";
@@ -32,7 +37,6 @@ const CHARACTER_DEFINITION_FILE = "character.md";
 const CHARACTER_NOTES_FILE = "character-notes.md";
 const CHARACTER_ICON_FILE_BASE = "icon";
 const CHARACTER_ICON_MAX_BYTE_SIZE = 10 * 1024 * 1024;
-const CHARACTER_ICON_ALLOWED_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"]);
 const CHARACTER_ID_MAX_LENGTH = 80;
 
 const CREATE_CHARACTER_TABLE_SQL = `
@@ -106,22 +110,14 @@ function normalizeDescription(value: unknown, fallback = ""): string {
   return value.trim().replace(/\s+/g, " ");
 }
 
-function normalizeOptionalPath(value: unknown, fallback = ""): string {
-  if (value === undefined || value === null) {
+function normalizeCharacterIconPathInput(value: unknown, fallback = ""): string {
+  if (value === undefined) {
     return fallback;
   }
   if (typeof value !== "string") {
-    return fallback;
+    throw new Error("Character icon path は文字列で指定してね。");
   }
   return value.trim();
-}
-
-function hasPathScheme(value: string): boolean {
-  if (/^[a-zA-Z]:[\\/]/.test(value)) {
-    return false;
-  }
-
-  return /^[a-z][a-z0-9+.-]*:/i.test(value);
 }
 
 function normalizeDbRelativePath(value: string): string {
@@ -130,17 +126,17 @@ function normalizeDbRelativePath(value: string): string {
 
 function materializeCharacterIconFilePath(userDataPath: string, filePath: string): string {
   const trimmed = filePath.trim();
-  if (!trimmed || path.isAbsolute(trimmed) || hasPathScheme(trimmed)) {
+  if (!trimmed || path.isAbsolute(trimmed) || hasCharacterIconPathScheme(trimmed)) {
     return trimmed;
   }
 
-  return path.join(userDataPath, normalizeDbRelativePath(trimmed));
+  return path.join(userDataPath, trimmed);
 }
 
 function safeIconExtension(sourcePath: string): string {
   const extension = path.extname(sourcePath).toLowerCase();
-  if (!CHARACTER_ICON_ALLOWED_EXTENSIONS.has(extension)) {
-    throw new Error("Character icon は png / jpg / jpeg / gif / webp / bmp / svg の画像ファイルを指定してね。");
+  if (!path.isAbsolute(sourcePath)) {
+    return extension;
   }
 
   const stats = statSync(sourcePath);
@@ -274,23 +270,24 @@ export class CharacterStorage {
   }
 
   private getManagedIconAbsolutePath(characterId: string, iconFilePath: string): string | null {
-    const trimmed = normalizeDbRelativePath(iconFilePath.trim());
-    if (!trimmed || path.isAbsolute(trimmed) || hasPathScheme(trimmed)) {
+    const rawPath = iconFilePath.trim();
+    const trimmed = process.platform === "win32"
+      ? normalizeDbRelativePath(rawPath)
+      : rawPath;
+    if (!trimmed || path.isAbsolute(trimmed) || hasCharacterIconPathScheme(trimmed)) {
       return null;
     }
 
-    const prefix = `${CHARACTER_ROOT_DIRECTORY}/${characterId}/`;
-    if (!trimmed.startsWith(prefix)) {
-      return null;
-    }
-
-    const basename = path.basename(trimmed);
-    if (!/^icon\.[a-z0-9]+$/.test(basename)) {
+    const resolvedIconPath = path.resolve(this.userDataPath, trimmed);
+    const basename = path.basename(resolvedIconPath);
+    const comparableBasename = process.platform === "win32"
+      ? basename.toLowerCase()
+      : basename;
+    if (!/^icon\.[a-z0-9]+$/.test(comparableBasename)) {
       return null;
     }
 
     const characterDirectoryPath = path.resolve(this.characterDirectory(characterId));
-    const resolvedIconPath = path.resolve(this.userDataPath, trimmed);
     const relativePath = path.relative(characterDirectoryPath, resolvedIconPath);
     if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
       return null;
@@ -300,12 +297,27 @@ export class CharacterStorage {
   }
 
   private cleanupReplacedManagedIcon(characterId: string, previousIconFilePath: string, nextIconFilePath: string): void {
-    if (normalizeDbRelativePath(previousIconFilePath) === normalizeDbRelativePath(nextIconFilePath)) {
+    if (areCharacterIconPathReferencesEquivalent(
+      previousIconFilePath,
+      nextIconFilePath,
+      { fileSystemStyle: process.platform === "win32" ? "windows" : "posix" },
+    )) {
       return;
     }
 
     const previousIconAbsolutePath = this.getManagedIconAbsolutePath(characterId, previousIconFilePath);
     if (!previousIconAbsolutePath) {
+      return;
+    }
+    const nextIconAbsolutePath = this.getManagedIconAbsolutePath(characterId, nextIconFilePath);
+    if (
+      nextIconAbsolutePath
+      && areCharacterIconPathReferencesEquivalent(
+        previousIconAbsolutePath,
+        nextIconAbsolutePath,
+        { fileSystemStyle: process.platform === "win32" ? "windows" : "posix" },
+      )
+    ) {
       return;
     }
 
@@ -320,13 +332,60 @@ export class CharacterStorage {
     }
   }
 
-  private copyIconFromSourcePath(characterId: string, sourceIconFilePath: string): string {
-    if (!path.isAbsolute(sourceIconFilePath) || hasPathScheme(sourceIconFilePath)) {
-      return sourceIconFilePath;
+  private isCurrentIconReference(
+    currentIconFilePath: string,
+    sourceIconFilePath: string,
+    managedRelativePath: string | null,
+  ): boolean {
+    if (!currentIconFilePath) {
+      return false;
+    }
+
+    const comparisonOptions = {
+      fileSystemStyle: process.platform === "win32" ? "windows" : "posix",
+    } as const;
+    return areCharacterIconPathReferencesEquivalent(
+      sourceIconFilePath,
+      currentIconFilePath,
+      comparisonOptions,
+    )
+      || (
+        managedRelativePath !== null
+        && areCharacterIconPathReferencesEquivalent(
+          managedRelativePath,
+          currentIconFilePath,
+          comparisonOptions,
+        )
+      )
+      || areCharacterIconPathReferencesEquivalent(
+        sourceIconFilePath,
+        this.materializeIconFilePath(currentIconFilePath),
+        comparisonOptions,
+      );
+  }
+
+  private copyIconFromSourcePath(
+    characterId: string,
+    sourceIconFilePath: string,
+    currentIconFilePath = "",
+  ): string {
+    if (!sourceIconFilePath) {
+      return "";
+    }
+
+    const managedRelativePath = this.maybeGetManagedIconRelativePath(characterId, sourceIconFilePath);
+    if (this.isCurrentIconReference(currentIconFilePath, sourceIconFilePath, managedRelativePath)) {
+      return currentIconFilePath;
+    }
+    const registrationPathError = validateCharacterIconRegistrationPath(sourceIconFilePath);
+    if (registrationPathError) {
+      throw new Error(registrationPathError);
     }
 
     const extension = safeIconExtension(sourceIconFilePath);
-    const managedRelativePath = this.maybeGetManagedIconRelativePath(characterId, sourceIconFilePath);
+    if (!path.isAbsolute(sourceIconFilePath)) {
+      return sourceIconFilePath;
+    }
     if (managedRelativePath) {
       return managedRelativePath;
     }
@@ -450,7 +509,7 @@ export class CharacterStorage {
     const description = normalizeDescription(input.description);
     const theme = normalizeTheme(input.theme);
     const characterId = this.createUniqueCharacterId(name);
-    const sourceIconFilePath = normalizeOptionalPath(input.iconFilePath);
+    const sourceIconFilePath = normalizeCharacterIconPathInput(input.iconFilePath);
     const createdAt = nowIso();
     const definitionMarkdown = input.definitionMarkdown ?? buildDefaultDefinitionMarkdown(name, description);
     const notesMarkdown = input.notesMarkdown ?? buildDefaultNotesMarkdown(name);
@@ -509,7 +568,11 @@ export class CharacterStorage {
       : normalizeDescription(input.description);
     const iconFilePath = input.iconFilePath === undefined
       ? currentRow.icon_file_path
-      : this.copyIconFromSourcePath(input.characterId, normalizeOptionalPath(input.iconFilePath));
+      : this.copyIconFromSourcePath(
+          input.characterId,
+          normalizeCharacterIconPathInput(input.iconFilePath),
+          currentRow.icon_file_path,
+        );
     const theme = normalizeTheme(input.theme, current.theme);
     const updatedAt = nowIso();
 

--- a/src-electron/main-ipc-deps.ts
+++ b/src-electron/main-ipc-deps.ts
@@ -61,6 +61,7 @@ import type { AppSettings } from "../src/provider-settings-state.js";
 import type { DiscoveredCustomAgent, DiscoveredSkill } from "../src/runtime-state.js";
 import type { CreateSessionRequest, DiffPreviewPayload, MessageArtifact, Session } from "../src/session-state.js";
 import type {
+  ImageFilePickerPurpose,
   OpenPathOptions,
   DeleteSessionsLastActiveBeforeRequest,
   DeleteSessionsResult,
@@ -101,7 +102,11 @@ export type MainIpcWindowDepsArgs = {
   pickSessionFiles(targetWindow: MaybeWindow, sessionId: string): Promise<string[]>;
   pickSessionFolder(targetWindow: MaybeWindow, sessionId: string): Promise<string | null>;
   pickSessionImageFile(targetWindow: MaybeWindow, sessionId: string): Promise<string | null>;
-  pickImageFile(targetWindow: MaybeWindow, initialPath: string | null): Promise<string | null>;
+  pickImageFile(
+    targetWindow: MaybeWindow,
+    initialPath: string | null,
+    purpose: ImageFilePickerPurpose,
+  ): Promise<string | null>;
   copyFilesToSessionFiles(sessionId: string, sourcePaths: string[]): Promise<string[]>;
   savePastedSessionFile(request: SavePastedSessionFileRequest): Promise<string>;
   openSessionFilesDirectory(sessionId: string): Promise<void>;

--- a/src-electron/main-ipc-registration.ts
+++ b/src-electron/main-ipc-registration.ts
@@ -190,12 +190,14 @@ import {
   WITHMATE_UPDATE_COMPANION_SESSION_CHANNEL,
   WITHMATE_UPDATE_SESSION_CHANNEL,
 } from "../src/withmate-ipc-channels.js";
-import type {
-  OpenPathOptions,
-  DeleteSessionsLastActiveBeforeRequest,
-  DeleteSessionsResult,
-  ResetAppDatabaseRequest,
-  SavePastedSessionFileRequest,
+import {
+  parseImageFilePickerPurpose,
+  type ImageFilePickerPurpose,
+  type OpenPathOptions,
+  type DeleteSessionsLastActiveBeforeRequest,
+  type DeleteSessionsResult,
+  type ResetAppDatabaseRequest,
+  type SavePastedSessionFileRequest,
 } from "../src/withmate-window-types.js";
 
 type MaybeWindow = BrowserWindow | null | undefined;
@@ -352,7 +354,11 @@ export type MainIpcRegistrationDeps = {
   pickSessionFiles(targetWindow: MaybeWindow, sessionId: string): Promise<string[]>;
   pickSessionFolder(targetWindow: MaybeWindow, sessionId: string): Promise<string | null>;
   pickSessionImageFile(targetWindow: MaybeWindow, sessionId: string): Promise<string | null>;
-  pickImageFile(targetWindow: MaybeWindow, initialPath: string | null): Promise<string | null>;
+  pickImageFile(
+    targetWindow: MaybeWindow,
+    initialPath: string | null,
+    purpose: ImageFilePickerPurpose,
+  ): Promise<string | null>;
   copyFilesToSessionFiles(sessionId: string, sourcePaths: string[]): Promise<string[]>;
   savePastedSessionFile(request: SavePastedSessionFileRequest): Promise<string>;
   openSessionFilesDirectory(sessionId: string): Promise<void>;
@@ -719,8 +725,16 @@ function registerWindowHandlers(ipcMain: IpcHandleRegistrar, deps: MainIpcWindow
   ipcMain.handle(WITHMATE_PICK_SESSION_IMAGE_FILE_CHANNEL, async (event, sessionId: string) =>
     deps.pickSessionImageFile(resolveTargetWindow(event, deps), sessionId),
   );
-  ipcMain.handle(WITHMATE_PICK_IMAGE_FILE_CHANNEL, async (event, initialPath: string | null) =>
-    deps.pickImageFile(resolveTargetWindow(event, deps), initialPath),
+  ipcMain.handle(WITHMATE_PICK_IMAGE_FILE_CHANNEL, async (
+    event,
+    initialPath: string | null,
+    rawPurpose: unknown,
+  ) =>
+    deps.pickImageFile(
+      resolveTargetWindow(event, deps),
+      initialPath,
+      parseImageFilePickerPurpose(rawPurpose),
+    ),
   );
   ipcMain.handle(
     WITHMATE_COPY_FILES_TO_SESSION_FILES_CHANNEL,

--- a/src-electron/main.ts
+++ b/src-electron/main.ts
@@ -1276,8 +1276,8 @@ function requireMainInfrastructureRegistry(): MainInfrastructureRegistry<
                 pickSessionFiles,
                 pickSessionFolder,
                 pickSessionImageFile,
-                pickImageFile: (targetWindow, initialPath) =>
-                  requireWindowDialogService().pickImageFile(targetWindow, initialPath),
+                pickImageFile: (targetWindow, initialPath, purpose) =>
+                  requireWindowDialogService().pickImageFile(targetWindow, initialPath, purpose),
                 copyFilesToSessionFiles,
                 savePastedSessionFile,
                 openSessionFilesDirectory,

--- a/src-electron/preload-api.ts
+++ b/src-electron/preload-api.ts
@@ -612,8 +612,12 @@ function createPickerApi(ipcRenderer: IpcRendererLike): WithMateWindowPickerApi 
     pickSessionImageFile(sessionId) {
       return ipcRenderer.invoke(WITHMATE_PICK_SESSION_IMAGE_FILE_CHANNEL, sessionId);
     },
-    pickImageFile(initialPath) {
-      return ipcRenderer.invoke(WITHMATE_PICK_IMAGE_FILE_CHANNEL, initialPath ?? null);
+    pickImageFile(initialPath, purpose) {
+      return ipcRenderer.invoke(
+        WITHMATE_PICK_IMAGE_FILE_CHANNEL,
+        initialPath ?? null,
+        purpose ?? "general",
+      );
     },
     copyFilesToSessionFiles(sessionId, sourcePaths) {
       return ipcRenderer.invoke(WITHMATE_COPY_FILES_TO_SESSION_FILES_CHANNEL, sessionId, sourcePaths);

--- a/src-electron/window-dialog-service.ts
+++ b/src-electron/window-dialog-service.ts
@@ -1,10 +1,14 @@
 import type { BrowserWindow, OpenDialogOptions, OpenDialogReturnValue, SaveDialogOptions, SaveDialogReturnValue } from "electron";
 
 import type { ModelCatalogDocument, ModelCatalogSnapshot } from "../src/model-catalog.js";
+import type { ImageFilePickerPurpose } from "../src/withmate-window-types.js";
 
 const MODEL_CATALOG_JSON_FILTER = [{ name: "JSON", extensions: ["json"] }];
 const IMAGE_FILE_FILTER = [
   { name: "Images", extensions: ["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg"] },
+];
+const CHARACTER_ICON_FILE_FILTER = [
+  { name: "PNG / JPEG", extensions: ["png", "jpg", "jpeg"] },
 ];
 
 export type WindowDialogServiceDeps = {
@@ -65,11 +69,16 @@ export class WindowDialogService {
     return [...result.filePaths];
   }
 
-  async pickImageFile(targetWindow?: BrowserWindow | null, initialPath?: string | null): Promise<string | null> {
+  async pickImageFile(
+    targetWindow?: BrowserWindow | null,
+    initialPath?: string | null,
+    purpose: ImageFilePickerPurpose = "general",
+  ): Promise<string | null> {
+    const characterIcon = purpose === "character-icon";
     const result = await this.deps.showOpenDialog(targetWindow ?? undefined, {
       properties: ["openFile"],
-      title: "画像を選択",
-      filters: [...IMAGE_FILE_FILTER],
+      title: characterIcon ? "Character icon を選択" : "画像を選択",
+      filters: [...(characterIcon ? CHARACTER_ICON_FILE_FILTER : IMAGE_FILE_FILTER)],
       ...buildDefaultPathOption(initialPath),
     });
     if (result.canceled || result.filePaths.length === 0) {

--- a/src/CharacterEditorApp.tsx
+++ b/src/CharacterEditorApp.tsx
@@ -9,6 +9,7 @@ import {
   createCharacterEditorDraftFromDetail,
   createNewCharacterEditorDraft,
   formatCharacterEditorError,
+  getCharacterIconDraftValidationMessage,
   isCharacterEditorDraftDirty,
   replaceCharacterDefinitionDraft,
   resolveCharacterDefinitionMetadata,
@@ -95,6 +96,10 @@ export default function CharacterEditorApp() {
   const confirmedCloseRef = useRef(false);
 
   const validation = useMemo(() => buildCharacterEditorValidationSummary(draft), [draft]);
+  const iconValidationMessage = useMemo(
+    () => getCharacterIconDraftValidationMessage(draft.iconFilePath, persistedDetail?.iconFilePath),
+    [draft.iconFilePath, persistedDetail?.iconFilePath],
+  );
   const dirty = isCharacterEditorDraftDirty(draft, persistedDetail);
   const archived = draft.state === "archived";
   const enabledAuthoringProviders = useMemo(
@@ -262,6 +267,11 @@ export default function CharacterEditorApp() {
       setFeedback("Archived Character は保存できません。");
       return;
     }
+    if (iconValidationMessage) {
+      setFeedback(iconValidationMessage);
+      setSelectedTab("profile");
+      return;
+    }
     if (validation.blockingIssues.length > 0) {
       setFeedback("validation issue を解消してから保存してください。");
       setSelectedTab(validation.definitionIssues.length > 0 ? "definition" : "notes");
@@ -403,7 +413,6 @@ export default function CharacterEditorApp() {
         description: draft.description,
         definitionMarkdown: draft.definitionMarkdown,
         notesMarkdown: draft.notesMarkdown,
-        iconFilePath: draft.iconFilePath,
         theme: draft.theme,
         userInstruction: "",
         provider: selectedAuthoringProvider.id,
@@ -460,7 +469,7 @@ export default function CharacterEditorApp() {
       return;
     }
     const api = getWithMateApi();
-    const selected = await api?.pickImageFile(draft.iconFilePath || null);
+    const selected = await api?.pickImageFile(draft.iconFilePath || null, "character-icon");
     if (selected) {
       updateDraft({ iconFilePath: selected });
       setSelectedTab("profile");

--- a/src/character-editor/character-editor-state.ts
+++ b/src/character-editor/character-editor-state.ts
@@ -11,6 +11,10 @@ import {
   validateCharacterNotesMarkdown,
   type CharacterDefinitionValidationIssue,
 } from "../character/character-definition.js";
+import {
+  areCharacterIconPathReferencesEquivalent,
+  validateCharacterIconRegistrationPath,
+} from "../character/character-icon.js";
 
 export type CharacterEditorTab = "profile" | "definition" | "notes" | "preview";
 
@@ -191,6 +195,21 @@ export function shouldBlockCharacterEditorBeforeUnload(args: {
   confirmedClose: boolean;
 }): boolean {
   return args.dirty && !args.saving && !args.confirmedClose;
+}
+
+export function getCharacterIconDraftValidationMessage(
+  draftIconFilePath: string,
+  persistedIconFilePath: string | null | undefined,
+): string | null {
+  if (
+    persistedIconFilePath !== null
+    && persistedIconFilePath !== undefined
+    && areCharacterIconPathReferencesEquivalent(draftIconFilePath, persistedIconFilePath)
+  ) {
+    return null;
+  }
+
+  return validateCharacterIconRegistrationPath(draftIconFilePath);
 }
 
 export function normalizeThemeColorDraft(value: string, fallback: string): string {

--- a/src/character/character-authoring.ts
+++ b/src/character/character-authoring.ts
@@ -13,7 +13,6 @@ export type StartCharacterAuthoringSessionInput = {
   description?: string;
   definitionMarkdown?: string;
   notesMarkdown?: string;
-  iconFilePath?: string;
   theme?: Partial<CharacterTheme>;
   userInstruction?: string;
   provider?: string;

--- a/src/character/character-icon.ts
+++ b/src/character/character-icon.ts
@@ -1,0 +1,97 @@
+const CHARACTER_ICON_SUPPORTED_EXTENSION_PATTERN = /\.(?:png|jpe?g)$/i;
+
+export const CHARACTER_ICON_FORMAT_ERROR =
+  "Character icon は png / jpg / jpeg の画像ファイルを指定してね。";
+export const CHARACTER_ICON_LOCAL_PATH_ERROR =
+  "Character icon は local file path で指定してね。";
+
+export function hasCharacterIconPathScheme(value: string): boolean {
+  if (/^[a-zA-Z]:[\\/]/.test(value)) {
+    return false;
+  }
+
+  return /^[a-z][a-z0-9+.-]*:/i.test(value);
+}
+
+function isWindowsDrivePathReference(value: string): boolean {
+  return /^[a-zA-Z]:[\\/]/.test(value);
+}
+
+function isBackslashUncPathReference(value: string): boolean {
+  return value.startsWith("\\\\");
+}
+
+function isForwardSlashUncPathReference(value: string): boolean {
+  return value.startsWith("//");
+}
+
+function isPosixAbsolutePathReference(value: string): boolean {
+  return value.startsWith("/") && !isForwardSlashUncPathReference(value);
+}
+
+function shouldUseWindowsPathComparison(
+  left: string,
+  right: string,
+  fileSystemStyle: "windows" | "posix" | undefined,
+): boolean {
+  const leftIsWindowsDrivePath = isWindowsDrivePathReference(left);
+  const rightIsWindowsDrivePath = isWindowsDrivePathReference(right);
+  if (leftIsWindowsDrivePath || rightIsWindowsDrivePath) {
+    return leftIsWindowsDrivePath && rightIsWindowsDrivePath;
+  }
+
+  const leftIsBackslashUncPath = isBackslashUncPathReference(left);
+  const rightIsBackslashUncPath = isBackslashUncPathReference(right);
+  const leftIsUncPath = leftIsBackslashUncPath || isForwardSlashUncPathReference(left);
+  const rightIsUncPath = rightIsBackslashUncPath || isForwardSlashUncPathReference(right);
+  if (leftIsUncPath || rightIsUncPath) {
+    return leftIsUncPath && rightIsUncPath;
+  }
+
+  if (isPosixAbsolutePathReference(left) || isPosixAbsolutePathReference(right)) {
+    return false;
+  }
+
+  return fileSystemStyle === "windows";
+}
+
+export function areCharacterIconPathReferencesEquivalent(
+  left: string,
+  right: string,
+  options: { fileSystemStyle?: "windows" | "posix" } = {},
+): boolean {
+  const normalizedLeft = left.trim();
+  const normalizedRight = right.trim();
+  if (normalizedLeft === normalizedRight) {
+    return true;
+  }
+  if (
+    hasCharacterIconPathScheme(normalizedLeft)
+    || hasCharacterIconPathScheme(normalizedRight)
+    || !shouldUseWindowsPathComparison(
+      normalizedLeft,
+      normalizedRight,
+      options.fileSystemStyle,
+    )
+  ) {
+    return false;
+  }
+
+  return normalizedLeft.replaceAll("\\", "/").toLowerCase()
+    === normalizedRight.replaceAll("\\", "/").toLowerCase();
+}
+
+export function validateCharacterIconRegistrationPath(value: string): string | null {
+  const normalizedValue = value.trim();
+  if (!normalizedValue) {
+    return null;
+  }
+  if (hasCharacterIconPathScheme(normalizedValue)) {
+    return CHARACTER_ICON_LOCAL_PATH_ERROR;
+  }
+  if (!CHARACTER_ICON_SUPPORTED_EXTENSION_PATTERN.test(normalizedValue)) {
+    return CHARACTER_ICON_FORMAT_ERROR;
+  }
+
+  return null;
+}

--- a/src/withmate-window-api.ts
+++ b/src/withmate-window-api.ts
@@ -46,6 +46,7 @@ import type {
   CreateAuxiliarySessionInput,
 } from "./auxiliary-session-state.js";
 import type {
+  ImageFilePickerPurpose,
   OpenPathOptions,
   DeleteSessionsLastActiveBeforeRequest,
   DeleteSessionsResult,
@@ -213,7 +214,10 @@ export type WithMateWindowPickerApi = {
   pickSessionFiles(sessionId: string): Promise<string[]>;
   pickSessionFolder(sessionId: string): Promise<string | null>;
   pickSessionImageFile(sessionId: string): Promise<string | null>;
-  pickImageFile(initialPath?: string | null): Promise<string | null>;
+  pickImageFile(
+    initialPath?: string | null,
+    purpose?: ImageFilePickerPurpose,
+  ): Promise<string | null>;
   copyFilesToSessionFiles(sessionId: string, sourcePaths: string[]): Promise<string[]>;
   savePastedSessionFile(request: SavePastedSessionFileRequest): Promise<string>;
   openSessionFilesDirectory(sessionId: string): Promise<void>;

--- a/src/withmate-window-types.ts
+++ b/src/withmate-window-types.ts
@@ -12,6 +12,20 @@ export type OpenPathOptions = {
   baseDirectory?: string | null;
 };
 
+export const IMAGE_FILE_PICKER_PURPOSES = ["general", "character-icon"] as const;
+
+export type ImageFilePickerPurpose = (typeof IMAGE_FILE_PICKER_PURPOSES)[number];
+
+export function parseImageFilePickerPurpose(value: unknown): ImageFilePickerPurpose {
+  if (value === undefined || value === null) {
+    return "general";
+  }
+  if (value === "general" || value === "character-icon") {
+    return value;
+  }
+  throw new Error("画像選択の用途が不正です。");
+}
+
 export const ALL_RESET_APP_DATABASE_TARGETS = [
   "sessions",
   "auditLogs",


### PR DESCRIPTION
## 概要
- Character icon の新規登録・差し替えを PNG / JPG / JPEG に制限
- 既存の非対応 icon は同一参照を維持する更新で保持
- Character authoring Session は保存済み Character の icon を使用
- managed icon cleanup と raw IPC input の境界条件を修正

## 検証
- npx tsx --test scripts/tests/character-editor-state.test.ts scripts/tests/character-storage.test.ts
- npm run typecheck
- npm test
- npm run build
- git diff --check