### PR TITLE
fix(chat): Markdown画像の読み込み表示を修正

### DIFF
--- a/scripts/tests/message-rich-text.test.ts
+++ b/scripts/tests/message-rich-text.test.ts
@@ -400,6 +400,44 @@ test("MessageRichText は local / data / external Markdown image を既定表示
   assert.match(html, /src="https:\/\/cdn\.example\.test\/image\.png"/);
 });
 
+test("MessageRichText は直接 image を表示しながら load 完了後に loading 表示を消す", async () => {
+  const dom = new JSDOM("<!doctype html><div id=\"root\"></div>", {
+    pretendToBeVisual: true,
+    url: "http://localhost/",
+  });
+  const restoreGlobals = installDomGlobals(dom);
+  const container = dom.window.document.getElementById("root");
+  let root: Root | null = null;
+
+  try {
+    assert.ok(container);
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(React.createElement(MessageRichText, {
+        forceFullRender: true,
+        text: "![cached](data:image/png;base64,AAAA)",
+      }));
+    });
+
+    const image = container.querySelector("img");
+    assert.ok(image);
+    assert.equal(image.hidden, false);
+    assert.notEqual(container.querySelector(".message-image-loading"), null);
+
+    await act(async () => {
+      image.dispatchEvent(new dom.window.Event("load"));
+    });
+
+    assert.equal(container.querySelector(".message-image-loading"), null);
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    restoreGlobals();
+    dom.window.close();
+  }
+});
+
 test("MessageRichText は chat context の相対 Markdown image を環境依存URLとして読み込まない", () => {
   const html = renderToStaticMarkup(
     React.createElement(MessageRichText, { text: "![relative](images/sample.png)" }),

--- a/scripts/tests/session-entry-csp.test.ts
+++ b/scripts/tests/session-entry-csp.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const sessionEntryUrl = new URL("../../session.html", import.meta.url);
+
+function readCspDirective(content: string, directiveName: string): string[] {
+  const directive = content
+    .split(";")
+    .map((entry) => entry.trim())
+    .find((entry) => entry.startsWith(`${directiveName} `));
+  return directive?.split(/\s+/).slice(1) ?? [];
+}
+
+test("Session Window CSP は Markdown の HTTP / HTTPS image を許可する", async () => {
+  const html = await readFile(sessionEntryUrl, "utf8");
+  const csp = html.match(/<meta\s+http-equiv="Content-Security-Policy"\s+content="([^"]+)"/i)?.[1];
+
+  assert.ok(csp);
+  const imageSources = readCspDirective(csp, "img-src");
+  assert.ok(imageSources.includes("http:"));
+  assert.ok(imageSources.includes("https:"));
+});

--- a/session.html
+++ b/session.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline' http://localhost:4173 http://127.0.0.1:4173; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: file:; font-src 'self' data:; connect-src 'self' http://localhost:4173 ws://localhost:4173 http://127.0.0.1:4173 ws://127.0.0.1:4173; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-src 'none'; form-action 'self'"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline' http://localhost:4173 http://127.0.0.1:4173; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: file: http: https:; font-src 'self' data:; connect-src 'self' http://localhost:4173 ws://localhost:4173 http://127.0.0.1:4173 ws://127.0.0.1:4173; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-src 'none'; form-action 'self'"
     />
     <title>Session</title>
   </head>

--- a/src/MessageRichText.tsx
+++ b/src/MessageRichText.tsx
@@ -375,16 +375,12 @@ function MarkdownImage({ source, alt, title, resolveImageSource }: MarkdownImage
   );
 
   useEffect(() => {
+    if (!resolveImageSource) {
+      return;
+    }
+
     let active = true;
     let ownedObjectUrl: string | null = null;
-    if (!resolveImageSource) {
-      const directSource = isDirectMarkdownImageSource(source);
-      setResolvedSource(directSource ? source : "");
-      setLoadStatus(directSource ? "loading" : "error");
-      return () => {
-        active = false;
-      };
-    }
 
     setResolvedSource("");
     setLoadStatus("resolving");
@@ -436,7 +432,6 @@ function MarkdownImage({ source, alt, title, resolveImageSource }: MarkdownImage
           alt={alt ?? ""}
           title={title}
           loading="lazy"
-          hidden={loadStatus !== "ready"}
           onLoad={() => setLoadStatus("ready")}
           onError={() => setLoadStatus("error")}
         />
@@ -521,6 +516,7 @@ function createMarkdownComponents(
       const source = typeof src === "string" ? src.trim() : "";
       return source ? (
         <MarkdownImage
+          key={`${options?.resolveImageSource ? "resolved" : "direct"}:${source}`}
           source={source}
           alt={alt}
           title={title}


### PR DESCRIPTION
## 概要

チャットレスポンス内のMarkdown画像で、画像表示後も `Image loading…` が残る問題を修正します。
あわせて、Session WindowでHTTP/HTTPS画像を表示できるようCSPを既存のMarkdown画像ポリシーへ揃えます。

## 原因

- direct imageのload完了後にeffectが状態を `loading` へ戻す場合があった
- 実際のチャット画面をホストする `session.html` の `img-src` に `http:` / `https:` がなく、外部画像がCSPで拒否されていた

## 変更内容

- direct imageの状態をDOMのload/errorイベントで確定し、effectからの巻き戻しを防止
- sourceとresolve modeの切替時に画像ライフサイクルを分離
- 読み込み中も画像要素を表示し、完了後にloading表示を除去
- `session.html` の `img-src` に `http:` / `https:` を追加
- 画像ライフサイクルとSession CSPの回帰テストを追加

## 影響

- 有効な外部画像はチャットとSession file previewで表示される
- 取得失敗時はloading表示へ戻らず、既存のエラー表示へ遷移する
- 外部画像取得に伴う通信方針は既存ADR 012の範囲内

## 検証

- targeted tests: 32件成功
- `npm run typecheck`: 成功
- `npm test`: 2,110件成功、1件skip、失敗なし
- `npm run build:renderer`: 成功
- `git diff --check`: 問題なし
- CSP/network authority review: approve、blockingなし
- image lifecycle review: approve、blockingなし

## 補足

`temp/v6.3.16` の最新変更を取り込んだ状態で検証しています。