### PR TITLE
feat(file-preview): JSONとYAMLの整形表示を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,10 @@
       "dependencies": {
         "@github/copilot-sdk": "^1.0.6",
         "@openai/codex-sdk": "^0.145.0",
+        "@shikijs/core": "^4.4.2",
+        "@shikijs/engine-javascript": "^4.4.2",
+        "@shikijs/langs": "^4.4.2",
+        "@shikijs/themes": "^4.4.2",
         "@tanstack/react-virtual": "^3.14.6",
         "ignore": "^7.0.5",
         "mdast-util-from-markdown": "^2.0.3",
@@ -19,6 +23,7 @@
         "mermaid": "^11.16.0",
         "micromark-extension-gfm": "^3.0.0",
         "micromark-extension-math": "^3.1.0",
+        "prettier": "^3.9.6",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-markdown": "^10.1.0",
@@ -2433,6 +2438,93 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@shikijs/core": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.4.2.tgz",
+      "integrity": "sha512-StyzbAyxg2/tBGf78gwbBkGyeQ73lf8UiJArFaQhTQIDqQOCKPCQFanvrs4/Yv3Yfyc+ONInJM6K+FMIf+P+kA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.4.2",
+        "@shikijs/types": "4.4.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.4.2.tgz",
+      "integrity": "sha512-MnIkeqWdVPUWsxlx8gKLVCJFTsqrQJgpTPBPpQwaFeJ56lOnJxj5aN2LUFnfxUEcvOQuNocmbaMnVrCEln6rkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.4.2.tgz",
+      "integrity": "sha512-8DfeusD+Zdv/eYIDdXyJTUnSMHt+aAWjAOCXV20HNGAHRlInXpG8wh421v6B91WOm9TFwRLN+b/LG5F2NAIojg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.4.2.tgz",
+      "integrity": "sha512-l6fQQKsOMlz72n38fztmSgZ76MO6KSWuw8o+GJ+FhmqrpC9pIOJNQNXGgbb5yX2AwpzlEHwsaLPnk/8o4Fm+rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.4.2.tgz",
+      "integrity": "sha512-H0CFoL07ddDC2Dd6EdrPYNkRhUR6YCkJlnuYFceYYUJJA5TIm2b5B33qqiDYryBExgbKMndFJPb2u1gTuqO37g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.4.2.tgz",
+      "integrity": "sha512-PFYitV4vpDr/iPCIhnHp+Q4ftic5N5VeNJ3KQ1O8gn3h2ar8qgwMAXF7tq4m1CWaMS60fV4VqF6vfnWH4F7vqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
@@ -5802,6 +5894,29 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -5909,6 +6024,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -7902,6 +8027,23 @@
         "wrappy": "1"
       }
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
@@ -8199,6 +8341,21 @@
         "node": "^12.20.0 || >=14"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/proc-log": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
@@ -8392,6 +8549,30 @@
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
     },
     "node_modules/rehype-katex": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
   "dependencies": {
     "@github/copilot-sdk": "^1.0.6",
     "@openai/codex-sdk": "^0.145.0",
+    "@shikijs/core": "^4.4.2",
+    "@shikijs/engine-javascript": "^4.4.2",
+    "@shikijs/langs": "^4.4.2",
+    "@shikijs/themes": "^4.4.2",
     "@tanstack/react-virtual": "^3.14.6",
     "ignore": "^7.0.5",
     "mdast-util-gfm": "^3.1.0",
@@ -40,6 +44,7 @@
     "mermaid": "^11.16.0",
     "micromark-extension-gfm": "^3.0.0",
     "micromark-extension-math": "^3.1.0",
+    "prettier": "^3.9.6",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-markdown": "^10.1.0",

--- a/scripts/tests/session-file-preview-image-lifecycle.test.tsx
+++ b/scripts/tests/session-file-preview-image-lifecycle.test.tsx
@@ -9,6 +9,7 @@ import type {
   SessionFileDescriptor,
   SessionFileResourceRequest,
 } from "../../src/file-explorer/file-explorer-contract.js";
+import { STRUCTURED_TEXT_PREVIEW_MAX_BYTES } from "../../src/file-explorer/structured-text-preview.js";
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -97,6 +98,26 @@ function installDomGlobals(dom: JSDOM): () => void {
   };
 }
 
+function installElementSize(dom: JSDOM): () => void {
+  const prototype = dom.window.HTMLElement.prototype;
+  const previousOffsetWidth = Object.getOwnPropertyDescriptor(prototype, "offsetWidth");
+  const previousOffsetHeight = Object.getOwnPropertyDescriptor(prototype, "offsetHeight");
+  Object.defineProperty(prototype, "offsetWidth", { configurable: true, get: () => 800 });
+  Object.defineProperty(prototype, "offsetHeight", { configurable: true, get: () => 600 });
+  return () => {
+    if (previousOffsetWidth) {
+      Object.defineProperty(prototype, "offsetWidth", previousOffsetWidth);
+    } else {
+      Reflect.deleteProperty(prototype, "offsetWidth");
+    }
+    if (previousOffsetHeight) {
+      Object.defineProperty(prototype, "offsetHeight", previousOffsetHeight);
+    } else {
+      Reflect.deleteProperty(prototype, "offsetHeight");
+    }
+  };
+}
+
 function copyArrayBuffer(bytes: Uint8Array): ArrayBuffer {
   const copy = new Uint8Array(bytes.byteLength);
   copy.set(bytes);
@@ -161,6 +182,50 @@ function createPreviewApi(
     },
   };
   return { api, getImageInspectCount: () => imageInspectCount };
+}
+
+function createTextPreviewApi(
+  request: SessionFileResourceRequest,
+  name: string,
+  raw: string,
+  revision: string,
+): PreviewApi {
+  const bytes = new TextEncoder().encode(raw);
+  return {
+    ...DEFAULT_IMAGE_COPY_API,
+    async listSessionFileRoots() {
+      return [{ id: "workspace", kind: "workspace", label: "Workspace", displayPath: "C:\\workspace" }];
+    },
+    async inspectSessionFile() {
+      return {
+        ...request,
+        name,
+        kind: "text",
+        byteLength: bytes.byteLength,
+        modifiedAt: "2026-08-09T00:00:00.000Z",
+        mimeType: "text/plain",
+        suggestedEncoding: "utf-8",
+        revision,
+      };
+    },
+    async readSessionFileChunk(chunkRequest) {
+      const chunk = bytes.slice(chunkRequest.offset, chunkRequest.offset + chunkRequest.length);
+      return {
+        data: copyArrayBuffer(chunk),
+        offset: chunkRequest.offset,
+        nextOffset: chunkRequest.offset + chunk.byteLength,
+        totalBytes: bytes.byteLength,
+        done: chunkRequest.offset + chunk.byteLength >= bytes.byteLength,
+        revision: chunkRequest.expectedRevision,
+      };
+    },
+    async openSessionFile() {
+      return { status: "opened", targetType: "local-path", target: request.relativePath };
+    },
+    async openPath(target) {
+      return { status: "opened", targetType: "local-path", target };
+    },
+  };
 }
 
 async function waitFor(condition: () => boolean): Promise<void> {
@@ -346,6 +411,123 @@ test("inspection prefix より後ろで binary と判明した Markdown は rich
     await waitFor(() => container.querySelector(".session-file-preview-metadata") !== null);
     assert.equal(container.querySelector(".session-file-markdown"), null);
     assert.match(container.textContent ?? "", /Preview is not available for this binary file/);
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    restoreGlobals();
+    dom.window.close();
+  }
+});
+
+test("JSON preview は Formatted と原文を保持した Raw を切り替える", async () => {
+  const dom = new JSDOM("<!doctype html><div id=\"root\"></div>", {
+    pretendToBeVisual: true,
+    url: "http://localhost/",
+  });
+  const restoreGlobals = installDomGlobals(dom);
+  const restoreElementSize = installElementSize(dom);
+  const request: SessionFileResourceRequest = {
+    sessionId: "session-1",
+    rootId: "workspace",
+    relativePath: "config/settings.json",
+  };
+  const raw = "{\"markup\":\"<img src=x onerror=alert(1)>\",\"enabled\":true}";
+  const api = createTextPreviewApi(request, "settings.json", raw, "json-r1");
+  const container = dom.window.document.getElementById("root");
+  let root: Root | null = null;
+
+  try {
+    assert.ok(container);
+    root = await renderPreview(api, container, request);
+    await waitFor(() => {
+      const formatted = Array.from(container.querySelectorAll<HTMLButtonElement>("button"))
+        .find((button) => button.textContent === "Formatted");
+      return formatted?.disabled === false;
+    });
+    const formattedButton = Array.from(container.querySelectorAll<HTMLButtonElement>("button"))
+      .find((button) => button.textContent === "Formatted");
+    const rawButton = Array.from(container.querySelectorAll<HTMLButtonElement>("button"))
+      .find((button) => button.textContent === "Raw");
+    assert.ok(formattedButton?.classList.contains("is-active"));
+    assert.ok(rawButton);
+    assert.equal(container.querySelector("img[src='x']"), null);
+    assert.match(container.textContent ?? "", /<img src=x onerror=alert\(1\)>/);
+
+    await act(async () => rawButton.click());
+    await waitFor(() => rawButton.classList.contains("is-active"));
+    const displayedLines = Array.from(container.querySelectorAll(".session-file-text-line code"))
+      .map((element) => element.textContent ?? "");
+    assert.deepEqual(displayedLines, [raw]);
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    restoreGlobals();
+    restoreElementSize();
+    dom.window.close();
+  }
+});
+
+test("不正な YAML preview は parse error を示して Raw へ fallback する", async () => {
+  const dom = new JSDOM("<!doctype html><div id=\"root\"></div>", {
+    pretendToBeVisual: true,
+    url: "http://localhost/",
+  });
+  const restoreGlobals = installDomGlobals(dom);
+  const restoreElementSize = installElementSize(dom);
+  const request: SessionFileResourceRequest = {
+    sessionId: "session-1",
+    rootId: "workspace",
+    relativePath: "config/settings.yaml",
+  };
+  const raw = "root: [";
+  const api = createTextPreviewApi(request, "settings.yaml", raw, "yaml-r1");
+  const container = dom.window.document.getElementById("root");
+  let root: Root | null = null;
+
+  try {
+    assert.ok(container);
+    root = await renderPreview(api, container, request);
+    await waitFor(() => container.textContent?.includes("Formatted preview is unavailable") ?? false);
+    const formattedButton = Array.from(container.querySelectorAll<HTMLButtonElement>("button"))
+      .find((button) => button.textContent === "Formatted");
+    const rawButton = Array.from(container.querySelectorAll<HTMLButtonElement>("button"))
+      .find((button) => button.textContent === "Raw");
+    assert.equal(formattedButton?.disabled, true);
+    assert.ok(rawButton?.classList.contains("is-active"));
+    assert.match(container.textContent ?? "", /root: \[/);
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    restoreGlobals();
+    restoreElementSize();
+    dom.window.close();
+  }
+});
+
+test("上限を超える JSON preview はformatせず既存Raw表示へ戻す", async () => {
+  const dom = new JSDOM("<!doctype html><div id=\"root\"></div>", {
+    pretendToBeVisual: true,
+    url: "http://localhost/",
+  });
+  const restoreGlobals = installDomGlobals(dom);
+  const request: SessionFileResourceRequest = {
+    sessionId: "session-1",
+    rootId: "workspace",
+    relativePath: "large.json",
+  };
+  const raw = `{"value":"${"a".repeat(STRUCTURED_TEXT_PREVIEW_MAX_BYTES)}"}`;
+  const api = createTextPreviewApi(request, "large.json", raw, "large-json-r1");
+  const container = dom.window.document.getElementById("root");
+  let root: Root | null = null;
+
+  try {
+    assert.ok(container);
+    root = await renderPreview(api, container, request);
+    await waitFor(() => container.textContent?.includes("Formatted preview is skipped") ?? false);
+    assert.equal(container.querySelector("[aria-label='Structured text display mode']"), null);
   } finally {
     if (root) {
       await act(async () => root?.unmount());

--- a/scripts/tests/structured-text-preview.test.ts
+++ b/scripts/tests/structured-text-preview.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  canProjectStructuredText,
+  projectStructuredText,
+  resolveStructuredTextFormat,
+  STRUCTURED_TEXT_PREVIEW_MAX_BYTES,
+} from "../../src/file-explorer/structured-text-preview.js";
+
+test("structured text format は対応拡張子だけを大小文字を区別せず分類する", () => {
+  assert.equal(resolveStructuredTextFormat("settings.JSON"), "json");
+  assert.equal(resolveStructuredTextFormat("config.jsonc"), "jsonc");
+  assert.equal(resolveStructuredTextFormat("config.yaml"), "yaml");
+  assert.equal(resolveStructuredTextFormat("config.yml"), "yaml");
+  assert.equal(resolveStructuredTextFormat("config.ts"), null);
+  assert.equal(resolveStructuredTextFormat("table.csv"), null);
+});
+
+test("structured text projection は JSON の raw を保持しつつ整形結果とtokenを返す", async () => {
+  const raw = "{\"nested\":{\"enabled\":true},\"count\":2}";
+  const projection = await projectStructuredText(raw, "json");
+
+  assert.equal(projection.formattedText, [
+    "{",
+    "  \"nested\": {",
+    "    \"enabled\": true",
+    "  },",
+    "  \"count\": 2",
+    "}",
+    "",
+  ].join("\n"));
+  assert.equal(projection.rawTokens.flat().map((token) => token.content).join(""), raw);
+  assert.equal(
+    projection.formattedTokens.map((line) => line.map((token) => token.content).join("")).join("\n"),
+    projection.formattedText,
+  );
+});
+
+test("structured text projection は JSONC と YAML を同じ境界で整形する", async () => {
+  const jsonc = await projectStructuredText("{/* keep */\"enabled\":true}", "jsonc");
+  const yaml = await projectStructuredText("root:\n  enabled: true\n", "yaml");
+
+  assert.match(jsonc.formattedText, /\/\* keep \*\//);
+  assert.equal(jsonc.rawTokens.flat().map((token) => token.content).join(""), "{/* keep */\"enabled\":true}");
+  assert.equal(yaml.formattedText, "root:\n  enabled: true\n");
+});
+
+test("structured text projection は不正構文を成功扱いしない", async () => {
+  await assert.rejects(() => projectStructuredText("{\"missing\":", "json"));
+  await assert.rejects(() => projectStructuredText("root: [", "yaml"));
+});
+
+test("structured text projection は256 KiBを上限にする", () => {
+  assert.equal(canProjectStructuredText(STRUCTURED_TEXT_PREVIEW_MAX_BYTES), true);
+  assert.equal(canProjectStructuredText(STRUCTURED_TEXT_PREVIEW_MAX_BYTES + 1), false);
+});

--- a/src/file-explorer/SessionFilePreview.tsx
+++ b/src/file-explorer/SessionFilePreview.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
   type PointerEvent as ReactPointerEvent,
   type MouseEvent as ReactMouseEvent,
   type ReactNode,
@@ -55,6 +56,16 @@ import {
   type UnifiedDiffContentRow,
   type UnifiedDiffDisplayRow,
 } from "./unified-diff.js";
+import {
+  canProjectStructuredText,
+  highlightRawStructuredText,
+  projectStructuredText,
+  resolveStructuredTextFormat,
+  STRUCTURED_TEXT_PREVIEW_MAX_BYTES,
+  type PreviewSyntaxToken,
+  type StructuredTextFormat,
+  type StructuredTextProjection,
+} from "./structured-text-preview.js";
 
 type FilePreviewApi = Pick<
   WithMateWindowApi,
@@ -98,6 +109,22 @@ type FileLoadState =
   | { status: "loading"; descriptor: SessionFileDescriptor; loadedBytes: number }
   | { status: "ready"; loaded: LoadedFile | null; descriptor: SessionFileDescriptor }
   | { status: "error"; message: string };
+
+type StructuredTextProjectionState =
+  | { status: "idle" | "loading" }
+  | {
+    status: "ready";
+    sourceText: string;
+    format: StructuredTextFormat;
+    projection: StructuredTextProjection;
+  }
+  | {
+    status: "error";
+    sourceText: string;
+    format: StructuredTextFormat;
+    message: string;
+    rawTokens: PreviewSyntaxToken[][] | null;
+  };
 
 const MARKDOWN_LOCAL_IMAGE_CONCURRENCY = 4;
 const IMAGE_ZOOM_MIN = 10;
@@ -183,6 +210,7 @@ type VirtualizedTextContentProps = {
   matches: PreviewTextMatch[];
   currentMatchIndex: number;
   variant?: "text" | "diff";
+  syntaxTokens?: PreviewSyntaxToken[][] | null;
 };
 
 type IndexedPreviewTextMatch = PreviewTextMatch & { matchIndex: number };
@@ -217,12 +245,73 @@ function renderHighlightedLine(
   return content;
 }
 
+function syntaxTokenStyle(token: PreviewSyntaxToken, includeColor: boolean): CSSProperties {
+  return {
+    ...(includeColor && token.color ? { color: token.color } : {}),
+    ...(token.fontStyle && (token.fontStyle & 1) !== 0 ? { fontStyle: "italic" } : {}),
+    ...(token.fontStyle && (token.fontStyle & 2) !== 0 ? { fontWeight: 700 } : {}),
+    ...(token.fontStyle && (token.fontStyle & 4) !== 0 ? { textDecoration: "underline" } : {}),
+  };
+}
+
+function renderSyntaxHighlightedLine(
+  line: string,
+  tokens: PreviewSyntaxToken[],
+  matches: IndexedPreviewTextMatch[],
+  currentMatchIndex: number,
+): ReactNode {
+  if (tokens.map((token) => token.content).join("") !== line) {
+    return renderHighlightedLine(line, matches, currentMatchIndex);
+  }
+  const content: ReactNode[] = [];
+  let lineOffset = 0;
+  let key = 0;
+  for (const token of tokens) {
+    const tokenStart = lineOffset;
+    const tokenEnd = tokenStart + token.content.length;
+    const boundaries = new Set([tokenStart, tokenEnd]);
+    for (const match of matches) {
+      if (match.endOffset > tokenStart && match.startOffset < tokenEnd) {
+        boundaries.add(Math.max(tokenStart, match.startOffset));
+        boundaries.add(Math.min(tokenEnd, match.endOffset));
+      }
+    }
+    const sortedBoundaries = [...boundaries].sort((left, right) => left - right);
+    for (let index = 0; index < sortedBoundaries.length - 1; index += 1) {
+      const start = sortedBoundaries[index] ?? tokenStart;
+      const end = sortedBoundaries[index + 1] ?? tokenEnd;
+      if (end <= start) {
+        continue;
+      }
+      const text = token.content.slice(start - tokenStart, end - tokenStart);
+      const match = matches.find((candidate) => candidate.startOffset <= start && candidate.endOffset >= end);
+      if (match) {
+        content.push(
+          <mark
+            key={key}
+            className={match.matchIndex === currentMatchIndex ? "is-current" : undefined}
+            style={syntaxTokenStyle(token, false)}
+          >
+            {text}
+          </mark>,
+        );
+      } else {
+        content.push(<span key={key} style={syntaxTokenStyle(token, true)}>{text}</span>);
+      }
+      key += 1;
+    }
+    lineOffset = tokenEnd;
+  }
+  return content.length > 0 ? content : " ";
+}
+
 function VirtualizedTextContent({
   text,
   copyText,
   matches,
   currentMatchIndex,
   variant = "text",
+  syntaxTokens = null,
 }: VirtualizedTextContentProps) {
   const lines = useMemo(() => splitPreviewLines(text), [text]);
   const matchesByLine = useMemo(() => {
@@ -277,7 +366,16 @@ function VirtualizedTextContent({
               style={{ transform: `translateY(${virtualLine.start}px)` }}
             >
               <span className="session-file-line-number" aria-hidden="true">{virtualLine.index + 1}</span>
-              <code>{renderHighlightedLine(line, matchesByLine.get(virtualLine.index) ?? [], currentMatchIndex)}</code>
+              <code>
+                {syntaxTokens?.[virtualLine.index]
+                  ? renderSyntaxHighlightedLine(
+                    line,
+                    syntaxTokens[virtualLine.index] ?? [],
+                    matchesByLine.get(virtualLine.index) ?? [],
+                    currentMatchIndex,
+                  )
+                  : renderHighlightedLine(line, matchesByLine.get(virtualLine.index) ?? [], currentMatchIndex)}
+              </code>
             </div>
           );
         })}
@@ -438,6 +536,10 @@ export function SessionFilePreview({
   const [loadState, setLoadState] = useState<FileLoadState>({ status: "inspecting" });
   const [encoding, setEncoding] = useState<SessionFileEncodingSelection>("auto");
   const [markdownMode, setMarkdownMode] = useState<"preview" | "source">("preview");
+  const [structuredTextMode, setStructuredTextMode] = useState<"formatted" | "raw">("formatted");
+  const [structuredTextProjection, setStructuredTextProjection] = useState<StructuredTextProjectionState>({
+    status: "idle",
+  });
   const [imageZoom, setImageZoom] = useState<"fit" | number>("fit");
   const [imageFitZoom, setImageFitZoom] = useState(100);
   const [imageObjectUrl, setImageObjectUrl] = useState("");
@@ -534,6 +636,8 @@ export function SessionFilePreview({
     setLoadState({ status: "inspecting" });
     setEncoding("auto");
     setMarkdownMode("preview");
+    setStructuredTextMode("formatted");
+    setStructuredTextProjection({ status: "idle" });
     setImageZoom("fit");
     imagePanSessionRef.current = null;
     setIsImagePanning(false);
@@ -592,7 +696,79 @@ export function SessionFilePreview({
     }
     return decodeSessionFileBytes(loaded.bytes, encoding, loaded.descriptor.suggestedEncoding);
   }, [encoding, loaded]);
-  const textLines = useMemo(() => splitPreviewLines(decodedText), [decodedText]);
+  const structuredTextFormat = previewKind === "text" && descriptor
+    ? resolveStructuredTextFormat(descriptor.name)
+    : null;
+  const structuredTextEligible = Boolean(
+    loaded &&
+    structuredTextFormat &&
+    canProjectStructuredText(loaded.bytes.byteLength),
+  );
+
+  useEffect(() => {
+    if (!structuredTextFormat || !structuredTextEligible) {
+      setStructuredTextProjection({ status: "idle" });
+      return;
+    }
+    let current = true;
+    setStructuredTextMode("formatted");
+    setStructuredTextProjection({ status: "loading" });
+    void projectStructuredText(decodedText, structuredTextFormat).then((projection) => {
+      if (current) {
+        setStructuredTextProjection({
+          status: "ready",
+          sourceText: decodedText,
+          format: structuredTextFormat,
+          projection,
+        });
+      }
+    }).catch(async (error) => {
+      const message = error instanceof Error
+        ? error.message.split(/\r?\n/, 1)[0] ?? "Structured text could not be formatted."
+        : "Structured text could not be formatted.";
+      let rawTokens: PreviewSyntaxToken[][] | null = null;
+      try {
+        rawTokens = await highlightRawStructuredText(decodedText, structuredTextFormat);
+      } catch {
+        rawTokens = null;
+      }
+      if (current) {
+        setStructuredTextMode("raw");
+        setStructuredTextProjection({
+          status: "error",
+          sourceText: decodedText,
+          format: structuredTextFormat,
+          message,
+          rawTokens,
+        });
+      }
+    });
+    return () => {
+      current = false;
+    };
+  }, [decodedText, structuredTextEligible, structuredTextFormat]);
+
+  const currentStructuredTextProjection = structuredTextProjection.status === "ready" &&
+    structuredTextProjection.sourceText === decodedText &&
+    structuredTextProjection.format === structuredTextFormat
+    ? structuredTextProjection.projection
+    : null;
+  const currentStructuredTextError = structuredTextProjection.status === "error" &&
+    structuredTextProjection.sourceText === decodedText &&
+    structuredTextProjection.format === structuredTextFormat
+    ? structuredTextProjection
+    : null;
+  const displayedText = currentStructuredTextProjection && structuredTextMode === "formatted"
+    ? currentStructuredTextProjection.formattedText
+    : decodedText;
+  const displayedSyntaxTokens = currentStructuredTextProjection
+    ? structuredTextMode === "formatted"
+      ? currentStructuredTextProjection.formattedTokens
+      : currentStructuredTextProjection.rawTokens
+    : currentStructuredTextError
+      ? currentStructuredTextError.rawTokens
+      : null;
+  const textLines = useMemo(() => splitPreviewLines(displayedText), [displayedText]);
   const findMatches = useMemo(
     () => findPreviewTextMatches(textLines, findQuery),
     [findQuery, textLines],
@@ -990,6 +1166,13 @@ export function SessionFilePreview({
     }
   }, [onOpenDiff]);
 
+  const structuredTextFeedback = currentStructuredTextError
+    ? `Formatted preview is unavailable: ${currentStructuredTextError.message} Showing raw content.`
+    : loaded && structuredTextFormat && loaded.bytes.byteLength > STRUCTURED_TEXT_PREVIEW_MAX_BYTES
+      ? `Formatted preview is skipped for files larger than ${formatFileByteLength(STRUCTURED_TEXT_PREVIEW_MAX_BYTES)}.`
+      : "";
+  const previewFeedback = [feedback, diffAvailabilityMessage, structuredTextFeedback].filter(Boolean);
+
   return (
     <section className="session-file-preview" aria-label="File preview">
       <header className="session-file-preview-header">
@@ -1013,6 +1196,21 @@ export function SessionFilePreview({
             <div className="session-file-preview-segmented" role="group" aria-label="Markdown display mode">
               <button type="button" className={markdownMode === "preview" ? "is-active" : ""} onClick={() => setMarkdownMode("preview")}>Preview</button>
               <button type="button" className={markdownMode === "source" ? "is-active" : ""} onClick={() => setMarkdownMode("source")}>Source</button>
+            </div>
+          ) : null}
+          {structuredTextFormat && structuredTextEligible ? (
+            <div className="session-file-preview-segmented" role="group" aria-label="Structured text display mode">
+              <button
+                type="button"
+                className={structuredTextMode === "formatted" ? "is-active" : ""}
+                disabled={!currentStructuredTextProjection}
+                onClick={() => setStructuredTextMode("formatted")}
+              >Formatted</button>
+              <button
+                type="button"
+                className={structuredTextMode === "raw" ? "is-active" : ""}
+                onClick={() => setStructuredTextMode("raw")}
+              >Raw</button>
             </div>
           ) : null}
           {descriptor && (previewKind === "image" || previewKind === "svg") ? (
@@ -1105,10 +1303,11 @@ export function SessionFilePreview({
 
       {loadState.status === "ready" && loaded && previewKind === "text" ? (
         <VirtualizedTextContent
-          text={decodedText}
+          text={displayedText}
           copyText={onCopyText}
           matches={findMatches}
           currentMatchIndex={activeCurrentMatch}
+          syntaxTokens={displayedSyntaxTokens}
         />
       ) : null}
       {loadState.status === "ready" && loaded && previewKind === "markdown" ? (
@@ -1163,11 +1362,14 @@ export function SessionFilePreview({
           </div>
         </div>
       ) : null}
-      {feedback || diffAvailabilityMessage ? (
+      {previewFeedback.length > 0 ? (
         <p className="session-file-preview-feedback" role="alert">
-          {feedback}
-          {feedback && diffAvailabilityMessage ? <br /> : null}
-          {diffAvailabilityMessage}
+          {previewFeedback.map((message, index) => (
+            <span key={message}>
+              {index > 0 ? <br /> : null}
+              {message}
+            </span>
+          ))}
         </p>
       ) : null}
     </section>

--- a/src/file-explorer/structured-text-preview.ts
+++ b/src/file-explorer/structured-text-preview.ts
@@ -1,0 +1,126 @@
+import { createHighlighterCore, type ThemedToken } from "@shikijs/core";
+import { createJavaScriptRegexEngine } from "@shikijs/engine-javascript";
+
+export const STRUCTURED_TEXT_PREVIEW_MAX_BYTES = 256 * 1024;
+
+export type StructuredTextFormat = "json" | "jsonc" | "yaml";
+
+export type PreviewSyntaxToken = {
+  content: string;
+  color?: string;
+  fontStyle?: number;
+};
+
+export type StructuredTextProjection = {
+  formattedText: string;
+  formattedTokens: PreviewSyntaxToken[][];
+  rawTokens: PreviewSyntaxToken[][];
+};
+
+const FORMAT_BY_EXTENSION: Readonly<Record<string, StructuredTextFormat>> = {
+  ".json": "json",
+  ".jsonc": "jsonc",
+  ".yaml": "yaml",
+  ".yml": "yaml",
+};
+
+let highlighterPromise: ReturnType<typeof createHighlighterCore> | null = null;
+
+function getStructuredTextHighlighter(): ReturnType<typeof createHighlighterCore> {
+  if (!highlighterPromise) {
+    const createdHighlighter = createHighlighterCore({
+      themes: [import("@shikijs/themes/github-dark-default")],
+      langs: [
+        import("@shikijs/langs/json"),
+        import("@shikijs/langs/jsonc"),
+        import("@shikijs/langs/yaml"),
+      ],
+      engine: createJavaScriptRegexEngine(),
+    });
+    highlighterPromise = createdHighlighter;
+    void createdHighlighter.catch(() => {
+      if (highlighterPromise === createdHighlighter) {
+        highlighterPromise = null;
+      }
+    });
+  }
+  return highlighterPromise;
+}
+
+function extensionOf(fileName: string): string {
+  const normalized = fileName.toLocaleLowerCase("en-US");
+  const separatorIndex = Math.max(normalized.lastIndexOf("/"), normalized.lastIndexOf("\\"));
+  const dotIndex = normalized.lastIndexOf(".");
+  return dotIndex > separatorIndex ? normalized.slice(dotIndex) : "";
+}
+
+export function resolveStructuredTextFormat(fileName: string): StructuredTextFormat | null {
+  return FORMAT_BY_EXTENSION[extensionOf(fileName)] ?? null;
+}
+
+export function canProjectStructuredText(byteLength: number): boolean {
+  return byteLength >= 0 && byteLength <= STRUCTURED_TEXT_PREVIEW_MAX_BYTES;
+}
+
+function toPreviewTokens(lines: ThemedToken[][]): PreviewSyntaxToken[][] {
+  return lines.map((line) => line.map((token) => ({
+    content: token.content,
+    ...(token.color ? { color: token.color } : {}),
+    ...(token.fontStyle === undefined ? {} : { fontStyle: token.fontStyle }),
+  })));
+}
+
+async function highlightStructuredText(
+  text: string,
+  format: StructuredTextFormat,
+): Promise<PreviewSyntaxToken[][]> {
+  const highlighter = await getStructuredTextHighlighter();
+  return toPreviewTokens(highlighter.codeToTokensBase(text, {
+    lang: format,
+    theme: "github-dark-default",
+  }));
+}
+
+async function formatStructuredText(text: string, format: StructuredTextFormat): Promise<string> {
+  if (format === "json") {
+    JSON.parse(text);
+  }
+  const { format: formatWithPrettier } = await import("prettier/standalone");
+  const plugins = format === "yaml"
+    ? [await import("prettier/plugins/yaml")]
+    : await Promise.all([
+      import("prettier/plugins/babel"),
+      import("prettier/plugins/estree"),
+    ]);
+  return formatWithPrettier(text, {
+    parser: format === "json" ? "json-stringify" : format,
+    plugins,
+  });
+}
+
+export async function projectStructuredText(
+  text: string,
+  format: StructuredTextFormat,
+): Promise<StructuredTextProjection> {
+  const formattedText = await formatStructuredText(text, format);
+  const formattedTokensPromise = highlightStructuredText(formattedText, format);
+  const rawTokensPromise = formattedText === text
+    ? formattedTokensPromise
+    : highlightStructuredText(text, format);
+  const [formattedTokens, rawTokens] = await Promise.all([
+    formattedTokensPromise,
+    rawTokensPromise,
+  ]);
+  return {
+    formattedText,
+    formattedTokens,
+    rawTokens: formattedText === text ? formattedTokens : rawTokens,
+  };
+}
+
+export async function highlightRawStructuredText(
+  text: string,
+  format: StructuredTextFormat,
+): Promise<PreviewSyntaxToken[][]> {
+  return highlightStructuredText(text, format);
+}


### PR DESCRIPTION
## 概要

JSON / JSONC / YAMLファイルの整形・構文強調プレビューを追加します。

## 変更内容

- `.json` / `.jsonc` / `.yaml` / `.yml` をPrettierとShikiで表示
- Formatted / Raw切替とparse error時のRaw fallback
- 256 KiBを超えるファイルは既存テキストプレビューへfallback
- binary判定、文字コード、検索、危険な埋め込み内容の既存境界を維持

## 検証

- `npm run typecheck`
- `node --import tsx --test scripts/tests/structured-text-preview.test.ts scripts/tests/session-file-preview-image-lifecycle.test.tsx`
- 関連targeted tests 99件
- `npm test`（2148 pass / 1 skip / 0 fail）
- `npm run build`
- `scripts/start-withmate-visual-check.ps1` による目視確認