### PR TITLE
fix(file-preview): Markdownプレビューの表示幅を広げる

### DIFF
--- a/scripts/tests/session-context-pane-style.test.ts
+++ b/scripts/tests/session-context-pane-style.test.ts
@@ -109,3 +109,16 @@ test("Markdown preview は暗いsurface上のlinkとMermaid errorへ高contrast�
     /\.session-file-markdown \.message-mermaid-error\s*{\s*color:\s*var\(--session-file-error\);\s*}/,
   );
 });
+
+test("Markdown preview は中央本文を固定幅にせずcontent領域を使う", async () => {
+  const stylesSource = await readFile("src/styles.css", "utf8");
+
+  assert.match(
+    stylesSource,
+    /\.session-file-markdown-scroll\s*{\s*padding:\s*18px\s+10px\s+40px;\s*}/,
+  );
+  assert.match(
+    stylesSource,
+    /\.session-file-markdown\s*{\s*width:\s*100%;\s*max-width:\s*none;\s*margin:\s*0;\s*}/,
+  );
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -4129,12 +4129,13 @@ button:disabled {
 }
 
 .session-file-markdown-scroll {
-  padding: 18px clamp(16px, 4vw, 52px) 40px;
+  padding: 18px 10px 40px;
 }
 
 .session-file-markdown {
-  max-width: 920px;
-  margin: 0 auto;
+  width: 100%;
+  max-width: none;
+  margin: 0;
 }
 
 .session-file-markdown a,


### PR DESCRIPTION
## 概要

MarkdownファイルのPreview表示が中央のコンテンツ領域を十分に使わず、左右に大きな余白が生じる問題を修正します。

## 変更内容

- Markdownプレビューの可変左右paddingを、Source表示に近い小さな固定paddingへ変更
- Markdown本文の`max-width: 920px`と中央寄せを解除
- プレビューが固定幅へ戻らないことを確認する回帰テストを追加

## 原因

ファイルプレビュー専用CSSで、スクロール領域の可変paddingと本文の最大幅・中央寄せが重なっていました。共通のMarkdownレンダラーやSessionチャット本文の幅指定には変更を加えていません。

## 影響

MarkdownファイルのPreview表示が中央領域の横幅を使用します。Source表示およびSessionチャットのMarkdown表示には影響しません。

## 検証

- `npx tsx --test scripts/tests/session-context-pane-style.test.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check`