### PR TITLE
feat(changes): 変更ファイルをツリー表示する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,12 +62,14 @@ WithMate は Electron + React + TypeScript のデスクトップアプリであ�
 - `npm run typecheck`: renderer と Electron の TypeScript 型検査を実行する。
 - `npm test`: `scripts/tests/*.test.ts(x)` を `tsx --test` で実行する。
 - `npm run dist:win`: Windows installer を作成する。
+- `& .\scripts\start-withmate-visual-check.ps1`: 現在の Worktree を build し、`%APPDATA%\WithMate-visual-check` を使う検証用 Electron を起動する。既存の検証用プロセスは安全に識別できる場合だけ差し替え、インストール版 WithMate は停止しない。
 
 ## Testing
 
 - 変更種別に合う最小の targeted test を優先する。
 - 永続化、migration、IPC、provider adapter を変更した場合は、関連 test に加えて TypeScript 型検査を実行する。
 - UI 変更では、可能なら state / projection / component test を追加または更新する。
+- UI 変更や branch 固有の smoke / 目視確認が有効な場合、agent は `scripts/start-withmate-visual-check.ps1` による分離起動を候補としてユーザーへ提案する。実行する場合は対象 Worktree の root から呼び出し、検証用プロセスが差し替わることを明示する。
 - 全体検証が既存の unrelated failure で落ちる場合は、関係する failure と unrelated failure を切り分けて報告する。
 - 検証できない場合は、理由、代替確認、残リスクを明記する。
 

--- a/scripts/start-withmate-visual-check.ps1
+++ b/scripts/start-withmate-visual-check.ps1
@@ -1,0 +1,417 @@
+[CmdletBinding()]
+param(
+  [Parameter(Position = 0)]
+  [string]$WorktreePath = (Get-Location).Path,
+
+  [string]$ElectronPath,
+
+  [switch]$ValidateOnly
+)
+
+$ErrorActionPreference = "Stop"
+$VisualCheckProcessMarker = "--withmate-visual-check"
+
+if (-not ("WithMate.VisualCheck.NativeCommandLine" -as [type])) {
+  Add-Type -TypeDefinition @'
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace WithMate.VisualCheck {
+  public static class NativeCommandLine {
+    [DllImport("shell32.dll", SetLastError = true)]
+    private static extern IntPtr CommandLineToArgvW(
+      [MarshalAs(UnmanagedType.LPWStr)] string commandLine,
+      out int argumentCount
+    );
+
+    [DllImport("kernel32.dll")]
+    private static extern IntPtr LocalFree(IntPtr memory);
+
+    public static string[] Split(string commandLine) {
+      IntPtr arguments = CommandLineToArgvW(commandLine, out int argumentCount);
+      if (arguments == IntPtr.Zero) {
+        throw new Win32Exception(Marshal.GetLastWin32Error());
+      }
+
+      try {
+        string[] result = new string[argumentCount];
+        for (int index = 0; index < argumentCount; index++) {
+          IntPtr argument = Marshal.ReadIntPtr(arguments, index * IntPtr.Size);
+          result[index] = Marshal.PtrToStringUni(argument);
+        }
+        return result;
+      } finally {
+        LocalFree(arguments);
+      }
+    }
+  }
+}
+'@
+}
+
+function Resolve-FullPath {
+  param([Parameter(Mandatory = $true)][string]$Path)
+
+  return [System.IO.Path]::GetFullPath($Path)
+}
+
+function Assert-NotReparsePoint {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][string]$Label
+  )
+
+  if (-not (Test-Path -LiteralPath $Path)) {
+    return
+  }
+  $item = Get-Item -LiteralPath $Path -Force
+  if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+    throw "$Label must not be a junction or symbolic link: $Path"
+  }
+}
+
+function Get-RequiredElectronVersion {
+  param([Parameter(Mandatory = $true)][string]$RepositoryPath)
+
+  $lockPath = Join-Path $RepositoryPath "package-lock.json"
+  if (-not (Test-Path -LiteralPath $lockPath -PathType Leaf)) {
+    throw "package-lock.json was not found in $RepositoryPath"
+  }
+
+  $lock = Get-Content -LiteralPath $lockPath -Raw | ConvertFrom-Json -AsHashtable
+  $version = $lock["packages"]["node_modules/electron"]["version"]
+  if ([string]::IsNullOrWhiteSpace($version)) {
+    throw "Electron version was not found in package-lock.json"
+  }
+
+  return $version
+}
+
+function Get-WithMateWorktreePaths {
+  param([Parameter(Mandatory = $true)][string]$RepositoryPath)
+
+  $worktreeLines = & git.exe -C $RepositoryPath worktree list --porcelain
+  if ($LASTEXITCODE -ne 0) {
+    throw "Unable to list Git worktrees"
+  }
+
+  return @($worktreeLines | Where-Object {
+    $_.StartsWith("worktree ", [System.StringComparison]::Ordinal)
+  } | ForEach-Object {
+    Resolve-FullPath $_.Substring("worktree ".Length)
+  })
+}
+
+function Get-ElectronExecutable {
+  param(
+    [Parameter(Mandatory = $true)][string]$RepositoryPath,
+    [Parameter(Mandatory = $true)][string]$RequiredVersion,
+    [string]$ExplicitPath
+  )
+
+  $candidatePaths = [System.Collections.Generic.List[string]]::new()
+  if (-not [string]::IsNullOrWhiteSpace($ExplicitPath)) {
+    $candidatePaths.Add((Resolve-FullPath $ExplicitPath))
+  }
+  $candidatePaths.Add((Join-Path $RepositoryPath "node_modules\electron\dist\electron.exe"))
+
+  foreach ($candidateRoot in Get-WithMateWorktreePaths -RepositoryPath $RepositoryPath) {
+    $candidatePaths.Add((Join-Path $candidateRoot "node_modules\electron\dist\electron.exe"))
+  }
+
+  foreach ($candidatePath in $candidatePaths | Select-Object -Unique) {
+    if (-not (Test-Path -LiteralPath $candidatePath -PathType Leaf)) {
+      continue
+    }
+
+    $packagePath = Join-Path (Split-Path -Parent (Split-Path -Parent $candidatePath)) "package.json"
+    if (-not (Test-Path -LiteralPath $packagePath -PathType Leaf)) {
+      continue
+    }
+
+    $candidateVersion = (Get-Content -LiteralPath $packagePath -Raw | ConvertFrom-Json).version
+    if ($candidateVersion -eq $RequiredVersion) {
+      return (Resolve-FullPath $candidatePath)
+    }
+  }
+
+  throw "Electron $RequiredVersion was not found in this or another WithMate worktree. Run npm install in one worktree or pass -ElectronPath."
+}
+
+function Backup-SqliteDatabase {
+  param(
+    [Parameter(Mandatory = $true)][string]$SourcePath,
+    [Parameter(Mandatory = $true)][string]$DestinationPath
+  )
+
+  $backupScript = @'
+const { DatabaseSync, backup } = require("node:sqlite");
+(async () => {
+  const database = new DatabaseSync(process.argv[1], { readOnly: true, timeout: 10000 });
+  try {
+    await backup(database, process.argv[2], { rate: 256, sleep: 0 });
+  } finally {
+    database.close();
+  }
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
+'@
+
+  & node.exe --no-warnings -e $backupScript $SourcePath $DestinationPath
+  if ($LASTEXITCODE -ne 0) {
+    throw "SQLite backup failed: $SourcePath"
+  }
+}
+
+function Initialize-VisualCheckUserData {
+  param(
+    [Parameter(Mandatory = $true)][string]$SourcePath,
+    [Parameter(Mandatory = $true)][string]$DestinationPath
+  )
+
+  if (Test-Path -LiteralPath $DestinationPath) {
+    return
+  }
+  if (-not (Test-Path -LiteralPath $SourcePath -PathType Container)) {
+    throw "Source userData was not found: $SourcePath"
+  }
+
+  $stagingPath = "$DestinationPath.copying-$PID"
+  if (Test-Path -LiteralPath $stagingPath) {
+    throw "Staging path already exists: $stagingPath"
+  }
+
+  New-Item -ItemType Directory -Path $stagingPath | Out-Null
+  Write-Host "Copying userData to a staging directory..."
+
+  $excludedFiles = @(
+    "withmate*.db",
+    "withmate*.db-wal",
+    "withmate*.db-shm",
+    "withmate.sqlite3",
+    "withmate.sqlite3-wal",
+    "withmate.sqlite3-shm",
+    "lockfile",
+    "DevToolsActivePort",
+    "SingletonCookie",
+    "SingletonLock",
+    "SingletonSocket"
+  )
+  & robocopy.exe $SourcePath $stagingPath /E /XJ /COPY:DAT /DCOPY:DAT /R:2 /W:1 /MT:8 /NFL /NDL /NP /XF $excludedFiles
+  $copyExitCode = $LASTEXITCODE
+  if ($copyExitCode -ge 8) {
+    throw "Robocopy failed with exit code $copyExitCode. Partial data remains at $stagingPath"
+  }
+
+  $databaseFiles = Get-ChildItem -LiteralPath $SourcePath -File | Where-Object {
+    $_.Name -match '^withmate(?:-v\d+)?\.(?:db|sqlite3)$'
+  }
+  foreach ($databaseFile in $databaseFiles) {
+    Write-Host "Creating consistent SQLite snapshot: $($databaseFile.Name)"
+    Backup-SqliteDatabase `
+      -SourcePath $databaseFile.FullName `
+      -DestinationPath (Join-Path $stagingPath $databaseFile.Name)
+  }
+
+  Move-Item -LiteralPath $stagingPath -Destination $DestinationPath
+  Write-Host "Created visual-check userData: $DestinationPath"
+}
+
+function Get-CommandLineArguments {
+  param([string]$CommandLine)
+
+  if ([string]::IsNullOrWhiteSpace($CommandLine)) {
+    return @()
+  }
+
+  return @([WithMate.VisualCheck.NativeCommandLine]::Split($CommandLine))
+}
+
+function Test-VisualCheckProcess {
+  param(
+    [Parameter(Mandatory = $true)]$Process,
+    [Parameter(Mandatory = $true)][string[]]$KnownMainPaths,
+    [Parameter(Mandatory = $true)][string]$ProcessMarker
+  )
+
+  if ($Process.Name -ne "electron.exe") {
+    return $false
+  }
+
+  $arguments = @(Get-CommandLineArguments -CommandLine $Process.CommandLine)
+  if (-not ($arguments -ccontains $ProcessMarker)) {
+    return $false
+  }
+
+  return [bool]($KnownMainPaths | Where-Object {
+    $knownMainPath = $_
+    $arguments | Where-Object {
+      $_.Equals($knownMainPath, [System.StringComparison]::OrdinalIgnoreCase)
+    } | Select-Object -First 1
+  } | Select-Object -First 1)
+}
+
+function Get-ProcessTreeIds {
+  param([Parameter(Mandatory = $true)][int]$RootProcessId)
+
+  $allProcesses = @(Get-CimInstance Win32_Process)
+  $pending = [System.Collections.Generic.Queue[int]]::new()
+  $orderedIds = [System.Collections.Generic.List[int]]::new()
+  $pending.Enqueue($RootProcessId)
+  while ($pending.Count -gt 0) {
+    $currentId = $pending.Dequeue()
+    $orderedIds.Add($currentId)
+    foreach ($child in $allProcesses | Where-Object { $_.ParentProcessId -eq $currentId }) {
+      $pending.Enqueue([int]$child.ProcessId)
+    }
+  }
+
+  $result = $orderedIds.ToArray()
+  [array]::Reverse($result)
+  return $result
+}
+
+function Stop-ProcessTree {
+  param([Parameter(Mandatory = $true)][int]$RootProcessId)
+
+  foreach ($processId in Get-ProcessTreeIds -RootProcessId $RootProcessId) {
+    Stop-Process -Id $processId -Force -ErrorAction SilentlyContinue
+  }
+
+  $deadline = [DateTimeOffset]::UtcNow.AddSeconds(10)
+  while ((Get-Process -Id $RootProcessId -ErrorAction SilentlyContinue) -and
+    [DateTimeOffset]::UtcNow -lt $deadline) {
+    Start-Sleep -Milliseconds 100
+  }
+  if (Get-Process -Id $RootProcessId -ErrorAction SilentlyContinue) {
+    throw "Visual-check process did not stop: PID $RootProcessId"
+  }
+}
+
+function Stop-ExistingVisualCheckProcess {
+  param(
+    [Parameter(Mandatory = $true)][string]$RepositoryPath,
+    [Parameter(Mandatory = $true)][string]$UserDataPath,
+    [Parameter(Mandatory = $true)][string]$ProcessMarker
+  )
+
+  $statePath = Join-Path $UserDataPath "visual-check-process.json"
+  $knownMainPaths = @(Get-WithMateWorktreePaths -RepositoryPath $RepositoryPath | ForEach-Object {
+    Resolve-FullPath (Join-Path $_ "dist-electron\src-electron\main.js")
+  })
+  $markedCandidates = @(Get-CimInstance Win32_Process -Filter "Name = 'electron.exe'" | Where-Object {
+    Test-VisualCheckProcess `
+      -Process $_ `
+      -KnownMainPaths $knownMainPaths `
+      -ProcessMarker $ProcessMarker
+  })
+  if ($markedCandidates.Count -gt 1) {
+    $candidateIds = ($markedCandidates.ProcessId | Sort-Object) -join ", "
+    throw "Multiple visual-check WithMate processes are running ($candidateIds). Close all but one manually."
+  }
+  $selectedProcess = $markedCandidates | Select-Object -First 1
+
+  if ($selectedProcess) {
+    Write-Host "Stopping previous visual-check WithMate: PID $($selectedProcess.ProcessId)"
+    Stop-ProcessTree -RootProcessId ([int]$selectedProcess.ProcessId)
+  }
+  if (Test-Path -LiteralPath $statePath) {
+    Remove-Item -LiteralPath $statePath -Force
+  }
+
+  $lockPath = Join-Path $UserDataPath "lockfile"
+  $deadline = [DateTimeOffset]::UtcNow.AddSeconds(10)
+  while ((Test-Path -LiteralPath $lockPath) -and [DateTimeOffset]::UtcNow -lt $deadline) {
+    Start-Sleep -Milliseconds 100
+  }
+  if (Test-Path -LiteralPath $lockPath) {
+    throw "The visual-check userData remains locked, and no safely identifiable process can be stopped."
+  }
+}
+
+$resolvedWorktreePath = Resolve-FullPath $WorktreePath
+$resolvedUserDataPath = Resolve-FullPath (Join-Path $env:APPDATA "WithMate-visual-check")
+$resolvedSourceUserDataPath = Resolve-FullPath (Join-Path $env:APPDATA "WithMate")
+
+if (-not (Test-Path -LiteralPath (Join-Path $resolvedWorktreePath "package.json") -PathType Leaf)) {
+  throw "WorktreePath is not a WithMate repository: $resolvedWorktreePath"
+}
+Assert-NotReparsePoint -Path $resolvedSourceUserDataPath -Label "Source userData"
+Assert-NotReparsePoint -Path $resolvedUserDataPath -Label "Visual-check userData"
+
+Initialize-VisualCheckUserData `
+  -SourcePath $resolvedSourceUserDataPath `
+  -DestinationPath $resolvedUserDataPath
+
+$requiredElectronVersion = Get-RequiredElectronVersion -RepositoryPath $resolvedWorktreePath
+$resolvedElectronPath = Get-ElectronExecutable `
+  -RepositoryPath $resolvedWorktreePath `
+  -RequiredVersion $requiredElectronVersion `
+  -ExplicitPath $ElectronPath
+
+Write-Host "Building $resolvedWorktreePath"
+Push-Location $resolvedWorktreePath
+try {
+  & npm.cmd run build
+  if ($LASTEXITCODE -ne 0) {
+    throw "WithMate build failed"
+  }
+} finally {
+  Pop-Location
+}
+
+$mainPath = Join-Path $resolvedWorktreePath "dist-electron\src-electron\main.js"
+if (-not (Test-Path -LiteralPath $mainPath -PathType Leaf)) {
+  throw "Electron main build was not found: $mainPath"
+}
+
+if ($ValidateOnly) {
+  [pscustomobject]@{
+    WorktreePath = $resolvedWorktreePath
+    UserDataPath = $resolvedUserDataPath
+    ElectronPath = $resolvedElectronPath
+    ElectronVersion = $requiredElectronVersion
+    MainPath = $mainPath
+    Ready = $true
+  }
+  return
+}
+
+Stop-ExistingVisualCheckProcess `
+  -RepositoryPath $resolvedWorktreePath `
+  -UserDataPath $resolvedUserDataPath `
+  -ProcessMarker $VisualCheckProcessMarker
+
+$env:WITHMATE_USER_DATA_PATH = $resolvedUserDataPath
+Remove-Item Env:VITE_DEV_SERVER_URL -ErrorAction SilentlyContinue
+$process = Start-Process `
+  -FilePath $resolvedElectronPath `
+  -ArgumentList @($mainPath, $VisualCheckProcessMarker) `
+  -WorkingDirectory $resolvedWorktreePath `
+  -PassThru
+
+Start-Sleep -Seconds 3
+if (-not (Get-Process -Id $process.Id -ErrorAction SilentlyContinue)) {
+  throw "WithMate exited during startup (PID $($process.Id))"
+}
+
+$processStatePath = Join-Path $resolvedUserDataPath "visual-check-process.json"
+@{
+  schemaVersion = 1
+  processId = $process.Id
+  mainPath = $mainPath
+  electronPath = $resolvedElectronPath
+  marker = $VisualCheckProcessMarker
+  launchedAt = [DateTimeOffset]::UtcNow.ToString("O")
+} | ConvertTo-Json | Set-Content -LiteralPath $processStatePath -Encoding utf8
+
+[pscustomobject]@{
+  ProcessId = $process.Id
+  WorktreePath = $resolvedWorktreePath
+  UserDataPath = $resolvedUserDataPath
+  ElectronPath = $resolvedElectronPath
+  ElectronVersion = $requiredElectronVersion
+}

--- a/scripts/tests/changed-file-tree.test.ts
+++ b/scripts/tests/changed-file-tree.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildChangedFileTree,
+  changedFileDisplayName,
+} from "../../src/file-explorer/changed-file-tree.js";
+import type { FileRootGitChangeEntry } from "../../src/file-explorer/file-explorer-contract.js";
+
+const entries: FileRootGitChangeEntry[] = [
+  {
+    relativePath: "README.md",
+    previousRelativePath: null,
+    kinds: { "working-tree": "modified" },
+    scopes: ["working-tree"],
+  },
+  {
+    relativePath: "src/zeta.ts",
+    previousRelativePath: null,
+    kinds: { staged: "modified" },
+    scopes: ["staged"],
+  },
+  {
+    relativePath: "src/components/Button.tsx",
+    previousRelativePath: null,
+    kinds: { "working-tree": "untracked" },
+    scopes: ["working-tree"],
+  },
+  {
+    relativePath: "docs/guide.md",
+    previousRelativePath: null,
+    kinds: { "working-tree": "modified" },
+    scopes: ["working-tree"],
+  },
+  {
+    relativePath: "src/alpha.ts",
+    previousRelativePath: "legacy/old-alpha.ts",
+    kinds: { "working-tree": "renamed" },
+    scopes: ["working-tree"],
+  },
+];
+
+test("buildChangedFileTree は scope を分離し directory-first の階層へ投影する", () => {
+  const tree = buildChangedFileTree(entries, "working-tree");
+
+  assert.deepEqual(tree.map((node) => [node.type, node.name]), [
+    ["directory", "docs"],
+    ["directory", "src"],
+    ["file", "README.md"],
+  ]);
+  const src = tree[1];
+  assert.equal(src?.type, "directory");
+  if (src?.type !== "directory") {
+    return;
+  }
+  assert.deepEqual(src.children.map((node) => [node.type, node.name]), [
+    ["directory", "components"],
+    ["file", "alpha.ts"],
+  ]);
+  assert.equal(src.children.some((node) => node.name === "zeta.ts"), false);
+});
+
+test("buildChangedFileTree は同名の directory と file を別nodeとして保持する", () => {
+  const replacementEntries: FileRootGitChangeEntry[] = [
+    {
+      relativePath: "target",
+      previousRelativePath: null,
+      kinds: { staged: "deleted" },
+      scopes: ["staged"],
+    },
+    {
+      relativePath: "target/new.txt",
+      previousRelativePath: null,
+      kinds: { staged: "added" },
+      scopes: ["staged"],
+    },
+  ];
+
+  assert.deepEqual(
+    buildChangedFileTree(replacementEntries, "staged").map((node) => [node.type, node.name]),
+    [["directory", "target"], ["file", "target"]],
+  );
+});
+
+test("changedFileDisplayName は rename の旧名と新名を表示する", () => {
+  const renamed = entries.find((entry) => entry.previousRelativePath);
+  assert.ok(renamed);
+  assert.equal(changedFileDisplayName(renamed), "old-alpha.ts → alpha.ts");
+  assert.equal(changedFileDisplayName(entries[0]!), "README.md");
+});

--- a/scripts/tests/workspace-changes-pane.test.tsx
+++ b/scripts/tests/workspace-changes-pane.test.tsx
@@ -74,13 +74,13 @@ test("FileRootChangesPane は大量の変更を constrained viewport 内で仮�
   const { FileRootChangesPane } = await import("../../src/file-explorer/FileRootChangesPane.js");
 
   const entries: FileRootGitChangeEntry[] = Array.from({ length: 400 }, (_, index) => ({
-    relativePath: index === 0 ? "src/shared.ts" : `src/file-${index}.ts`,
+    relativePath: index === 0 ? "src/00-shared.ts" : `src/file-${index}.ts`,
     previousRelativePath: null,
     scopes: ["working-tree"],
     kinds: { "working-tree": "modified", staged: null },
   }));
   const additionalEntries: FileRootGitChangeEntry[] = [{
-    relativePath: "app/src/shared.ts",
+    relativePath: "app/src/00-shared.ts",
     previousRelativePath: null,
     scopes: ["working-tree"],
     kinds: { "working-tree": "modified" },
@@ -140,11 +140,26 @@ test("FileRootChangesPane は大量の変更を constrained viewport 内で仮�
     assert.ok(rows.length > 0, dom.window.document.body.innerHTML);
     assert.ok(rows.length < entries.length, `mounted ${rows.length} rows for ${entries.length} entries`);
     assert.ok(rows.every((row) => row.dataset.index !== undefined));
+    const rootPath = dom.window.document.querySelector<HTMLElement>(".workspace-changes-root-header[title='C:/repo'] span");
+    assert.equal(rootPath?.textContent, "C:/repo");
+
+    const appDirectory = [...dom.window.document.querySelectorAll<HTMLButtonElement>(".workspace-change-directory-row")]
+      .find((button) => button.title === "app");
+    assert.ok(appDirectory);
+    assert.equal(appDirectory.getAttribute("aria-expanded"), "true");
+    await act(async () => appDirectory.click());
+    assert.equal(
+      [...dom.window.document.querySelectorAll<HTMLButtonElement>(".workspace-change-row")]
+        .some((button) => button.title === "app/src/00-shared.ts"),
+      false,
+    );
+    assert.equal(appDirectory.getAttribute("aria-expanded"), "false");
+    await act(async () => appDirectory.click());
 
     const additionalChange = [...dom.window.document.querySelectorAll<HTMLButtonElement>(".workspace-change-row")]
-      .find((button) => button.title === "app/src/shared.ts");
+      .find((button) => button.title === "app/src/00-shared.ts");
     const workspaceChange = [...dom.window.document.querySelectorAll<HTMLButtonElement>(".workspace-change-row")]
-      .find((button) => button.title === "src/shared.ts");
+      .find((button) => button.title === "src/00-shared.ts");
     assert.ok(additionalChange);
     assert.ok(workspaceChange);
     await act(async () => {
@@ -156,8 +171,8 @@ test("FileRootChangesPane は大量の変更を constrained viewport 内で仮�
       await Promise.resolve();
     });
     assert.deepEqual(diffRequests.map(({ rootId, relativePath }) => ({ rootId, relativePath })), [
-      { rootId: "additional:repo", relativePath: "app/src/shared.ts" },
-      { rootId: "workspace", relativePath: "src/shared.ts" },
+      { rootId: "additional:repo", relativePath: "app/src/00-shared.ts" },
+      { rootId: "workspace", relativePath: "src/00-shared.ts" },
     ]);
 
     let rejectStaleRequest: ((reason?: unknown) => void) | null = null;

--- a/src/file-explorer/FileRootChangesPane.tsx
+++ b/src/file-explorer/FileRootChangesPane.tsx
@@ -2,6 +2,11 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { WithMateWindowApi } from "../withmate-window-api.js";
+import {
+  buildChangedFileTree,
+  changedFileDisplayName,
+  type ChangedFileTreeNode,
+} from "./changed-file-tree.js";
 import type {
   FileRootFileDiffRequest,
   FileRootChangesResult,
@@ -53,11 +58,26 @@ type FileRootChangeRow =
   | { key: string; type: "error"; label: string }
   | {
       key: string;
+      type: "directory";
+      rootId: string;
+      scope: FileRootGitChangeScope;
+      relativePath: string;
+      name: string;
+      depth: number;
+      expanded: boolean;
+    }
+  | {
+      key: string;
       type: "entry";
       rootId: string;
       entry: FileRootGitChangeEntry;
       scope: FileRootGitChangeScope;
+      depth: number;
     };
+
+function directoryStateKey(rootId: string, scope: FileRootGitChangeScope, relativePath: string): string {
+  return `${rootId}\u0000${scope}\u0000${relativePath}`;
+}
 
 export function FileRootChangesPane({
   api,
@@ -73,6 +93,7 @@ export function FileRootChangesPane({
   const [loading, setLoading] = useState(false);
   const [loadingKey, setLoadingKey] = useState("");
   const [message, setMessage] = useState("");
+  const [collapsedDirectories, setCollapsedDirectories] = useState<Record<string, boolean>>({});
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
   const reload = useCallback(async () => {
@@ -142,6 +163,15 @@ export function FileRootChangesPane({
     };
   }, [reload, rootsRevision]);
 
+  useEffect(() => {
+    setCollapsedDirectories({});
+  }, [rootsRevision, sessionId]);
+
+  const toggleDirectory = (rootId: string, scope: FileRootGitChangeScope, relativePath: string) => {
+    const key = directoryStateKey(rootId, scope, relativePath);
+    setCollapsedDirectories((current) => ({ ...current, [key]: !current[key] }));
+  };
+
   const openEntry = async (
     rootId: string,
     entry: FileRootGitChangeEntry,
@@ -181,6 +211,41 @@ export function FileRootChangesPane({
 
   const rows = useMemo(() => {
     const nextRows: FileRootChangeRow[] = [];
+    const appendTreeNodes = (
+      nodes: ChangedFileTreeNode[],
+      rootId: string,
+      scope: FileRootGitChangeScope,
+      depth: number,
+    ) => {
+      for (const node of nodes) {
+        if (node.type === "directory") {
+          const stateKey = directoryStateKey(rootId, scope, node.relativePath);
+          const expanded = !collapsedDirectories[stateKey];
+          nextRows.push({
+            key: `directory:${rootId}:${scope}:${node.relativePath}`,
+            type: "directory",
+            rootId,
+            scope,
+            relativePath: node.relativePath,
+            name: node.name,
+            depth,
+            expanded,
+          });
+          if (expanded) {
+            appendTreeNodes(node.children, rootId, scope, depth + 1);
+          }
+        } else {
+          nextRows.push({
+            key: `${rootId}:${scope}:${node.relativePath}`,
+            type: "entry",
+            rootId,
+            entry: node.entry,
+            scope,
+            depth,
+          });
+        }
+      }
+    };
     for (const rootChange of rootChanges) {
       nextRows.push({ key: `root:${rootChange.root.id}`, type: "root", root: rootChange.root });
       if (rootChange.message) {
@@ -198,15 +263,7 @@ export function FileRootChangesPane({
         if (scopedEntries.length === 0) {
           nextRows.push({ key: `empty:${rootChange.root.id}:${scope}`, type: "empty", label: "No changes." });
         } else {
-          scopedEntries.forEach((entry) => {
-            nextRows.push({
-              key: `${rootChange.root.id}:${scope}:${entry.relativePath}`,
-              type: "entry",
-              rootId: rootChange.root.id,
-              entry,
-              scope,
-            });
-          });
+          appendTreeNodes(buildChangedFileTree(scopedEntries, scope), rootChange.root.id, scope, 0);
         }
       }
     }
@@ -214,12 +271,12 @@ export function FileRootChangesPane({
       nextRows.push({ key: "no-git-roots", type: "empty", label: "No Git repositories." });
     }
     return nextRows;
-  }, [loading, rootChanges]);
+  }, [collapsedDirectories, loading, rootChanges]);
   const virtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => scrollRef.current,
     getItemKey: (index) => rows[index]?.key ?? index,
-    estimateSize: (index) => rows[index]?.type === "root" ? 38 : rows[index]?.type === "header" ? 31 : 30,
+    estimateSize: (index) => rows[index]?.type === "root" ? 48 : rows[index]?.type === "header" ? 31 : 30,
     overscan: 16,
     initialRect: { width: 280, height: 480 },
     useFlushSync: false,
@@ -258,6 +315,18 @@ export function FileRootChangesPane({
                   <p>{row.label}</p>
                 ) : row.type === "error" ? (
                   <p className="workspace-changes-root-error">{row.label}</p>
+                ) : row.type === "directory" ? (
+                  <button
+                    className="workspace-change-directory-row"
+                    type="button"
+                    style={{ paddingLeft: `${6 + row.depth * 14}px` }}
+                    aria-expanded={row.expanded}
+                    title={row.relativePath}
+                    onClick={() => toggleDirectory(row.rootId, row.scope, row.relativePath)}
+                  >
+                    <span className={`workspace-change-directory-icon${row.expanded ? " is-expanded" : ""}`}>▸</span>
+                    <span className="workspace-change-directory-name">{row.name}</span>
+                  </button>
                 ) : (() => {
                   const key = `${row.rootId}:${row.scope}:${row.entry.relativePath}`;
                   const kind = row.entry.kinds[row.scope] ?? "modified";
@@ -265,6 +334,7 @@ export function FileRootChangesPane({
                     <button
                       className="workspace-change-row"
                       type="button"
+                      style={{ paddingLeft: `${6 + row.depth * 14}px` }}
                       disabled={!!loadingKey}
                       onClick={() => void openEntry(row.rootId, row.entry, row.scope)}
                       title={row.entry.previousRelativePath
@@ -272,7 +342,7 @@ export function FileRootChangesPane({
                         : row.entry.relativePath}
                     >
                       <span className={`workspace-change-kind ${kind}`}>{changeKindLabel(kind)}</span>
-                      <span className="workspace-change-path">{row.entry.relativePath}</span>
+                      <span className="workspace-change-path">{changedFileDisplayName(row.entry)}</span>
                       {loadingKey === key ? <span className="workspace-change-loading">…</span> : null}
                     </button>
                   );

--- a/src/file-explorer/changed-file-tree.ts
+++ b/src/file-explorer/changed-file-tree.ts
@@ -1,0 +1,106 @@
+import type {
+  FileRootGitChangeEntry,
+  FileRootGitChangeScope,
+} from "./file-explorer-contract.js";
+
+export type ChangedFileTreeDirectory = {
+  type: "directory";
+  name: string;
+  relativePath: string;
+  children: ChangedFileTreeNode[];
+};
+
+export type ChangedFileTreeFile = {
+  type: "file";
+  name: string;
+  relativePath: string;
+  entry: FileRootGitChangeEntry;
+};
+
+export type ChangedFileTreeNode = ChangedFileTreeDirectory | ChangedFileTreeFile;
+
+type MutableDirectory = {
+  name: string;
+  relativePath: string;
+  directories: Map<string, MutableDirectory>;
+  files: ChangedFileTreeFile[];
+};
+
+function pathBasename(relativePath: string): string {
+  return relativePath.slice(relativePath.lastIndexOf("/") + 1);
+}
+
+function compareNames(left: string, right: string): number {
+  return left.localeCompare(right, undefined, { sensitivity: "base" })
+    || left.localeCompare(right);
+}
+
+function compareNodes(left: ChangedFileTreeNode, right: ChangedFileTreeNode): number {
+  const typeOrder = (left.type === "directory" ? 0 : 1) - (right.type === "directory" ? 0 : 1);
+  return typeOrder
+    || compareNames(left.name, right.name)
+    || left.relativePath.localeCompare(right.relativePath);
+}
+
+function finishDirectory(directory: MutableDirectory): ChangedFileTreeNode[] {
+  return [
+    ...[...directory.directories.values()].map((child): ChangedFileTreeDirectory => ({
+      type: "directory",
+      name: child.name,
+      relativePath: child.relativePath,
+      children: finishDirectory(child),
+    })),
+    ...directory.files,
+  ].sort(compareNodes);
+}
+
+export function changedFileDisplayName(entry: FileRootGitChangeEntry): string {
+  return entry.previousRelativePath
+    ? `${pathBasename(entry.previousRelativePath)} → ${pathBasename(entry.relativePath)}`
+    : pathBasename(entry.relativePath);
+}
+
+export function buildChangedFileTree(
+  entries: FileRootGitChangeEntry[],
+  scope: FileRootGitChangeScope,
+): ChangedFileTreeNode[] {
+  const root: MutableDirectory = {
+    name: "",
+    relativePath: "",
+    directories: new Map(),
+    files: [],
+  };
+  for (const entry of entries) {
+    if (!entry.scopes.includes(scope)) {
+      continue;
+    }
+    const segments = entry.relativePath.split("/");
+    const fileName = segments.pop();
+    if (!fileName) {
+      continue;
+    }
+    let directory = root;
+    let directoryPath = "";
+    for (const segment of segments) {
+      directoryPath = directoryPath ? `${directoryPath}/${segment}` : segment;
+      let child = directory.directories.get(segment);
+      if (!child) {
+        child = {
+          name: segment,
+          relativePath: directoryPath,
+          directories: new Map(),
+          files: [],
+        };
+        directory.directories.set(segment, child);
+      }
+      directory = child;
+    }
+    directory.files.push({
+      type: "file",
+      name: fileName,
+      relativePath: entry.relativePath,
+      entry,
+    });
+  }
+  return finishDirectory(root);
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -4681,8 +4681,7 @@ button:disabled {
   border-top: 0;
 }
 
-.workspace-changes-root-header strong,
-.workspace-changes-root-header span {
+.workspace-changes-root-header strong {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -4691,6 +4690,7 @@ button:disabled {
 .workspace-changes-root-header span {
   color: var(--muted);
   font-size: 0.7rem;
+  overflow-wrap: anywhere;
 }
 
 .workspace-changes-group-header {
@@ -4732,8 +4732,43 @@ button:disabled {
   cursor: pointer;
 }
 
+.workspace-change-directory-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding-top: 5px;
+  padding-right: 6px;
+  padding-bottom: 5px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--ink);
+  text-align: left;
+  cursor: pointer;
+}
+
+.workspace-change-directory-row:hover,
 .workspace-change-row:hover {
   background: color-mix(in srgb, var(--character-sub-soft) 24%, rgba(15, 23, 42, 0.54));
+}
+
+.workspace-change-directory-icon {
+  flex: 0 0 16px;
+  color: var(--muted);
+  text-align: center;
+  transition: transform 120ms ease;
+}
+
+.workspace-change-directory-icon.is-expanded {
+  transform: rotate(90deg);
+}
+
+.workspace-change-directory-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.78rem;
 }
 
 .workspace-change-kind {


### PR DESCRIPTION
## 概要

- Changes pane の変更ファイルを repository / directory / file のツリーで表示
- Working tree と Staged の表示・既存diff操作を維持
- repository path の折り返し表示とdirectory開閉を追加
- rename、同名path、scope分離、並び順の投影テストを追加
- 分離したuserDataを使って任意のWorktreeをbuild・起動する検証スクリプトを追加
- 検証用プロセスだけを安全に差し替え、インストール版WithMateを対象外にする

## 検証

- `npx tsx --test scripts/tests/changed-file-tree.test.ts scripts/tests/workspace-changes-pane.test.tsx scripts/tests/message-rich-text.test.ts scripts/tests/open-path.test.ts`
- `npm test`（2145 pass / 1 skip / 0 fail）
- `npm run typecheck`
- `npm run build`
- `scripts/start-withmate-visual-check.ps1` のPowerShell構文、引数完全一致、build後のプロセス差し替えを確認
- 分離したuserData環境で目視確認
