### PR TITLE
feat(session): 会話時間コンテキストを追加

### DIFF
--- a/docs/adr/016-conversation-timing-context.md
+++ b/docs/adr/016-conversation-timing-context.md
@@ -1,0 +1,60 @@
+# 016 Conversation Timing Context
+
+- 状態: Accepted
+- 日付: 2026-08-09
+
+## Context
+
+Character はprovider実行時の現在日時や、正常に完了した前回turnからの経過を正確には取得できない。Sessionの`updated_at`は実行開始、失敗、設定変更でも更新され、messageの`created_at`は保存処理で再作成されるため、会話完了時刻の正本にはできない。
+
+時間情報は会話の入り方と親しさを調整する弱いシグナルであり、別Sessionの会話内容を知る経路や、生活状況を推測する根拠にはしない。また、Copilotのsession system messageをturnごとに変えると固定指示のcache境界を崩す。
+
+## Decision
+
+- 会話完了時刻は`session_turns_v6.completed_at`、turn実行開始時刻は`session_turns_v6.started_at`を正本とする。
+- 対象は`session_kind = 'default'`の通常Sessionに属する、`phase = 'completed'`かつ`assistant_message_seq IS NOT NULL`のturnだけとする。Auxiliary、Companion、Character Authoringは集計および注入から除外する。
+- user turn開始時にローカル日時を一度だけ取得し、storage snapshotから経過時間、同じCharacterの別Sessionにおける最新完了時刻、今日と累積のturn壁時計時間を純粋resolverで算出する。同一turnの監査、provider実行、internal retryでは同じ結果を再利用する。
+- parse不能な時刻、基準時刻より未来の完了時刻、`completed_at < started_at`の実行時間は推測や0への丸めを行わず除外する。
+- Character ownerを確定できない場合、Character単位の値は未取得とする。ownerを確定できるが対象turnがない場合、共同作業時間は0とする。
+- 可変な時間情報は`# Conversation Timing`としてinput側の`# User Input`直前へ置き、system側へ入れない。Codexのlogical promptとCopilotの`session.send.prompt`は同じsectionを使う。
+- sectionには、時間情報を会話のペースと親しさの弱いシグナルとして扱い、別Session内容、空白期間の出来事、所在地、睡眠、勤務、休日、予定を推測しない固定規則を含める。
+- 既存indexでread queryを実装し、migrationや新規indexは追加しない。性能上の根拠が得られた場合は別の論理変更で再検討する。
+
+実装の正本は`src-electron/audit-log-storage-v6.ts`、`src-electron/conversation-timing.ts`、`src-electron/session-runtime-service.ts`、`src-electron/provider-prompt.ts`とする。観測可能な契約は対応する`scripts/tests/`のtestに置く。
+
+## Alternatives
+
+### `Session.updatedAt`を使う
+
+Session一覧から取得しやすいが、正常完了以外の更新を会話時刻として誤認する。
+
+### messageの`created_at`を使う
+
+発言に近い名前だが、現在の保存処理ではmessage行の再作成時刻であり、個々の発言時刻を表さない。
+
+### providerまたはprompt composerが現在時刻とDBを直接取得する
+
+配線は短くなるが、監査とtransport、internal retryで値がずれ、prompt composerの純粋境界も失われる。
+
+### system promptへ時間情報を入れる
+
+固定指示とまとめられるが、turnごとの可変値がCopilotのsystem message設定へ入り、provider間の監査境界とcache安定性を損なう。
+
+### 経過時間を固定区分や挨拶へ変換する
+
+Character間の表現を揃えやすいが、会話の入り方が機械的になり、Character固有の温度調整を妨げる。
+
+## Consequences
+
+### Positive
+
+- 正常完了した会話だけを根拠に、短い中断と長い中断をCharacterが区別できる。
+- 監査promptと実transport、stale retryが同じ基準時刻と集計結果を共有する。
+- 別Sessionの存在による親しさと、そのSession内容の非共有を明確に分離できる。
+- schema変更なしで、現在日時とCharacter単位の共同作業量を提供できる。
+
+### Negative
+
+- 通常turn開始ごとにSessionとturnを読むqueryが増える。
+- turn壁時計時間にはprovider、tool、internal retryが含まれ、連続滞在時間や純粋な会話時間としては利用できない。
+- 不正な保存時刻は値全体または該当turnを欠損として扱うため、履歴が存在してもprompt行が省略される場合がある。

--- a/docs/design/prompt-composition.md
+++ b/docs/design/prompt-composition.md
@@ -1,7 +1,7 @@
 # Prompt Composition
 
 - 作成日: 2026-03-13
-- 更新日: 2026-07-14
+- 更新日: 2026-08-09
 - 対象: WithMate における coding plane の prompt 合成
 
 ## Goal
@@ -18,6 +18,7 @@ WithMate が保持する system 指示、character 定義、ユーザー入力�
 - V5 Character Core の Character 注入境界は `docs/design/character-storage.md` と `docs/design/character-definition-format.md` を正本にする
 - Memory の保存方針は `docs/design/memory-architecture.md` を参照する
 - provider 境界は `docs/design/provider-adapter.md` を参照する
+- 会話時間コンテキストの選択理由と時刻の正本は `docs/adr/016-conversation-timing-context.md` を参照する
 
 ## Source Of Truth
 
@@ -50,13 +51,15 @@ coding plane に渡す turn prompt は、次のレイヤーを基本にする。
 2. `Output Boundary`
 3. `Tool Call Presence`
 4. 必要最小限の WithMate run marker
-5. ユーザー入力
-6. 添付 reference
+5. `Conversation Timing`
+6. ユーザー入力
+7. 添付 reference
 
 通常 session / companion の Character snapshot は session / companion 開始時点の保存済み値を使い、catalog の現在値へ追従しない。`character-authoring` session は turn 開始時に最新の `character.md` から runtime snapshot を作り直す。app 共通 system prompt は挿入しない。
 provider に渡す `Character Definition Snapshot` では、snapshot の取得時点説明を prompt 本体には入れない。保存済み snapshot の frontmatter は除外し、Character 名と説明を metadata として示したうえで、`character.md` 本文だけを markdown block として囲む。Character section の固定説明は、話し方への反映と coding agent 境界の guard に絞る。
 通常 session / companion では Character section の直後に `Output Boundary` を置き、Character 定義の適用先をユーザー向け自然言語レスポンスへ限定する。コード、設定、テスト、ドキュメント、コミットメッセージ案、PR本文案、生成ファイル、diff、artifact summary は、ユーザーが明示しない限り Character の口調・設定・台詞・メタ説明を混ぜず、repository instruction、既存文体、対象ファイルの目的を優先する。
 通常 session / companion では `Output Boundary` の直後に `Tool Call Presence` を置き、tool call や command 実行前に短い自然言語レスポンスを返すことで、Character が無言のまま作業へ入ったように見える体験を避ける。
+通常 session では可変な `Conversation Timing` を input 側の `User Input` 直前に置く。Copilotの`session.systemMessage`へは入れず、Codexのlogical promptとCopilotの`session.send.prompt`から同じ論理sectionを監査できるようにする。Auxiliary、Companion、`character-authoring` sessionには注入しない。
 `character-authoring` session は `character.md` / `character-notes.md` 自体が成果物なので、`Output Boundary`、`Tool Call Presence`、coding agent 境界の固定 guard を注入しない。
 
 ### 4.0.0 SingleMate target
@@ -76,6 +79,7 @@ Mate Core / Bond Profile / Work Style は provider instruction file へ同期し
 論理 prompt では `Character Definition Snapshot` section を system 側に置く。
 通常 session / companion では `Output Boundary` section も system 側に置く。`character-authoring` session では置かない。
 通常 session / companion では `Tool Call Presence` section も system 側に置く。`character-authoring` session では置かない。
+通常 session では `Conversation Timing` sectionをinput側の`User Input`直前に置く。値の解決は`src-electron/conversation-timing.ts`、sectionの合成は`src-electron/provider-prompt.ts`を参照する。
 
 `# Session Memory`、`# Project Memory`、`# Project Context`、`# Character Memory` も coding plane prompt では作らない。
 
@@ -99,6 +103,16 @@ Mate Core / Bond Profile / Work Style は provider instruction file へ同期し
 - 形式:
   - `# User Input` 見出しの下に入力本文をそのまま置く
   - Character Definition Snapshot や Output Boundary の直後でも、ここからがユーザー入力であることを明示する
+
+### `# Conversation Timing`
+
+- source:
+  - turn開始時に固定したruntime resolverの出力
+- 形式:
+  - input側の`# User Input`直前に置く
+  - 会話のペースと親しさの弱いシグナルであり、別Sessionの内容理解や生活状況の推測には使わないことを固定文で明示する
+  - 固定の解釈規則を先に置き、turnごとに変わる観測値はsection末尾の`Observed values`へまとめる
+  - query条件、型、時刻計算の詳細はsourceとtestを正本とし、この文書へ複製しない
 
 ### `# Output Boundary`
 
@@ -225,6 +239,7 @@ Session Window の composer では、参照対象は最終的に textarea 内の
     - provider instruction projection の要約
     - app 共通 system prompt は空
   - `inputText`
+    - `# Conversation Timing`
     - `# User Input`
     - ユーザー入力本文
   - `composedText`

--- a/scripts/tests/conversation-timing-storage.test.ts
+++ b/scripts/tests/conversation-timing-storage.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { describe, it } from "node:test";
+
+import { createOrVerifyV6FreshDatabase } from "../../src-electron/app-database-v6-bootstrap.js";
+import { AuditLogStorageV6 } from "../../src-electron/audit-log-storage-v6.js";
+
+function insertCharacter(db: DatabaseSync, id: string): void {
+  db.prepare(`
+    INSERT INTO characters (id, name, created_at, updated_at)
+    VALUES (?, ?, '2026-08-01T00:00:00.000Z', '2026-08-01T00:00:00.000Z')
+  `).run(id, id);
+}
+
+function insertSession(db: DatabaseSync, id: string, characterId: string | null, sessionKind = "default"): void {
+  db.prepare(`
+    INSERT INTO sessions_v6 (
+      id, title, state, session_kind, provider_id, catalog_revision, model_id,
+      reasoning_effort, approval_mode, character_id, character_snapshot_json,
+      created_at, updated_at, last_active_at
+    ) VALUES (?, ?, 'active', ?, 'codex', 1, 'gpt-5.4', 'medium', 'untrusted', ?, ?, ?, ?, ?)
+  `).run(
+    id,
+    id,
+    sessionKind,
+    characterId,
+    characterId ? "{}" : null,
+    "2026-08-01T00:00:00.000Z",
+    "2026-08-01T00:00:00.000Z",
+    "2026-08-01T00:00:00.000Z",
+  );
+}
+
+function insertTurn(
+  db: DatabaseSync,
+  owner: { sessionId?: string; auxiliarySessionId?: string },
+  phase: "running" | "completed" | "failed" | "canceled",
+  startedAt: string,
+  completedAt: string | null,
+  assistantMessageSeq: number | null,
+): void {
+  db.prepare(`
+    INSERT INTO session_turns_v6 (
+      session_id, auxiliary_session_id, phase, assistant_message_seq,
+      started_at, completed_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    owner.sessionId ?? null,
+    owner.auxiliarySessionId ?? null,
+    phase,
+    assistantMessageSeq,
+    startedAt,
+    completedAt,
+    completedAt ?? startedAt,
+  );
+}
+
+describe("AuditLogStorageV6 conversation timing", () => {
+  it("通常Sessionの正常完了turnだけをcurrent・別Session・共同作業へ投影する", async () => {
+    const userDataPath = await mkdtemp(path.join(tmpdir(), "withmate-conversation-timing-"));
+    try {
+      const { dbPath } = await createOrVerifyV6FreshDatabase(userDataPath);
+      const db = new DatabaseSync(dbPath);
+      try {
+        insertCharacter(db, "char-a");
+        insertCharacter(db, "char-b");
+        insertCharacter(db, "char-empty");
+        insertSession(db, "current", "char-a");
+        insertSession(db, "other", "char-a");
+        insertSession(db, "authoring", "char-a", "character-authoring");
+        insertSession(db, "different", "char-b");
+        insertSession(db, "no-owner", null);
+        insertSession(db, "empty-owner", "char-empty");
+        db.prepare(`
+          INSERT INTO auxiliary_sessions (id, parent_session_id, status, created_at, updated_at, payload_json)
+          VALUES ('aux', 'current', 'active', ?, ?, '{}')
+        `).run("2026-08-01T00:00:00.000Z", "2026-08-01T00:00:00.000Z");
+
+        insertTurn(db, { sessionId: "current" }, "completed", "2026-08-04T09:50:00.000Z", "2026-08-04T10:00:00.000Z", 1);
+        insertTurn(db, { sessionId: "other" }, "completed", "2026-08-04T10:50:00.000Z", "2026-08-04T11:00:00.000Z", 1);
+        insertTurn(db, { sessionId: "current" }, "failed", "2026-08-04T11:30:00.000Z", "2026-08-04T11:40:00.000Z", 2);
+        insertTurn(db, { sessionId: "other" }, "completed", "2026-08-04T11:40:00.000Z", "2026-08-04T11:50:00.000Z", null);
+        insertTurn(db, { sessionId: "authoring" }, "completed", "2026-08-04T11:50:00.000Z", "2026-08-04T12:00:00.000Z", 1);
+        insertTurn(db, { sessionId: "different" }, "completed", "2026-08-04T12:00:00.000Z", "2026-08-04T12:10:00.000Z", 1);
+        insertTurn(db, { auxiliarySessionId: "aux" }, "completed", "2026-08-04T12:10:00.000Z", "2026-08-04T12:20:00.000Z", 1);
+      } finally {
+        db.close();
+      }
+
+      const storage = new AuditLogStorageV6(dbPath);
+      try {
+        const observedAt = "2026-08-04T11:30:00.000Z";
+        assert.deepEqual(storage.getConversationTimingSnapshot("current", observedAt), {
+          currentSessionLastCompletedAt: "2026-08-04T10:00:00.000Z",
+          sameCharacterOtherSessionLastCompletedAt: "2026-08-04T11:00:00.000Z",
+          sameCharacterCompletedTurns: [
+            { startedAt: "2026-08-04T09:50:00.000Z", completedAt: "2026-08-04T10:00:00.000Z" },
+            { startedAt: "2026-08-04T10:50:00.000Z", completedAt: "2026-08-04T11:00:00.000Z" },
+          ],
+        });
+        assert.equal(storage.getConversationTimingSnapshot("no-owner", observedAt).sameCharacterCompletedTurns, null);
+        assert.deepEqual(storage.getConversationTimingSnapshot("empty-owner", observedAt).sameCharacterCompletedTurns, []);
+
+        const concurrentDb = new DatabaseSync(dbPath);
+        try {
+          insertTurn(concurrentDb, { sessionId: "current" }, "completed", "2026-08-04T11:29:59.000Z", "2026-08-04T11:30:00.050Z", 3);
+          insertTurn(concurrentDb, { sessionId: "current" }, "completed", "2026-08-04T11:30:00.100Z", "2026-08-04T11:30:00.900Z", 4);
+          insertTurn(concurrentDb, { sessionId: "other" }, "completed", "2026-08-04T11:29:59.000Z", "2026-08-04T11:30:00.060Z", 3);
+          insertTurn(concurrentDb, { sessionId: "other" }, "completed", "2026-08-04T11:30:00.100Z", "2026-08-04T11:30:00.800Z", 4);
+        } finally {
+          concurrentDb.close();
+        }
+        const asOfSnapshot = storage.getConversationTimingSnapshot("current", "2026-08-04T11:30:00.100Z");
+        assert.equal(asOfSnapshot.currentSessionLastCompletedAt, "2026-08-04T11:30:00.050Z");
+        assert.equal(asOfSnapshot.sameCharacterOtherSessionLastCompletedAt, "2026-08-04T11:30:00.060Z");
+      } finally {
+        storage.close();
+      }
+    } finally {
+      await rm(userDataPath, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/tests/conversation-timing.test.ts
+++ b/scripts/tests/conversation-timing.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { resolveConversationTimingContext } from "../../src-electron/conversation-timing.js";
+
+describe("resolveConversationTimingContext", () => {
+  it("固定したoffset付き日時と曜日から経過時間・今日・累積を算出する", () => {
+    const observedAt = new Date("2026-08-04T12:32:00.000Z");
+    const result = resolveConversationTimingContext({
+      currentSessionLastCompletedAt: "2026-08-04T10:19:00.000Z",
+      sameCharacterOtherSessionLastCompletedAt: "2026-08-01T07:20:00.000Z",
+      sameCharacterCompletedTurns: [
+        {
+          startedAt: "2026-08-04T11:00:00.000Z",
+          completedAt: "2026-08-04T11:30:00.000Z",
+        },
+        {
+          startedAt: "2026-08-03T13:30:00.000Z",
+          completedAt: "2026-08-03T14:30:00.000Z",
+        },
+      ],
+    }, observedAt, () => 9 * 60);
+
+    assert.equal(result.observedAt, "2026-08-04T21:32:00.000+09:00");
+    assert.equal(result.observedDayOfWeek, "tuesday");
+    assert.deepEqual(result.currentSession, {
+      lastCompletedAt: "2026-08-04T19:19:00.000+09:00",
+      elapsedMs: 2 * 60 * 60_000 + 13 * 60_000,
+    });
+    assert.deepEqual(result.sameCharacterOtherSession, {
+      lastCompletedAt: "2026-08-01T16:20:00.000+09:00",
+      elapsedMs: 3 * 24 * 60 * 60_000 + 5 * 60 * 60_000 + 12 * 60_000,
+    });
+    assert.deepEqual(result.sameCharacterSharedWork, {
+      todayCompletedTurnDurationMs: 30 * 60_000,
+      totalCompletedTurnDurationMs: 90 * 60_000,
+    });
+  });
+
+  it("ローカル日付境界を使い、parse不能・未来・負の実行時間を除外する", () => {
+    const observedAt = new Date("2026-08-04T00:30:00.000Z");
+    const result = resolveConversationTimingContext({
+      currentSessionLastCompletedAt: "invalid",
+      sameCharacterOtherSessionLastCompletedAt: "2026-08-04T00:31:00.000Z",
+      sameCharacterCompletedTurns: [
+        {
+          startedAt: "2026-08-03T14:40:00.000Z",
+          completedAt: "2026-08-03T14:50:00.000Z",
+        },
+        { startedAt: "invalid", completedAt: "2026-08-03T15:10:00.000Z" },
+        {
+          startedAt: "2026-08-03T16:00:00.000Z",
+          completedAt: "2026-08-03T15:00:00.000Z",
+        },
+        {
+          startedAt: "2026-08-04T00:20:00.000Z",
+          completedAt: "2026-08-04T00:40:00.000Z",
+        },
+      ],
+    }, observedAt, () => 9 * 60);
+
+    assert.equal(result.currentSession, null);
+    assert.equal(result.sameCharacterOtherSession, null);
+    assert.deepEqual(result.sameCharacterSharedWork, {
+      todayCompletedTurnDurationMs: 0,
+      totalCompletedTurnDurationMs: 10 * 60_000,
+    });
+  });
+
+  it("DST切替をまたぐ履歴は各instantのoffsetで表示し、ローカル日付へ集計する", () => {
+    const observedAt = new Date("2026-03-08T16:00:00.000Z");
+    const dstTransitionAt = Date.parse("2026-03-08T07:00:00.000Z");
+    const result = resolveConversationTimingContext({
+      currentSessionLastCompletedAt: "2026-03-08T04:30:00.000Z",
+      sameCharacterOtherSessionLastCompletedAt: null,
+      sameCharacterCompletedTurns: [
+        {
+          startedAt: "2026-03-08T04:20:00.000Z",
+          completedAt: "2026-03-08T04:30:00.000Z",
+        },
+      ],
+    }, observedAt, (date) => date.getTime() < dstTransitionAt ? -5 * 60 : -4 * 60);
+
+    assert.equal(result.observedAt, "2026-03-08T12:00:00.000-04:00");
+    assert.equal(result.observedDayOfWeek, "sunday");
+    assert.deepEqual(result.currentSession, {
+      lastCompletedAt: "2026-03-07T23:30:00.000-05:00",
+      elapsedMs: 11 * 60 * 60_000 + 30 * 60_000,
+    });
+    assert.deepEqual(result.sameCharacterSharedWork, {
+      todayCompletedTurnDurationMs: 0,
+      totalCompletedTurnDurationMs: 10 * 60_000,
+    });
+  });
+
+  it("Character owner不明は共同作業時間を未取得にし、ownerあり履歴なしは0にする", () => {
+    const observedAt = new Date("2026-08-04T12:00:00.000Z");
+    assert.equal(resolveConversationTimingContext({
+      currentSessionLastCompletedAt: null,
+      sameCharacterOtherSessionLastCompletedAt: null,
+      sameCharacterCompletedTurns: null,
+    }, observedAt, () => 9 * 60).sameCharacterSharedWork, null);
+    assert.deepEqual(resolveConversationTimingContext({
+      currentSessionLastCompletedAt: null,
+      sameCharacterOtherSessionLastCompletedAt: null,
+      sameCharacterCompletedTurns: [],
+    }, observedAt, () => 9 * 60).sameCharacterSharedWork, {
+      todayCompletedTurnDurationMs: 0,
+      totalCompletedTurnDurationMs: 0,
+    });
+  });
+});

--- a/scripts/tests/copilot-adapter.test.ts
+++ b/scripts/tests/copilot-adapter.test.ts
@@ -483,10 +483,10 @@ describe("CopilotAdapter env", () => {
     ]);
   });
 
-  it("character prompt は Copilot systemMessage append へ変換する", () => {
+  it("character prompt だけをCopilot systemMessageへ変換し、可変timingはinput側に留める", () => {
     const systemMessage = buildCopilotSystemMessage({
       systemBodyText: "あなたは頼れる相棒です。",
-      inputBodyText: "hello",
+      inputBodyText: "# Conversation Timing\n\n- Observed local time: 2026-08-04T21:32:00+09:00\n\n# User Input\n\nhello",
       logicalPrompt: {
         systemText: "# System Prompt\n\nあなたは頼れる相棒です。",
         inputText: "# User Input Prompt\n\nhello",
@@ -500,6 +500,7 @@ describe("CopilotAdapter env", () => {
       mode: "append",
       content: "あなたは頼れる相棒です。",
     });
+    assert.doesNotMatch(systemMessage?.content ?? "", /Conversation Timing|2026-08-04/);
   });
 
   it("quota snapshot は Copilot の 0-1 percentage を 0-100 表示用へ正規化する", () => {

--- a/scripts/tests/provider-prompt.test.ts
+++ b/scripts/tests/provider-prompt.test.ts
@@ -75,6 +75,103 @@ function createCharacterRuntimeSnapshot(overrides?: Partial<CharacterRuntimeSnap
 }
 
 describe("composeProviderPrompt", () => {
+  it("Conversation Timingをinput側のUser Input直前へ置き、system側へ入れない", () => {
+    const session = buildNewSession({
+      taskTitle: "task",
+      workspaceLabel: "workspace",
+      workspacePath: "workspace",
+      branch: "",
+      characterId: "character-1",
+      character: "Test",
+      characterIconPath: "",
+      characterThemeColors,
+      approvalMode: "untrusted",
+    });
+    const prompt = composeProviderPrompt({
+      session,
+      sessionMemory: createDefaultSessionMemory(session),
+      projectMemoryEntries: [],
+      providerCatalog,
+      userMessage: "続きやろっか",
+      appSettings: createDefaultAppSettings(),
+      attachments: [],
+      conversationTimingContext: {
+        observedAt: "2026-08-04T21:32:00.000+09:00",
+        observedDayOfWeek: "tuesday",
+        currentSession: {
+          lastCompletedAt: "2026-08-04T19:19:00.000+09:00",
+          elapsedMs: 2 * 60 * 60_000 + 13 * 60_000,
+        },
+        sameCharacterOtherSession: {
+          lastCompletedAt: "2026-08-01T16:20:00.000+09:00",
+          elapsedMs: 3 * 24 * 60 * 60_000 + 5 * 60 * 60_000,
+        },
+        sameCharacterSharedWork: {
+          todayCompletedTurnDurationMs: 84 * 60_000,
+          totalCompletedTurnDurationMs: 18 * 60 * 60_000 + 37 * 60_000,
+        },
+      },
+    });
+
+    assert.doesNotMatch(prompt.systemBodyText, /Conversation Timing|2026-08-04T21:32/);
+    assert.match(prompt.inputBodyText, /Observed local time: 2026-08-04T21:32:00\.000\+09:00 \(Tuesday\)/);
+    assert.match(prompt.inputBodyText, /2 hours 13 minutes ago/);
+    assert.match(prompt.inputBodyText, /3 days 5 hours ago/);
+    assert.match(prompt.inputBodyText, /1 hour 24 minutes today; 18 hours 37 minutes total/);
+    assert.match(prompt.inputBodyText, /does not reveal what was discussed there/);
+    assert.match(prompt.inputBodyText, /not continuous presence or conversation time/);
+    assert.match(prompt.inputBodyText, /Do not infer or judge the user's location, schedule, sleep/);
+    assertSectionOrder(prompt.inputBodyText, [
+      "# Conversation Timing",
+      "Use same-session timing",
+      "Prioritize the current user input and tone",
+      "Observed values:",
+      "- Observed local time:",
+      "# User Input",
+      "続きやろっか",
+    ]);
+  });
+
+  it("履歴と共同作業時間がない時も基準時刻だけを出し、未取得行は省略する", () => {
+    const session = buildNewSession({
+      taskTitle: "task",
+      workspaceLabel: "workspace",
+      workspacePath: "workspace",
+      branch: "",
+      characterId: "character-1",
+      character: "Test",
+      characterIconPath: "",
+      characterThemeColors,
+      approvalMode: "untrusted",
+    });
+    const prompt = composeProviderPrompt({
+      session,
+      sessionMemory: createDefaultSessionMemory(session),
+      projectMemoryEntries: [],
+      providerCatalog,
+      userMessage: "開始",
+      appSettings: createDefaultAppSettings(),
+      attachments: [],
+      conversationTimingContext: {
+        observedAt: "2026-08-04T09:00:00.000+09:00",
+        observedDayOfWeek: "tuesday",
+        currentSession: null,
+        sameCharacterOtherSession: null,
+        sameCharacterSharedWork: {
+          todayCompletedTurnDurationMs: 0,
+          totalCompletedTurnDurationMs: 0,
+        },
+      },
+    });
+
+    assert.match(prompt.inputBodyText, /# Conversation Timing/);
+    assert.doesNotMatch(
+      prompt.inputBodyText,
+      /^- (?:Previous completed exchange|Latest completed exchange|Completed turn execution time with this character:)/m,
+    );
+    assert.doesNotMatch(prompt.inputBodyText, /never/);
+  });
+
   it("User Input 境界を明示し、Memory は注入しない", () => {
     const session = buildNewSession({
       taskTitle: "task",

--- a/scripts/tests/session-runtime-service.test.ts
+++ b/scripts/tests/session-runtime-service.test.ts
@@ -31,6 +31,7 @@ import {
   isRetryableStaleThreadSessionError,
   type SessionRuntimeServiceDeps,
 } from "../../src-electron/session-runtime-service.js";
+import type { ConversationTimingContext } from "../../src-electron/conversation-timing.js";
 
 function createSession(overrides?: Partial<Session>): Session {
   return {
@@ -1862,11 +1863,23 @@ describe("SessionRuntimeService", () => {
     const invalidated: Array<{ providerId: string | null | undefined; sessionId: string }> = [];
     const auditUpdates: UpdateAuditLogInput[] = [];
     const seenThreadIds: string[] = [];
+    const timingContexts: Array<ConversationTimingContext | undefined> = [];
+    const fixedObservedAt = new Date("2026-08-04T12:32:00.000Z");
+    const timingContext: ConversationTimingContext = {
+      observedAt: "2026-08-04T21:32:00.000+09:00",
+      observedDayOfWeek: "tuesday",
+      currentSession: null,
+      sameCharacterOtherSession: null,
+      sameCharacterSharedWork: null,
+    };
     let attempt = 0;
     let notificationCount = 0;
+    let timingResolutionCount = 0;
+    let currentDateCount = 0;
 
     const adapter: ProviderCodingAdapter = {
-      composePrompt() {
+      composePrompt(input) {
+        timingContexts.push(input.conversationTimingContext);
         return {
           systemBodyText: "system",
           inputBodyText: "input",
@@ -1883,6 +1896,7 @@ describe("SessionRuntimeService", () => {
       async runSessionTurn(input) {
         attempt += 1;
         seenThreadIds.push(input.session.threadId);
+        timingContexts.push(input.conversationTimingContext);
         if (attempt === 1) {
           throw new ProviderTurnError("thread not found", createPartialResult({ threadId: "thread-stale" }), false);
         }
@@ -1923,6 +1937,11 @@ describe("SessionRuntimeService", () => {
       resolveProjectMemoryEntriesForPrompt() {
         return [];
       },
+      resolveConversationTimingContext(_session, observedAt) {
+        timingResolutionCount += 1;
+        assert.equal(observedAt, fixedObservedAt);
+        return timingContext;
+      },
       createAuditLog(input) {
         return createAuditLogBase(input);
       },
@@ -1953,6 +1972,10 @@ describe("SessionRuntimeService", () => {
         notificationCount += 1;
       },
       currentTimestampLabel,
+      currentDate() {
+        currentDateCount += 1;
+        return fixedObservedAt;
+      },
     });
 
     const result = await service.runSessionTurn(session.id, { userMessage: "お願いします" });
@@ -1969,6 +1992,11 @@ describe("SessionRuntimeService", () => {
     assert.equal(auditUpdates[0]?.phase, "running");
     assert.equal(auditUpdates.at(-1)?.phase, "completed");
     assert.equal(notificationCount, 1);
+    assert.equal(currentDateCount, 1);
+    assert.equal(timingResolutionCount, 1);
+    assert.deepEqual(timingContexts, [timingContext, timingContext, timingContext]);
+    assert.equal(timingContexts[0], timingContexts[1]);
+    assert.equal(timingContexts[1], timingContexts[2]);
   });
 
   it("stale retry 後の running audit log は前回 progress の断片を引き継がない", async () => {

--- a/src-electron/audit-log-storage-v6.ts
+++ b/src-electron/audit-log-storage-v6.ts
@@ -12,6 +12,10 @@ import type {
 } from "../src/app-state.js";
 import { ensureV6Schema } from "./database-schema-v6.js";
 import { openAppDatabase } from "./sqlite-connection.js";
+import type {
+  CompletedTurnTimingRow,
+  ConversationTimingStorageSnapshot,
+} from "./conversation-timing.js";
 
 type SessionTurnV6Row = {
   id: number;
@@ -374,6 +378,71 @@ export class AuditLogStorageV6 {
 
   listSessionAuditLogs(sessionId: string): AuditLogEntry[] {
     return this.readEntries(sessionId, { includeOperationDetails: true });
+  }
+
+  getConversationTimingSnapshot(sessionId: string, observedAt: string): ConversationTimingStorageSnapshot {
+    const currentSessionRow = this.db.prepare(`
+      SELECT character_id, session_kind
+      FROM sessions_v6
+      WHERE id = ?
+    `).get(sessionId) as { character_id: string | null; session_kind: string } | undefined;
+    const currentSessionCompleted = this.db.prepare(`
+      SELECT completed_at
+      FROM session_turns_v6
+      WHERE session_id = ?
+        AND phase = 'completed'
+        AND assistant_message_seq IS NOT NULL
+        AND completed_at IS NOT NULL
+        AND julianday(completed_at) <= julianday(?)
+      ORDER BY completed_at DESC, id DESC
+      LIMIT 1
+    `).get(sessionId, observedAt) as { completed_at: string } | undefined;
+
+    const characterId = currentSessionRow?.session_kind === "default"
+      ? currentSessionRow.character_id?.trim() || null
+      : null;
+    if (!characterId) {
+      return {
+        currentSessionLastCompletedAt: currentSessionCompleted?.completed_at ?? null,
+        sameCharacterOtherSessionLastCompletedAt: null,
+        sameCharacterCompletedTurns: null,
+      };
+    }
+
+    const otherSessionCompleted = this.db.prepare(`
+      SELECT turns.completed_at
+      FROM session_turns_v6 AS turns
+      INNER JOIN sessions_v6 AS sessions ON sessions.id = turns.session_id
+      WHERE sessions.character_id = ?
+        AND sessions.session_kind = 'default'
+        AND sessions.id <> ?
+        AND turns.phase = 'completed'
+        AND turns.assistant_message_seq IS NOT NULL
+        AND turns.completed_at IS NOT NULL
+        AND julianday(turns.completed_at) <= julianday(?)
+      ORDER BY turns.completed_at DESC, turns.id DESC
+      LIMIT 1
+    `).get(characterId, sessionId, observedAt) as { completed_at: string } | undefined;
+    const completedTurns = this.db.prepare(`
+      SELECT turns.started_at, turns.completed_at
+      FROM session_turns_v6 AS turns
+      INNER JOIN sessions_v6 AS sessions ON sessions.id = turns.session_id
+      WHERE sessions.character_id = ?
+        AND sessions.session_kind = 'default'
+        AND turns.phase = 'completed'
+        AND turns.assistant_message_seq IS NOT NULL
+        AND turns.completed_at IS NOT NULL
+      ORDER BY turns.id ASC
+    `).all(characterId) as Array<{ started_at: string; completed_at: string }>;
+
+    return {
+      currentSessionLastCompletedAt: currentSessionCompleted?.completed_at ?? null,
+      sameCharacterOtherSessionLastCompletedAt: otherSessionCompleted?.completed_at ?? null,
+      sameCharacterCompletedTurns: completedTurns.map((turn): CompletedTurnTimingRow => ({
+        startedAt: turn.started_at,
+        completedAt: turn.completed_at,
+      })),
+    };
   }
 
   listSessionAuditLogSummaries(sessionId: string): AuditLogSummary[] {

--- a/src-electron/conversation-timing.ts
+++ b/src-electron/conversation-timing.ts
@@ -1,0 +1,146 @@
+export type CompletedExchangeTiming = {
+  lastCompletedAt: string;
+  elapsedMs: number;
+};
+
+export type CharacterSharedWorkTiming = {
+  todayCompletedTurnDurationMs: number;
+  totalCompletedTurnDurationMs: number;
+};
+
+export type DayOfWeek =
+  | "monday"
+  | "tuesday"
+  | "wednesday"
+  | "thursday"
+  | "friday"
+  | "saturday"
+  | "sunday";
+
+export type ConversationTimingContext = {
+  observedAt: string;
+  observedDayOfWeek: DayOfWeek;
+  currentSession: CompletedExchangeTiming | null;
+  sameCharacterOtherSession: CompletedExchangeTiming | null;
+  sameCharacterSharedWork: CharacterSharedWorkTiming | null;
+};
+
+export type CompletedTurnTimingRow = {
+  startedAt: string;
+  completedAt: string;
+};
+
+export type ConversationTimingStorageSnapshot = {
+  currentSessionLastCompletedAt: string | null;
+  sameCharacterOtherSessionLastCompletedAt: string | null;
+  sameCharacterCompletedTurns: CompletedTurnTimingRow[] | null;
+};
+
+const DAY_OF_WEEK: readonly DayOfWeek[] = [
+  "sunday",
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+];
+
+function pad(value: number, width = 2): string {
+  return String(value).padStart(width, "0");
+}
+
+function formatOffset(offsetMinutes: number): string {
+  const sign = offsetMinutes >= 0 ? "+" : "-";
+  const absoluteMinutes = Math.abs(offsetMinutes);
+  return `${sign}${pad(Math.floor(absoluteMinutes / 60))}:${pad(absoluteMinutes % 60)}`;
+}
+
+function shiftedDate(date: Date, offsetMinutes: number): Date {
+  return new Date(date.getTime() + offsetMinutes * 60_000);
+}
+
+export function formatIsoDateTimeAtOffset(date: Date, offsetMinutes: number): string {
+  const shifted = shiftedDate(date, offsetMinutes);
+  return [
+    `${pad(shifted.getUTCFullYear(), 4)}-${pad(shifted.getUTCMonth() + 1)}-${pad(shifted.getUTCDate())}`,
+    `T${pad(shifted.getUTCHours())}:${pad(shifted.getUTCMinutes())}:${pad(shifted.getUTCSeconds())}`,
+    `.${pad(shifted.getUTCMilliseconds(), 3)}${formatOffset(offsetMinutes)}`,
+  ].join("");
+}
+
+function parseTimestamp(value: string | null): Date | null {
+  if (!value) {
+    return null;
+  }
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? new Date(timestamp) : null;
+}
+
+function resolveCompletedExchange(
+  value: string | null,
+  observedAt: Date,
+  resolveOffsetMinutes: (date: Date) => number,
+): CompletedExchangeTiming | null {
+  const completedAt = parseTimestamp(value);
+  if (!completedAt || completedAt.getTime() > observedAt.getTime()) {
+    return null;
+  }
+  return {
+    lastCompletedAt: formatIsoDateTimeAtOffset(completedAt, resolveOffsetMinutes(completedAt)),
+    elapsedMs: observedAt.getTime() - completedAt.getTime(),
+  };
+}
+
+function localDateKey(date: Date, offsetMinutes: number): string {
+  const shifted = shiftedDate(date, offsetMinutes);
+  return `${pad(shifted.getUTCFullYear(), 4)}-${pad(shifted.getUTCMonth() + 1)}-${pad(shifted.getUTCDate())}`;
+}
+
+export function resolveConversationTimingContext(
+  snapshot: ConversationTimingStorageSnapshot,
+  observedAt: Date,
+  resolveOffsetMinutes: (date: Date) => number = (date) => -date.getTimezoneOffset(),
+): ConversationTimingContext {
+  const observedOffsetMinutes = resolveOffsetMinutes(observedAt);
+  const observedAtText = formatIsoDateTimeAtOffset(observedAt, observedOffsetMinutes);
+  const observedLocalDate = shiftedDate(observedAt, observedOffsetMinutes);
+  let sameCharacterSharedWork: CharacterSharedWorkTiming | null = null;
+
+  if (snapshot.sameCharacterCompletedTurns !== null) {
+    let todayCompletedTurnDurationMs = 0;
+    let totalCompletedTurnDurationMs = 0;
+    const observedDateKey = localDateKey(observedAt, observedOffsetMinutes);
+    for (const turn of snapshot.sameCharacterCompletedTurns) {
+      const startedAt = parseTimestamp(turn.startedAt);
+      const completedAt = parseTimestamp(turn.completedAt);
+      if (!startedAt || !completedAt || completedAt.getTime() > observedAt.getTime()) {
+        continue;
+      }
+      const durationMs = completedAt.getTime() - startedAt.getTime();
+      if (durationMs < 0) {
+        continue;
+      }
+      totalCompletedTurnDurationMs += durationMs;
+      if (localDateKey(completedAt, resolveOffsetMinutes(completedAt)) === observedDateKey) {
+        todayCompletedTurnDurationMs += durationMs;
+      }
+    }
+    sameCharacterSharedWork = {
+      todayCompletedTurnDurationMs,
+      totalCompletedTurnDurationMs,
+    };
+  }
+
+  return {
+    observedAt: observedAtText,
+    observedDayOfWeek: DAY_OF_WEEK[observedLocalDate.getUTCDay()] ?? "sunday",
+    currentSession: resolveCompletedExchange(snapshot.currentSessionLastCompletedAt, observedAt, resolveOffsetMinutes),
+    sameCharacterOtherSession: resolveCompletedExchange(
+      snapshot.sameCharacterOtherSessionLastCompletedAt,
+      observedAt,
+      resolveOffsetMinutes,
+    ),
+    sameCharacterSharedWork,
+  };
+}

--- a/src-electron/main.ts
+++ b/src-electron/main.ts
@@ -103,6 +103,7 @@ import { CompanionAuditLogStorageV3 } from "./companion-audit-log-storage-v3.js"
 import { CompanionStorage } from "./companion-storage.js";
 import { CompanionStorageV3 } from "./companion-storage-v3.js";
 import { SessionRuntimeService } from "./session-runtime-service.js";
+import { resolveConversationTimingContext } from "./conversation-timing.js";
 import { SessionTurnNotificationService } from "./session-turn-notification-service.js";
 import { SessionPersistenceService } from "./session-persistence-service.js";
 import { SessionWindowBridge } from "./session-window-bridge.js";
@@ -1973,6 +1974,17 @@ function requireSessionRuntimeService(): SessionRuntimeService {
         taskTitle: session.taskTitle,
       }),
       resolveProjectMemoryEntriesForPrompt: () => [],
+      resolveConversationTimingContext: async (session, observedAt) => {
+        if (session.sessionKind !== "default") {
+          return null;
+        }
+        const storage = requireAuditLogStorage();
+        if (!storage.getConversationTimingSnapshot) {
+          return null;
+        }
+        const snapshot = await storage.getConversationTimingSnapshot(session.id, observedAt.toISOString());
+        return resolveConversationTimingContext(snapshot, observedAt);
+      },
       createAuditLog: (entry) => requireAuditLogService().createAuditLog(entry),
       updateAuditLog: (id, entry) => requireAuditLogService().updateAuditLog(id, entry),
       setLiveSessionRun,

--- a/src-electron/persistent-store-lifecycle-service.ts
+++ b/src-electron/persistent-store-lifecycle-service.ts
@@ -38,6 +38,7 @@ import { SessionStorageV3 } from "./session-storage-v3.js";
 import { SessionStorageV6 } from "./session-storage-v6.js";
 import { sessionSummariesToSessions } from "./session-summary-adapter.js";
 import { openAppDatabase, truncateAppDatabaseWal } from "./sqlite-connection.js";
+import type { ConversationTimingStorageSnapshot } from "./conversation-timing.js";
 
 type ClosableStore = {
   close(): void;
@@ -73,7 +74,9 @@ export type AuditLogStorageRead = AwaitableStorageMethods<
   | "getSessionAuditLogDetail"
   | "getSessionAuditLogDetailSection"
   | "getSessionAuditLogOperationDetail"
-> & Pick<AuditLogStorage, "close">;
+> & Pick<AuditLogStorage, "close"> & {
+  getConversationTimingSnapshot?(sessionId: string, observedAt: string): Awaitable<ConversationTimingStorageSnapshot>;
+};
 export type AuditLogStorageWrite = AwaitableStorageMethods<
   AuditLogStorage,
   "createAuditLog" | "updateAuditLog" | "clearAuditLogs"

--- a/src-electron/provider-prompt.ts
+++ b/src-electron/provider-prompt.ts
@@ -1,6 +1,62 @@
 import type { RunSessionTurnInput, ProviderPromptComposition } from "./provider-runtime.js";
 import { normalizeAllowedAdditionalDirectories } from "./additional-directories.js";
 import { buildCharacterRuntimePromptSection } from "../src/character/character-runtime-snapshot.js";
+import type { ConversationTimingContext } from "./conversation-timing.js";
+
+function formatTimingDuration(durationMs: number): string {
+  const totalMinutes = Math.floor(durationMs / 60_000);
+  if (totalMinutes <= 0) {
+    return durationMs > 0 ? "less than 1 minute" : "0 minutes";
+  }
+  const days = Math.floor(totalMinutes / (24 * 60));
+  const hours = Math.floor((totalMinutes % (24 * 60)) / 60);
+  const minutes = totalMinutes % 60;
+  const parts: string[] = [];
+  if (days > 0) {
+    parts.push(`${days} ${days === 1 ? "day" : "days"}`);
+  }
+  if (hours > 0) {
+    parts.push(`${hours} ${hours === 1 ? "hour" : "hours"}`);
+  }
+  if (minutes > 0 && days === 0) {
+    parts.push(`${minutes} ${minutes === 1 ? "minute" : "minutes"}`);
+  }
+  return parts.slice(0, 2).join(" ");
+}
+
+function buildConversationTimingSection(context?: ConversationTimingContext): string {
+  if (!context) {
+    return "";
+  }
+  const dayLabel = `${context.observedDayOfWeek[0]?.toUpperCase() ?? ""}${context.observedDayOfWeek.slice(1)}`;
+  const timingLines = [
+    `- Observed local time: ${context.observedAt} (${dayLabel})`,
+    context.currentSession
+      ? `- Previous completed exchange in this session: ${context.currentSession.lastCompletedAt} (${formatTimingDuration(context.currentSession.elapsedMs)} ago)`
+      : "",
+    context.sameCharacterOtherSession
+      ? `- Latest completed exchange with this character in another session: ${context.sameCharacterOtherSession.lastCompletedAt} (${formatTimingDuration(context.sameCharacterOtherSession.elapsedMs)} ago)`
+      : "",
+    context.sameCharacterSharedWork && context.sameCharacterSharedWork.totalCompletedTurnDurationMs > 0
+      ? `- Completed turn execution time with this character: ${formatTimingDuration(context.sameCharacterSharedWork.todayCompletedTurnDurationMs)} today; ${formatTimingDuration(context.sameCharacterSharedWork.totalCompletedTurnDurationMs)} total`
+      : "",
+  ].filter(Boolean);
+
+  return [
+    "# Conversation Timing",
+    "",
+    "Use this app-observed timing metadata only as a soft signal for conversational pacing and familiarity.",
+    "",
+    "- Use same-session timing to decide whether to continue directly or briefly restore context. Other-session timing may adjust familiarity, but does not reveal what was discussed there.",
+    "- Use local time only as a weak signal for time-appropriate greetings and conversational tone. Do not infer or judge the user's location, schedule, sleep, work, holidays, or lifestyle.",
+    "- Work time is a rough measure of completed work with this character. It is wall-clock turn runtime, including provider execution, tools, and retries; it is not continuous presence or conversation time.",
+    "- Prioritize the current user input and tone. Do not routinely quote timing values, guilt the user about an absence, or invent events during a gap.",
+    "",
+    "Observed values:",
+    "",
+    ...timingLines,
+  ].join("\n");
+}
 
 function buildCharacterOutputBoundarySection(enabled: boolean): string {
   if (!enabled) {
@@ -50,6 +106,11 @@ export function composeProviderPrompt(input: RunSessionTurnInput): ProviderPromp
   const referencedImages = input.attachments.filter((attachment) => attachment.kind === "image");
   const inputSections: string[] = [];
   const userMessageText = input.userMessage.trim();
+  const conversationTimingBody = buildConversationTimingSection(input.conversationTimingContext);
+
+  if (conversationTimingBody) {
+    inputSections.push(conversationTimingBody);
+  }
 
   if (userMessageText) {
     inputSections.push(`# User Input\n\n${userMessageText}`);

--- a/src-electron/provider-runtime.ts
+++ b/src-electron/provider-runtime.ts
@@ -24,6 +24,7 @@ import type { ModelReasoningEffort, ModelCatalogProvider } from "../src/model-ca
 import type { ApprovalMode } from "../src/approval-mode.js";
 import type { CodexSandboxMode } from "../src/codex-sandbox-mode.js";
 import type { SessionMemoryExtractionPrompt } from "./session-memory-extraction.js";
+import type { ConversationTimingContext } from "./conversation-timing.js";
 
 export type ProviderPromptComposition = {
   systemBodyText: string;
@@ -43,6 +44,7 @@ export type RunSessionTurnInput = {
   userMessage: string;
   appSettings: AppSettings;
   attachments: ComposerAttachment[];
+  conversationTimingContext?: ConversationTimingContext;
   signal?: AbortSignal;
   onApprovalRequest?: RunSessionTurnApprovalRequestHandler;
   onElicitationRequest?: RunSessionTurnElicitationRequestHandler;

--- a/src-electron/session-runtime-service.ts
+++ b/src-electron/session-runtime-service.ts
@@ -31,6 +31,7 @@ import { appendTransportPayloadFields, calculateAuditDurationMs } from "./audit-
 import { estimateLogicalPromptTokens } from "./prompt-token-estimate.js";
 import { toAuditTextPreview } from "./audit-payload-limits.js";
 import type { Awaitable } from "./persistent-store-lifecycle-service.js";
+import type { ConversationTimingContext } from "./conversation-timing.js";
 
 type CreateAuditLogInput = Omit<AuditLogEntry, "id">;
 
@@ -65,6 +66,10 @@ export type SessionRuntimeServiceDeps = {
     userMessage: string,
     sessionMemory: SessionMemory,
   ): ProjectMemoryEntry[];
+  resolveConversationTimingContext?: (
+    session: Session,
+    observedAt: Date,
+  ) => Awaitable<ConversationTimingContext | null>;
   createAuditLog(input: CreateAuditLogInput): Awaitable<AuditLogEntry>;
   updateAuditLog(id: number, entry: CreateAuditLogInput): Awaitable<void | AuditLogEntry>;
   setLiveSessionRun(sessionId: string, state: LiveSessionRunState | null): void;
@@ -89,6 +94,7 @@ export type SessionRuntimeServiceDeps = {
   getMateState?: () => MateStorageState;
   notifySessionTurnCompleted?: (session: Session, lastNonEmptyAssistantMessageText: string) => Awaitable<void>;
   currentTimestampLabel?: () => string;
+  currentDate?: () => Date;
   providerCancelGraceMs?: number;
   auditEnrichmentGraceMs?: number;
 };
@@ -729,6 +735,7 @@ export class SessionRuntimeService {
     request: RunSessionTurnRequest,
     runAbortController: AbortController,
   ): Promise<Session> {
+    const observedAt = (this.deps.currentDate ?? (() => new Date()))();
     const investigationStartedAt = Date.now();
     const storedSession = await this.deps.getSession(sessionId);
     throwIfRunCanceled(runAbortController.signal);
@@ -788,6 +795,9 @@ export class SessionRuntimeService {
     const sessionMemory = this.deps.getSessionMemory(session);
     const projectMemoryEntries = this.deps.resolveProjectMemoryEntriesForPrompt(session, nextMessage, sessionMemory);
     const sessionCharacter = await this.deps.resolveSessionCharacter?.(session) ?? null;
+    const conversationTimingContext = await Promise.resolve(
+      this.deps.resolveConversationTimingContext?.(session, observedAt) ?? null,
+    );
     throwIfRunCanceled(runAbortController.signal);
     const currentTimestampLabel = this.deps.currentTimestampLabel ?? defaultCurrentTimestampLabel;
 
@@ -808,6 +818,7 @@ export class SessionRuntimeService {
         userMessage: nextMessage,
         appSettings,
         attachments: composerPreview.attachments,
+        conversationTimingContext: conversationTimingContext ?? undefined,
       });
 
       runningSession = {
@@ -972,6 +983,7 @@ export class SessionRuntimeService {
         userMessage: nextMessage,
         appSettings,
         attachments: composerPreview.attachments,
+        conversationTimingContext: conversationTimingContext ?? undefined,
         signal: runAbortController.signal,
         onApprovalRequest: (approvalRequest) => {
           const decision = this.deps.waitForApprovalDecision(sessionId, approvalRequest, runAbortController.signal);


### PR DESCRIPTION
## 概要

- 通常Sessionのturn開始時に、ローカル日時、同一Sessionと同一Character別Sessionの直近正常完了turn、同じCharacterとの共同作業時間を解決する
- 解決した時間情報をturn内で固定し、監査prompt、provider実行、stale retryで同じ値を再利用する
- Conversation Timingをinput側のUser Input直前へ配置し、固定の解釈規則と可変な観測値を分離する
- Auxiliary、Companion、Character Authoring Sessionを集計および注入対象から除外する
- 選択理由と時刻の正本をADR 016へ記録し、prompt composition設計文書へpointerを追加する

## 検証

- npm test: 2165 passed / 0 failed / 1 skipped
- npm run typecheck: 成功
- git diff --check: 問題なし

## 補足

- DB migrationは追加していない
- 手動のアプリ起動確認は実施していない。時間計算、storage投影、runtime固定、prompt合成は固定時計を用いた自動testで検証した