### PR TITLE
fix(chat): 展開アイコンの表示崩れを修正

### DIFF
--- a/scripts/tests/chat-window.test.ts
+++ b/scripts/tests/chat-window.test.ts
@@ -63,13 +63,15 @@ test("ChatDockSplitter は各辺の表示状態を切り替える affordance を
   assert.match(expandedHtml, /aria-controls="session-right-pane"/);
   assert.match(expandedHtml, /aria-expanded="true"/);
   assert.match(expandedHtml, /クリックで右ペインを折りたたみ、ドラッグでサイズを調整/);
-  assert.match(expandedHtml, />›<\/span>/);
+  assert.match(expandedHtml, /session-dock-splitter-chevron direction-right/);
+  assert.match(expandedHtml, /<svg viewBox="0 0 12 12" focusable="false">/);
+  assert.match(expandedHtml, /<path d="M4 2.5 8 6 4 9.5"><\/path>/);
 
   assert.match(collapsedHtml, /class="session-dock-splitter edge-bottom is-toggle-only is-collapsed"/);
   assert.match(collapsedHtml, /aria-label="ActionDockを展開"/);
   assert.match(collapsedHtml, /aria-controls="session-action-dock"/);
   assert.match(collapsedHtml, /aria-expanded="false"/);
-  assert.match(collapsedHtml, />⌃<\/span>/);
+  assert.match(collapsedHtml, /session-dock-splitter-chevron direction-up/);
 
   assert.match(fixedHeaderHtml, /class="session-dock-splitter edge-top is-toggle-only"/);
   assert.match(fixedHeaderHtml, /title="クリックでヘッダーを折りたたみ"/);

--- a/scripts/tests/session-context-pane-style.test.ts
+++ b/scripts/tests/session-context-pane-style.test.ts
@@ -73,6 +73,23 @@ test("左右ペイン非表示時は pane track を除き、splitter の再表�
   );
 });
 
+test("splitter の枠は各 track に収まり、modal より背面に残る", async () => {
+  const stylesSource = await readFile("src/styles.css", "utf8");
+
+  assert.match(
+    stylesSource,
+    /\.session-dock-splitter-chevron\s*{[\s\S]*?box-sizing:\s*border-box;[\s\S]*?width:\s*12px;[\s\S]*?height:\s*24px;/,
+  );
+  assert.match(
+    stylesSource,
+    /\.session-dock-splitter\.edge-top \.session-dock-splitter-chevron,\s*\.session-dock-splitter\.edge-bottom \.session-dock-splitter-chevron\s*{\s*width:\s*24px;\s*height:\s*12px;/,
+  );
+  assert.match(
+    stylesSource,
+    /\.launch-modal,\s*\.diff-modal\s*{[\s\S]*?position:\s*fixed;[\s\S]*?z-index:\s*40;/,
+  );
+});
+
 test("Header と ActionDock は中央・左右ペインの外側に全幅 dock として配置する", async () => {
   const [componentSource, chatWindowSource, sessionProjectionSource, companionProjectionSource, stylesSource] = await Promise.all([
     readFile("src/session-components.tsx", "utf8"),

--- a/src/chat/chat-window.tsx
+++ b/src/chat/chat-window.tsx
@@ -203,13 +203,13 @@ export function ChatDockSplitter({
       : edge === "left"
         ? SESSION_LEFT_PANE_ID
         : SESSION_RIGHT_PANE_ID;
-  const chevron = edge === "top"
-    ? (isPanelExpanded ? "⌃" : "⌄")
+  const chevronDirection = edge === "top"
+    ? (isPanelExpanded ? "up" : "down")
     : edge === "bottom"
-      ? (isPanelExpanded ? "⌄" : "⌃")
+      ? (isPanelExpanded ? "down" : "up")
       : edge === "left"
-        ? (isPanelExpanded ? "‹" : "›")
-        : (isPanelExpanded ? "›" : "‹");
+        ? (isPanelExpanded ? "left" : "right")
+        : (isPanelExpanded ? "right" : "left");
 
   return (
     <button
@@ -225,8 +225,13 @@ export function ChatDockSplitter({
       title={resolvedTitle}
     >
       {effectiveTogglePanel ? (
-        <span className="session-dock-splitter-chevron" aria-hidden="true">
-          {chevron}
+        <span
+          className={`session-dock-splitter-chevron direction-${chevronDirection}`}
+          aria-hidden="true"
+        >
+          <svg viewBox="0 0 12 12" focusable="false">
+            <path d="M4 2.5 8 6 4 9.5" />
+          </svg>
         </span>
       ) : null}
     </button>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1949,6 +1949,7 @@ button:disabled {
 .diff-modal {
   position: fixed;
   inset: 0;
+  z-index: 40;
   display: grid;
   place-items: center;
   padding: 26px;
@@ -4877,24 +4878,46 @@ button:disabled {
   top: 50%;
   left: 50%;
   z-index: 1;
+  box-sizing: border-box;
   display: grid;
   place-items: center;
-  width: 18px;
-  height: 28px;
+  width: 12px;
+  height: 24px;
   border: 1px solid rgba(203, 213, 225, 0.18);
   border-radius: 999px;
   background: rgba(12, 17, 25, 0.96);
   color: var(--ink);
-  font-size: 1rem;
-  line-height: 1;
   transform: translate(-50%, -50%);
   pointer-events: none;
 }
 
 .session-dock-splitter.edge-top .session-dock-splitter-chevron,
 .session-dock-splitter.edge-bottom .session-dock-splitter-chevron {
-  width: 28px;
-  height: 18px;
+  width: 24px;
+  height: 12px;
+}
+
+.session-dock-splitter-chevron svg {
+  width: 8px;
+  height: 8px;
+  overflow: visible;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.session-dock-splitter-chevron.direction-down svg {
+  transform: rotate(90deg);
+}
+
+.session-dock-splitter-chevron.direction-left svg {
+  transform: rotate(180deg);
+}
+
+.session-dock-splitter-chevron.direction-up svg {
+  transform: rotate(-90deg);
 }
 
 .session-dock-splitter:hover .session-dock-splitter-chevron,


### PR DESCRIPTION
## 概要

Session UIのHeader、ActionDock、左右ペインで使う展開アイコンの表示を揃えました。

## 背景

- 方向記号を文字グリフで描画していたため、フォントメトリクスによって上下の見た目の中心がずれていました。
- 左右splitterの12px trackに対して楕円枠が18pxあり、閉じた状態で枠が見切れていました。
- Auxiliary起動モーダルよりsplitterのアイコンが前面に描画され、モーダルを貫通していました。

## 変更内容

- 展開アイコンを共通のSVG chevronへ置き換え、回転で方向を表現
- 楕円枠を各splitter track内へ収まる寸法に調整
- launch/diff modalの重なり順を明示
- SVG方向、枠寸法、モーダル階層の回帰テストを追加

## 検証

- `npx tsx --test scripts/tests/chat-window.test.ts scripts/tests/session-context-pane-style.test.ts`
- `npm run typecheck`
- `npm run build:renderer`
- `git diff --check origin/temp/v6.3.17...HEAD`