### PR TITLE
fix: Markdownソースを選択して引用できるようにする

### DIFF
--- a/docs/design/message-rich-text.md
+++ b/docs/design/message-rich-text.md
@@ -33,6 +33,8 @@ Session message と Markdown file preview に同じ rich text renderer を使い
 
 - message と file preview は同じ component mapping を使う
 - 呼び出し元は path open と local image resolution の context だけを注入する
+- Quote を提供する共通 chat window は Preview を既定とし、ActionDock の表示切替で message column 全体を Source にできる。Source は元 Markdown を plain text として表示し、選択、Quote、検索は表示中の source text を対象にする
+- message の表示 mode は window mount 中だけ保持し、永続化しない。切替時は既存の selection を解除する
 - Markdown file preview は Preview を既定とし、Source は file preview 側が切り替える
 
 ## Safety

--- a/scripts/tests/chat-window.test.ts
+++ b/scripts/tests/chat-window.test.ts
@@ -5,8 +5,65 @@ import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { ChatDockSplitter, ChatWindowStatusScreen } from "../../src/chat/chat-window.js";
+import { ChatDockSplitter, ChatWindow, ChatWindowStatusScreen, type ChatWindowProps } from "../../src/chat/chat-window.js";
+import {
+  createHiddenControlsTextChatComposerProps,
+  createStaticChatHeaderProps,
+  createStaticTextChatCompactActionDockProps,
+  createStaticTextConversationMessageColumnProps,
+} from "../../src/chat/chat-window-adapter.js";
 import { SessionActionDockCompactRow, SessionChatScreen } from "../../src/session-components.js";
+
+const noop = () => {};
+
+function createChatWindowProps(
+  overrides: Partial<ChatWindowProps["messageColumnProps"]> = {},
+): ChatWindowProps {
+  const draft = "";
+  return {
+    mode: "agent",
+    headerSplitter: null,
+    actionDockSplitter: null,
+    layoutPriority: "dock-first",
+    rightPane: null,
+    splitter: null,
+    isHeaderExpanded: true,
+    headerProps: createStaticChatHeaderProps({ taskTitle: "Test chat", isRunning: false }),
+    messageColumnProps: createStaticTextConversationMessageColumnProps({
+      sessionId: "chat-1",
+      characterId: "character-1",
+      characterName: "Character",
+      characterIconPath: "",
+      messages: [{ role: "mate", text: "[label](https://example.test/source)" }],
+      messageListRef: React.createRef<HTMLDivElement>(),
+      isRunning: false,
+      onQuoteMessageText: noop,
+      ...overrides,
+    }),
+    isActionDockExpanded: true,
+    composerProps: createHiddenControlsTextChatComposerProps({
+      draft,
+      isRunning: false,
+      feedback: "",
+      composerTextareaRef: React.createRef<HTMLTextAreaElement>(),
+      modelOptions: [{ value: "gpt-test", label: "GPT Test" }],
+      selectedModel: "gpt-test",
+      selectedModelFallbackLabel: "GPT Test",
+      reasoningOptions: [{ value: "low", label: "low" }],
+      selectedReasoningEffort: "low",
+      onDraftChange: noop,
+      onDraftKeyDown: noop,
+      onSendOrCancel: noop,
+      onChangeModel: noop,
+      onChangeReasoningEffort: noop,
+    }),
+    compactActionDockProps: createStaticTextChatCompactActionDockProps({
+      draft,
+      isRunning: false,
+      onSendOrCancel: noop,
+    }),
+  };
+}
 
 test("ChatWindowStatusScreen は Session 共通 shell で状態表示をレンダリングする", () => {
   const html = renderToStaticMarkup(React.createElement(ChatWindowStatusScreen, { message: "準備しています。" }));
@@ -15,6 +72,76 @@ test("ChatWindowStatusScreen は Session 共通 shell で状態表示をレン�
   assert.match(html, /<section class="session-work-surface chat-panel" aria-live="polite">/);
   assert.match(html, /<p class="session-message-empty">準備しています。<\/p>/);
   assert.doesNotMatch(html, /session-plain/);
+});
+
+test("ChatWindow は Quote 対応 chat の表示 mode を message column と ActionDock で共有する", async () => {
+  const previousActEnvironment = (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT;
+  const previousWindow = globalThis.window;
+  const previousDocument = globalThis.document;
+  const previousHTMLElement = globalThis.HTMLElement;
+  const previousNode = globalThis.Node;
+  const previousNavigator = globalThis.navigator;
+  const previousResizeObserver = globalThis.ResizeObserver;
+  const dom = new JSDOM("<!doctype html><html><body><div id=\"root\"></div></body></html>", {
+    pretendToBeVisual: true,
+  });
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  class TestResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  Object.defineProperty(globalThis, "window", { configurable: true, value: dom.window });
+  Object.defineProperty(globalThis, "document", { configurable: true, value: dom.window.document });
+  Object.defineProperty(globalThis, "HTMLElement", { configurable: true, value: dom.window.HTMLElement });
+  Object.defineProperty(globalThis, "Node", { configurable: true, value: dom.window.Node });
+  Object.defineProperty(globalThis, "navigator", { configurable: true, value: dom.window.navigator });
+  Object.defineProperty(globalThis, "ResizeObserver", { configurable: true, value: TestResizeObserver });
+
+  let root: Root | null = null;
+  try {
+    await act(async () => {
+      root = createRoot(dom.window.document.getElementById("root") as HTMLElement);
+      root.render(React.createElement(ChatWindow, createChatWindowProps({
+        messages: [],
+        isRunning: true,
+        pendingMessageText: "[label](https://example.test/source)",
+      })));
+    });
+    const sourceButton = Array.from(dom.window.document.querySelectorAll<HTMLButtonElement>(
+      ".composer-message-view-mode-button",
+    )).find((button) => button.textContent === "Source");
+    assert.ok(sourceButton);
+    assert.ok(dom.window.document.querySelector("[data-pending-message-body='true'] a"));
+
+    await act(async () => sourceButton.click());
+
+    const source = dom.window.document.querySelector("[data-pending-message-body='true'] > .message-body");
+    assert.equal(source?.textContent, "[label](https://example.test/source)");
+    assert.equal(dom.window.document.querySelector("[data-pending-message-body='true'] a"), null);
+    assert.equal(sourceButton.getAttribute("aria-pressed"), "true");
+  } finally {
+    await act(async () => root?.unmount());
+    dom.window.close();
+    Object.defineProperty(globalThis, "window", { configurable: true, value: previousWindow });
+    Object.defineProperty(globalThis, "document", { configurable: true, value: previousDocument });
+    Object.defineProperty(globalThis, "HTMLElement", { configurable: true, value: previousHTMLElement });
+    Object.defineProperty(globalThis, "Node", { configurable: true, value: previousNode });
+    Object.defineProperty(globalThis, "navigator", { configurable: true, value: previousNavigator });
+    Object.defineProperty(globalThis, "ResizeObserver", { configurable: true, value: previousResizeObserver });
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+      previousActEnvironment;
+  }
+});
+
+test("ChatWindow は Quote 非対応 chat に表示 mode controls を出さない", () => {
+  const html = renderToStaticMarkup(React.createElement(ChatWindow, createChatWindowProps({
+    onQuoteMessageText: undefined,
+  })));
+
+  assert.doesNotMatch(html, /Message display mode/);
+  assert.doesNotMatch(html, />Source<\/button>/);
 });
 
 test("ChatDockSplitter は resize handler がない場合に静的 splitter をレンダリングする", () => {

--- a/scripts/tests/message-rich-text.test.ts
+++ b/scripts/tests/message-rich-text.test.ts
@@ -82,6 +82,28 @@ test("MessageRichText は **bold** を strong として render する", () => {
   assert.match(html, /<strong class="message-inline-strong">message<\/strong>/);
 });
 
+test("MessageRichText の Source は元 Markdown を変換せず plain text で描画する", () => {
+  const source = [
+    "[link label](https://example.test/path)",
+    "`inline code`",
+    "> quoted line",
+    "- list item",
+    "",
+    "second paragraph",
+  ].join("\n");
+  const html = renderToStaticMarkup(
+    React.createElement(MessageRichText, {
+      text: source,
+      displayMode: "source",
+    }),
+  );
+  const dom = new JSDOM(html);
+  const sourceElement = dom.window.document.body.firstElementChild;
+
+  assert.equal(sourceElement?.textContent, source);
+  assert.equal(sourceElement?.querySelector("a, code, blockquote, ul"), null);
+});
+
 test("MessageRichText は inline code と link を優先しつつ bold を併用できる", () => {
   const html = renderToStaticMarkup(
     React.createElement(MessageRichText, {

--- a/scripts/tests/session-message-column.test.ts
+++ b/scripts/tests/session-message-column.test.ts
@@ -180,6 +180,7 @@ function renderSessionMessageColumn(options: {
   pendingMessageGroupId?: string | null;
   withResponseActions?: boolean;
   messageGroups?: SessionMessageColumnProps["messageGroups"];
+  messageViewMode?: SessionMessageColumnProps["messageViewMode"];
 }): string {
   return renderToStaticMarkup(
     React.createElement(SessionMessageColumn, {
@@ -211,6 +212,7 @@ function renderSessionMessageColumn(options: {
       },
       onCopyMessageText: options.withResponseActions ? () => {} : undefined,
       onQuoteMessageText: options.withResponseActions ? () => {} : undefined,
+      messageViewMode: options.messageViewMode,
     }),
   );
 }
@@ -251,6 +253,7 @@ type MountedSessionMessageColumn = {
     onQuoteMessageText?: (text: string) => void;
     pendingMessageGroupId?: string | null;
     pendingMessageText?: string;
+    messageViewMode?: SessionMessageColumnProps["messageViewMode"];
   }) => Promise<void>;
   resizeMessageRow: (index: number, height: number) => Promise<void>;
   cleanup: () => Promise<void>;
@@ -268,6 +271,7 @@ async function mountSessionMessageColumn(options: {
   messageGroups?: SessionMessageColumnProps["messageGroups"];
   pendingMessageGroupId?: string | null;
   pendingMessageText?: string;
+  messageViewMode?: SessionMessageColumnProps["messageViewMode"];
 }): Promise<MountedSessionMessageColumn> {
   const previousWindow = globalThis.window;
   const previousDocument = globalThis.document;
@@ -416,6 +420,7 @@ async function mountSessionMessageColumn(options: {
     onQuoteMessageText?: (text: string) => void;
     pendingMessageGroupId?: string | null;
     pendingMessageText?: string;
+    messageViewMode?: SessionMessageColumnProps["messageViewMode"];
   }) => {
     await act(async () => {
       root.render(
@@ -447,6 +452,7 @@ async function mountSessionMessageColumn(options: {
           getChangedFilesEmptyText: callbacks.getChangedFilesEmptyText ?? defaultGetChangedFilesEmptyText,
           onCopyMessageText: callbacks.onCopyMessageText,
           onQuoteMessageText: callbacks.onQuoteMessageText,
+          messageViewMode: callbacks.messageViewMode ?? options.messageViewMode,
         }),
       );
     });
@@ -719,6 +725,63 @@ test("SessionMessageColumn の検索は表示文字列とpendingを同じ順序�
     });
     assert.equal(mounted.container.querySelector(".session-content-find-count")?.textContent, "1/1");
     assert.equal(highlights.get("withmate-find-current")?.ranges.length, 1);
+  } finally {
+    await mounted.cleanup();
+  }
+});
+
+test("SessionMessageColumn の Source 検索は link URL を含む元 Markdown を対象にする", async () => {
+  class TestHighlight {
+    readonly ranges: Range[] = [];
+
+    constructor(...ranges: Range[]) {
+      assert.equal(ranges.length, 0);
+    }
+
+    add(range: Range) {
+      this.ranges.push(range);
+      return this;
+    }
+  }
+
+  const mounted = await mountSessionMessageColumn({
+    messages: [{ role: "assistant", text: "[label](https://example.test/source-path)" }],
+    messageViewMode: "source",
+  });
+
+  try {
+    const highlights = new Map<string, TestHighlight>();
+    Object.defineProperty(mounted.dom.window, "CSS", {
+      configurable: true,
+      value: { highlights },
+    });
+    Object.defineProperty(mounted.dom.window, "Highlight", {
+      configurable: true,
+      value: TestHighlight,
+    });
+    await act(async () => {
+      mounted.dom.window.dispatchEvent(new mounted.dom.window.KeyboardEvent("keydown", {
+        key: "f",
+        ctrlKey: true,
+        bubbles: true,
+      }));
+    });
+    const input = mounted.container.querySelector<HTMLInputElement>("input[aria-label='Find in current content']");
+    assert.ok(input);
+    const setInputValue = Object.getOwnPropertyDescriptor(
+      mounted.dom.window.HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    assert.ok(setInputValue);
+    await act(async () => {
+      setInputValue.call(input, "example.test/source-path");
+      const propertyChange = new mounted.dom.window.Event("propertychange", { bubbles: true });
+      Object.defineProperty(propertyChange, "propertyName", { value: "value" });
+      input.dispatchEvent(propertyChange);
+    });
+
+    assert.equal(mounted.container.querySelector(".session-content-find-count")?.textContent, "1/1");
+    assert.equal(highlights.get("withmate-find-current")?.ranges[0]?.toString(), "example.test/source-path");
   } finally {
     await mounted.cleanup();
   }
@@ -1222,8 +1285,17 @@ test("SessionMessageColumn は選択範囲にだけ response action toolbar を�
 
     await selectText(assistantBody, "assistant result", createRect({ left: 100, top: 100, width: 60, height: 20 }));
     assert.ok(container.querySelector(".message-response-actions"));
-    await clearSelection();
+    await mounted.rerender({
+      messageViewMode: "source",
+      onCopyMessageText: (text) => copiedTexts.push(text),
+      onQuoteMessageText: (text) => quotedTexts.push(text),
+    });
     assert.equal(container.querySelector(".message-response-actions"), null);
+    assert.equal(
+      container.querySelector("[data-message-text-actions='true']")?.textContent,
+      "assistant result text",
+    );
+    await clearSelection();
   } finally {
     mounted.cleanup();
   }
@@ -1250,6 +1322,25 @@ test("SessionMessageColumn は Auxiliary transcript group を message list 内�
     html.indexOf("auxiliary-message-group-label") < html.indexOf("aux prompt"),
     "Auxiliary group label は対象 transcript の先頭 message より前に描画する",
   );
+});
+
+test("SessionMessageColumn の Source は通常 message と pending の元 Markdown を表示する", () => {
+  const messageSource = "> quote\n- [label](https://example.test/path)\n- `code`";
+  const pendingSource = "pending  line\n\nnext";
+  const html = renderSessionMessageColumn({
+    messages: [{ role: "assistant", text: messageSource }],
+    isRunning: true,
+    pendingMessageText: pendingSource,
+    messageViewMode: "source",
+  });
+  const dom = new JSDOM(html);
+  const sources = [
+    dom.window.document.querySelector("[data-message-body='true'] > .message-body"),
+    dom.window.document.querySelector("[data-pending-message-body='true'] > .message-body"),
+  ];
+
+  assert.deepEqual(sources.map((element) => element?.textContent), [messageSource, pendingSource]);
+  assert.equal(dom.window.document.querySelector("[data-message-body='true'] a"), null);
 });
 
 test("SessionMessageColumn は pending と live approval\/elicitation を message window の末尾で維持する", () => {
@@ -1384,6 +1475,8 @@ test("SessionComposerExpanded は Hide を描画せず、Send を設定グルー
       canSelectCustomAgent: true,
       showCustomAgentPicker: true,
       showSkillPicker: true,
+      showMessageViewModeControls: true,
+      messageViewMode: "source",
       isAgentPickerOpen: false,
       isSkillPickerOpen: false,
       isAdditionalDirectoryListOpen: false,
@@ -1443,6 +1536,7 @@ test("SessionComposerExpanded は Hide を描画せず、Send を設定グルー
       onChangeCodexSandboxMode() {},
       onChangeModel() {},
       onChangeReasoningEffort() {},
+      onMessageViewModeChange() {},
     }),
   );
 
@@ -1450,6 +1544,12 @@ test("SessionComposerExpanded は Hide を描画せず、Send を設定グルー
   assert.doesNotMatch(html, />Hide<\/button>/);
   assert.match(html, /composer-attachment-trigger-plus/);
   assert.match(html, /Attach<\/button>/);
+  assert.match(html, /role="group" aria-label="Message display mode"/);
+  assert.match(html, /aria-pressed="false">Preview<\/button>/);
+  assert.match(html, /aria-pressed="true">Source<\/button>/);
+  assert.ok(html.indexOf("Add Directory") < html.indexOf("Preview"));
+  assert.ok(html.indexOf("末尾へ移動") < html.indexOf("Preview"));
+  assert.match(html, /composer-toolbar-view-actions[\s\S]*末尾へ移動[\s\S]*Message display mode/);
   assert.doesNotMatch(html, />Session <span/);
   assert.doesNotMatch(html, /Attach Copy|Session File|Session Folder|Session Image/);
   const composerInputRowHtml = html.match(
@@ -1464,7 +1564,7 @@ test("SessionComposerExpanded は Hide を描画せず、Send を設定グルー
   );
 });
 
-test("SessionComposerExpanded は実行中の progress、jump button、Cancel を compact と同じ順で上部 toolbar に描画する", () => {
+test("SessionComposerExpanded は実行中の操作後に jump button と表示切替を右側 group へ描画する", () => {
   const html = renderToStaticMarkup(
     React.createElement(SessionComposerExpanded, {
       retryBanner: null,
@@ -1475,6 +1575,8 @@ test("SessionComposerExpanded は実行中の progress、jump button、Cancel �
       canSelectCustomAgent: true,
       showCustomAgentPicker: true,
       showSkillPicker: true,
+      showMessageViewModeControls: true,
+      messageViewMode: "preview",
       isAgentPickerOpen: false,
       isSkillPickerOpen: false,
       isAdditionalDirectoryListOpen: false,
@@ -1534,6 +1636,7 @@ test("SessionComposerExpanded は実行中の progress、jump button、Cancel �
       onChangeCodexSandboxMode() {},
       onChangeModel() {},
       onChangeReasoningEffort() {},
+      onMessageViewModeChange() {},
     }),
   );
 
@@ -1542,8 +1645,10 @@ test("SessionComposerExpanded は実行中の progress、jump button、Cancel �
   assert.match(html, /末尾へ移動/);
   assert.match(html, /composer-toolbar-cancel-button/);
   assert.ok(html.indexOf("Attach") < html.indexOf("処理を実行中"));
-  assert.ok(html.indexOf("処理を実行中") < html.indexOf("末尾へ移動"));
-  assert.ok(html.indexOf("末尾へ移動") < html.indexOf("Cancel"));
+  assert.ok(html.indexOf("処理を実行中") < html.indexOf("Cancel"));
+  assert.ok(html.indexOf("Cancel") < html.indexOf("末尾へ移動"));
+  assert.ok(html.indexOf("末尾へ移動") < html.indexOf("Preview"));
+  assert.match(html, /composer-toolbar-view-actions[\s\S]*末尾へ移動[\s\S]*Message display mode/);
   assert.doesNotMatch(html, />Send<\/button>/);
 });
 

--- a/src/MessageRichText.tsx
+++ b/src/MessageRichText.tsx
@@ -9,10 +9,13 @@ import { getWithMateApi } from "./renderer-withmate-api.js";
 import { toLocalFileUrl } from "./local-file-url.js";
 import { resolveOpenPathFeedback, showOpenPathFeedback } from "./open-path-result.js";
 
+export type MessageViewMode = "preview" | "source";
+
 type MessageRichTextProps = {
   text: string;
   className?: string;
   forceFullRender?: boolean;
+  displayMode?: MessageViewMode;
   onOpenPath?: (target: string) => void;
   resolveImageSource?: (target: string) => Promise<string | null>;
 };
@@ -532,7 +535,7 @@ function createMarkdownComponents(
   };
 }
 
-function MessageRichTextComponent({
+function MessageMarkdownPreview({
   text,
   className = "message-body",
   forceFullRender = false,
@@ -591,6 +594,22 @@ function MessageRichTextComponent({
       </ReactMarkdown>
     </div>
   );
+}
+
+function MessageRichTextComponent({
+  displayMode = "preview",
+  ...props
+}: MessageRichTextProps) {
+  if (displayMode === "source") {
+    const className = props.className ?? "message-body";
+    return (
+      <pre className={`${className} rich-text message-source-text`.trim()}>
+        {props.text}
+      </pre>
+    );
+  }
+
+  return <MessageMarkdownPreview {...props} />;
 }
 
 export const MessageRichText = memo(MessageRichTextComponent);

--- a/src/chat/chat-window.tsx
+++ b/src/chat/chat-window.tsx
@@ -1,11 +1,15 @@
 import {
   memo,
+  useCallback,
   useMemo,
   useRef,
+  useState,
   type ComponentProps,
   type MouseEventHandler,
   type PointerEventHandler,
 } from "react";
+
+import type { MessageViewMode } from "../MessageRichText.js";
 
 import {
   SESSION_ACTION_DOCK_ID,
@@ -120,13 +124,25 @@ export function ChatWindow({
   compactActionDockProps,
   ...screenProps
 }: ChatWindowProps) {
+  const [messageViewMode, setMessageViewMode] = useState<MessageViewMode>("preview");
+  const showMessageViewModeControls = messageColumnProps.onQuoteMessageText !== undefined;
+  const handleMessageViewModeChange = useCallback((mode: MessageViewMode) => {
+    window.getSelection()?.removeAllRanges();
+    setMessageViewMode(mode);
+  }, []);
+
   return (
     <SessionChatScreen
       {...screenProps}
       header={<SessionHeader {...headerProps} />}
       isHeaderVisible={isHeaderExpanded}
       isActionDockExpanded={isActionDockExpanded}
-      messageColumn={<StableSessionMessageColumn {...messageColumnProps} />}
+      messageColumn={(
+        <StableSessionMessageColumn
+          {...messageColumnProps}
+          messageViewMode={messageViewMode}
+        />
+      )}
       actionDock={(
         <div className={`session-action-dock${isActionDockExpanded ? "" : " compact"}`}>
           <div
@@ -136,7 +152,12 @@ export function ChatWindow({
             aria-hidden={!isActionDockExpanded}
             inert={!isActionDockExpanded}
           >
-            <SessionComposerExpanded {...composerProps} />
+            <SessionComposerExpanded
+              {...composerProps}
+              showMessageViewModeControls={showMessageViewModeControls}
+              messageViewMode={messageViewMode}
+              onMessageViewModeChange={handleMessageViewModeChange}
+            />
           </div>
           <div
             className={`session-action-dock-content session-action-dock-compact-content${

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -18,7 +18,7 @@ import type {
   AuditLogSummary,
 } from "./app-state.js";
 import { DiffViewer } from "./DiffViewer.js";
-import { MessageRichText } from "./MessageRichText.js";
+import { MessageRichText, type MessageViewMode } from "./MessageRichText.js";
 import {
   approvalModeLabel,
   CharacterAvatar,
@@ -2101,6 +2101,7 @@ export type SessionMessageColumnProps = {
   inlinePathFeedback?: string;
   onDismissInlinePathFeedback?: () => void;
   isContentActive?: boolean;
+  messageViewMode?: MessageViewMode;
 };
 
 function getNonBlankSelectionText(selection: Selection): string | null {
@@ -2342,6 +2343,7 @@ export function SessionMessageColumn({
   inlinePathFeedback = "",
   onDismissInlinePathFeedback,
   isContentActive = true,
+  messageViewMode = "preview",
 }: SessionMessageColumnProps) {
   const [openArtifactFolds, setOpenArtifactFolds] = useState<Record<string, boolean>>({});
   const [loadedArtifactDetails, setLoadedArtifactDetails] = useState<Record<string, MessageArtifact>>({});
@@ -2352,6 +2354,7 @@ export function SessionMessageColumn({
   const [currentFindMatch, setCurrentFindMatch] = useState(0);
   const selectionToolbarRef = useRef<HTMLDivElement | null>(null);
   const wasContentActiveRef = useRef(isContentActive);
+  const previousMessageViewModeRef = useRef(messageViewMode);
   const getMessageKey = useCallback(
     (index: number) => messageKeys?.[index] ?? `${sessionId}-${index}`,
     [messageKeys, sessionId],
@@ -2382,15 +2385,21 @@ export function SessionMessageColumn({
   const hasFindQuery = findQuery.trim().length > 0;
   const messageRenderedSearchTexts = useMemo(
     () => (hasFindQuery
-      ? messages.map((message) => projectMessageRenderedSearchText(message.text))
+      ? messages.map((message) => (
+          messageViewMode === "source"
+            ? message.text
+            : projectMessageRenderedSearchText(message.text)
+        ))
       : []),
-    [hasFindQuery, messages],
+    [hasFindQuery, messageViewMode, messages],
   );
   const pendingRenderedSearchText = useMemo(
     () => (hasFindQuery && isRunning && hasPendingMessageText
-      ? projectMessageRenderedSearchText(pendingMessageText)
+      ? messageViewMode === "source"
+        ? pendingMessageText
+        : projectMessageRenderedSearchText(pendingMessageText)
       : ""),
-    [hasFindQuery, hasPendingMessageText, isRunning, pendingMessageText],
+    [hasFindQuery, hasPendingMessageText, isRunning, messageViewMode, pendingMessageText],
   );
   const hasPendingInlineContent =
     liveApprovalRequest !== null ||
@@ -2451,6 +2460,14 @@ export function SessionMessageColumn({
     return messages.length > 0 ? messages.length - 1 : null;
   }, [messages.length, pendingMessageGroupEndIndex]);
   const firstFindScrollIndex = getFindMatchScrollIndex(messageFindMatches[0]);
+
+  useEffect(() => {
+    if (previousMessageViewModeRef.current === messageViewMode) {
+      return;
+    }
+    previousMessageViewModeRef.current = messageViewMode;
+    setSelectionToolbar(null);
+  }, [messageViewMode]);
 
   const handleMessageListScroll: UIEventHandler<HTMLDivElement> = (event) => {
     onMessageListScroll(event);
@@ -2730,6 +2747,7 @@ export function SessionMessageColumn({
             <MessageRichText
               text={pendingMessageText}
               forceFullRender={findOpen && hasFindQuery}
+              displayMode={messageViewMode}
               onOpenPath={onOpenPath}
             />
           </div>
@@ -2879,6 +2897,7 @@ export function SessionMessageColumn({
                     <MessageRichText
                       text={message.text}
                       forceFullRender={findOpen && hasFindQuery}
+                      displayMode={messageViewMode}
                       onOpenPath={onOpenPath}
                     />
                   </div>
@@ -3222,6 +3241,8 @@ export type SessionComposerExpandedProps = {
   showSkillPicker?: boolean;
   showAdditionalDirectoryControls?: boolean;
   showExecutionModeControls?: boolean;
+  showMessageViewModeControls?: boolean;
+  messageViewMode?: MessageViewMode;
   isAgentPickerOpen: boolean;
   isSkillPickerOpen: boolean;
   isAdditionalDirectoryListOpen: boolean;
@@ -3280,6 +3301,7 @@ export type SessionComposerExpandedProps = {
   onChangeCodexSandboxMode: (value: CodexSandboxMode) => void;
   onChangeModel: (value: string) => void;
   onChangeReasoningEffort: (value: string) => void;
+  onMessageViewModeChange?: (mode: MessageViewMode) => void;
 };
 
 export function SessionComposerExpanded({
@@ -3296,6 +3318,8 @@ export function SessionComposerExpanded({
   showSkillPicker = true,
   showAdditionalDirectoryControls = true,
   showExecutionModeControls = true,
+  showMessageViewModeControls = false,
+  messageViewMode = "preview",
   isAgentPickerOpen,
   isSkillPickerOpen,
   isAdditionalDirectoryListOpen,
@@ -3354,6 +3378,7 @@ export function SessionComposerExpanded({
   onChangeCodexSandboxMode,
   onChangeModel,
   onChangeReasoningEffort,
+  onMessageViewModeChange = () => {},
 }: SessionComposerExpandedProps) {
   const customAgentListRef = useRef<HTMLDivElement | null>(null);
   const skillListRef = useRef<HTMLDivElement | null>(null);
@@ -3390,6 +3415,7 @@ export function SessionComposerExpanded({
     showCustomAgentPicker ||
     showSkillPicker ||
     showAdditionalDirectoryControls ||
+    showMessageViewModeControls ||
     showJumpToBottom ||
     !!modeLabel ||
     !!chatNotice ||
@@ -3502,15 +3528,6 @@ export function SessionComposerExpanded({
               />
             </div>
           ) : null}
-          {showJumpToBottom ? (
-            <button
-              className="drawer-toggle compact secondary message-jump-bottom-button"
-              type="button"
-              onClick={onJumpToBottom}
-            >
-              末尾へ移動
-            </button>
-          ) : null}
           {isRunning ? (
               <button
                 className="drawer-toggle compact danger composer-toolbar-cancel-button"
@@ -3520,6 +3537,39 @@ export function SessionComposerExpanded({
               >
                 Cancel
               </button>
+          ) : null}
+          {showJumpToBottom || showMessageViewModeControls ? (
+            <div className="composer-toolbar-view-actions">
+              {showJumpToBottom ? (
+                <button
+                  className="drawer-toggle compact secondary message-jump-bottom-button"
+                  type="button"
+                  onClick={onJumpToBottom}
+                >
+                  末尾へ移動
+                </button>
+              ) : null}
+              {showMessageViewModeControls ? (
+                <div className="composer-message-view-mode" role="group" aria-label="Message display mode">
+                  <button
+                    className="composer-message-view-mode-button"
+                    type="button"
+                    aria-pressed={messageViewMode === "preview"}
+                    onClick={() => onMessageViewModeChange("preview")}
+                  >
+                    Preview
+                  </button>
+                  <button
+                    className="composer-message-view-mode-button"
+                    type="button"
+                    aria-pressed={messageViewMode === "source"}
+                    onClick={() => onMessageViewModeChange("source")}
+                  >
+                    Source
+                  </button>
+                </div>
+              ) : null}
+            </div>
           ) : null}
         </div>
       ) : null}

--- a/src/styles.css
+++ b/src/styles.css
@@ -5798,6 +5798,14 @@ button:disabled {
   gap: 8px;
 }
 
+.message-source-text {
+  display: block;
+  white-space: pre-wrap;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.9em;
+  line-height: 1.6;
+}
+
 .message-paragraph {
   margin: 0;
   line-height: 1.6;
@@ -7663,6 +7671,45 @@ button:disabled {
   align-items: center;
   gap: 8px;
   min-width: 0;
+}
+
+.composer-toolbar-view-actions {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.composer-message-view-mode {
+  display: inline-flex;
+  flex: 0 0 auto;
+  padding: 2px;
+  border: 1px solid rgba(203, 213, 225, 0.18);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.composer-message-view-mode-button {
+  padding: 5px 9px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.72rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.composer-message-view-mode-button[aria-pressed="true"] {
+  background: color-mix(in srgb, var(--character-main-soft) 42%, rgba(255, 255, 255, 0.08));
+  color: var(--ink);
+}
+
+.composer-message-view-mode-button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--character-main) 70%, white 30%);
+  outline-offset: 2px;
 }
 
 .composer-toolbar-progress {


### PR DESCRIPTION
## 概要

- 通常SessionとCompanionで共通のPreview / Source表示切り替えを追加
- Source表示では元のMarkdown文字列をそのまま表示し、選択範囲をそのまま引用へ挿入
- URL、link label、code、blockquote、list、改行、Markdown token途中の部分選択を元文字列基準で維持
- 末尾へ移動と表示切り替えをActionDock右端の表示操作グループへ配置

## 検証

- `npx tsx --test scripts/tests/session-message-column.test.ts scripts/tests/chat-window.test.ts`（40件成功）
- `npm run typecheck`
- `npm run build`
- 分離userDataの検証用WithMateでPreview / Source切り替え、引用、右端配置を目視確認