### PR TITLE
fix(markdown): Windowsパスリンクの誤遷移を防ぐ

### DIFF
--- a/scripts/tests/message-rich-text.test.ts
+++ b/scripts/tests/message-rich-text.test.ts
@@ -133,6 +133,50 @@ test("MessageRichText は local/file href の encode を保持して render す�
   assert.match(html, /<a href="C:\/tmp\/a%20b\.txt">windows<\/a>/);
 });
 
+test("MessageRichText は backslash 形式の Windows absolute path を既定ナビゲーションせず開く", async () => {
+  const dom = new JSDOM("<!doctype html><div id=\"root\"></div>", {
+    pretendToBeVisual: true,
+    url: "http://localhost/",
+  });
+  const restoreGlobals = installDomGlobals(dom);
+  const container = dom.window.document.getElementById("root");
+  const opened: string[] = [];
+  let root: Root | null = null;
+
+  try {
+    assert.ok(container);
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(React.createElement(MessageRichText, {
+        text: String.raw`[file](C:\workspace\session-files\report.txt)`,
+        forceFullRender: true,
+        onOpenPath: (target) => opened.push(target),
+      }));
+    });
+
+    const anchor = container.querySelector("a");
+    assert.ok(anchor);
+    assert.equal(anchor.getAttribute("href"), "C:%5Cworkspace%5Csession-files%5Creport.txt");
+
+    const clickEvent = new dom.window.MouseEvent("click", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+    });
+    const dispatchResult = anchor.dispatchEvent(clickEvent);
+
+    assert.equal(dispatchResult, false);
+    assert.equal(clickEvent.defaultPrevented, true);
+    assert.deepEqual(opened, ["C:%5Cworkspace%5Csession-files%5Creport.txt"]);
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    restoreGlobals();
+    dom.window.close();
+  }
+});
+
 test("MessageRichText は unsafe href を render しない", () => {
   const html = renderToStaticMarkup(
     React.createElement(MessageRichText, {
@@ -454,14 +498,18 @@ test("MessageRichText は protocol-relative link を HTTPS に正規化する", 
   assert.match(html, /href="https:\/\/example\.test\/docs"/);
 });
 
-test("MessageRichText は Windows absolute image path を file URL に変換する", () => {
+test("MessageRichText は slash / backslash 形式の Windows absolute image path を file URL に変換する", () => {
   const html = renderToStaticMarkup(
     React.createElement(MessageRichText, {
-      text: "![local](C:/workspace/image%20folder/sample.png)",
+      text: [
+        "![slash](C:/workspace/image%20folder/sample.png)",
+        String.raw`![backslash](C:\workspace\image-folder\sample.png)`,
+      ].join("\n"),
     }),
   );
 
   assert.match(html, /src="file:\/\/\/C:\/workspace\/image%20folder\/sample\.png"/);
+  assert.match(html, /src="file:\/\/\/C:\/workspace\/image-folder\/sample\.png"/);
 });
 
 test("MessageRichText は先頭空白付き Markdown 行でも停止せずに render できる", { timeout: 2_000 }, () => {

--- a/scripts/tests/open-path.test.ts
+++ b/scripts/tests/open-path.test.ts
@@ -154,6 +154,13 @@ describe("resolveOpenPathTarget", () => {
     });
   });
 
+  it("percent-encoded backslash 形式の Windows absolute path を local path に戻す", () => {
+    assert.deepEqual(resolveOpenPathTarget("C:%5Cworkspace%5Csession-files%5Creport.txt"), {
+      type: "local-path",
+      targetPath: "C:\\workspace\\session-files\\report.txt",
+    });
+  });
+
   it("absolute path の fragment は外して開く path にする", () => {
     assert.deepEqual(resolveOpenPathTarget("C:/workspace/project/src/App.tsx#L10"), {
       type: "local-path",

--- a/src/MessageRichText.tsx
+++ b/src/MessageRichText.tsx
@@ -84,8 +84,17 @@ function mergeClassName(baseClassName: string, className?: string) {
   return className ? `${baseClassName} ${className}` : baseClassName;
 }
 
+function decodeEncodedWindowsPathSeparators(target: string): string {
+  return target.replace(/%5c/gi, "\\");
+}
+
+function isWindowsAbsolutePathTarget(target: string): boolean {
+  const normalizedTarget = decodeEncodedWindowsPathSeparators(target);
+  return /^[a-zA-Z]:[\\/]/.test(normalizedTarget) || /^\\\\[^\\]+\\[^\\]+/.test(normalizedTarget);
+}
+
 function hasUnsupportedUrlScheme(target: string): boolean {
-  if (/^[a-zA-Z]:[\\/]/.test(target)) {
+  if (isWindowsAbsolutePathTarget(target)) {
     return false;
   }
 
@@ -96,10 +105,6 @@ function hasUnsupportedUrlScheme(target: string): boolean {
 
   const scheme = schemeMatch[1].toLowerCase();
   return scheme !== "http" && scheme !== "https" && scheme !== "file" && scheme !== "mailto" && scheme !== "tel";
-}
-
-function isWindowsAbsolutePathTarget(target: string): boolean {
-  return /^[a-zA-Z]:[\\/]/.test(target) || /^\\\\[^\\]+\\[^\\]+/.test(target);
 }
 
 function isAllowedMarkdownHref(target: string): boolean {
@@ -138,7 +143,7 @@ const markdownUrlTransform: UrlTransform = (url, key) => {
     if (url.startsWith("//")) {
       return `https:${url}`;
     }
-    return isWindowsAbsolutePathTarget(url) ? toLocalFileUrl(url) : url;
+    return isWindowsAbsolutePathTarget(url) ? toLocalFileUrl(decodeEncodedWindowsPathSeparators(url)) : url;
   }
   if (key !== "href") {
     return defaultUrlTransform(url);


### PR DESCRIPTION
## 概要

Windowsのバックスラッシュ形式で記載されたMarkdownファイルリンクが空の`href`へ変換され、Session Window内の既定ナビゲーションとして処理される問題を修正します。

## 原因

`react-markdown`は`C:\...`のバックスラッシュを`%5C`へencodeしてURL変換処理へ渡します。既存判定はencode前の`C:\`または`C:/`だけをWindows絶対パスとして扱っていたため、`C:%5C...`を未対応URL schemeとして除外していました。

## 変更内容

- encode済みWindows path separatorを絶対パス判定へ反映
- Markdown linkではencode済みtargetを保持して`openPath`へ渡す
- Markdown imageではseparatorを復元して`file:///` URLへ変換
- 実DOMクリックとmain側path復元の回帰テストを追加

## 検証

- `npx tsx --test scripts/tests/message-rich-text.test.ts scripts/tests/open-path.test.ts`（75件成功）
- `npm run typecheck`
- `npm run build:renderer`
- `git diff --check`