### PR TITLE
fix(session): ローカルパスリンクを正規化する

### DIFF
--- a/docs/design/message-rich-text.md
+++ b/docs/design/message-rich-text.md
@@ -12,7 +12,7 @@ Session message と Markdown file preview に同じ rich text renderer を使い
 - `http://` / `https://` は外部ブラウザで開く
 - ローカル絶対パスは OS に関連付けられた既定動作で開く
 - Session 文脈では workspace 相対 path link も workspace root 基準で解決して開く
-- ローカル path link に `#L10` などの fragment が付いている場合は、少なくとも path 本体を開けるように fragment を無視して扱う
+- ローカル path link に `#L10` などの fragment が付いている場合は、少なくとも path 本体を開けるように fragment を無視して扱う。`:10` または `:10:4` 形式は、指定された path が存在しない場合だけ行番号または行番号と列番号として扱う
 - Markdown file preview の相対 link と相対 image は、その file の親 directory と同じ認可済み root の中で解決する
 - OS の既定アプリで file を開けない場合は理由を表示し、通常の Open から Explorer 表示へ自動で切り替えない
 

--- a/scripts/tests/open-path.test.ts
+++ b/scripts/tests/open-path.test.ts
@@ -161,6 +161,17 @@ describe("resolveOpenPathTarget", () => {
     });
   });
 
+  it("leading slash 付き Windows absolute path は drive path に正規化する", () => {
+    assert.deepEqual(resolveOpenPathTarget("/C:/workspace/project/src/App.tsx"), {
+      type: "local-path",
+      targetPath: "C:/workspace/project/src/App.tsx",
+    });
+    assert.deepEqual(resolveOpenPathTarget("/C:/workspace/project/src/App.tsx:12:4"), {
+      type: "local-path",
+      targetPath: "C:/workspace/project/src/App.tsx:12:4",
+    });
+  });
+
   it("file url の fragment も外して local path に変換する", () => {
     assert.deepEqual(resolveOpenPathTarget("file:///C:/workspace/project/docs/spec.md#intro"), {
       type: "local-path",
@@ -185,6 +196,101 @@ describe("resolveOpenPathTarget", () => {
 });
 
 describe("openLocalPathWithDefaultApp", () => {
+  it("存在する数字suffix付き path は行番号と解釈せずそのまま開く", async () => {
+    const inspected: string[] = [];
+    const opened: string[] = [];
+    const result = await openLocalPathWithDefaultApp("/workspace/report:12", {
+      statTarget: async (targetPath) => {
+        inspected.push(targetPath);
+        return localPathStat("file");
+      },
+      openWithDefaultApp: async (targetPath) => {
+        opened.push(targetPath);
+        return "";
+      },
+    });
+
+    assert.equal(result.status, "opened");
+    assert.deepEqual(inspected, ["/workspace/report:12"]);
+    assert.deepEqual(opened, ["/workspace/report:12"]);
+  });
+
+  it("存在しない :line suffix は外した file を開く", async () => {
+    const inspected: string[] = [];
+    const opened: string[] = [];
+    const result = await openLocalPathWithDefaultApp("C:\\workspace\\notes.md:12", {
+      statTarget: async (targetPath) => {
+        inspected.push(targetPath);
+        if (targetPath.endsWith(":12")) {
+          throw Object.assign(new Error("ENOENT: missing"), { code: "ENOENT" });
+        }
+        return localPathStat("file");
+      },
+      openWithDefaultApp: async (targetPath) => {
+        opened.push(targetPath);
+        return "";
+      },
+    });
+
+    assert.equal(result.status, "opened");
+    assert.deepEqual(inspected, ["C:\\workspace\\notes.md:12", "C:\\workspace\\notes.md"]);
+    assert.deepEqual(opened, ["C:\\workspace\\notes.md"]);
+  });
+
+  it("存在しない :line:column suffix は外した file を開く", async () => {
+    const opened: string[] = [];
+    const result = await openLocalPathWithDefaultApp("C:\\workspace\\notes.md:12:4", {
+      statTarget: async (targetPath) => {
+        if (targetPath.endsWith(":12:4")) {
+          throw Object.assign(new Error("ENOENT: missing"), { code: "ENOENT" });
+        }
+        return localPathStat("file");
+      },
+      openWithDefaultApp: async (targetPath) => {
+        opened.push(targetPath);
+        return "";
+      },
+    });
+
+    assert.equal(result.status, "opened");
+    assert.deepEqual(opened, ["C:\\workspace\\notes.md"]);
+  });
+
+  it("数字suffix付き path と fallback path が存在しない場合は元の path を not-found として返す", async () => {
+    let openCalls = 0;
+    const result = await openLocalPathWithDefaultApp("C:\\workspace\\missing.md:12", {
+      statTarget: async () => {
+        throw Object.assign(new Error("ENOENT: missing"), { code: "ENOENT" });
+      },
+      openWithDefaultApp: async () => {
+        openCalls += 1;
+        return "";
+      },
+    });
+
+    assert.deepEqual(result, {
+      status: "not-found",
+      targetType: "local-path",
+      target: "C:\\workspace\\missing.md:12",
+      message: "The local path was not found.",
+    });
+    assert.equal(openCalls, 0);
+  });
+
+  it("数字suffix付き path の permission error は fallback せず failed を返す", async () => {
+    const inspected: string[] = [];
+    const result = await openLocalPathWithDefaultApp("C:\\workspace\\protected.md:12", {
+      statTarget: async (targetPath) => {
+        inspected.push(targetPath);
+        throw Object.assign(new Error("EACCES: access denied"), { code: "EACCES" });
+      },
+      openWithDefaultApp: async () => "",
+    });
+
+    assert.equal(result.status, "failed");
+    assert.deepEqual(inspected, ["C:\\workspace\\protected.md:12"]);
+  });
+
   it("既定アプリで file を開けない場合は自動で Explorer に切り替えず failed を返す", async () => {
     const revealed: string[] = [];
     const result = await openLocalPathWithDefaultApp("C:\\workspace\\notes.md", {
@@ -278,6 +384,23 @@ describe("openLocalPathWithDefaultApp", () => {
 });
 
 describe("revealLocalPathInFileManager", () => {
+  it("存在しない :line suffix は外した file を Explorer に表示する", async () => {
+    const revealed: string[] = [];
+    const result = await revealLocalPathInFileManager("C:\\workspace\\notes.md:12", {
+      statTarget: async (targetPath) => {
+        if (targetPath.endsWith(":12")) {
+          throw Object.assign(new Error("ENOENT: missing"), { code: "ENOENT" });
+        }
+        return localPathStat("file");
+      },
+      openWithDefaultApp: async () => "",
+      revealInFileManager: (targetPath) => revealed.push(targetPath),
+    });
+
+    assert.equal(result.status, "revealed");
+    assert.deepEqual(revealed, ["C:\\workspace\\notes.md"]);
+  });
+
   it("file は明示操作のときだけ file manager に表示する", async () => {
     const revealed: string[] = [];
     const result = await revealLocalPathInFileManager("C:\\workspace\\notes.md", {

--- a/src-electron/open-path.ts
+++ b/src-electron/open-path.ts
@@ -38,6 +38,10 @@ function isWindowsAbsolutePath(targetPath: string): boolean {
   return /^[a-zA-Z]:[\\/]/.test(targetPath) || /^\\\\[^\\]+\\[^\\]+/.test(targetPath);
 }
 
+function normalizeLeadingSlashWindowsAbsolutePath(targetPath: string): string {
+  return /^\/[a-zA-Z]:[\\/]/.test(targetPath) ? targetPath.slice(1) : targetPath;
+}
+
 function isWindowsFileUrl(url: URL): boolean {
   const hostname = url.hostname;
   if (hostname && hostname !== "localhost") {
@@ -154,10 +158,12 @@ export function resolveOpenPathTarget(target: string, options: OpenPathOptions =
     throw new Error("開く対象の path が空だよ。");
   }
 
-  if (path.isAbsolute(decodedTarget) || isWindowsAbsolutePath(decodedTarget)) {
+  const localTarget = normalizeLeadingSlashWindowsAbsolutePath(decodedTarget);
+
+  if (path.isAbsolute(localTarget) || isWindowsAbsolutePath(localTarget)) {
     return {
       type: "local-path",
-      targetPath: decodedTarget,
+      targetPath: localTarget,
     };
   }
 
@@ -166,18 +172,18 @@ export function resolveOpenPathTarget(target: string, options: OpenPathOptions =
     if (isWindowsAbsolutePath(baseDirectory)) {
       return {
         type: "local-path",
-        targetPath: path.win32.resolve(baseDirectory, decodedTarget),
+        targetPath: path.win32.resolve(baseDirectory, localTarget),
       };
     }
     return {
       type: "local-path",
-      targetPath: path.resolve(baseDirectory, decodedTarget),
+      targetPath: path.resolve(baseDirectory, localTarget),
     };
   }
 
   return {
     type: "local-path",
-    targetPath: decodedTarget,
+    targetPath: localTarget,
   };
 }
 
@@ -231,6 +237,56 @@ function projectUnsupportedLocalPathType(targetPath: string): OpenPathResult {
   };
 }
 
+type InspectedLocalPath =
+  | {
+      targetPath: string;
+      targetStat: LocalPathStat;
+    }
+  | {
+      result: OpenPathResult;
+    };
+
+function resolveTextLocationFallbackPath(targetPath: string): string | null {
+  const match = /^(.*):[1-9]\d*:[1-9]\d*$/.exec(targetPath)
+    ?? /^(.*):[1-9]\d*$/.exec(targetPath);
+  const fallbackPath = match?.[1] ?? "";
+  return fallbackPath ? fallbackPath : null;
+}
+
+async function inspectLocalPath(
+  targetPath: string,
+  statTarget: OpenLocalPathDeps["statTarget"],
+): Promise<InspectedLocalPath> {
+  try {
+    return {
+      targetPath,
+      targetStat: await statTarget(targetPath),
+    };
+  } catch (error) {
+    if (!isMissingLocalPathError(error)) {
+      return { result: projectLocalPathStatError(targetPath, error) };
+    }
+
+    const fallbackPath = resolveTextLocationFallbackPath(targetPath);
+    if (!fallbackPath) {
+      return { result: projectLocalPathStatError(targetPath, error) };
+    }
+
+    try {
+      return {
+        targetPath: fallbackPath,
+        targetStat: await statTarget(fallbackPath),
+      };
+    } catch (fallbackError) {
+      return {
+        result: isMissingLocalPathError(fallbackError)
+          ? projectLocalPathStatError(targetPath, error)
+          : projectLocalPathStatError(fallbackPath, fallbackError),
+      };
+    }
+  }
+}
+
 async function openExistingLocalPathWithDefaultApp(
   targetPath: string,
   openWithDefaultApp: OpenLocalPathDeps["openWithDefaultApp"],
@@ -254,53 +310,49 @@ export async function openLocalPathWithDefaultApp(
   targetPath: string,
   deps: OpenLocalPathDeps,
 ): Promise<OpenPathResult> {
-  let targetStat: LocalPathStat;
-  try {
-    targetStat = await deps.statTarget(targetPath);
-  } catch (error) {
-    return projectLocalPathStatError(targetPath, error);
+  const inspected = await inspectLocalPath(targetPath, deps.statTarget);
+  if ("result" in inspected) {
+    return inspected.result;
   }
 
-  if (!targetStat.isFile() && !targetStat.isDirectory()) {
-    return projectUnsupportedLocalPathType(targetPath);
+  if (!inspected.targetStat.isFile() && !inspected.targetStat.isDirectory()) {
+    return projectUnsupportedLocalPathType(inspected.targetPath);
   }
 
-  return openExistingLocalPathWithDefaultApp(targetPath, deps.openWithDefaultApp);
+  return openExistingLocalPathWithDefaultApp(inspected.targetPath, deps.openWithDefaultApp);
 }
 
 export async function revealLocalPathInFileManager(
   targetPath: string,
   deps: RevealLocalPathDeps,
 ): Promise<OpenPathResult> {
-  let targetStat: LocalPathStat;
-  try {
-    targetStat = await deps.statTarget(targetPath);
-  } catch (error) {
-    return projectLocalPathStatError(targetPath, error);
+  const inspected = await inspectLocalPath(targetPath, deps.statTarget);
+  if ("result" in inspected) {
+    return inspected.result;
   }
 
-  if (targetStat.isFile()) {
+  if (inspected.targetStat.isFile()) {
     try {
-      deps.revealInFileManager(targetPath);
+      deps.revealInFileManager(inspected.targetPath);
       return {
         status: "revealed",
         targetType: "local-path",
-        target: targetPath,
+        target: inspected.targetPath,
         message: "The file was revealed in the file manager.",
       };
     } catch (error) {
       return {
         status: "failed",
         targetType: "local-path",
-        target: targetPath,
+        target: inspected.targetPath,
         message: `The file could not be revealed: ${describeLocalPathError(error)}`,
       };
     }
   }
 
-  if (targetStat.isDirectory()) {
-    return openExistingLocalPathWithDefaultApp(targetPath, deps.openWithDefaultApp);
+  if (inspected.targetStat.isDirectory()) {
+    return openExistingLocalPathWithDefaultApp(inspected.targetPath, deps.openWithDefaultApp);
   }
 
-  return projectUnsupportedLocalPathType(targetPath);
+  return projectUnsupportedLocalPathType(inspected.targetPath);
 }


### PR DESCRIPTION
## 概要
- レスポンス内の `/C:/...` 形式を Windows の絶対パスとして正規化
- `:line` / `:line:column` は、元のパスが存在しない場合だけ行・列注釈として解決
- Open と Explorer 表示でパス検査を共通化し、設計契約と回帰テストを更新

## 検証
- `npx tsx --test scripts/tests/open-path.test.ts scripts/tests/open-path-result.test.ts scripts/tests/companion-inline-path.test.ts`
- `npm run typecheck`
- `npm test`
- `git diff --check origin/temp/v6.3.16...HEAD`