### PR TITLE
fix: 画像プレビューのFit倍率表示を修正

### DIFF
--- a/scripts/tests/file-preview-utils.test.ts
+++ b/scripts/tests/file-preview-utils.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  calculateImageFitZoom,
   decodeSessionFileBytes,
   findPreviewTextMatches,
   PreviewByteAccumulator,
@@ -13,6 +14,12 @@ import {
   shouldInitiallyFitSvg,
 } from "../../src/file-explorer/file-preview-utils.js";
 import { detectSessionFileEncoding } from "../../src/file-explorer/file-content-detection.js";
+
+test("calculateImageFitZoom は画像を拡大せずviewport内に収める倍率を返す", () => {
+  assert.equal(calculateImageFitZoom(800, 450, 1600, 900), 50);
+  assert.equal(calculateImageFitZoom(800, 600, 400, 300), 100);
+  assert.equal(calculateImageFitZoom(0, 600, 400, 300), 100);
+});
 
 test("decodeSessionFileBytes は Auto と手動指定で UTF-8 / Shift_JIS / UTF-16 を decode する", () => {
   assert.equal(decodeSessionFileBytes(new TextEncoder().encode("hello"), "auto", "utf-8"), "hello");

--- a/scripts/tests/session-file-preview-image-lifecycle.test.tsx
+++ b/scripts/tests/session-file-preview-image-lifecycle.test.tsx
@@ -393,6 +393,63 @@ test("寸法情報のないSVGは初回だけFitで表示する", async () => {
   }
 });
 
+test("Fitは実効倍率を表示しZoom Inの基準にする", async () => {
+  const dom = new JSDOM("<!doctype html><div id=\"root\"></div>", {
+    pretendToBeVisual: true,
+    url: "http://localhost/",
+  });
+  const restoreGlobals = installDomGlobals(dom);
+  const originalCreateObjectUrl = URL.createObjectURL;
+  const originalRevokeObjectUrl = URL.revokeObjectURL;
+  URL.createObjectURL = () => "blob:fit-image";
+  URL.revokeObjectURL = () => undefined;
+  const { api } = createPreviewApi(async () => IMAGE_DESCRIPTOR);
+  const container = dom.window.document.getElementById("root");
+  let root: Root | null = null;
+
+  try {
+    assert.ok(container);
+    root = await renderPreview(api, container, IMAGE_DESCRIPTOR);
+    await waitFor(() => container.querySelector<HTMLImageElement>(".session-file-image") !== null);
+    const viewport = container.querySelector<HTMLElement>(".session-file-image-scroll");
+    const image = container.querySelector<HTMLImageElement>(".session-file-image");
+    assert.ok(viewport);
+    assert.ok(image);
+    Object.defineProperties(viewport, {
+      clientWidth: { configurable: true, value: 800 },
+      clientHeight: { configurable: true, value: 450 },
+    });
+    Object.defineProperties(image, {
+      naturalWidth: { configurable: true, value: 1600 },
+      naturalHeight: { configurable: true, value: 900 },
+    });
+    await act(async () => {
+      image.dispatchEvent(new dom.window.Event("load"));
+      container.querySelector<HTMLButtonElement>("button[aria-label='Fit image to preview']")?.click();
+    });
+    assert.equal(
+      container.querySelector<HTMLButtonElement>("button[aria-label='Reset image zoom to 100%']")?.textContent,
+      "50%",
+    );
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("button[aria-label='Zoom image in']")?.click();
+    });
+    assert.equal(
+      container.querySelector<HTMLButtonElement>("button[aria-label='Reset image zoom to 100%']")?.textContent,
+      "60%",
+    );
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    URL.createObjectURL = originalCreateObjectUrl;
+    URL.revokeObjectURL = originalRevokeObjectUrl;
+    restoreGlobals();
+    dom.window.close();
+  }
+});
+
 test("file切替後に完了したOpenとOpen Diffの結果を新しいpreviewへ表示しない", async () => {
   const dom = new JSDOM("<!doctype html><div id=\"root\"></div>", {
     pretendToBeVisual: true,

--- a/src/file-explorer/SessionFilePreview.tsx
+++ b/src/file-explorer/SessionFilePreview.tsx
@@ -19,6 +19,7 @@ import type {
   WorkspaceChangeScope,
 } from "./file-explorer-contract.js";
 import {
+  calculateImageFitZoom,
   decodeSessionFileBytes,
   findPreviewTextMatches,
   formatFileByteLength,
@@ -79,6 +80,9 @@ type FileLoadState =
   | { status: "error"; message: string };
 
 const MARKDOWN_LOCAL_IMAGE_CONCURRENCY = 4;
+const IMAGE_ZOOM_MIN = 10;
+const IMAGE_ZOOM_MAX = 800;
+const IMAGE_ZOOM_STEP = 10;
 
 const ENCODING_OPTIONS: Array<{ value: SessionFileEncodingSelection; label: string }> = [
   { value: "auto", label: "Auto" },
@@ -258,6 +262,7 @@ export function SessionFilePreview({
   const [encoding, setEncoding] = useState<SessionFileEncodingSelection>("auto");
   const [markdownMode, setMarkdownMode] = useState<"preview" | "source">("preview");
   const [imageZoom, setImageZoom] = useState<"fit" | number>(100);
+  const [imageFitZoom, setImageFitZoom] = useState(100);
   const [imageObjectUrl, setImageObjectUrl] = useState("");
   const [roots, setRoots] = useState<SessionFileRoot[]>([]);
   const [feedback, setFeedback] = useState("");
@@ -266,6 +271,8 @@ export function SessionFilePreview({
   const [currentMatch, setCurrentMatch] = useState(0);
   const [reloadRevision, setReloadRevision] = useState(0);
   const markdownSurfaceRef = useRef<HTMLDivElement | null>(null);
+  const imageScrollRef = useRef<HTMLDivElement | null>(null);
+  const imageRef = useRef<HTMLImageElement | null>(null);
   const renderedMarkdownIndexRef = useRef<RenderedTextSearchIndex | null>(null);
   const renderedMarkdownMatchesRef = useRef<RenderedTextMatchOffsets>({
     offsets: new Uint32Array(0),
@@ -472,10 +479,46 @@ export function SessionFilePreview({
       return;
     }
     setImageZoom(loaded.descriptor.kind === "svg" && shouldInitiallyFitSvg(loaded.bytes) ? "fit" : 100);
+    setImageFitZoom(100);
     const objectUrl = URL.createObjectURL(new Blob([copyBytesToArrayBuffer(loaded.bytes)], { type: loaded.descriptor.mimeType }));
     setImageObjectUrl(objectUrl);
     return () => URL.revokeObjectURL(objectUrl);
   }, [loaded]);
+
+  const updateImageFitZoom = useCallback(() => {
+    const viewport = imageScrollRef.current;
+    const image = imageRef.current;
+    if (!viewport || !image) {
+      return;
+    }
+    const styles = window.getComputedStyle(viewport);
+    const horizontalPadding = (Number.parseFloat(styles.paddingLeft) || 0)
+      + (Number.parseFloat(styles.paddingRight) || 0);
+    const verticalPadding = (Number.parseFloat(styles.paddingTop) || 0)
+      + (Number.parseFloat(styles.paddingBottom) || 0);
+    setImageFitZoom(calculateImageFitZoom(
+      viewport.clientWidth - horizontalPadding,
+      viewport.clientHeight - verticalPadding,
+      image.naturalWidth,
+      image.naturalHeight,
+    ));
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!imageObjectUrl) {
+      return;
+    }
+    updateImageFitZoom();
+    if (typeof ResizeObserver === "undefined" || !imageScrollRef.current) {
+      return;
+    }
+    const observer = new ResizeObserver(updateImageFitZoom);
+    observer.observe(imageScrollRef.current);
+    return () => observer.disconnect();
+  }, [imageObjectUrl, updateImageFitZoom]);
+
+  const effectiveImageZoom = typeof imageZoom === "number" ? imageZoom : imageFitZoom;
+  const imageZoomLabel = `${effectiveImageZoom}%`;
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -693,10 +736,20 @@ export function SessionFilePreview({
           ) : null}
           {descriptor && (previewKind === "image" || previewKind === "svg") ? (
             <div className="session-file-preview-segmented" role="group" aria-label="Image zoom">
-              <button type="button" onClick={() => setImageZoom((current) => Math.max(10, (typeof current === "number" ? current : 100) - 10))}>−</button>
-              <button type="button" onClick={() => setImageZoom(100)}>{typeof imageZoom === "number" ? `${imageZoom}%` : "100%"}</button>
-              <button type="button" onClick={() => setImageZoom((current) => Math.min(800, (typeof current === "number" ? current : 100) + 10))}>＋</button>
-              <button type="button" className={imageZoom === "fit" ? "is-active" : ""} onClick={() => setImageZoom("fit")}>Fit</button>
+              <button
+                type="button"
+                aria-label="Zoom image out"
+                disabled={effectiveImageZoom <= IMAGE_ZOOM_MIN}
+                onClick={() => setImageZoom(Math.max(IMAGE_ZOOM_MIN, effectiveImageZoom - IMAGE_ZOOM_STEP))}
+              >−</button>
+              <button type="button" aria-label="Reset image zoom to 100%" onClick={() => setImageZoom(100)}>{imageZoomLabel}</button>
+              <button
+                type="button"
+                aria-label="Zoom image in"
+                disabled={effectiveImageZoom >= IMAGE_ZOOM_MAX}
+                onClick={() => setImageZoom(Math.min(IMAGE_ZOOM_MAX, effectiveImageZoom + IMAGE_ZOOM_STEP))}
+              >＋</button>
+              <button type="button" aria-label="Fit image to preview" className={imageZoom === "fit" ? "is-active" : ""} onClick={() => setImageZoom("fit")}>Fit</button>
             </div>
           ) : null}
           {onOpenDiff && diffScopes.length > 0 ? diffScopes.map((scope) => (
@@ -798,12 +851,14 @@ export function SessionFilePreview({
         )
       ) : null}
       {loadState.status === "ready" && loaded && descriptor && (previewKind === "image" || previewKind === "svg") ? (
-        <div className="session-file-image-scroll">
+        <div ref={imageScrollRef} className="session-file-image-scroll">
           {imageObjectUrl ? (
             <img
+              ref={imageRef}
               className={`session-file-image${imageZoom === "fit" ? " is-fit" : ""}`}
               src={imageObjectUrl}
               alt={descriptor.name}
+              onLoad={updateImageFitZoom}
               style={imageZoom === "fit" ? undefined : { zoom: imageZoom / 100 }}
             />
           ) : null}

--- a/src/file-explorer/file-preview-utils.ts
+++ b/src/file-explorer/file-preview-utils.ts
@@ -78,6 +78,19 @@ export function shouldInitiallyFitSvg(bytes: Uint8Array): boolean {
   );
 }
 
+export function calculateImageFitZoom(
+  viewportWidth: number,
+  viewportHeight: number,
+  imageWidth: number,
+  imageHeight: number,
+): number {
+  if (viewportWidth <= 0 || viewportHeight <= 0 || imageWidth <= 0 || imageHeight <= 0) {
+    return 100;
+  }
+  const scale = Math.min(1, viewportWidth / imageWidth, viewportHeight / imageHeight);
+  return Math.max(0.1, Math.round(scale * 1_000) / 10);
+}
+
 export function projectWorkspaceFileDiffAvailability(
   result: WorkspaceChangesResult,
   relativePath: string,

--- a/src/styles.css
+++ b/src/styles.css
@@ -4209,9 +4209,10 @@ button:disabled {
 }
 
 .session-file-image {
-  display: inline-block;
+  display: block;
   max-width: none;
   height: auto;
+  margin-inline: auto;
 }
 
 .session-file-image.is-fit {


### PR DESCRIPTION
## 概要

画像プレビューのFit表示とズーム操作を、実際の表示倍率に整合させます。

## 変更内容

- プレビュー領域と画像の実寸からFit時の実効倍率を計算
- Fit時の倍率表示を固定の100%から実効倍率へ変更
- Fit後のZoom In / Outを実効倍率基準で動作させる
- プレビュー領域のリサイズ時にFit倍率を再計算
- 画像のインライン配置に由来する余白を除去し、不要なスクロールバーを抑止

## 原因

Fit状態はCSSの最大幅・最大高さだけで表現され、UI上の倍率表示とZoom In / Outの基準には固定値の100%が使われていました。また、画像がインライン要素として配置されていたため、ベースライン下の余白がスクロール領域へ加算されていました。

## 影響

Fit時に実際の縮小率が表示され、そこから連続的に拡大・縮小できます。小さい画像は従来どおり100%を上限とし、Fitによる拡大は行いません。

## 検証

- `tsx --test scripts/tests/file-preview-utils.test.ts scripts/tests/session-file-preview-image-lifecycle.test.tsx scripts/tests/open-path.test.ts`（63件成功）
- `npm run typecheck`
- `npm run build:renderer`
- `git diff --check`

`npm run build:renderer`では既存の`::highlight`およびchunkサイズに関する警告が出ますが、ビルドは成功しています。