### PR TITLE
fix(chat): ActionDockの操作順を統一

### DIFF
--- a/scripts/tests/session-message-column.test.ts
+++ b/scripts/tests/session-message-column.test.ts
@@ -1464,7 +1464,7 @@ test("SessionComposerExpanded は Hide を描画せず、Send を設定グルー
   );
 });
 
-test("SessionComposerExpanded は実行中の progress と Cancel を上部 toolbar に描画し、下段の送信ボタンを隠す", () => {
+test("SessionComposerExpanded は実行中の progress、jump button、Cancel を compact と同じ順で上部 toolbar に描画する", () => {
   const html = renderToStaticMarkup(
     React.createElement(SessionComposerExpanded, {
       retryBanner: null,
@@ -1482,7 +1482,7 @@ test("SessionComposerExpanded は実行中の progress と Cancel を上部 tool
       selectedCustomAgentTitle: "Agent",
       additionalDirectoryCount: 0,
       canCollapseActionDock: true,
-      showJumpToBottom: false,
+      showJumpToBottom: true,
       isCustomAgentListLoading: false,
       isSkillListLoading: false,
       customAgentItems: [],
@@ -1539,9 +1539,11 @@ test("SessionComposerExpanded は実行中の progress と Cancel を上部 tool
 
   assert.match(html, /composer-toolbar-progress/);
   assert.match(html, /処理を実行中/);
+  assert.match(html, /末尾へ移動/);
   assert.match(html, /composer-toolbar-cancel-button/);
   assert.ok(html.indexOf("Attach") < html.indexOf("処理を実行中"));
-  assert.ok(html.indexOf("処理を実行中") < html.indexOf("Cancel"));
+  assert.ok(html.indexOf("処理を実行中") < html.indexOf("末尾へ移動"));
+  assert.ok(html.indexOf("末尾へ移動") < html.indexOf("Cancel"));
   assert.doesNotMatch(html, />Send<\/button>/);
 });
 

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -3485,6 +3485,14 @@ export function SessionComposerExpanded({
               </button>
             </div>
           ) : null}
+          {isRunning ? (
+            <div className="composer-toolbar-progress">
+              <PendingRunIndicator
+                announcement={pendingRunIndicatorAnnouncement}
+                text={pendingRunIndicatorText}
+              />
+            </div>
+          ) : null}
           {showJumpToBottom ? (
             <button
               className="drawer-toggle compact secondary message-jump-bottom-button"
@@ -3495,13 +3503,6 @@ export function SessionComposerExpanded({
             </button>
           ) : null}
           {isRunning ? (
-            <>
-              <div className="composer-toolbar-progress">
-                <PendingRunIndicator
-                  announcement={pendingRunIndicatorAnnouncement}
-                  text={pendingRunIndicatorText}
-                />
-              </div>
               <button
                 className="drawer-toggle compact danger composer-toolbar-cancel-button"
                 type="button"
@@ -3510,7 +3511,6 @@ export function SessionComposerExpanded({
               >
                 Cancel
               </button>
-            </>
           ) : null}
         </div>
       ) : null}


### PR DESCRIPTION
## 概要

- Session の ActionDock 展開時に、実行中バブル、末尾へ移動、Cancel の順で操作を表示する
- 閉じた状態と展開時で同じ操作順になることをコンポーネントテストで検証する

## 背景

閉じた状態では「実行中バブル → 末尾へ移動 → Cancel」、展開時では「末尾へ移動 → 実行中バブル → Cancel」と表示順が異なっていた。展開時の JSX の要素順を閉じた状態に合わせ、状態切り替えによるボタン位置の移動を解消する。

## 影響

ActionDock の開閉にかかわらず、実行中の各操作が同じ順序で表示される。機能や操作内容の変更はない。

## 検証

- `npx --no-install tsx --test --test-name-pattern="Session(ActionDockCompactRow|ComposerExpanded).*" scripts/tests/session-message-column.test.ts`
- `npm run typecheck`
