### PR TITLE
feat(ui): Changesペインのスクロールと表示を整理

### DIFF
--- a/scripts/tests/chat-header-actions.test.tsx
+++ b/scripts/tests/chat-header-actions.test.tsx
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+
+import { SessionHeader } from "../../src/session-components.js";
 
 import {
   buildLiveSessionHeaderProps,
@@ -10,6 +13,31 @@ import {
 } from "../../src/chat/chat-header-actions.js";
 
 const noop = () => {};
+
+test("SessionHeader は低頻度の管理操作を menu にまとめる", () => {
+  const html = renderToStaticMarkup(
+    <SessionHeader
+      taskTitle="Session"
+      isEditingTitle={false}
+      titleDraft="Session"
+      isRunning={false}
+      onOpenAuditLog={noop}
+      onOpenTerminal={noop}
+      onTitleDraftChange={noop}
+      onTitleInputKeyDown={noop}
+      onSaveTitle={noop}
+      onCancelTitleEdit={noop}
+      onStartTitleEdit={noop}
+      onDeleteSession={noop}
+    />,
+  );
+
+  assert.match(html, /<summary aria-label="Session actions"/);
+  assert.match(html, /role="menu"/);
+  assert.match(html, /role="menuitem">Rename<\/button>/);
+  assert.match(html, /role="menuitem">Audit Log<\/button>/);
+  assert.match(html, /role="menuitem">Delete<\/button>/);
+});
 
 test("createWorkspaceExplorerAction は共通の workspace Explorer action を描画する", () => {
   const html = renderToStaticMarkup(createWorkspaceExplorerAction({ onOpenExplorer: noop }));

--- a/scripts/tests/companion-chat-projection.test.ts
+++ b/scripts/tests/companion-chat-projection.test.ts
@@ -308,8 +308,8 @@ test("buildCompanionChatWindowProps は retry actions を共通 chat layout に�
   const html = renderToStaticMarkup(React.createElement(React.Fragment, null, props.recoveryActions));
 
   assert.match(html, /retry-banner failed/);
-  assert.match(html, />同じ依頼を再送<\/button>/);
-  assert.match(html, />編集して再送<\/button>/);
+  assert.match(html, />再送<\/button>/);
+  assert.match(html, />編集<\/button>/);
 });
 
 test("buildCompanionChatWindowProps は retry draft 上書き確認を共通 composer に渡す", () => {

--- a/scripts/tests/retry-banner-adapter.test.tsx
+++ b/scripts/tests/retry-banner-adapter.test.tsx
@@ -25,9 +25,10 @@ test("buildLiveSessionRetryBanner は retry banner UI を mode-neutral に組み
 
   assert.match(html, /retry-banner failed/);
   assert.match(html, /aria-label="完了できなかった依頼の操作"/);
-  assert.match(html, />同じ依頼を再送<\/button>/);
-  assert.match(html, />編集して再送<\/button>/);
-  assert.doesNotMatch(html, /停止地点|前回の依頼<\/span>|>Details<|>Hide</);
+  assert.match(html, />再送<\/button>/);
+  assert.match(html, />編集<\/button>/);
+  assert.match(html, /title="前回の依頼は完了できませんでした"/);
+  assert.doesNotMatch(html, /停止地点|resume-banner-title|>Details<|>Hide</);
 });
 
 test("buildLiveSessionRetryBanner は banner がない場合 null を描画する", () => {

--- a/scripts/tests/session-chat-projection.test.ts
+++ b/scripts/tests/session-chat-projection.test.ts
@@ -285,8 +285,8 @@ test("buildAgentSessionChatWindowProps は retry actions を共通 chat layout �
 
   assert.equal(props.isActionDockExpanded, false);
   assert.match(html, /retry-banner failed/);
-  assert.match(html, />同じ依頼を再送<\/button>/);
-  assert.match(html, />編集して再送<\/button>/);
+  assert.match(html, />再送<\/button>/);
+  assert.match(html, />編集<\/button>/);
 });
 
 test("buildAgentSessionChatWindowProps は Auxiliary mode で parent header 操作だけ隠す", () => {

--- a/scripts/tests/session-file-explorer-pane.test.tsx
+++ b/scripts/tests/session-file-explorer-pane.test.tsx
@@ -119,6 +119,7 @@ test("SessionFileExplorerPane は directory load を明示展開と現行 reques
       return request.promise;
     },
   };
+  let changesRefreshCalls = 0;
   let root: Root | null = null;
   try {
     await act(async () => {
@@ -131,6 +132,9 @@ test("SessionFileExplorerPane は directory load を明示展開と現行 reques
         selectedFile: null,
         activeTab: "files",
         onActiveTabChange() {},
+        onRefreshChanges() {
+          changesRefreshCalls += 1;
+        },
         onOpenFile() {},
       }));
     });
@@ -180,6 +184,28 @@ test("SessionFileExplorerPane は directory load を明示展開と現行 reques
     });
     assert.match(dom.window.document.body.textContent ?? "", /new\.txt/);
     assert.doesNotMatch(dom.window.document.body.textContent ?? "", /old\.txt/);
+
+    await act(async () => {
+      root?.render(React.createElement(SessionFileExplorerPane, {
+        api,
+        sessionId: "session-1",
+        enabled: true,
+        rootsRevision: "roots-1",
+        selectedFile: null,
+        activeTab: "changes",
+        onActiveTabChange() {},
+        onRefreshChanges() {
+          changesRefreshCalls += 1;
+        },
+        onOpenFile() {},
+        changesContent: React.createElement("div", null, "Changes content"),
+      }));
+    });
+    const changesRefresh = dom.window.document.querySelector<HTMLButtonElement>(".session-file-explorer-refresh");
+    assert.ok(changesRefresh);
+    assert.equal(changesRefresh.ariaLabel, "Refresh changes");
+    await act(async () => changesRefresh.click());
+    assert.equal(changesRefreshCalls, 1);
   } finally {
     if (root) {
       await act(async () => root?.unmount());

--- a/scripts/tests/workspace-changes-pane.test.tsx
+++ b/scripts/tests/workspace-changes-pane.test.tsx
@@ -87,40 +87,52 @@ test("FileRootChangesPane は大量の変更を constrained viewport 内で仮�
   }];
   const requestedRootIds: string[] = [];
   const diffRequests: FileRootFileDiffRequest[] = [];
+  let rootListFailure: Error | null = null;
+  let workspaceEntries = entries;
+  const testApi = {
+    listSessionFileRoots: async () => {
+      if (rootListFailure) {
+        throw rootListFailure;
+      }
+      return [
+        { id: "session-folder", kind: "session-folder" as const, label: "Session Folder", displayPath: "C:/session" },
+        { id: "additional:broken", kind: "additional" as const, label: "broken", displayPath: "C:/broken" },
+        { id: "additional:repo", kind: "additional" as const, label: "repo", displayPath: "C:/repo" },
+        { id: "workspace", kind: "workspace" as const, label: "Workspace", displayPath: "C:/repo/app" },
+      ];
+    },
+    listFileRootChanges: async (request: { rootId: string }) => {
+      requestedRootIds.push(request.rootId);
+      if (request.rootId === "session-folder") {
+        return { status: "not-git" as const, message: "Not a Git repository." };
+      }
+      if (request.rootId === "additional:broken") {
+        return { status: "failed" as const, message: "Git status failed for broken root." };
+      }
+      return {
+        status: "ok" as const,
+        entries: request.rootId === "workspace" ? workspaceEntries : additionalEntries,
+      };
+    },
+  };
+  const baseProps = {
+    api: testApi,
+    enabled: true,
+    rootsRevision: "roots-1",
+    refreshRevision: 0,
+    onOpenFile: () => undefined,
+    onOpenDiff: async (request: FileRootFileDiffRequest) => {
+      diffRequests.push(request);
+      return null;
+    },
+  };
   let root: Root | null = null;
   try {
     await act(async () => {
       root = createRoot(dom.window.document.getElementById("root") as HTMLElement);
       root.render(React.createElement(FileRootChangesPane, {
-        api: {
-          listSessionFileRoots: async () => [
-            { id: "session-folder", kind: "session-folder" as const, label: "Session Folder", displayPath: "C:/session" },
-            { id: "additional:broken", kind: "additional" as const, label: "broken", displayPath: "C:/broken" },
-            { id: "additional:repo", kind: "additional" as const, label: "repo", displayPath: "C:/repo" },
-            { id: "workspace", kind: "workspace" as const, label: "Workspace", displayPath: "C:/repo/app" },
-          ],
-          listFileRootChanges: async (request) => {
-            requestedRootIds.push(request.rootId);
-            if (request.rootId === "session-folder") {
-              return { status: "not-git" as const, message: "Not a Git repository." };
-            }
-            if (request.rootId === "additional:broken") {
-              return { status: "failed" as const, message: "Git status failed for broken root." };
-            }
-            return {
-              status: "ok" as const,
-              entries: request.rootId === "workspace" ? entries : additionalEntries,
-            };
-          },
-        },
+        ...baseProps,
         sessionId: "session-1",
-        enabled: true,
-        rootsRevision: "roots-1",
-        onOpenFile: () => undefined,
-        onOpenDiff: async (request) => {
-          diffRequests.push(request);
-          return null;
-        },
       }));
     });
     await act(async () => {
@@ -129,9 +141,22 @@ test("FileRootChangesPane は大量の変更を constrained viewport 内で仮�
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
-    const list = dom.window.document.querySelector<HTMLElement>(".workspace-changes-list");
+    const groups = [...dom.window.document.querySelectorAll<HTMLElement>(".workspace-changes-root-group")];
+    const lists = [...dom.window.document.querySelectorAll<HTMLElement>(".workspace-changes-list")];
     const rows = [...dom.window.document.querySelectorAll<HTMLElement>(".workspace-change-virtual-row")];
-    assert.ok(list);
+    assert.equal(groups.length, 3);
+    assert.equal(lists.length, 3);
+    assert.ok(lists.every((list) => list.tabIndex === 0));
+    assert.doesNotMatch(dom.window.document.body.textContent ?? "", /Live root status/);
+    assert.equal(dom.window.document.querySelector(".workspace-changes-refresh"), null);
+    assert.equal(
+      groups.find((group) => group.dataset.rootId === "workspace")
+        ?.querySelector(".workspace-changes-root-count")?.textContent,
+      String(entries.length),
+    );
+    assert.equal(groups.find((group) => group.dataset.rootId === "additional:broken")?.style.minHeight, "78px");
+    assert.equal(groups.find((group) => group.dataset.rootId === "additional:repo")?.style.maxHeight, "230px");
+    assert.equal(groups.find((group) => group.dataset.rootId === "workspace")?.style.maxHeight, "408px");
     assert.deepEqual(requestedRootIds, ["session-folder", "additional:broken", "additional:repo", "workspace"]);
     assert.doesNotMatch(dom.window.document.body.textContent ?? "", /Session Folder/);
     assert.match(dom.window.document.body.textContent ?? "", /Git status failed for broken root/);
@@ -140,7 +165,9 @@ test("FileRootChangesPane は大量の変更を constrained viewport 内で仮�
     assert.ok(rows.length > 0, dom.window.document.body.innerHTML);
     assert.ok(rows.length < entries.length, `mounted ${rows.length} rows for ${entries.length} entries`);
     assert.ok(rows.every((row) => row.dataset.index !== undefined));
-    const rootPath = dom.window.document.querySelector<HTMLElement>(".workspace-changes-root-header[title='C:/repo'] span");
+    const rootPath = dom.window.document.querySelector<HTMLElement>(
+      ".workspace-changes-root-header[title='C:/repo'] .workspace-changes-root-path",
+    );
     assert.equal(rootPath?.textContent, "C:/repo");
 
     const appDirectory = [...dom.window.document.querySelectorAll<HTMLButtonElement>(".workspace-change-directory-row")]
@@ -175,6 +202,104 @@ test("FileRootChangesPane は大量の変更を constrained viewport 内で仮�
       { rootId: "workspace", relativePath: "src/00-shared.ts" },
     ]);
 
+    const repoList = dom.window.document.querySelector<HTMLElement>(
+      ".workspace-changes-root-group[data-root-id='additional:repo'] .workspace-changes-list",
+    );
+    const workspaceList = dom.window.document.querySelector<HTMLElement>(
+      ".workspace-changes-root-group[data-root-id='workspace'] .workspace-changes-list",
+    );
+    assert.ok(repoList);
+    assert.ok(workspaceList);
+    repoList.scrollTop = 20;
+    workspaceList.scrollTop = 120;
+    assert.equal(repoList.scrollTop, 20);
+    assert.equal(workspaceList.scrollTop, 120);
+    await act(async () => {
+      root?.render(React.createElement(FileRootChangesPane, {
+        ...baseProps,
+        sessionId: "session-1",
+        refreshRevision: 1,
+      }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    const refreshedRepoList = dom.window.document.querySelector<HTMLElement>(
+      ".workspace-changes-root-group[data-root-id='additional:repo'] .workspace-changes-list",
+    );
+    const refreshedWorkspaceList = dom.window.document.querySelector<HTMLElement>(
+      ".workspace-changes-root-group[data-root-id='workspace'] .workspace-changes-list",
+    );
+    assert.equal(refreshedRepoList, repoList);
+    assert.equal(refreshedWorkspaceList, workspaceList);
+    assert.equal(refreshedRepoList?.scrollTop, 20);
+    assert.equal(refreshedWorkspaceList?.scrollTop, 120);
+
+    rootListFailure = new Error("Temporary root refresh failure.");
+    await act(async () => {
+      root?.render(React.createElement(FileRootChangesPane, {
+        ...baseProps,
+        sessionId: "session-1",
+        refreshRevision: 2,
+      }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    assert.equal(
+      dom.window.document.querySelector(".workspace-changes-root-group[data-root-id='additional:repo'] .workspace-changes-list"),
+      repoList,
+    );
+    assert.equal(
+      dom.window.document.querySelector(".workspace-changes-root-group[data-root-id='workspace'] .workspace-changes-list"),
+      workspaceList,
+    );
+    assert.equal(repoList.scrollTop, 20);
+    assert.equal(workspaceList.scrollTop, 120);
+    assert.match(dom.window.document.body.textContent ?? "", /Temporary root refresh failure/);
+
+    rootListFailure = null;
+    await act(async () => {
+      root?.render(React.createElement(FileRootChangesPane, {
+        ...baseProps,
+        sessionId: "session-1",
+        refreshRevision: 3,
+      }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    assert.equal(
+      dom.window.document.querySelector(".workspace-changes-root-group[data-root-id='workspace'] .workspace-changes-list"),
+      workspaceList,
+    );
+    assert.equal(workspaceList.scrollTop, 120);
+    assert.doesNotMatch(dom.window.document.body.textContent ?? "", /Temporary root refresh failure/);
+
+    workspaceEntries = entries.slice(0, 1);
+    await act(async () => {
+      root?.render(React.createElement(FileRootChangesPane, {
+        ...baseProps,
+        sessionId: "session-1",
+        refreshRevision: 4,
+      }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    assert.equal(
+      dom.window.document.querySelector(".workspace-changes-root-group[data-root-id='workspace'] .workspace-changes-list"),
+      workspaceList,
+    );
+    assert.equal(workspaceList.scrollTop, 0);
+    assert.equal(repoList.scrollTop, 20);
+
+    await act(async () => {
+      root?.render(React.createElement(FileRootChangesPane, {
+        ...baseProps,
+        sessionId: "session-2",
+      }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    const nextSessionWorkspaceList = dom.window.document.querySelector<HTMLElement>(
+      ".workspace-changes-root-group[data-root-id='workspace'] .workspace-changes-list",
+    );
+    assert.ok(nextSessionWorkspaceList);
+    assert.notEqual(nextSessionWorkspaceList, workspaceList);
+    assert.equal(nextSessionWorkspaceList.scrollTop, 0);
+
     let rejectStaleRequest: ((reason?: unknown) => void) | null = null;
     let statusRequestCount = 0;
     const staleReloadApi = {
@@ -203,6 +328,7 @@ test("FileRootChangesPane は大量の変更を constrained viewport 内で仮�
       api: staleReloadApi,
       sessionId: "session-1",
       enabled: true,
+      refreshRevision: 0,
       onOpenFile: () => undefined,
       onOpenDiff: async () => null,
     };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -457,6 +457,7 @@ export default function AgentSessionWindowApp() {
   const [selectedFileDiffScopes, setSelectedFileDiffScopes] = useState<FileRootGitChangeScope[]>([]);
   const [selectedFileDiffAvailabilityMessage, setSelectedFileDiffAvailabilityMessage] = useState("");
   const [fileExplorerTab, setFileExplorerTab] = useState<"files" | "changes">("files");
+  const [fileRootChangesRefreshRevision, setFileRootChangesRefreshRevision] = useState(0);
   const [fileRootDiffPreview, setFileRootDiffPreview] = useState<{
     sessionId: string;
     rootId: string;
@@ -3229,6 +3230,7 @@ export default function AgentSessionWindowApp() {
       selectedFile={selectedFilePreview}
       activeTab={fileExplorerTab}
       onActiveTabChange={setFileExplorerTab}
+      onRefreshChanges={() => setFileRootChangesRefreshRevision((current) => current + 1)}
       onOpenFile={(request) => {
         fileRootDiffRequestRevisionRef.current += 1;
         beginCentralPreviewIfNeeded();
@@ -3243,6 +3245,7 @@ export default function AgentSessionWindowApp() {
           sessionId={activeRunSessionId}
           enabled={isFilesPaneVisible && fileExplorerTab === "changes"}
           rootsRevision={fileExplorerRootsRevision}
+          refreshRevision={fileRootChangesRefreshRevision}
           onOpenFile={handleOpenFileRootFile}
           onOpenDiff={handleShowFileRootDiff}
         />

--- a/src/file-explorer/FileRootChangesGroup.tsx
+++ b/src/file-explorer/FileRootChangesGroup.tsx
@@ -1,0 +1,271 @@
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { useEffect, useId, useMemo, useRef, type CSSProperties } from "react";
+
+import {
+  buildChangedFileTree,
+  changedFileDisplayName,
+  type ChangedFileTreeNode,
+} from "./changed-file-tree.js";
+import type {
+  FileRootGitChangeEntry,
+  FileRootGitChangeScope,
+  SessionFileRoot,
+} from "./file-explorer-contract.js";
+
+const ROOT_HEADER_ESTIMATED_HEIGHT = 48;
+const ROOT_GROUP_MIN_HEIGHT = 168;
+const ROOT_GROUP_MAX_HEIGHT = 408;
+
+export type GitRootChanges = {
+  root: SessionFileRoot;
+  entries: FileRootGitChangeEntry[];
+  message: string;
+};
+
+type FileRootChangeRow =
+  | { key: string; type: "header"; label: string; count: number }
+  | { key: string; type: "empty"; label: string }
+  | { key: string; type: "error"; label: string }
+  | {
+      key: string;
+      type: "directory";
+      rootId: string;
+      scope: FileRootGitChangeScope;
+      relativePath: string;
+      name: string;
+      depth: number;
+      expanded: boolean;
+    }
+  | {
+      key: string;
+      type: "entry";
+      rootId: string;
+      entry: FileRootGitChangeEntry;
+      scope: FileRootGitChangeScope;
+      depth: number;
+    };
+
+function changeKindLabel(kind: FileRootGitChangeEntry["kinds"][FileRootGitChangeScope]): string {
+  switch (kind) {
+    case "added":
+      return "A";
+    case "deleted":
+      return "D";
+    case "renamed":
+      return "R";
+    case "untracked":
+      return "U";
+    default:
+      return "M";
+  }
+}
+
+function directoryStateKey(rootId: string, scope: FileRootGitChangeScope, relativePath: string): string {
+  return `${rootId}\u0000${scope}\u0000${relativePath}`;
+}
+
+function estimatedRowHeight(row: FileRootChangeRow): number {
+  return row.type === "header" ? 31 : 30;
+}
+
+type FileRootChangesGroupProps = {
+  rootChange: GitRootChanges;
+  groupCount: number;
+  collapsedDirectories: Record<string, boolean>;
+  loadingKey: string;
+  onToggleDirectory: (rootId: string, scope: FileRootGitChangeScope, relativePath: string) => void;
+  onOpenEntry: (
+    rootId: string,
+    entry: FileRootGitChangeEntry,
+    scope: FileRootGitChangeScope,
+  ) => Promise<void>;
+};
+
+export function FileRootChangesGroup({
+  rootChange,
+  groupCount,
+  collapsedDirectories,
+  loadingKey,
+  onToggleDirectory,
+  onOpenEntry,
+}: FileRootChangesGroupProps) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const headingId = useId();
+  const rows = useMemo(() => {
+    const nextRows: FileRootChangeRow[] = [];
+    const appendTreeNodes = (
+      nodes: ChangedFileTreeNode[],
+      scope: FileRootGitChangeScope,
+      depth: number,
+    ) => {
+      for (const node of nodes) {
+        if (node.type === "directory") {
+          const stateKey = directoryStateKey(rootChange.root.id, scope, node.relativePath);
+          const expanded = !collapsedDirectories[stateKey];
+          nextRows.push({
+            key: `directory:${rootChange.root.id}:${scope}:${node.relativePath}`,
+            type: "directory",
+            rootId: rootChange.root.id,
+            scope,
+            relativePath: node.relativePath,
+            name: node.name,
+            depth,
+            expanded,
+          });
+          if (expanded) {
+            appendTreeNodes(node.children, scope, depth + 1);
+          }
+        } else {
+          nextRows.push({
+            key: `${rootChange.root.id}:${scope}:${node.relativePath}`,
+            type: "entry",
+            rootId: rootChange.root.id,
+            entry: node.entry,
+            scope,
+            depth,
+          });
+        }
+      }
+    };
+
+    if (rootChange.message) {
+      nextRows.push({ key: `error:${rootChange.root.id}`, type: "error", label: rootChange.message });
+      return nextRows;
+    }
+    for (const [scope, label] of [["working-tree", "Working Tree"], ["staged", "Staged"]] as const) {
+      const scopedEntries = rootChange.entries.filter((entry) => entry.scopes.includes(scope));
+      nextRows.push({
+        key: `header:${rootChange.root.id}:${scope}`,
+        type: "header",
+        label,
+        count: scopedEntries.length,
+      });
+      if (scopedEntries.length === 0) {
+        nextRows.push({ key: `empty:${rootChange.root.id}:${scope}`, type: "empty", label: "No changes." });
+      } else {
+        appendTreeNodes(buildChangedFileTree(scopedEntries, scope), scope, 0);
+      }
+    }
+    return nextRows;
+  }, [collapsedDirectories, rootChange]);
+  const naturalHeight = ROOT_HEADER_ESTIMATED_HEIGHT
+    + rows.reduce((total, row) => total + estimatedRowHeight(row), 0);
+  const minimumHeight = Math.min(naturalHeight, ROOT_GROUP_MIN_HEIGHT);
+  const maximumHeight = naturalHeight <= ROOT_GROUP_MAX_HEIGHT
+    ? naturalHeight
+    : groupCount === 1
+      ? undefined
+      : ROOT_GROUP_MAX_HEIGHT;
+  const groupStyle: CSSProperties = {
+    flexBasis: `${minimumHeight}px`,
+    minHeight: `${minimumHeight}px`,
+    ...(maximumHeight === undefined ? {} : { maxHeight: `${maximumHeight}px` }),
+  };
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollRef.current,
+    getItemKey: (index) => rows[index]?.key ?? index,
+    estimateSize: (index) => estimatedRowHeight(rows[index]!),
+    overscan: 16,
+    initialRect: { width: 280, height: Math.min(360, Math.max(90, naturalHeight - ROOT_HEADER_ESTIMATED_HEIGHT)) },
+    useFlushSync: false,
+  });
+  const totalSize = virtualizer.getTotalSize();
+
+  useEffect(() => {
+    const scrollElement = scrollRef.current;
+    if (!scrollElement) {
+      return;
+    }
+    const maximumScrollTop = Math.max(0, scrollElement.scrollHeight - scrollElement.clientHeight);
+    if (scrollElement.scrollTop > maximumScrollTop) {
+      scrollElement.scrollTop = maximumScrollTop;
+    }
+  }, [totalSize]);
+
+  return (
+    <section
+      className="workspace-changes-root-group"
+      style={groupStyle}
+      role="listitem"
+      aria-labelledby={headingId}
+      data-root-id={rootChange.root.id}
+    >
+      <div className="workspace-changes-root-header" title={rootChange.root.displayPath}>
+        <div className="workspace-changes-root-title-row">
+          <strong id={headingId}>{rootChange.root.label}</strong>
+          {rootChange.message ? null : (
+            <span className="workspace-changes-root-count" aria-label={`${rootChange.entries.length} changed files`}>
+              {rootChange.entries.length}
+            </span>
+          )}
+        </div>
+        <span className="workspace-changes-root-path">{rootChange.root.displayPath}</span>
+      </div>
+      <div
+        className="workspace-changes-list"
+        ref={scrollRef}
+        role="list"
+        aria-label={`${rootChange.root.label} changes`}
+        tabIndex={0}
+      >
+        <div className="workspace-changes-list-inner" style={{ height: totalSize }}>
+          {virtualizer.getVirtualItems().map((virtualRow) => {
+            const row = rows[virtualRow.index];
+            if (!row) {
+              return null;
+            }
+            return (
+              <div
+                key={row.key}
+                className={`workspace-change-virtual-row ${row.type}`}
+                data-index={virtualRow.index}
+                ref={virtualizer.measureElement}
+                style={{ transform: `translateY(${virtualRow.start}px)` }}
+              >
+                {row.type === "header" ? (
+                  <div className="workspace-changes-group-header"><strong>{row.label}</strong><span>{row.count}</span></div>
+                ) : row.type === "empty" ? (
+                  <p>{row.label}</p>
+                ) : row.type === "error" ? (
+                  <p className="workspace-changes-root-error">{row.label}</p>
+                ) : row.type === "directory" ? (
+                  <button
+                    className="workspace-change-directory-row"
+                    type="button"
+                    style={{ paddingLeft: `${6 + row.depth * 14}px` }}
+                    aria-expanded={row.expanded}
+                    title={row.relativePath}
+                    onClick={() => onToggleDirectory(row.rootId, row.scope, row.relativePath)}
+                  >
+                    <span className={`workspace-change-directory-icon${row.expanded ? " is-expanded" : ""}`}>▸</span>
+                    <span className="workspace-change-directory-name">{row.name}</span>
+                  </button>
+                ) : (() => {
+                  const key = `${row.rootId}:${row.scope}:${row.entry.relativePath}`;
+                  const kind = row.entry.kinds[row.scope] ?? "modified";
+                  return (
+                    <button
+                      className="workspace-change-row"
+                      type="button"
+                      style={{ paddingLeft: `${6 + row.depth * 14}px` }}
+                      disabled={!!loadingKey}
+                      onClick={() => void onOpenEntry(row.rootId, row.entry, row.scope)}
+                      title={row.entry.previousRelativePath
+                        ? `${row.entry.previousRelativePath} → ${row.entry.relativePath}`
+                        : row.entry.relativePath}
+                    >
+                      <span className={`workspace-change-kind ${kind}`}>{changeKindLabel(kind)}</span>
+                      <span className="workspace-change-path">{changedFileDisplayName(row.entry)}</span>
+                      {loadingKey === key ? <span className="workspace-change-loading">…</span> : null}
+                    </button>
+                  );
+                })()}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/file-explorer/FileRootChangesPane.tsx
+++ b/src/file-explorer/FileRootChangesPane.tsx
@@ -1,19 +1,16 @@
-import { useVirtualizer } from "@tanstack/react-virtual";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { WithMateWindowApi } from "../withmate-window-api.js";
 import {
-  buildChangedFileTree,
-  changedFileDisplayName,
-  type ChangedFileTreeNode,
-} from "./changed-file-tree.js";
+  FileRootChangesGroup,
+  type GitRootChanges,
+} from "./FileRootChangesGroup.js";
 import type {
   FileRootFileDiffRequest,
   FileRootChangesResult,
   FileRootGitChangeEntry,
   FileRootGitChangeScope,
   SessionFileResourceRequest,
-  SessionFileRoot,
 } from "./file-explorer-contract.js";
 
 type FileRootChangesApi = Pick<
@@ -26,54 +23,10 @@ export type FileRootChangesPaneProps = {
   sessionId: string | null;
   enabled: boolean;
   rootsRevision: string;
+  refreshRevision: number;
   onOpenFile: (request: SessionFileResourceRequest) => void;
   onOpenDiff: (request: FileRootFileDiffRequest) => Promise<string | null>;
 };
-
-type GitRootChanges = {
-  root: SessionFileRoot;
-  entries: FileRootGitChangeEntry[];
-  message: string;
-};
-
-function changeKindLabel(kind: FileRootGitChangeEntry["kinds"][FileRootGitChangeScope]): string {
-  switch (kind) {
-    case "added":
-      return "A";
-    case "deleted":
-      return "D";
-    case "renamed":
-      return "R";
-    case "untracked":
-      return "U";
-    default:
-      return "M";
-  }
-}
-
-type FileRootChangeRow =
-  | { key: string; type: "root"; root: SessionFileRoot }
-  | { key: string; type: "header"; label: string; count: number }
-  | { key: string; type: "empty"; label: string }
-  | { key: string; type: "error"; label: string }
-  | {
-      key: string;
-      type: "directory";
-      rootId: string;
-      scope: FileRootGitChangeScope;
-      relativePath: string;
-      name: string;
-      depth: number;
-      expanded: boolean;
-    }
-  | {
-      key: string;
-      type: "entry";
-      rootId: string;
-      entry: FileRootGitChangeEntry;
-      scope: FileRootGitChangeScope;
-      depth: number;
-    };
 
 function directoryStateKey(rootId: string, scope: FileRootGitChangeScope, relativePath: string): string {
   return `${rootId}\u0000${scope}\u0000${relativePath}`;
@@ -84,26 +37,32 @@ export function FileRootChangesPane({
   sessionId,
   enabled,
   rootsRevision,
+  refreshRevision,
   onOpenFile,
   onOpenDiff,
 }: FileRootChangesPaneProps) {
   const requestRevisionRef = useRef(0);
   const diffRevisionRef = useRef(0);
+  const rootChangesSessionIdRef = useRef<string | null>(null);
   const [rootChanges, setRootChanges] = useState<GitRootChanges[]>([]);
   const [loading, setLoading] = useState(false);
   const [loadingKey, setLoadingKey] = useState("");
   const [message, setMessage] = useState("");
   const [collapsedDirectories, setCollapsedDirectories] = useState<Record<string, boolean>>({});
-  const scrollRef = useRef<HTMLDivElement | null>(null);
 
   const reload = useCallback(async () => {
     const revision = requestRevisionRef.current + 1;
     requestRevisionRef.current = revision;
     if (!api || !sessionId || !enabled) {
+      rootChangesSessionIdRef.current = sessionId;
       setRootChanges([]);
       setLoading(false);
       setMessage("");
       return;
+    }
+    if (rootChangesSessionIdRef.current !== sessionId) {
+      rootChangesSessionIdRef.current = sessionId;
+      setRootChanges([]);
     }
     setLoading(true);
     setMessage("");
@@ -142,7 +101,6 @@ export function FileRootChangesPane({
       }
     } catch (error) {
       if (requestRevisionRef.current === revision) {
-        setRootChanges([]);
         setMessage(error instanceof Error ? error.message : "Git status failed.");
       }
     } finally {
@@ -161,7 +119,7 @@ export function FileRootChangesPane({
       diffRevisionRef.current += 1;
       window.removeEventListener("focus", handleWindowFocus);
     };
-  }, [reload, rootsRevision]);
+  }, [refreshRevision, reload, rootsRevision]);
 
   useEffect(() => {
     setCollapsedDirectories({});
@@ -209,149 +167,26 @@ export function FileRootChangesPane({
     }
   };
 
-  const rows = useMemo(() => {
-    const nextRows: FileRootChangeRow[] = [];
-    const appendTreeNodes = (
-      nodes: ChangedFileTreeNode[],
-      rootId: string,
-      scope: FileRootGitChangeScope,
-      depth: number,
-    ) => {
-      for (const node of nodes) {
-        if (node.type === "directory") {
-          const stateKey = directoryStateKey(rootId, scope, node.relativePath);
-          const expanded = !collapsedDirectories[stateKey];
-          nextRows.push({
-            key: `directory:${rootId}:${scope}:${node.relativePath}`,
-            type: "directory",
-            rootId,
-            scope,
-            relativePath: node.relativePath,
-            name: node.name,
-            depth,
-            expanded,
-          });
-          if (expanded) {
-            appendTreeNodes(node.children, rootId, scope, depth + 1);
-          }
-        } else {
-          nextRows.push({
-            key: `${rootId}:${scope}:${node.relativePath}`,
-            type: "entry",
-            rootId,
-            entry: node.entry,
-            scope,
-            depth,
-          });
-        }
-      }
-    };
-    for (const rootChange of rootChanges) {
-      nextRows.push({ key: `root:${rootChange.root.id}`, type: "root", root: rootChange.root });
-      if (rootChange.message) {
-        nextRows.push({ key: `error:${rootChange.root.id}`, type: "error", label: rootChange.message });
-        continue;
-      }
-      for (const [scope, label] of [["working-tree", "Working Tree"], ["staged", "Staged"]] as const) {
-        const scopedEntries = rootChange.entries.filter((entry) => entry.scopes.includes(scope));
-        nextRows.push({
-          key: `header:${rootChange.root.id}:${scope}`,
-          type: "header",
-          label,
-          count: scopedEntries.length,
-        });
-        if (scopedEntries.length === 0) {
-          nextRows.push({ key: `empty:${rootChange.root.id}:${scope}`, type: "empty", label: "No changes." });
-        } else {
-          appendTreeNodes(buildChangedFileTree(scopedEntries, scope), rootChange.root.id, scope, 0);
-        }
-      }
-    }
-    if (!loading && nextRows.length === 0) {
-      nextRows.push({ key: "no-git-roots", type: "empty", label: "No Git repositories." });
-    }
-    return nextRows;
-  }, [collapsedDirectories, loading, rootChanges]);
-  const virtualizer = useVirtualizer({
-    count: rows.length,
-    getScrollElement: () => scrollRef.current,
-    getItemKey: (index) => rows[index]?.key ?? index,
-    estimateSize: (index) => rows[index]?.type === "root" ? 48 : rows[index]?.type === "header" ? 31 : 30,
-    overscan: 16,
-    initialRect: { width: 280, height: 480 },
-    useFlushSync: false,
-  });
-
   return (
-    <div className="workspace-changes-pane">
-      <div className="workspace-changes-toolbar">
-        <span>{loading ? "Refreshing…" : "Live root status"}</span>
-        <button type="button" onClick={() => void reload()} disabled={loading}>Refresh</button>
-      </div>
+    <div className="workspace-changes-pane" aria-busy={loading}>
       {message ? <p className="workspace-changes-message" role="alert">{message}</p> : null}
-      <div className="workspace-changes-list" ref={scrollRef} role="list" aria-label="File root changes">
-        <div className="workspace-changes-list-inner" style={{ height: virtualizer.getTotalSize() }}>
-          {virtualizer.getVirtualItems().map((virtualRow) => {
-            const row = rows[virtualRow.index];
-            if (!row) {
-              return null;
-            }
-            return (
-              <div
-                key={row.key}
-                className={`workspace-change-virtual-row ${row.type}`}
-                data-index={virtualRow.index}
-                ref={virtualizer.measureElement}
-                style={{ transform: `translateY(${virtualRow.start}px)` }}
-              >
-                {row.type === "root" ? (
-                  <div className="workspace-changes-root-header" title={row.root.displayPath}>
-                    <strong>{row.root.label}</strong>
-                    <span>{row.root.displayPath}</span>
-                  </div>
-                ) : row.type === "header" ? (
-                  <div className="workspace-changes-group-header"><strong>{row.label}</strong><span>{row.count}</span></div>
-                ) : row.type === "empty" ? (
-                  <p>{row.label}</p>
-                ) : row.type === "error" ? (
-                  <p className="workspace-changes-root-error">{row.label}</p>
-                ) : row.type === "directory" ? (
-                  <button
-                    className="workspace-change-directory-row"
-                    type="button"
-                    style={{ paddingLeft: `${6 + row.depth * 14}px` }}
-                    aria-expanded={row.expanded}
-                    title={row.relativePath}
-                    onClick={() => toggleDirectory(row.rootId, row.scope, row.relativePath)}
-                  >
-                    <span className={`workspace-change-directory-icon${row.expanded ? " is-expanded" : ""}`}>▸</span>
-                    <span className="workspace-change-directory-name">{row.name}</span>
-                  </button>
-                ) : (() => {
-                  const key = `${row.rootId}:${row.scope}:${row.entry.relativePath}`;
-                  const kind = row.entry.kinds[row.scope] ?? "modified";
-                  return (
-                    <button
-                      className="workspace-change-row"
-                      type="button"
-                      style={{ paddingLeft: `${6 + row.depth * 14}px` }}
-                      disabled={!!loadingKey}
-                      onClick={() => void openEntry(row.rootId, row.entry, row.scope)}
-                      title={row.entry.previousRelativePath
-                        ? `${row.entry.previousRelativePath} → ${row.entry.relativePath}`
-                        : row.entry.relativePath}
-                    >
-                      <span className={`workspace-change-kind ${kind}`}>{changeKindLabel(kind)}</span>
-                      <span className="workspace-change-path">{changedFileDisplayName(row.entry)}</span>
-                      {loadingKey === key ? <span className="workspace-change-loading">…</span> : null}
-                    </button>
-                  );
-                })()}
-              </div>
-            );
-          })}
+      {rootChanges.length > 0 ? (
+        <div className="workspace-changes-groups" role="list" aria-label="File root changes">
+          {rootChanges.map((rootChange) => (
+            <FileRootChangesGroup
+              key={`${sessionId ?? ""}:${rootChange.root.id}`}
+              rootChange={rootChange}
+              groupCount={rootChanges.length}
+              collapsedDirectories={collapsedDirectories}
+              loadingKey={loadingKey}
+              onToggleDirectory={toggleDirectory}
+              onOpenEntry={openEntry}
+            />
+          ))}
         </div>
-      </div>
+      ) : !loading ? (
+        <p className="workspace-changes-empty">No Git repositories.</p>
+      ) : null}
     </div>
   );
 }

--- a/src/file-explorer/SessionFileExplorerPane.tsx
+++ b/src/file-explorer/SessionFileExplorerPane.tsx
@@ -18,6 +18,7 @@ type SessionFileExplorerPaneProps = {
   selectedFile: SessionFileResourceRequest | null;
   activeTab: "files" | "changes";
   onActiveTabChange: (tab: "files" | "changes") => void;
+  onRefreshChanges: () => void;
   onOpenFile: (request: SessionFileResourceRequest) => void;
   changesContent?: ReactNode;
 };
@@ -55,6 +56,7 @@ export function SessionFileExplorerPane({
   selectedFile,
   activeTab,
   onActiveTabChange,
+  onRefreshChanges,
   onOpenFile,
   changesContent,
 }: SessionFileExplorerPaneProps) {
@@ -223,7 +225,19 @@ export function SessionFileExplorerPane({
             Changes
           </button>
         </div>
-        <button className="session-file-explorer-refresh" type="button" onClick={() => void reloadRoots()} title="Refresh">
+        <button
+          className="session-file-explorer-refresh"
+          type="button"
+          onClick={() => {
+            if (activeTab === "changes") {
+              onRefreshChanges();
+              return;
+            }
+            void reloadRoots();
+          }}
+          aria-label={activeTab === "changes" ? "Refresh changes" : "Refresh files"}
+          title={activeTab === "changes" ? "Refresh changes" : "Refresh files"}
+        >
           ↻
         </button>
       </div>

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -703,20 +703,27 @@ export function SessionHeader({
               </div>
             ) : null}
             {actions}
-            {showRenameButton ? (
-              <button className="drawer-toggle compact secondary" type="button" onClick={onStartTitleEdit} disabled={isRunning || isReadOnly}>
-                Rename
-              </button>
-            ) : null}
-            {showAuditLogButton ? (
-              <button className="drawer-toggle compact secondary" type="button" onClick={onOpenAuditLog}>
-                Audit Log
-              </button>
-            ) : null}
-            {showDeleteButton ? (
-              <button className="drawer-toggle compact danger" type="button" onClick={onDeleteSession} disabled={isRunning}>
-                Delete
-              </button>
+            {showRenameButton || showAuditLogButton || showDeleteButton ? (
+              <details className="session-header-more">
+                <summary aria-label="Session actions" title="Session actions">⋯</summary>
+                <div className="session-header-more-menu" role="menu">
+                  {showRenameButton ? (
+                    <button type="button" role="menuitem" onClick={onStartTitleEdit} disabled={isRunning || isReadOnly}>
+                      Rename
+                    </button>
+                  ) : null}
+                  {showAuditLogButton ? (
+                    <button type="button" role="menuitem" onClick={onOpenAuditLog}>
+                      Audit Log
+                    </button>
+                  ) : null}
+                  {showDeleteButton ? (
+                    <button className="danger" type="button" role="menuitem" onClick={onDeleteSession} disabled={isRunning}>
+                      Delete
+                    </button>
+                  ) : null}
+                </div>
+              </details>
             ) : null}
           </div>
         ) : null}
@@ -2015,13 +2022,15 @@ export function SessionRetryBanner({
     >
       <div className="resume-banner-head">
         <div className="resume-banner-copy">
-          <span className={`resume-banner-badge ${retryBanner.kind}`}>{retryBanner.badge}</span>
-          <p className="resume-banner-title">{retryBanner.title}</p>
+          <span className={`resume-banner-badge ${retryBanner.kind}`} title={retryBanner.title}>
+            {retryBanner.badge}
+            <span className="sr-only">: {retryBanner.title}</span>
+          </span>
         </div>
       </div>
       <div className="resume-banner-actions">
         <button type="button" onClick={onResendLastMessage} disabled={isRetryActionDisabled}>
-          同じ依頼を再送
+          再送
         </button>
         <button
           className="drawer-toggle secondary"
@@ -2029,7 +2038,7 @@ export function SessionRetryBanner({
           onClick={onEditLastMessage}
           disabled={isRetryEditDisabled}
         >
-          編集して再送
+          編集
         </button>
       </div>
       {isRetryDraftReplacePending ? (

--- a/src/styles.css
+++ b/src/styles.css
@@ -625,7 +625,7 @@ button:disabled {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 12px;
+  gap: 8px;
   row-gap: 8px;
   flex-wrap: wrap;
   min-width: 0;
@@ -636,22 +636,108 @@ button:disabled {
   align-items: center;
   gap: 6px;
   min-width: 0;
-  padding: 2px;
-  border: 1px solid rgba(203, 213, 225, 0.12);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.04);
+  padding: 0;
+  border: 0;
+  background: transparent;
 }
 
 .session-window-control-group-label {
-  padding: 0 6px 0 8px;
+  padding: 0 2px;
   color: var(--muted);
-  font-size: 0.72rem;
+  font-size: 0.66rem;
   font-weight: 700;
   line-height: 1;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 .session-window-control-group .drawer-toggle {
   box-shadow: none;
+}
+
+.session-header-more {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.session-header-more > summary {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border: 1px solid rgba(203, 213, 225, 0.14);
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--ink);
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  list-style: none;
+}
+
+.session-header-more > summary::-webkit-details-marker {
+  display: none;
+}
+
+.session-header-more > summary:hover,
+.session-header-more[open] > summary {
+  border-color: color-mix(in srgb, var(--character-sub) 36%, rgba(203, 213, 225, 0.16));
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.session-header-more > summary:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--character-sub) 54%, transparent);
+  outline-offset: 2px;
+}
+
+.session-header-more-menu {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 6px);
+  right: 0;
+  display: grid;
+  min-width: 148px;
+  padding: 5px;
+  border: 1px solid rgba(203, 213, 225, 0.16);
+  border-radius: 10px;
+  background: rgba(13, 18, 27, 0.98);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.34);
+}
+
+.session-header-more-menu button {
+  width: 100%;
+  padding: 8px 10px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--ink);
+  text-align: left;
+  cursor: pointer;
+}
+
+.session-header-more-menu button:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.session-header-more-menu button.danger {
+  color: var(--danger, #fca5a5);
+}
+
+.session-header-more-menu button:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .session-title-shell-toggle {
@@ -4627,14 +4713,13 @@ button:disabled {
 .workspace-changes-pane {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 6px;
   min-height: 0;
   height: 100%;
   overflow: hidden;
   padding: 8px;
 }
 
-.workspace-changes-toolbar,
 .workspace-changes-group-header {
   display: flex;
   align-items: center;
@@ -4642,24 +4727,67 @@ button:disabled {
   gap: 8px;
 }
 
-.workspace-changes-toolbar {
-  color: var(--muted);
-  font-size: 0.72rem;
-}
-
-.workspace-changes-toolbar button {
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  border-radius: 7px;
-  background: rgba(15, 23, 42, 0.62);
-  color: var(--ink);
-  padding: 4px 7px;
-  cursor: pointer;
-}
-
 .workspace-changes-list {
-  flex: 1 1 auto;
   min-height: 0;
   overflow: auto;
+  overscroll-behavior-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(203, 213, 225, 0.38) transparent;
+}
+
+.workspace-changes-list:focus-visible {
+  outline: 1px solid color-mix(in srgb, var(--character-sub) 44%, transparent);
+  outline-offset: -1px;
+}
+
+.workspace-changes-groups {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 4px;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(203, 213, 225, 0.3) transparent;
+}
+
+.workspace-changes-list::-webkit-scrollbar,
+.workspace-changes-groups::-webkit-scrollbar {
+  width: 7px;
+  height: 7px;
+}
+
+.workspace-changes-list::-webkit-scrollbar-track,
+.workspace-changes-groups::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.workspace-changes-list::-webkit-scrollbar-thumb,
+.workspace-changes-groups::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: rgba(203, 213, 225, 0.28);
+}
+
+.workspace-changes-list::-webkit-scrollbar-thumb:hover,
+.workspace-changes-groups::-webkit-scrollbar-thumb:hover {
+  background: rgba(203, 213, 225, 0.48);
+}
+
+.workspace-changes-root-group {
+  display: grid;
+  flex: 1 0 auto;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-width: 0;
+  overflow: hidden;
+  border: 0;
+  border-top: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 0;
+  background: transparent;
+}
+
+.workspace-changes-root-group:first-child {
+  border-top: 0;
 }
 
 .workspace-changes-list-inner {
@@ -4677,13 +4805,17 @@ button:disabled {
 .workspace-changes-root-header {
   display: grid;
   gap: 2px;
-  padding: 8px 5px 5px;
-  border-top: 1px solid rgba(148, 163, 184, 0.16);
+  padding: 7px 5px 5px;
+  border-bottom: 0;
   color: var(--ink);
 }
 
-.workspace-change-virtual-row:first-child .workspace-changes-root-header {
-  border-top: 0;
+.workspace-changes-root-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
 }
 
 .workspace-changes-root-header strong {
@@ -4692,10 +4824,25 @@ button:disabled {
   white-space: nowrap;
 }
 
-.workspace-changes-root-header span {
+.workspace-changes-root-header .workspace-changes-root-path {
+  display: block;
   color: var(--muted);
   font-size: 0.7rem;
-  overflow-wrap: anywhere;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-changes-root-header .workspace-changes-root-count {
+  flex: 0 0 auto;
+  min-width: 20px;
+  padding: 1px 5px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--muted);
+  font-size: 0.66rem;
+  line-height: 1.4;
+  text-align: center;
 }
 
 .workspace-changes-group-header {
@@ -4707,7 +4854,8 @@ button:disabled {
 }
 
 .workspace-change-virtual-row > p,
-.workspace-changes-message {
+.workspace-changes-message,
+.workspace-changes-empty {
   margin: 0;
   padding: 5px;
   color: var(--muted);
@@ -7383,16 +7531,17 @@ button:disabled {
 
 .resume-banner {
   display: grid;
-  gap: 10px;
-  padding: 14px 16px;
+  gap: 8px;
+  margin-bottom: 8px;
+  padding: 10px 12px;
   border: 1px solid rgba(201, 106, 42, 0.18);
-  border-radius: 18px;
+  border-radius: 11px;
   background: rgba(255, 244, 236, 0.92);
 }
 
 .session-page .resume-banner {
-  border-color: rgba(255, 171, 119, 0.24);
-  background: rgba(76, 39, 25, 0.58);
+  border-color: rgba(255, 171, 119, 0.16);
+  background: rgba(76, 39, 25, 0.34);
 }
 
 .session-page .browse-only-banner {
@@ -7403,25 +7552,25 @@ button:disabled {
 .retry-banner {
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  gap: 12px 20px;
+  gap: 8px 12px;
 }
 
 .resume-banner-head {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
 }
 
 .resume-banner-copy {
-  display: grid;
-  gap: 8px;
+  display: flex;
+  align-items: center;
+  margin-right: auto;
 }
 
 .resume-banner-badge {
   justify-self: start;
-  padding: 4px 10px;
+  padding: 3px 8px;
   border-radius: 999px;
   font-size: 0.72rem;
   font-weight: 700;
@@ -7475,7 +7624,7 @@ button:disabled {
 .resume-banner-actions,
 .resume-banner-conflict-actions {
   display: flex;
-  gap: 10px;
+  gap: 6px;
   flex-wrap: wrap;
 }
 
@@ -7502,8 +7651,8 @@ button:disabled {
 
 .resume-banner button {
   justify-self: start;
-  padding: 10px 16px;
-  border-radius: 999px;
+  padding: 7px 11px;
+  border-radius: 8px;
   background: var(--orange);
   color: #fff;
 }


### PR DESCRIPTION
## 概要

- Changesペインをrepository単位の独立スクロールへ変更
- repository数と表示領域に応じた高さ配分、refresh後のscroll位置維持を追加
- Files / Changesの更新操作をヘッダーの1ボタンへ統合
- Sessionヘッダーとretry表示の常時説明を減らして操作を整理

## 検証

- `npx tsx --test scripts/tests/workspace-changes-pane.test.tsx scripts/tests/session-file-explorer-pane.test.tsx scripts/tests/changed-file-tree.test.ts scripts/tests/retry-state.test.ts scripts/tests/retry-banner-adapter.test.tsx scripts/tests/chat-header-actions.test.tsx scripts/tests/companion-chat-projection.test.ts scripts/tests/session-chat-projection.test.ts`（53件成功）
- `npm run typecheck`
- `npm test`（2182件成功、1件スキップ）
- `npm run build`
- visual-check用Electronで表示・操作確認