### PR TITLE
fix(file-preview): ヘッダーのパス表示を削除

### DIFF
--- a/src/file-explorer/SessionFilePreview.tsx
+++ b/src/file-explorer/SessionFilePreview.tsx
@@ -673,7 +673,6 @@ export function SessionFilePreview({
         </button>
         <div className="session-file-preview-title">
           <strong>{descriptor?.name ?? request.relativePath.split("/").at(-1)}</strong>
-          <span title={request.relativePath}>{request.relativePath}</span>
         </div>
         <div className="session-file-preview-actions">
           {descriptor && (previewKind === "text" || previewKind === "markdown") ? (


### PR DESCRIPTION
## 変更内容

- 中央ファイルプレビューのヘッダーから相対パス表示を削除
- ファイル名と `Show in Explorer` は維持
- Git Diff プレビューのサブタイトルは変更なし

## 背景

相対パスは基準となるディレクトリが分かりづらい一方、絶対パスへ変更するとヘッダー幅に収まりにくい。ファイルの場所は左側の File Explorer と `Show in Explorer` から確認できるため、ヘッダーではファイル名だけを表示する。

## ユーザーへの影響

ファイルプレビューのヘッダーが1段になり、表示内容が簡潔になる。ファイルを開く操作や場所を確認する導線は変わらない。

## 検証

- `npx tsx --test scripts/tests/session-file-preview-image-lifecycle.test.tsx`（8件成功）
- `npm run typecheck`
- `git diff --check`