### PR TITLE
fix: ランダムCharacterの重複選択を防止

### DIFF
--- a/docs/adr/004-launch-character-random-selection.md
+++ b/docs/adr/004-launch-character-random-selection.md
@@ -13,13 +13,15 @@ New Session ダイアログでは Character を固定選択できる。Character
 
 - New Session ダイアログの Character 一覧先頭に、ランダム選択を置く。
 - Agent と Companion のランダム開始は、active Character を共通の候補とする。
-- 通常 Session の最終利用順から Character ごとの直近位置を求め、最近使われた Character から順に `1, 2, 3, ...` の線形な重みを与える。履歴にない Character には、履歴にある候補より大きい同一の重みを与える。
+- 開いている通常 Session Window で使用中の Character は、未使用の active Character がある間は抽選候補から除外する。すべての active Character が使用中の場合は除外せず、重複を許容する。
+- 残った抽選候補について、通常 Session の最終利用順から Character ごとの直近位置を求め、最近使われた Character から順に `1, 2, 3, ...` の線形な重みを与える。履歴にない Character には、履歴にある候補より大きい同一の重みを与える。
 - Character 作成 Session は利用履歴に含めない。
-- 通常 Session の履歴が0件なら、active Character を均等に抽選する。active Character が0件なら、既存の neutral Character を使う。
+- 通常 Session の履歴が0件なら、残った抽選候補を均等に抽選する。active Character が0件なら、既存の neutral Character を使う。
 - 履歴の読み込み中または取得失敗時はランダム開始を拒否する。取得成功後の0件だけを均等抽選として扱う。
+- 開いている通常 Session Window 一覧の読み込み中または取得失敗時もランダム開始を拒否する。取得成功後の0件だけを「使用中なし」として扱う。
 - DB schema と Session summary API は変更しない。
 
-実装の正本は `src/home/home-launch-state.ts` と `src/home/home-launch-actions.ts`、観測可能な契約は `scripts/tests/home-launch-state.test.ts` と `scripts/tests/home-launch-actions.test.ts` に置く。
+実装の正本は `src/home/home-launch-state.ts`、`src/home/home-launch-actions.ts`、`src/open-session-window-subscription.ts`、観測可能な契約は `scripts/tests/home-launch-state.test.ts`、`scripts/tests/home-launch-actions.test.ts`、`scripts/tests/open-session-window-subscription.test.ts` に置く。
 
 ## Alternatives
 
@@ -53,5 +55,7 @@ provider ごとの実行設定は security boundary が異なるため、この�
 ### Negative
 
 - 抽選確率は利用回数ではなく、Character ごとの直近利用順だけで決まる。
+- Session Window の購読更新前に別の Home Window から同時に開始した場合は、同じ Character が選ばれる可能性が残る。
 - Session summary の読み込みに失敗している間は、固定 Character では開始できるが、ランダム選択では開始できない。
+- Session Window 一覧の初回取得に失敗している間も、固定 Character では開始できるが、ランダム選択では開始できない。
 - 複数の Home window 間で購読更新に短い遅延がある場合、その間は抽選時の重みが一致しない可能性がある。

--- a/docs/design/session-launch-ui.md
+++ b/docs/design/session-launch-ui.md
@@ -133,8 +133,10 @@ React モックでは次の形がよい。
 - `Character` は card で切り替える
 - `Character` は portrait 付きカードで切り替える
 - Character一覧の先頭にランダム選択カードを置く。ランダム選択時は、通常Sessionの最終利用順を使い、最近使っていないactive Characterほど高い重みで抽選する
-- Character利用履歴がない場合はactive Characterを均等に抽選し、active Characterが0件なら既存のneutral fallbackを使う
+- ランダム選択時は、開いている通常Session Windowで使用中のCharacterを、他にactive Characterがある間は候補から除外する。すべて使用中の場合は重複を許容する
+- Character利用履歴がない場合は使用中を除いた抽選候補を均等に抽選し、active Characterが0件なら既存のneutral fallbackを使う
 - Session履歴の読み込み中または取得失敗時はランダム選択で開始せず、取得成功した0件と区別する
+- 開いている通常Session Window一覧の読み込み中または取得失敗時もランダム選択で開始せず、取得成功した0件と区別する
 - `Character` には検索入力があり、`name / description` の部分一致で絞り込める
 - launch dialog 内の character card も Home と同じ theme rule を使う
   - background = character `main`

--- a/scripts/tests/home-launch-actions.test.ts
+++ b/scripts/tests/home-launch-actions.test.ts
@@ -166,6 +166,8 @@ function createStartHomeLaunchHarness(overrides: Partial<Parameters<typeof start
       characterEntries: createCharacterEntries(),
       selectedProviderId: "codex",
       sessions: [],
+      openSessionWindowIds: [],
+      openSessionWindowIdsLoadStatus: "loaded" as const,
       sessionSummariesLoadStatus: "loaded" as const,
       createSession: async () => createSessionSummary(),
       createCompanionSession: async () => createCompanionSession(),
@@ -277,6 +279,32 @@ describe("home-launch-actions", () => {
     assert.deepEqual(harness.openedSessions, ["session-1"]);
   });
 
+  it("random選択では開いているSession WindowのCharacterを候補から外す", async () => {
+    let capturedCharacterId = "";
+    const harness = createStartHomeLaunchHarness({
+      draft: {
+        ...createReadyDraft(),
+        characterSelectionMode: "random",
+      },
+      sessions: [createSessionSummary({
+        id: "open-mia",
+        characterId: "mia",
+        sessionKind: "character-authoring",
+      })],
+      openSessionWindowIds: ["open-mia"],
+      random: () => 0,
+      createSession: async (input) => {
+        capturedCharacterId = input.characterId;
+        return createSessionSummary();
+      },
+    });
+
+    await startHomeLaunch(harness.input);
+
+    assert.equal(capturedCharacterId, "noa");
+    assert.deepEqual(harness.openedSessions, ["session-1"]);
+  });
+
   it("履歴の読み込み中はrandom選択のsessionを開始しない", async () => {
     let createCount = 0;
     const harness = createStartHomeLaunchHarness({
@@ -317,6 +345,69 @@ describe("home-launch-actions", () => {
     assert.equal(createCount, 0);
     assert.deepEqual(harness.feedback, ["Session 履歴を読み込めていないため、ランダム選択を開始できないよ。"]);
     assert.deepEqual(harness.startingStates, []);
+  });
+
+  it("open Session Window 一覧の読み込み中はrandom選択のsessionを開始しない", async () => {
+    let createCount = 0;
+    const harness = createStartHomeLaunchHarness({
+      draft: {
+        ...createReadyDraft(),
+        characterSelectionMode: "random",
+      },
+      openSessionWindowIdsLoadStatus: "loading",
+      createSession: async () => {
+        createCount += 1;
+        return createSessionSummary();
+      },
+    });
+
+    await startHomeLaunch(harness.input);
+
+    assert.equal(createCount, 0);
+    assert.deepEqual(harness.feedback, [
+      "開いている Session Window を確認してるよ。完了してからもう一度開始してね。",
+    ]);
+    assert.deepEqual(harness.startingStates, []);
+  });
+
+  it("open Session Window 一覧の取得失敗後はrandom選択のcompanionを開始しない", async () => {
+    let createCount = 0;
+    const harness = createStartHomeLaunchHarness({
+      draft: {
+        ...createReadyDraft("companion"),
+        characterSelectionMode: "random",
+      },
+      requestedMode: "companion",
+      openSessionWindowIdsLoadStatus: "error",
+      createCompanionSession: async () => {
+        createCount += 1;
+        return createCompanionSession();
+      },
+    });
+
+    await startHomeLaunch(harness.input);
+
+    assert.equal(createCount, 0);
+    assert.deepEqual(harness.feedback, [
+      "開いている Session Window を確認できないため、ランダム選択を開始できないよ。",
+    ]);
+    assert.deepEqual(harness.startingStates, []);
+  });
+
+  it("open Session Window 一覧の取得失敗後でも固定Characterのsessionは開始できる", async () => {
+    let capturedCharacterId = "";
+    const harness = createStartHomeLaunchHarness({
+      openSessionWindowIdsLoadStatus: "error",
+      createSession: async (input) => {
+        capturedCharacterId = input.characterId;
+        return createSessionSummary();
+      },
+    });
+
+    await startHomeLaunch(harness.input);
+
+    assert.equal(capturedCharacterId, "mia");
+    assert.deepEqual(harness.openedSessions, ["session-1"]);
   });
 
   it("履歴の読み込み失敗後でも固定Characterのsessionは開始できる", async () => {

--- a/scripts/tests/home-launch-handlers.test.ts
+++ b/scripts/tests/home-launch-handlers.test.ts
@@ -52,6 +52,8 @@ describe("home-launch-handlers", () => {
       characterEntries: [createCharacterEntry({ id: "old", name: "Old" })],
       selectedLaunchProviderId: "codex",
       sessions: [],
+      openSessionWindowIds: [],
+      openSessionWindowIdsLoadStatus: "loaded",
       sessionSummariesLoadStatus: "loaded",
       refreshCharacterEntries: async () => {
         refreshCount += 1;

--- a/scripts/tests/home-launch-state.test.ts
+++ b/scripts/tests/home-launch-state.test.ts
@@ -164,6 +164,7 @@ describe("home-launch-state", () => {
       const characterId = selectWeightedRandomLaunchCharacterId(
         entries,
         sessions,
+        [],
         () => (index + 0.5) / 600,
       );
       selectionCounts.set(characterId, (selectionCounts.get(characterId) ?? 0) + 1);
@@ -175,7 +176,7 @@ describe("home-launch-state", () => {
   });
 
   it("random character selection はactive Characterがなければ空IDを返す", () => {
-    assert.equal(selectWeightedRandomLaunchCharacterId([], [], () => 0.5), "");
+    assert.equal(selectWeightedRandomLaunchCharacterId([], [], [], () => 0.5), "");
   });
 
   it("random character selection は利用履歴がなければactive Characterを均等に選ぶ", () => {
@@ -189,12 +190,68 @@ describe("home-launch-state", () => {
       const characterId = selectWeightedRandomLaunchCharacterId(
         entries,
         [],
+        [],
         () => (index + 0.5) / 200,
       );
       selectionCounts.set(characterId, (selectionCounts.get(characterId) ?? 0) + 1);
     }
 
     assert.deepEqual(Object.fromEntries(selectionCounts), { mia: 100, noa: 100 });
+  });
+
+  it("random character selection は未使用のactive Characterがあれば使用中を候補から外す", () => {
+    const entries = [
+      createCharacterEntry({ id: "mia", name: "Mia" }),
+      createCharacterEntry({ id: "noa", name: "Noa" }),
+      createCharacterEntry({ id: "yui", name: "Yui" }),
+    ];
+
+    assert.equal(
+      selectWeightedRandomLaunchCharacterId(entries, [], ["mia", "noa"], () => 0),
+      "yui",
+    );
+  });
+
+  it("random character selection は未使用候補の中で最終利用順の重み付けを維持する", () => {
+    const entries = [
+      createCharacterEntry({ id: "mia", name: "Mia" }),
+      createCharacterEntry({ id: "noa", name: "Noa" }),
+      createCharacterEntry({ id: "yui", name: "Yui" }),
+    ];
+    const sessions = [
+      { characterId: "mia", sessionKind: "default" as const },
+      { characterId: "noa", sessionKind: "default" as const },
+    ];
+    const selectionCounts = new Map(entries.map((entry) => [entry.id, 0] as const));
+
+    for (let index = 0; index < 300; index += 1) {
+      const characterId = selectWeightedRandomLaunchCharacterId(
+        entries,
+        sessions,
+        ["mia"],
+        () => (index + 0.5) / 300,
+      );
+      selectionCounts.set(characterId, (selectionCounts.get(characterId) ?? 0) + 1);
+    }
+
+    assert.deepEqual(Object.fromEntries(selectionCounts), { mia: 0, noa: 100, yui: 200 });
+  });
+
+  it("random character selection は全active Characterが使用中なら重複を許容する", () => {
+    const entries = [
+      createCharacterEntry({ id: "mia", name: "Mia" }),
+      createCharacterEntry({ id: "noa", name: "Noa" }),
+    ];
+
+    assert.equal(
+      selectWeightedRandomLaunchCharacterId(
+        entries,
+        [{ characterId: "mia", sessionKind: "default" }],
+        ["mia", "noa"],
+        () => 0.4,
+      ),
+      "noa",
+    );
   });
 
   it("launch validation message は既存の優先順位で返す", () => {

--- a/scripts/tests/open-session-window-subscription.test.ts
+++ b/scripts/tests/open-session-window-subscription.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  startOpenSessionWindowIdsSubscription,
+  type OpenSessionWindowIdsState,
+  type OpenSessionWindowIdsSubscriptionApi,
+} from "../../src/open-session-window-subscription.js";
+
+const flushPromises = () => new Promise<void>((resolve) => {
+  queueMicrotask(resolve);
+});
+
+test("open Session Window 一覧の初回取得成功を loaded として反映する", async () => {
+  const appliedStates: OpenSessionWindowIdsState[] = [];
+  const api: OpenSessionWindowIdsSubscriptionApi = {
+    listOpenSessionWindowIds: async () => ["session-1"],
+    subscribeOpenSessionWindowIds: () => () => undefined,
+  };
+
+  const cleanup = startOpenSessionWindowIdsSubscription({
+    api,
+    applyState: (state) => appliedStates.push(state),
+  });
+  await flushPromises();
+  cleanup();
+
+  assert.deepEqual(appliedStates, [{ status: "loaded", sessionIds: ["session-1"] }]);
+});
+
+test("open Session Window 一覧の初回取得失敗を error として反映する", async () => {
+  const appliedStates: OpenSessionWindowIdsState[] = [];
+  const api: OpenSessionWindowIdsSubscriptionApi = {
+    listOpenSessionWindowIds: async () => {
+      throw new Error("list failed");
+    },
+    subscribeOpenSessionWindowIds: () => () => undefined,
+  };
+
+  const cleanup = startOpenSessionWindowIdsSubscription({
+    api,
+    applyState: (state) => appliedStates.push(state),
+  });
+  await flushPromises();
+  cleanup();
+
+  assert.deepEqual(appliedStates, [{ status: "error", sessionIds: [] }]);
+});
+
+test("購読更新後の初回取得失敗は loaded state を error へ戻さない", async () => {
+  const appliedStates: OpenSessionWindowIdsState[] = [];
+  let subscribedListener: ((sessionIds: string[]) => void) | null = null;
+  let rejectList: (error: Error) => void = () => undefined;
+  const api: OpenSessionWindowIdsSubscriptionApi = {
+    listOpenSessionWindowIds: () => new Promise((_, reject) => {
+      rejectList = reject;
+    }),
+    subscribeOpenSessionWindowIds: (listener) => {
+      subscribedListener = listener;
+      return () => undefined;
+    },
+  };
+
+  const cleanup = startOpenSessionWindowIdsSubscription({
+    api,
+    applyState: (state) => appliedStates.push(state),
+  });
+  subscribedListener?.(["session-current"]);
+  rejectList(new Error("stale list failed"));
+  await flushPromises();
+  cleanup();
+
+  assert.deepEqual(appliedStates, [{ status: "loaded", sessionIds: ["session-current"] }]);
+});
+
+test("初回取得失敗後も購読更新で loaded state へ復帰する", async () => {
+  const appliedStates: OpenSessionWindowIdsState[] = [];
+  let subscribedListener: ((sessionIds: string[]) => void) | null = null;
+  const api: OpenSessionWindowIdsSubscriptionApi = {
+    listOpenSessionWindowIds: async () => {
+      throw new Error("list failed");
+    },
+    subscribeOpenSessionWindowIds: (listener) => {
+      subscribedListener = listener;
+      return () => undefined;
+    },
+  };
+
+  const cleanup = startOpenSessionWindowIdsSubscription({
+    api,
+    applyState: (state) => appliedStates.push(state),
+  });
+  await flushPromises();
+  subscribedListener?.(["session-recovered"]);
+  cleanup();
+
+  assert.deepEqual(appliedStates, [
+    { status: "error", sessionIds: [] },
+    { status: "loaded", sessionIds: ["session-recovered"] },
+  ]);
+});

--- a/src/HomeApp.tsx
+++ b/src/HomeApp.tsx
@@ -15,6 +15,7 @@ import {
 } from "./auxiliary-session-state.js";
 import { type ModelCatalogSnapshot } from "./model-catalog.js";
 import { startModelCatalogSubscription } from "./model-catalog-subscription.js";
+import type { OpenSessionWindowIdsState } from "./open-session-window-subscription.js";
 import type { MemoryV6Diagnostics } from "./memory-v6/memory-diagnostics-state.js";
 import { WITHMATE_MEMORY_PROVIDER_INSTRUCTION_SAMPLE } from "./memory-v6/provider-instruction-sample.js";
 import {
@@ -95,7 +96,11 @@ export default function HomeApp() {
   const sessions = sessionSummariesState.summaries;
   const [companionSessions, setCompanionSessions] = useState<CompanionSessionSummary[]>([]);
   const [activeAuxiliarySessions, setActiveAuxiliarySessions] = useState<AuxiliarySessionSummary[]>([]);
-  const [openSessionWindowIds, setOpenSessionWindowIds] = useState<string[]>([]);
+  const [openSessionWindowIdsState, setOpenSessionWindowIdsState] = useState<OpenSessionWindowIdsState>({
+    status: "loading",
+    sessionIds: [],
+  });
+  const openSessionWindowIds = openSessionWindowIdsState.sessionIds;
   const [openCompanionReviewWindowIds, setOpenCompanionReviewWindowIds] = useState<string[]>([]);
   const [sessionSearchText, setSessionSearchText] = useState("");
   const [rightPaneView, setRightPaneView] = useState<HomeRightPaneView>("monitor");
@@ -301,7 +306,7 @@ export default function HomeApp() {
 
   useHomeOpenWindowSubscriptions({
     getApi: getWithMateApi,
-    setOpenSessionWindowIds,
+    setOpenSessionWindowIdsState,
     setOpenCompanionReviewWindowIds,
   });
 
@@ -403,6 +408,8 @@ export default function HomeApp() {
     characterEntries,
     selectedLaunchProviderId: selectedLaunchProvider?.id ?? null,
     sessions,
+    openSessionWindowIds,
+    openSessionWindowIdsLoadStatus: openSessionWindowIdsState.status,
     sessionSummariesLoadStatus: sessionSummariesState.status,
     refreshCharacterEntries: async () => {
       const api = getWithMateApi();

--- a/src/home/home-launch-actions.ts
+++ b/src/home/home-launch-actions.ts
@@ -4,6 +4,7 @@ import { createCompanionSessionSummary } from "../companion-state.js";
 import type { MateProfile, MateStorageState } from "../mate/mate-state.js";
 import type { CreateSessionRequest, SessionSummary } from "../session-state.js";
 import type { SessionSummariesLoadStatus } from "../session-summary-subscription.js";
+import type { OpenSessionWindowIdsLoadStatus } from "../open-session-window-subscription.js";
 import { projectSessionSummary } from "../session-state.js";
 import {
   buildCreateCompanionSessionInputFromLaunchDraft,
@@ -25,6 +26,8 @@ export type StartHomeLaunchInput = {
   characterEntries: readonly CharacterCatalogEntry[];
   selectedProviderId: string | null;
   sessions: readonly SessionSummary[];
+  openSessionWindowIds: readonly string[];
+  openSessionWindowIdsLoadStatus: OpenSessionWindowIdsLoadStatus;
   sessionSummariesLoadStatus: SessionSummariesLoadStatus;
   createSession: HomeLaunchSessionCreator;
   createCompanionSession: HomeLaunchCompanionSessionCreator;
@@ -64,10 +67,24 @@ export async function startHomeLaunch(input: StartHomeLaunchInput): Promise<void
     return;
   }
 
+  if (input.draft.characterSelectionMode === "random" && input.openSessionWindowIdsLoadStatus !== "loaded") {
+    input.setLaunchFeedback(
+      input.openSessionWindowIdsLoadStatus === "loading"
+        ? "開いている Session Window を確認してるよ。完了してからもう一度開始してね。"
+        : "開いている Session Window を確認できないため、ランダム選択を開始できないよ。",
+    );
+    return;
+  }
+
   input.setLaunchFeedback(requestedMode === "companion" ? "Companion を開始してるよ..." : "Session を開始してるよ...");
   input.setLaunchStarting(true);
 
   try {
+    const openSessionWindowIdSet = new Set(input.openSessionWindowIds);
+    const openSessionCharacterIds = input.sessions
+      .filter((session) => openSessionWindowIdSet.has(session.id))
+      .map((session) => session.characterId);
+
     if (requestedMode === "companion") {
       const companionInput = buildCreateCompanionSessionInputFromLaunchDraft({
         draft: input.draft,
@@ -75,6 +92,7 @@ export async function startHomeLaunch(input: StartHomeLaunchInput): Promise<void
         selectedProviderId: input.selectedProviderId,
         characterEntries: input.characterEntries,
         sessions: input.sessions,
+        openSessionCharacterIds,
         random: input.random,
       });
       if (!companionInput) {
@@ -100,6 +118,7 @@ export async function startHomeLaunch(input: StartHomeLaunchInput): Promise<void
       selectedProviderId: input.selectedProviderId,
       characterEntries: input.characterEntries,
       sessions: input.sessions,
+      openSessionCharacterIds,
       random: input.random,
     });
     if (!sessionInput) {

--- a/src/home/home-launch-handlers.ts
+++ b/src/home/home-launch-handlers.ts
@@ -5,6 +5,7 @@ import type { MateProfile, MateStorageState } from "../mate/mate-state.js";
 import type { CreateCompanionSessionInput, CompanionSession } from "../companion-state.js";
 import type { ModelCatalogProvider } from "../model-catalog.js";
 import type { SessionSummariesLoadStatus } from "../session-summary-subscription.js";
+import type { OpenSessionWindowIdsLoadStatus } from "../open-session-window-subscription.js";
 import type { HomeLaunchDraft } from "./home-launch-state.js";
 import {
   closeLaunchDraft,
@@ -28,6 +29,8 @@ type HomeLaunchHandlersContext = {
   characterEntries: readonly CharacterCatalogEntry[];
   selectedLaunchProviderId: string | null;
   sessions: readonly SessionSummary[];
+  openSessionWindowIds: readonly string[];
+  openSessionWindowIdsLoadStatus: OpenSessionWindowIdsLoadStatus;
   sessionSummariesLoadStatus: SessionSummariesLoadStatus;
   refreshCharacterEntries: () => Promise<readonly CharacterCatalogEntry[]>;
   setLaunchFeedback: (message: string) => void;
@@ -64,6 +67,8 @@ export function buildHomeLaunchHandlers({
   characterEntries,
   selectedLaunchProviderId,
   sessions,
+  openSessionWindowIds,
+  openSessionWindowIdsLoadStatus,
   sessionSummariesLoadStatus,
   refreshCharacterEntries,
   setLaunchFeedback,
@@ -124,6 +129,8 @@ export function buildHomeLaunchHandlers({
       selectedProviderId: selectedLaunchProviderId,
       characterEntries,
       sessions,
+      openSessionWindowIds,
+      openSessionWindowIdsLoadStatus,
       sessionSummariesLoadStatus,
       createSession,
       createCompanionSession,

--- a/src/home/home-launch-state.ts
+++ b/src/home/home-launch-state.ts
@@ -72,6 +72,7 @@ export function buildCreateCompanionSessionInputFromLaunchDraft({
   selectedProviderId,
   characterEntries = [],
   sessions = [],
+  openSessionCharacterIds = [],
   random = Math.random,
 }: {
   draft: HomeLaunchDraft;
@@ -79,6 +80,7 @@ export function buildCreateCompanionSessionInputFromLaunchDraft({
   selectedProviderId: string | null;
   characterEntries?: readonly CharacterCatalogEntry[];
   sessions?: readonly CharacterUsageSessionSource[];
+  openSessionCharacterIds?: readonly string[];
   random?: () => number;
 }): CreateCompanionSessionInput | null {
   const normalizedTitle = draft.title.trim();
@@ -86,7 +88,13 @@ export function buildCreateCompanionSessionInputFromLaunchDraft({
   if (!normalizedTitle || !workspace || !selectedProviderId) {
     return null;
   }
-  const characterSnapshot = buildLaunchCharacterSnapshot(characterEntries, draft, sessions, random);
+  const characterSnapshot = buildLaunchCharacterSnapshot(
+    characterEntries,
+    draft,
+    sessions,
+    openSessionCharacterIds,
+    random,
+  );
 
   return {
     taskTitle: normalizedTitle,
@@ -185,6 +193,7 @@ export function buildCreateSessionRequestFromLaunchDraft({
   selectedProviderId,
   characterEntries = [],
   sessions = [],
+  openSessionCharacterIds = [],
   random = Math.random,
 }: {
   draft: HomeLaunchDraft;
@@ -192,13 +201,20 @@ export function buildCreateSessionRequestFromLaunchDraft({
   selectedProviderId: string | null;
   characterEntries?: readonly CharacterCatalogEntry[];
   sessions?: readonly CharacterUsageSessionSource[];
+  openSessionCharacterIds?: readonly string[];
   random?: () => number;
 }): CreateSessionRequest | null {
   const normalizedTitle = draft.title.trim();
   if (!normalizedTitle || !draft.workspace || !selectedProviderId) {
     return null;
   }
-  const characterSnapshot = buildLaunchCharacterSnapshot(characterEntries, draft, sessions, random);
+  const characterSnapshot = buildLaunchCharacterSnapshot(
+    characterEntries,
+    draft,
+    sessions,
+    openSessionCharacterIds,
+    random,
+  );
   const workspace = isSessionFolderLaunchWorkspace(draft.workspace)
     ? { kind: "session-folder" as const }
     : {
@@ -234,6 +250,7 @@ export function resolveLaunchCharacterId(
 export function selectWeightedRandomLaunchCharacterId(
   entries: readonly CharacterCatalogEntry[],
   sessionsByLastActiveDesc: readonly CharacterUsageSessionSource[],
+  openSessionCharacterIds: readonly string[] = [],
   random: () => number = Math.random,
 ): string {
   const activeEntries = entries.filter((entry) => entry.state === "active");
@@ -241,12 +258,15 @@ export function selectWeightedRandomLaunchCharacterId(
     return "";
   }
 
-  const activeCharacterIds = new Set(activeEntries.map((entry) => entry.id));
+  const openSessionCharacterIdSet = new Set(openSessionCharacterIds);
+  const unusedEntries = activeEntries.filter((entry) => !openSessionCharacterIdSet.has(entry.id));
+  const eligibleEntries = unusedEntries.length > 0 ? unusedEntries : activeEntries;
+  const eligibleCharacterIds = new Set(eligibleEntries.map((entry) => entry.id));
   const recencyRanks = new Map<string, number>();
   for (const session of sessionsByLastActiveDesc) {
     if (
       session.sessionKind !== "default" ||
-      !activeCharacterIds.has(session.characterId) ||
+      !eligibleCharacterIds.has(session.characterId) ||
       recencyRanks.has(session.characterId)
     ) {
       continue;
@@ -254,7 +274,7 @@ export function selectWeightedRandomLaunchCharacterId(
     recencyRanks.set(session.characterId, recencyRanks.size);
   }
 
-  const weightedEntries = activeEntries.map((entry) => ({
+  const weightedEntries = eligibleEntries.map((entry) => ({
     entry,
     weight: (recencyRanks.get(entry.id) ?? recencyRanks.size) + 1,
   }));
@@ -287,10 +307,11 @@ function buildLaunchCharacterSnapshot(
   entries: readonly CharacterCatalogEntry[],
   draft: Pick<HomeLaunchDraft, "characterId" | "characterSelectionMode">,
   sessions: readonly CharacterUsageSessionSource[],
+  openSessionCharacterIds: readonly string[],
   random: () => number,
 ): LaunchCharacterSnapshot {
   const characterId = draft.characterSelectionMode === "random"
-    ? selectWeightedRandomLaunchCharacterId(entries, sessions, random)
+    ? selectWeightedRandomLaunchCharacterId(entries, sessions, openSessionCharacterIds, random)
     : draft.characterId;
   const character = resolveLaunchCharacterEntry(entries, characterId);
   if (!character) {

--- a/src/home/use-home-open-window-subscriptions.ts
+++ b/src/home/use-home-open-window-subscriptions.ts
@@ -1,52 +1,29 @@
 import { useEffect } from "react";
 
 import { startOpenCompanionReviewWindowIdsSubscription } from "../open-companion-review-window-subscription.js";
+import {
+  startOpenSessionWindowIdsSubscription,
+  type OpenSessionWindowIdsState,
+} from "../open-session-window-subscription.js";
 import type { WithMateWindowApi } from "../withmate-window-api.js";
 
 type UseHomeOpenWindowSubscriptionsInput = {
   getApi: () => WithMateWindowApi | null;
-  setOpenSessionWindowIds: (sessionIds: string[]) => void;
+  setOpenSessionWindowIdsState: (state: OpenSessionWindowIdsState) => void;
   setOpenCompanionReviewWindowIds: (sessionIds: string[]) => void;
 };
 
 export function useHomeOpenWindowSubscriptions({
   getApi,
-  setOpenSessionWindowIds,
+  setOpenSessionWindowIdsState,
   setOpenCompanionReviewWindowIds,
 }: UseHomeOpenWindowSubscriptionsInput): void {
   useEffect(() => {
-    let active = true;
-    let receivedSubscriptionUpdate = false;
-    const api = getApi();
-
-    if (!api) {
-      return () => {
-        active = false;
-      };
-    }
-
-    const unsubscribeOpenSessionWindowIds = api.subscribeOpenSessionWindowIds((nextSessionIds) => {
-      if (!active) {
-        return;
-      }
-
-      receivedSubscriptionUpdate = true;
-      setOpenSessionWindowIds(nextSessionIds);
+    return startOpenSessionWindowIdsSubscription({
+      api: getApi(),
+      applyState: setOpenSessionWindowIdsState,
     });
-
-    void api.listOpenSessionWindowIds().then((nextSessionIds) => {
-      if (!active || receivedSubscriptionUpdate) {
-        return;
-      }
-
-      setOpenSessionWindowIds(nextSessionIds);
-    });
-
-    return () => {
-      active = false;
-      unsubscribeOpenSessionWindowIds();
-    };
-  }, [getApi, setOpenSessionWindowIds]);
+  }, [getApi, setOpenSessionWindowIdsState]);
 
   useEffect(() => {
     return startOpenCompanionReviewWindowIdsSubscription({

--- a/src/open-session-window-subscription.ts
+++ b/src/open-session-window-subscription.ts
@@ -1,0 +1,58 @@
+export type OpenSessionWindowIdsLoadStatus = "loading" | "loaded" | "error";
+
+export type OpenSessionWindowIdsState = {
+  status: OpenSessionWindowIdsLoadStatus;
+  sessionIds: string[];
+};
+
+export type OpenSessionWindowIdsSubscriptionApi = {
+  listOpenSessionWindowIds: () => Promise<string[]>;
+  subscribeOpenSessionWindowIds: (
+    listener: (sessionIds: string[]) => void,
+  ) => () => void;
+};
+
+export function startOpenSessionWindowIdsSubscription(input: {
+  api: OpenSessionWindowIdsSubscriptionApi | null;
+  applyState: (state: OpenSessionWindowIdsState) => void;
+}): () => void {
+  let active = true;
+  let receivedSubscriptionUpdate = false;
+
+  if (!input.api) {
+    return () => {
+      active = false;
+    };
+  }
+
+  const applyLoadedState = (sessionIds: string[]) => {
+    input.applyState({ status: "loaded", sessionIds });
+  };
+  const unsubscribe = input.api.subscribeOpenSessionWindowIds((nextSessionIds) => {
+    if (!active) {
+      return;
+    }
+
+    receivedSubscriptionUpdate = true;
+    applyLoadedState(nextSessionIds);
+  });
+
+  void input.api.listOpenSessionWindowIds().then((nextSessionIds) => {
+    if (!active || receivedSubscriptionUpdate) {
+      return;
+    }
+
+    applyLoadedState(nextSessionIds);
+  }).catch(() => {
+    if (!active || receivedSubscriptionUpdate) {
+      return;
+    }
+
+    input.applyState({ status: "error", sessionIds: [] });
+  });
+
+  return () => {
+    active = false;
+    unsubscribe();
+  };
+}


### PR DESCRIPTION
## Summary

- 開いている通常 Session Window で使用中の Character をランダム候補から除外
- 未使用候補がない場合は重複を許容し、既存の重み付き抽選を継続
- Open Session Window 一覧に loading / loaded / error を持たせ、未取得・失敗時のランダム開始を停止

## Why

Home の初期空配列を「Open Window が0件」と誤認すると、既存 Window と同じ Character がランダム選択されるため。取得状態を明示して、未確認状態ではランダム開始を許可しない。

## Validation

- targeted tests: 42 pass
- npm run typecheck
- npm test: 2130 pass / 1 skipped
- npm run build