### PR TITLE
feat(session): Sessionのピン止めに対応

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+resources/skills/withmate-memory/bin/withmate-memory.mjs text eol=lf

--- a/scripts/benchmark-data-loading.ts
+++ b/scripts/benchmark-data-loading.ts
@@ -182,6 +182,7 @@ function createSession(sessionIndex: number, options: ResolvedBenchmarkOptions):
     taskTitle: `benchmark session ${sessionIndex}`,
     status: "saved",
     updatedAt: nowIso(sessionIndex),
+    isPinned: false,
     provider: "codex",
     catalogRevision: 1,
     workspaceLabel: "benchmark",

--- a/scripts/tests/chat-header-actions.test.tsx
+++ b/scripts/tests/chat-header-actions.test.tsx
@@ -11,6 +11,7 @@ import {
   createWorkspaceExplorerAction,
   resolveAuxiliaryHeaderActionState,
 } from "../../src/chat/chat-header-actions.js";
+import { SessionHeader } from "../../src/session-components.js";
 
 const noop = () => {};
 
@@ -177,4 +178,33 @@ test("buildLiveSessionHeaderProps は live session header の共通 action を�
   assert.match(workspaceHtml, />Explorer<\/button>/);
   assert.match(sessionFilesHtml, />Explorer<\/button>/);
   assert.match(sessionFilesHtml, />Terminal<\/button>/);
+});
+
+test("SessionHeader はpin stateとpending stateを操作ボタンへ投影する", () => {
+  const html = renderToStaticMarkup(<SessionHeader
+    taskTitle="Pinned session"
+    isEditingTitle={false}
+    titleDraft="Pinned session"
+    isRunning={true}
+    isReadOnly={true}
+    isPinned={true}
+    isPinPending={true}
+    showRenameButton={false}
+    showAuditLogButton={false}
+    showTerminalButton={false}
+    showDeleteButton={false}
+    onTogglePin={noop}
+    onOpenAuditLog={noop}
+    onOpenTerminal={noop}
+    onTitleDraftChange={noop}
+    onTitleInputKeyDown={noop}
+    onSaveTitle={noop}
+    onCancelTitleEdit={noop}
+    onStartTitleEdit={noop}
+    onDeleteSession={noop}
+  />);
+
+  assert.match(html, /aria-pressed="true"/);
+  assert.match(html, /disabled=""/);
+  assert.match(html, />変更中\.\.\.<\/button>/);
 });

--- a/scripts/tests/database-schema-v6.test.ts
+++ b/scripts/tests/database-schema-v6.test.ts
@@ -10,8 +10,11 @@ import {
   APP_DATABASE_V6_SCHEMA_VERSION,
   CREATE_V6_AUDIT_EVENTS_TABLE_SQL,
   CREATE_V6_AUXILIARY_SESSIONS_TABLE_SQL,
+  CREATE_V6_CHARACTERS_TABLE_SQL,
   CREATE_V6_MEMORY_PROTECTED_OBJECTS_TABLE_SQL,
+  CREATE_V6_PROJECT_SCOPES_TABLE_SQL,
   CREATE_V6_SCHEMA_SQL,
+  CREATE_V6_SESSIONS_TABLE_SQL,
   CREATE_V6_SESSION_TURN_INTERIMS_TABLE_SQL,
   CREATE_V6_SESSION_TURN_PROVIDER_OUTPUTS_TABLE_SQL,
   CREATE_V6_SESSION_TURNS_TABLE_SQL,
@@ -102,6 +105,42 @@ function createV6DatabaseWithEmptyRequiredTables(dbPath: string): void {
 }
 
 describe("database-schema-v6", () => {
+  it("ensureV6Schemaは既存sessionを保持してis_pinnedを既定falseで追加する", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      db.exec(CREATE_V6_CHARACTERS_TABLE_SQL);
+      db.exec(CREATE_V6_PROJECT_SCOPES_TABLE_SQL);
+      db.exec(CREATE_V6_SESSIONS_TABLE_SQL.replace(
+        "    is_pinned INTEGER NOT NULL DEFAULT 0 CHECK (is_pinned IN (0, 1)),\n",
+        "",
+      ));
+      db.prepare(`
+        INSERT INTO sessions_v6 (
+          id, title, state, session_kind, provider_id, catalog_revision, model_id,
+          reasoning_effort, custom_agent_name, approval_mode, codex_sandbox_mode,
+          allowed_additional_directories_json, runtime_policy_json, thread_id,
+          workspace_path, created_at, updated_at, last_active_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        "existing-session", "Existing", "active", "default", "codex", 1, "gpt-test",
+        "high", "", "never", "danger-full-access", "[]", "{}", "", "C:/workspace",
+        "2026-08-01T00:00:00.000Z", "2026-08-09T04:38:00.000Z", "2026-08-09T04:38:00.000Z",
+      );
+
+      ensureV6Schema(db);
+      ensureV6Schema(db);
+
+      const row = db.prepare("SELECT id, is_pinned FROM sessions_v6").get() as {
+        id: string;
+        is_pinned: number;
+      };
+      assert.equal(row.id, "existing-session");
+      assert.equal(row.is_pinned, 0);
+    } finally {
+      db.close();
+    }
+  });
+
   it("withmate-v6.db 用の schema constants、fresh path、required tables を固定する", () => {
     assert.equal(APP_DATABASE_V6_FILENAME, "withmate-v6.db");
     assert.equal(APP_DATABASE_V6_SCHEMA_VERSION, 6);
@@ -252,6 +291,7 @@ describe("database-schema-v6", () => {
         "character_snapshot_json",
         "project_scope_id",
         "workspace_path",
+        "is_pinned",
         "created_at",
         "updated_at",
         "last_active_at",
@@ -260,6 +300,7 @@ describe("database-schema-v6", () => {
       assert.equal(findForeignKey(db, "sessions_v6", "project_scope_id")?.table, "project_scopes_v6");
       assert.equal(tableSql(db, "sessions_v6").includes("json_valid(character_snapshot_json)"), true);
       assert.equal(tableSql(db, "sessions_v6").includes("allowed_additional_directories_json TEXT NOT NULL DEFAULT '[]'"), true);
+      assert.equal(tableSql(db, "sessions_v6").includes("is_pinned INTEGER NOT NULL DEFAULT 0"), true);
 
       assert.deepEqual(columnNames(db, "session_messages_v6"), [
         "id",

--- a/scripts/tests/home-components.test.tsx
+++ b/scripts/tests/home-components.test.tsx
@@ -639,6 +639,7 @@ describe("HomeRecentSessionsPanel", () => {
   const createSessionSummary = (partial: Partial<SessionSummary> & Pick<SessionSummary, "id" | "taskTitle">): SessionSummary => ({
     status: "idle",
     updatedAt: "2026-06-17T00:00:00.000Z",
+    isPinned: false,
     provider: "codex",
     catalogRevision: 1,
     workspaceLabel: "workspace",
@@ -713,6 +714,7 @@ describe("HomeRecentSessionsPanel", () => {
       onChangeSearchText={noOp}
       onOpenLaunchDialog={noOp}
       onOpenSession={noOp}
+      onSetSessionPinned={noOp}
       onOpenCompanionReview={noOp}
       canUsePrimaryFeatures={canUsePrimaryFeatures}
     />,
@@ -748,6 +750,38 @@ describe("HomeRecentSessionsPanel", () => {
     assert.ok(html.includes("Mia の character.md 改善"));
     assert.ok(html.includes("session-mode-badge character"));
     assert.ok(html.includes(">Character<"));
+  });
+
+  it("pin済みAgentを先頭にし、開く操作とpin操作を兄弟buttonで表示する", () => {
+    const html = renderHomeRecentSessions({
+      filteredSessionEntries: [
+        {
+          kind: "agent",
+          session: createSessionSummary({
+            id: "recent",
+            taskTitle: "Recent task",
+            updatedAt: "2026-08-09T05:00:00.000Z",
+          }),
+          state: { kind: "neutral", label: "待機" },
+        },
+        {
+          kind: "agent",
+          session: createSessionSummary({
+            id: "pinned",
+            taskTitle: "Pinned task",
+            isPinned: true,
+            updatedAt: "2026-08-08T05:00:00.000Z",
+          }),
+          state: { kind: "neutral", label: "待機" },
+        },
+      ],
+    });
+
+    assert.ok(html.indexOf("Pinned task") < html.indexOf("Recent task"));
+    assert.match(html, /class="session-card home-session-card is-pinnable is-pinned"/);
+    assert.match(html, /class="home-session-card-open"/);
+    assert.match(html, /aria-pressed="true"/);
+    assert.match(html, />ピン解除<\/button>/);
   });
 
   it("companion kind label で Companion session を検索できる", () => {

--- a/scripts/tests/home-session-pinning.test.ts
+++ b/scripts/tests/home-session-pinning.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { SessionSummary } from "../../src/session-state.js";
+import { mergePinnedSessionSummary } from "../../src/home/session-pinning.js";
+
+function createSessionSummary(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    id: "session-1",
+    taskTitle: "Current title",
+    status: "running",
+    updatedAt: "2026-08-09T05:30:00.000Z",
+    isPinned: false,
+    provider: "codex",
+    catalogRevision: 1,
+    workspaceLabel: "workspace",
+    workspacePath: "C:/workspace",
+    branch: "main",
+    sessionKind: "default",
+    accessMode: "active",
+    sourceSchemaVersion: 5,
+    characterId: "character-1",
+    character: "Character",
+    characterIconPath: "",
+    characterThemeColors: {
+      main: "#112233",
+      sub: "#445566",
+    },
+    approvalMode: "untrusted",
+    ...overrides,
+  };
+}
+
+test("pin応答は新しいSessionSummaryを巻き戻さずisPinnedだけを反映する", () => {
+  const current = createSessionSummary();
+  const stalePinResponse = createSessionSummary({
+    taskTitle: "Stale title",
+    status: "idle",
+    updatedAt: "2026-08-09T05:00:00.000Z",
+    isPinned: true,
+  });
+
+  const [merged] = mergePinnedSessionSummary([current], stalePinResponse);
+
+  assert.deepEqual(merged, { ...current, isPinned: true });
+});

--- a/scripts/tests/main-session-command-facade.test.ts
+++ b/scripts/tests/main-session-command-facade.test.ts
@@ -89,6 +89,10 @@ test("MainSessionCommandFacade は create/update/delete/cancel を各 service �
           calls.push(`update:${session.id}`);
           return session as never;
         },
+        setSessionPinned(sessionId, isPinned) {
+          calls.push(`pin:${sessionId}:${isPinned}`);
+          return { id: sessionId, isPinned } as never;
+        },
         deleteSession(sessionId) {
           calls.push(`delete:${sessionId}`);
           return {
@@ -142,12 +146,14 @@ test("MainSessionCommandFacade は create/update/delete/cancel を各 service �
     approvalMode: "untrusted",
   });
   facade.updateSession({ id: "s-1" } as never);
+  await facade.setSessionPinned({ sessionId: " s-1 ", isPinned: true });
   await facade.deleteSession("s-1");
   facade.cancelSessionRun("s-1");
 
   assert.deepEqual(calls, [
     "create:launch-test",
     "update:s-1",
+    "pin:s-1:true",
     "delete:s-1",
     "dismiss-notification:s-1",
     "cleanup-files:s-1",

--- a/scripts/tests/preload-api.test.ts
+++ b/scripts/tests/preload-api.test.ts
@@ -420,6 +420,7 @@ test("createWithMateWindowApi は current public API の key を揃えて expose
     "searchMemoryV6Entries",
     "setMateAvatar",
     "setDefaultCharacter",
+    "setSessionPinned",
     "showSessionFilePreviewImageContextMenu",
     "startCharacterAuthoringSession",
     "stashCompanionTargetChanges",

--- a/scripts/tests/session-chat-projection.test.ts
+++ b/scripts/tests/session-chat-projection.test.ts
@@ -90,6 +90,8 @@ function createProjectionInput(overrides: Partial<AgentSessionChatProjectionInpu
     titleDraft: "Main session",
     isSelectedSessionRunning: false,
     isSelectedSessionReadOnly: false,
+    isSelectedSessionPinned: false,
+    isSessionPinPending: false,
     messageListRef: React.createRef<HTMLDivElement>(),
     pendingRunIndicatorAnnouncement: "",
     pendingRunIndicatorText: "",
@@ -183,6 +185,7 @@ function createProjectionInput(overrides: Partial<AgentSessionChatProjectionInpu
     onCancelTitleEdit: noop,
     onStartTitleEdit: noop,
     onDeleteSession: noop,
+    onToggleSessionPin: noop,
     onOpenSessionExplorer: noop,
     onOpenSessionFilesExplorer: noop,
     onMessageListScroll: noop,
@@ -344,10 +347,13 @@ test("buildAgentSessionChatWindowProps は header action callbacks を維持す�
   const onOpenSessionExplorer = () => {};
   const onOpenSessionFilesExplorer = () => {};
   const onOpenSessionFilesTerminal = () => {};
+  const onToggleSessionPin = () => {};
   const props = buildAgentSessionChatWindowProps(createProjectionInput({
+    isSelectedSessionPinned: true,
     onOpenSessionExplorer,
     onOpenSessionFilesExplorer,
     onOpenSessionFilesTerminal,
+    onToggleSessionPin,
   }));
   const workspaceAction = props.headerProps.workspaceActions as React.ReactElement<{
     onClick: () => void;
@@ -362,6 +368,8 @@ test("buildAgentSessionChatWindowProps は header action callbacks を維持す�
   assert.equal(workspaceAction.props.onClick, onOpenSessionExplorer);
   assert.equal(sessionFilesExplorer.props.onClick, onOpenSessionFilesExplorer);
   assert.equal(sessionFilesTerminal.props.onClick, onOpenSessionFilesTerminal);
+  assert.equal(props.headerProps.isPinned, true);
+  assert.equal(props.headerProps.onTogglePin, onToggleSessionPin);
 });
 
 test("buildAgentSessionChatWindowProps は composer と compact dock の live props を維持する", () => {

--- a/scripts/tests/session-persistence-service.test.ts
+++ b/scripts/tests/session-persistence-service.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "node:test";
 
 import {
   buildNewSession,
+  projectSessionSummary,
   type CreateSessionInput,
   type Session,
 } from "../../src/app-state.js";
@@ -79,6 +80,51 @@ function createCharacterRuntimeSnapshot(overrides?: Partial<CharacterRuntimeSnap
 }
 
 describe("SessionPersistenceService", () => {
+  it("setSessionPinnedは実行状態とupdatedAtを変えずにcacheとbroadcastを更新する", async () => {
+    const session = createSession({
+      id: "pin-target",
+      status: "running",
+      runState: "running",
+      accessMode: "legacy_readonly",
+      sourceSchemaVersion: 4,
+      updatedAt: "2026-08-09T04:38:00.000Z",
+      isPinned: false,
+    });
+    let cachedSessions = [session];
+    const broadcasts: string[][] = [];
+    const service = new SessionPersistenceService({
+      getSessions: () => cachedSessions,
+      setSessions: (next) => { cachedSessions = next; },
+      getSession: () => session,
+      isSessionRunInFlight: () => true,
+      upsertStoredSession: (next) => next,
+      replaceStoredSessions: () => undefined,
+      setStoredSessionPinned: (sessionId, isPinned) => ({
+        ...projectSessionSummary(session),
+        id: sessionId,
+        isPinned,
+      }),
+      listStoredSessions: () => [session],
+      getAppSettings: () => normalizeAppSettings({}),
+      getModelCatalogSnapshot: createSnapshot,
+      syncSessionDependencies: () => undefined,
+      clearSessionContextTelemetry: () => undefined,
+      clearSessionBackgroundActivities: () => undefined,
+      invalidateProviderSessionThread: () => undefined,
+      closeSessionWindow: () => undefined,
+      broadcastSessions: (sessionIds) => broadcasts.push(Array.from(sessionIds ?? [])),
+    });
+
+    const saved = await service.setSessionPinned(session.id, true);
+
+    assert.equal(saved.isPinned, true);
+    assert.equal(saved.updatedAt, session.updatedAt);
+    assert.equal(cachedSessions[0]?.status, "running");
+    assert.equal(cachedSessions[0]?.runState, "running");
+    assert.equal(cachedSessions[0]?.isPinned, true);
+    assert.deepEqual(broadcasts, [[session.id]]);
+  });
+
   it("createSession は有効な provider と model を解決して保存する", async () => {
     const storedSessions: Session[] = [];
     const syncedSessionIds: string[] = [];
@@ -1228,7 +1274,18 @@ describe("SessionPersistenceService", () => {
         replaceOrder.push("replaceStoredSessions:start");
         await new Promise<void>((resolve) => setTimeout(resolve, 0));
         replaceOrder.push("replaceStoredSessions:end");
-        storedSessions.splice(0, storedSessions.length, ...nextSessions);
+        storedSessions.splice(0, storedSessions.length, ...nextSessions.map((session) => ({
+          ...session,
+          isPinned: session.id === "session-a" ? true : session.isPinned,
+        })));
+      },
+      setStoredSessionPinned(sessionId, isPinned) {
+        replaceOrder.push("setStoredSessionPinned");
+        const session = storedSessions.find((entry) => entry.id === sessionId);
+        assert.ok(session);
+        const pinned = { ...session, isPinned };
+        storedSessions.splice(0, storedSessions.length, pinned);
+        return pinned;
       },
       listStoredSessions() {
         return [...storedSessions];
@@ -1256,15 +1313,26 @@ describe("SessionPersistenceService", () => {
       },
     });
 
-    const replaced = await service.replaceAllSessions([nextSessionA], {
+    const replacePromise = service.replaceAllSessions([nextSessionA], {
       invalidateSessionIds: ["session-a"],
     });
+    const pinPromise = service.setSessionPinned("session-a", false);
+    const [replaced, pinned] = await Promise.all([replacePromise, pinPromise]);
 
     assert.equal(replaced.length, 1);
+    assert.equal(replaced[0]?.isPinned, true);
+    assert.equal(pinned.isPinned, false);
+    assert.equal(storedSessions[0]?.isPinned, false);
     assert.deepEqual(clearedTelemetry.sort(), ["session-a", "session-b"]);
     assert.deepEqual(clearedBackground, ["session-b"]);
     assert.deepEqual(invalidated, [{ providerId: "copilot", sessionId: "session-a" }]);
-    assert.deepEqual(broadcastedSessionIds, [["session-a", "session-b"]]);
-    assert.deepEqual(replaceOrder, ["replaceStoredSessions:start", "replaceStoredSessions:end", "setSessions"]);
+    assert.deepEqual(broadcastedSessionIds, [["session-a", "session-b"], ["session-a"]]);
+    assert.deepEqual(replaceOrder, [
+      "replaceStoredSessions:start",
+      "replaceStoredSessions:end",
+      "setSessions",
+      "setStoredSessionPinned",
+      "setSessions",
+    ]);
   });
 });

--- a/scripts/tests/session-state.test.ts
+++ b/scripts/tests/session-state.test.ts
@@ -12,6 +12,7 @@ import {
   CURRENT_SESSION_SCHEMA_VERSION,
   isReadOnlySession,
   normalizeSession,
+  parseSetSessionPinnedRequest,
   selectHydrationTarget,
   type SessionSummary,
 } from "../../src/session-state.js";
@@ -73,12 +74,22 @@ function createSession(provider: string, id?: string) {
 }
 
 describe("session-state custom agent selection", () => {
+  it("pin requestはtrim済みIDとbooleanだけを受理する", () => {
+    assert.deepEqual(
+      parseSetSessionPinnedRequest({ sessionId: " session-1 ", isPinned: true }),
+      { sessionId: "session-1", isPinned: true },
+    );
+    assert.throws(() => parseSetSessionPinnedRequest({ sessionId: "", isPinned: true }), /正しくない/);
+    assert.throws(() => parseSetSessionPinnedRequest({ sessionId: "session-1", isPinned: "true" }), /正しくない/);
+  });
+
   it("新規 session は V5 schema version で作成し、V4 以前は閲覧専用として扱う", () => {
     const session = createSession("codex", "launch-fixed");
 
     assert.equal(session.id, "launch-fixed");
     assert.equal(CURRENT_SESSION_SCHEMA_VERSION, 5);
     assert.equal(session.sourceSchemaVersion, 5);
+    assert.equal(session.isPinned, false);
     assert.equal(isReadOnlySession(session), false);
     assert.equal(isReadOnlySession({ ...session, sourceSchemaVersion: 4 }), true);
     assert.equal(isReadOnlySession({ ...session, accessMode: "legacy_readonly", sourceSchemaVersion: 5 }), true);
@@ -290,6 +301,7 @@ function makeSummary(overrides: Partial<SessionSummary> = {}): SessionSummary {
     taskTitle: "task",
     status: "idle",
     updatedAt: "2026-04-15 12:00",
+    isPinned: false,
     provider: "codex",
     catalogRevision: 1,
     workspaceLabel: "workspace",
@@ -320,6 +332,12 @@ describe("buildSessionSummarySignature", () => {
   it("updatedAt が異なれば signature も異なる", () => {
     const a = makeSummary({ updatedAt: "2026-04-15 12:00" });
     const b = makeSummary({ updatedAt: "2026-04-15 12:01" });
+    assert.notEqual(buildSessionSummarySignature(a), buildSessionSummarySignature(b));
+  });
+
+  it("pin stateが異なればsignatureも異なる", () => {
+    const a = makeSummary({ isPinned: false });
+    const b = makeSummary({ isPinned: true });
     assert.notEqual(buildSessionSummarySignature(a), buildSessionSummarySignature(b));
   });
 

--- a/scripts/tests/session-storage-v6.test.ts
+++ b/scripts/tests/session-storage-v6.test.ts
@@ -195,6 +195,48 @@ function listSessionTurnSummaries(dbPath: string): string[] {
 }
 
 describe("SessionStorageV6", () => {
+  it("pin stateだけを更新し、updatedAtと本文を維持して再読込できる", async () => {
+    const tempDirectory = await mkdtemp(path.join(os.tmpdir(), "withmate-session-storage-v6-"));
+    const dbPath = path.join(tempDirectory, "withmate-v6.db");
+    let storage: SessionStorageV6 | null = null;
+
+    try {
+      storage = new SessionStorageV6(dbPath);
+      const session = storage.insertSession({
+        ...buildNewSession({
+          id: "pin-session",
+          taskTitle: "Pin session",
+          workspaceLabel: "workspace",
+          workspacePath: "C:/workspace",
+          branch: "main",
+          characterId: "char-a",
+          character: "A",
+          characterIconPath: "",
+          characterThemeColors: { main: "#6f8cff", sub: "#6fb8c7" },
+          approvalMode: DEFAULT_APPROVAL_MODE,
+        }),
+        updatedAt: "2026-08-09T04:38:00.000Z",
+        messages: [{ role: "user", text: "keep me" }],
+      });
+
+      const pinned = storage.setSessionPinned(session.id, true);
+      assert.equal(pinned.isPinned, true);
+      assert.equal(pinned.updatedAt, session.updatedAt);
+      assert.equal(storage.getSession(session.id)?.messages[0]?.text, "keep me");
+      storage.upsertSession({ ...session, taskTitle: "Updated title", isPinned: false });
+      assert.equal(storage.getSession(session.id)?.isPinned, true);
+
+      storage.close();
+      storage = new SessionStorageV6(dbPath);
+      assert.equal(storage.getSession(session.id)?.isPinned, true);
+      assert.equal(storage.setSessionPinned(session.id, false).isPinned, false);
+      assert.throws(() => storage?.setSessionPinned("missing", true), /見つからない/);
+    } finally {
+      storage?.close();
+      await removeDirectoryWithRetry(tempDirectory);
+    }
+  });
+
   it("snapshot を作れない Character authoring Session も修復対象 ID を round-trip する", async () => {
     const tempDirectory = await mkdtemp(path.join(os.tmpdir(), "withmate-session-storage-v6-"));
     const dbPath = path.join(tempDirectory, "withmate-v6.db");

--- a/scripts/tests/session-storage.test.ts
+++ b/scripts/tests/session-storage.test.ts
@@ -300,6 +300,7 @@ describe("SessionStorage", () => {
           taskTitle: session.taskTitle,
           status: session.status,
           updatedAt: session.updatedAt,
+          isPinned: session.isPinned,
           provider: session.provider,
           catalogRevision: session.catalogRevision,
           workspaceLabel: session.workspaceLabel,

--- a/src-electron/auxiliary-parent-session.ts
+++ b/src-electron/auxiliary-parent-session.ts
@@ -13,6 +13,7 @@ export function companionSessionToAuxiliaryParentSession(session: CompanionSessi
     taskTitle: session.taskTitle,
     status: session.runState === "running" ? "running" : "idle",
     updatedAt: session.updatedAt,
+    isPinned: false,
     provider: session.provider,
     catalogRevision: session.catalogRevision,
     workspaceLabel: session.repoRoot || session.worktreePath,

--- a/src-electron/companion-runtime-service.ts
+++ b/src-electron/companion-runtime-service.ts
@@ -85,6 +85,7 @@ function buildProviderSession(session: CompanionSession): Session {
     taskTitle: session.taskTitle,
     status: session.runState === "running" ? "running" : "idle",
     updatedAt: session.updatedAt,
+    isPinned: false,
     provider: session.provider,
     catalogRevision: session.catalogRevision,
     workspaceLabel: session.focusPath || session.repoRoot,

--- a/src-electron/database-schema-v6.ts
+++ b/src-electron/database-schema-v6.ts
@@ -494,6 +494,7 @@ export const CREATE_V6_SESSIONS_TABLE_SQL = `
     character_snapshot_json TEXT DEFAULT NULL,
     project_scope_id TEXT,
     workspace_path TEXT NOT NULL DEFAULT '',
+    is_pinned INTEGER NOT NULL DEFAULT 0 CHECK (is_pinned IN (0, 1)),
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
     last_active_at TEXT NOT NULL,
@@ -1059,6 +1060,11 @@ function ensureV6SchemaUnsafe(db: DatabaseSync): void {
       continue;
     }
     db.exec(statement);
+  }
+
+  const sessionColumns = tableColumnNames(db, "sessions_v6");
+  if (!sessionColumns.has("is_pinned")) {
+    db.exec("ALTER TABLE sessions_v6 ADD COLUMN is_pinned INTEGER NOT NULL DEFAULT 0 CHECK (is_pinned IN (0, 1));");
   }
 
   if (!tableExists(db, "auxiliary_sessions")) {

--- a/src-electron/main-ipc-deps.ts
+++ b/src-electron/main-ipc-deps.ts
@@ -77,7 +77,13 @@ import type {
   FileRootFileDiffResult,
 } from "../src/file-explorer/file-explorer-contract.js";
 import type { DiscoveredCustomAgent, DiscoveredSkill } from "../src/runtime-state.js";
-import type { CreateSessionRequest, DiffPreviewPayload, MessageArtifact, Session } from "../src/session-state.js";
+import type {
+  CreateSessionRequest,
+  DiffPreviewPayload,
+  MessageArtifact,
+  Session,
+  SetSessionPinnedRequest,
+} from "../src/session-state.js";
 import type {
   ImageFilePickerPurpose,
   OpenPathOptions,
@@ -270,6 +276,7 @@ export type MainIpcSessionRuntimeDepsArgs = {
   resolveLiveElicitation(sessionId: string, requestId: string, response: LiveElicitationResponse): void;
   createSession(input: CreateSessionRequest): Awaitable<Session>;
   updateSession(session: Session): Awaitable<Session>;
+  setSessionPinned(request: SetSessionPinnedRequest): Awaitable<SessionSummary>;
   deleteSession(sessionId: string): Awaitable<void>;
   deleteSessionsLastActiveBefore(
     request: DeleteSessionsLastActiveBeforeRequest | null | undefined,
@@ -470,6 +477,7 @@ export function createMainIpcRegistrationDeps(
     resolveLiveElicitation: args.sessionRuntime.resolveLiveElicitation,
     createSession: args.sessionRuntime.createSession,
     updateSession: args.sessionRuntime.updateSession,
+    setSessionPinned: args.sessionRuntime.setSessionPinned,
     deleteSession: args.sessionRuntime.deleteSession,
     deleteSessionsLastActiveBefore: args.sessionRuntime.deleteSessionsLastActiveBefore,
     runSessionTurn: args.sessionRuntime.runSessionTurn,

--- a/src-electron/main-ipc-registration.ts
+++ b/src-electron/main-ipc-registration.ts
@@ -88,7 +88,13 @@ import type {
   FileRootFileDiffResult,
 } from "../src/file-explorer/file-explorer-contract.js";
 import type { DiscoveredCustomAgent, DiscoveredSkill } from "../src/runtime-state.js";
-import type { CreateSessionRequest, DiffPreviewPayload, MessageArtifact, Session } from "../src/session-state.js";
+import type {
+  CreateSessionRequest,
+  DiffPreviewPayload,
+  MessageArtifact,
+  Session,
+  SetSessionPinnedRequest,
+} from "../src/session-state.js";
 import type { Awaitable } from "./persistent-store-lifecycle-service.js";
 import {
   WITHMATE_CANCEL_SESSION_RUN_CHANNEL,
@@ -219,6 +225,7 @@ import {
   WITHMATE_UPDATE_CHARACTER_METADATA_CHANNEL,
   WITHMATE_UPDATE_COMPANION_SESSION_CHANNEL,
   WITHMATE_UPDATE_SESSION_CHANNEL,
+  WITHMATE_SET_SESSION_PINNED_CHANNEL,
 } from "../src/withmate-ipc-channels.js";
 import {
   parseImageFilePickerPurpose,
@@ -373,6 +380,7 @@ export type MainIpcRegistrationDeps = {
   runCompanionSessionTurn(sessionId: string, request: RunSessionTurnRequest): Promise<CompanionSession>;
   cancelCompanionSessionRun(sessionId: string): void;
   updateSession(session: Session): Awaitable<Session>;
+  setSessionPinned(request: SetSessionPinnedRequest): Awaitable<SessionSummary>;
   deleteSession(sessionId: string): Awaitable<void>;
   deleteSessionsLastActiveBefore(
     request: DeleteSessionsLastActiveBeforeRequest | null | undefined,
@@ -587,6 +595,7 @@ type MainIpcSessionRuntimeDeps = Pick<
   | "resolveLiveElicitation"
   | "createSession"
   | "updateSession"
+  | "setSessionPinned"
   | "deleteSession"
   | "deleteSessionsLastActiveBefore"
   | "runSessionTurn"
@@ -1283,6 +1292,10 @@ function registerSessionRuntimeHandlers(ipcMain: IpcHandleRegistrar, deps: MainI
   );
   ipcMain.handle(WITHMATE_CREATE_SESSION_CHANNEL, (_event, input: CreateSessionRequest) => deps.createSession(input));
   ipcMain.handle(WITHMATE_UPDATE_SESSION_CHANNEL, (_event, session: Session) => deps.updateSession(session));
+  ipcMain.handle(
+    WITHMATE_SET_SESSION_PINNED_CHANNEL,
+    (_event, request: SetSessionPinnedRequest) => deps.setSessionPinned(request),
+  );
   ipcMain.handle(WITHMATE_DELETE_SESSION_CHANNEL, (event, sessionId: string) => {
     assertSessionDeleteSender(event, sessionId, deps);
     return deps.deleteSession(sessionId);

--- a/src-electron/main-session-command-facade.ts
+++ b/src-electron/main-session-command-facade.ts
@@ -1,5 +1,12 @@
 import type { ProviderQuotaTelemetry, RunSessionTurnRequest } from "../src/runtime-state.js";
-import type { CreateSessionInput, CreateSessionRequest, Session, SessionSummary } from "../src/session-state.js";
+import {
+  parseSetSessionPinnedRequest,
+  type CreateSessionInput,
+  type CreateSessionRequest,
+  type Session,
+  type SessionSummary,
+  type SetSessionPinnedRequest,
+} from "../src/session-state.js";
 import {
   resolveDeleteSessionsLastActiveBeforeCutoff,
   type DeleteSessionsLastActiveBeforeRequest,
@@ -99,6 +106,11 @@ export class MainSessionCommandFacade {
 
   async updateSession(session: Session): Promise<Session> {
     return this.deps.getSessionPersistenceService().updateSession(session);
+  }
+
+  async setSessionPinned(request: SetSessionPinnedRequest): Promise<SessionSummary> {
+    const normalized = parseSetSessionPinnedRequest(request);
+    return this.deps.getSessionPersistenceService().setSessionPinned(normalized.sessionId, normalized.isPinned);
   }
 
   async deleteSession(sessionId: string): Promise<void> {

--- a/src-electron/main.ts
+++ b/src-electron/main.ts
@@ -139,6 +139,7 @@ import {
   type PersistentStoreBundle,
   type ProjectMemoryStorageAccess,
   type SessionMemoryStorageAccess,
+  type SessionPinStorage,
   type SessionStorageRead,
 } from "./persistent-store-lifecycle-service.js";
 import { AppLifecycleService } from "./app-lifecycle-service.js";
@@ -1487,6 +1488,7 @@ function requireMainInfrastructureRegistry(): MainInfrastructureRegistry<
                 resolveLiveElicitation,
                 createSession: (input) => requireMainSessionCommandFacade().createSessionFromRequest(input),
                 updateSession: (session) => requireMainSessionCommandFacade().updateSession(session),
+                setSessionPinned: (request) => requireMainSessionCommandFacade().setSessionPinned(request),
                 deleteSession: (sessionId) => requireMainSessionCommandFacade().deleteSession(sessionId),
                 deleteSessionsLastActiveBefore: (request) =>
                   requireMainSessionCommandFacade().deleteSessionsLastActiveBefore(request),
@@ -1537,6 +1539,15 @@ function requireSessionStorageForWrite(): SessionStorage {
   }
 
   throw new Error("session storage は V2 DB の読み取り専用のため書き込み不可です。");
+}
+
+function requireSessionPinStorage(): SessionPinStorage {
+  const storage = requireSessionStorage();
+  const candidate = storage as Partial<SessionPinStorage>;
+  if (typeof candidate.setSessionPinned === "function") {
+    return candidate as SessionPinStorage;
+  }
+  throw new Error("このセッション保存形式ではピン止めを利用できないよ。");
 }
 
 function isSessionStorageWritable(storage: SessionStorageRead): storage is SessionStorage {
@@ -2256,6 +2267,8 @@ function requireSessionPersistenceService(): SessionPersistenceService {
       replaceStoredSessions: async (nextSessions) => {
         await requireSessionStorageForWrite().replaceSessions(nextSessions);
       },
+      setStoredSessionPinned: (sessionId, isPinned) =>
+        requireSessionPinStorage().setSessionPinned(sessionId, isPinned),
       listStoredSessions: () => requireSessionStorage().listSessions(),
       listStoredSessionIdsLastActiveBefore: (cutoff) =>
         requireSessionStorage().listSessionIdsLastActiveBefore(cutoff),

--- a/src-electron/persistent-store-lifecycle-service.ts
+++ b/src-electron/persistent-store-lifecycle-service.ts
@@ -2,7 +2,7 @@ import { basename, dirname, join } from "node:path";
 import { rm } from "node:fs/promises";
 
 import type { ModelCatalogSnapshot } from "../src/model-catalog.js";
-import type { Session } from "../src/session-state.js";
+import type { Session, SessionSummary } from "../src/session-state.js";
 import type { AuxiliarySession, AuxiliarySessionSummary } from "../src/auxiliary-session-state.js";
 import type {
   CharacterCatalogEntry,
@@ -65,6 +65,9 @@ export type SessionStorageWrite = AwaitableStorageMethods<
   SessionStorage,
   "insertSession" | "upsertSession" | "replaceSessions" | "deleteSession" | "deleteSessions" | "clearSessions"
 > & SessionStorageRead;
+export type SessionPinStorage = {
+  setSessionPinned(sessionId: string, isPinned: boolean): Awaitable<SessionSummary>;
+};
 
 export type AuditLogStorageRead = AwaitableStorageMethods<
   AuditLogStorage,

--- a/src-electron/preload-api.ts
+++ b/src-electron/preload-api.ts
@@ -154,6 +154,7 @@ import {
   WITHMATE_UPDATE_MATE_CHANNEL,
   WITHMATE_UPDATE_COMPANION_SESSION_CHANNEL,
   WITHMATE_UPDATE_SESSION_CHANNEL,
+  WITHMATE_SET_SESSION_PINNED_CHANNEL,
   WITHMATE_SEARCH_MEMORY_V6_ENTRIES_CHANNEL,
   WITHMATE_GET_MEMORY_V6_ENTRY_CHANNEL,
   WITHMATE_FORGET_MEMORY_V6_ENTRY_CHANNEL,
@@ -329,6 +330,9 @@ function createSessionApi(ipcRenderer: IpcRendererLike): WithMateWindowSessionAp
     },
     updateSession(session) {
       return ipcRenderer.invoke(WITHMATE_UPDATE_SESSION_CHANNEL, session);
+    },
+    setSessionPinned(request) {
+      return ipcRenderer.invoke(WITHMATE_SET_SESSION_PINNED_CHANNEL, request);
     },
     deleteSession(sessionId) {
       return ipcRenderer.invoke(WITHMATE_DELETE_SESSION_CHANNEL, sessionId);

--- a/src-electron/session-persistence-service.ts
+++ b/src-electron/session-persistence-service.ts
@@ -6,6 +6,7 @@ import {
   projectSessionSummary,
   type CreateSessionInput,
   type Session,
+  type SessionSummary,
 } from "../src/session-state.js";
 import {
   DEFAULT_PROVIDER_ID,
@@ -43,6 +44,7 @@ export type SessionPersistenceServiceDeps = {
   listRunningActiveAuxiliaryParentIds?(sessionIds: readonly string[]): Awaitable<ReadonlySet<string>>;
   upsertStoredSession(session: Session, operation: "create" | "upsert"): Awaitable<Session>;
   replaceStoredSessions(sessions: Session[]): Awaitable<void>;
+  setStoredSessionPinned?(sessionId: string, isPinned: boolean): Awaitable<SessionSummary>;
   listStoredSessions(): Awaitable<Session[]>;
   listStoredSessionIdsLastActiveBefore?(cutoff: DeleteSessionsLastActiveBeforeCutoff): Awaitable<string[]>;
   deleteStoredSession?(sessionId: string): Awaitable<void>;
@@ -81,7 +83,15 @@ function assertSessionWritable(session: Session): void {
 }
 
 export class SessionPersistenceService {
+  private sessionMutationQueue: Promise<void> = Promise.resolve();
+
   constructor(private readonly deps: SessionPersistenceServiceDeps) {}
+
+  private enqueueSessionMutation<T>(operation: () => Promise<T>): Promise<T> {
+    const pending = this.sessionMutationQueue.then(operation);
+    this.sessionMutationQueue = pending.then(() => undefined, () => undefined);
+    return pending;
+  }
 
   resolveCharacterAuthoringProvider(providerId: string): string {
     return this.resolveEnabledProviderCatalog(
@@ -180,6 +190,22 @@ export class SessionPersistenceService {
     return updatedSession;
   }
 
+  async setSessionPinned(sessionId: string, isPinned: boolean): Promise<SessionSummary> {
+    return this.enqueueSessionMutation(() => this.setSessionPinnedNow(sessionId, isPinned));
+  }
+
+  private async setSessionPinnedNow(sessionId: string, isPinned: boolean): Promise<SessionSummary> {
+    if (!this.deps.setStoredSessionPinned) {
+      throw new Error("このセッション保存形式ではピン止めを利用できないよ。");
+    }
+    const stored = await this.deps.setStoredSessionPinned(sessionId, isPinned);
+    this.deps.setSessions(this.deps.getSessions().map((session) => (
+      session.id === stored.id ? { ...session, isPinned: stored.isPinned } : session
+    )));
+    this.deps.broadcastSessions([stored.id]);
+    return projectSessionSummary(stored);
+  }
+
   async deleteSession(sessionId: string): Promise<DeleteSessionsResult> {
     return this.deleteSessionsByIds([sessionId], { runningPolicy: "throw", allowUncachedDeletion: false });
   }
@@ -270,6 +296,13 @@ export class SessionPersistenceService {
     nextSession: Session,
     operation: "create" | "upsert" = "upsert",
   ): Promise<Session> {
+    return this.enqueueSessionMutation(() => this.upsertSessionNow(nextSession, operation));
+  }
+
+  private async upsertSessionNow(
+    nextSession: Session,
+    operation: "create" | "upsert",
+  ): Promise<Session> {
     const startedAt = Date.now();
     const currentSession = this.deps.getSession(nextSession.id);
     if (currentSession) {
@@ -314,6 +347,16 @@ export class SessionPersistenceService {
       invalidateSessionIds?: Iterable<string>;
     },
   ): Promise<Session[]> {
+    return this.enqueueSessionMutation(() => this.replaceAllSessionsNow(nextSessions, options));
+  }
+
+  private async replaceAllSessionsNow(
+    nextSessions: Session[],
+    options?: {
+      broadcast?: boolean;
+      invalidateSessionIds?: Iterable<string>;
+    },
+  ): Promise<Session[]> {
     const previousSessions = cloneSessions(this.deps.getSessions());
     const normalizedSessions = nextSessions.map((session) => ({
       ...session,
@@ -324,8 +367,8 @@ export class SessionPersistenceService {
     }));
 
     await this.deps.replaceStoredSessions(normalizedSessions);
-    this.deps.setSessions(toCachedSessions(normalizedSessions));
-    const storedSessions = normalizedSessions;
+    const storedSessions = await this.deps.listStoredSessions();
+    this.deps.setSessions(toCachedSessions(storedSessions));
     for (const session of storedSessions) {
       this.syncStoredSession(session);
     }

--- a/src-electron/session-storage-v6.ts
+++ b/src-electron/session-storage-v6.ts
@@ -51,6 +51,7 @@ type SessionV6Row = {
   character_id: string | null;
   character_snapshot_json: string | null;
   workspace_path: string;
+  is_pinned: number;
   updated_at: string;
   last_active_at: string;
 };
@@ -257,6 +258,15 @@ export class SessionStorageV6 {
     return row ? this.rowToSession(row) : null;
   }
 
+  setSessionPinned(sessionId: string, isPinned: boolean): SessionSummary {
+    this.db.prepare("UPDATE sessions_v6 SET is_pinned = ? WHERE id = ?").run(isPinned ? 1 : 0, sessionId);
+    const row = this.db.prepare("SELECT * FROM sessions_v6 WHERE id = ?").get(sessionId) as SessionV6Row | undefined;
+    if (!row) {
+      throw new Error("対象セッションが見つからないよ。");
+    }
+    return this.rowToSessionSummary(row);
+  }
+
   getSessionMessageArtifact(sessionId: string, messageIndex: number): MessageArtifact | null {
     const row = this.db.prepare(`
       SELECT role, body, artifact_body
@@ -445,11 +455,12 @@ export class SessionStorageV6 {
         character_id,
         character_snapshot_json,
         workspace_path,
+        is_pinned,
         created_at,
         updated_at,
         last_active_at
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ${conflictClause}
     `).run(
       session.id,
@@ -469,6 +480,7 @@ export class SessionStorageV6 {
       snapshot ? session.characterId : null,
       snapshot ? stringifyCharacterRuntimeSnapshot(snapshot) : null,
       session.workspacePath,
+      session.isPinned === true ? 1 : 0,
       session.updatedAt,
       session.updatedAt,
       session.updatedAt,
@@ -533,6 +545,7 @@ export class SessionStorageV6 {
       taskTitle: row.title,
       status: typeof runtimePolicy.appStatus === "string" ? runtimePolicy.appStatus : row.state === "active" ? "running" : "idle",
       updatedAt: row.updated_at || row.last_active_at,
+      isPinned: row.is_pinned === 1,
       provider: row.provider_id,
       catalogRevision: row.catalog_revision,
       workspaceLabel: runtimePolicy.workspaceLabel,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -451,6 +451,7 @@ export default function AgentSessionWindowApp() {
   const [modelCatalog, setModelCatalog] = useState<ModelCatalogSnapshot | null>(null);
   const [titleDraft, setTitleDraft] = useState("");
   const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [isSessionPinPending, setIsSessionPinPending] = useState(false);
   const [expandedArtifacts, setExpandedArtifacts] = useState<Record<string, boolean>>({});
   const [selectedDiff, setSelectedDiff] = useState<DiffPreviewPayload | null>(null);
   const [selectedFilePreview, setSelectedFilePreview] = useState<SessionFileResourceRequest | null>(null);
@@ -2219,6 +2220,26 @@ export default function AgentSessionWindowApp() {
     return savedSession;
   };
 
+  const handleToggleSessionPin = async () => {
+    if (!withmateApi || !selectedSession || isSessionPinPending) {
+      return;
+    }
+    setIsSessionPinPending(true);
+    try {
+      const saved = await withmateApi.setSessionPinned({
+        sessionId: selectedSession.id,
+        isPinned: selectedSession.isPinned !== true,
+      });
+      setSessions((current) => current.map((session) => (
+        session.id === saved.id ? { ...session, isPinned: saved.isPinned } : session
+      )));
+    } catch (error) {
+      window.alert(error instanceof Error ? error.message : "ピン止めの変更に失敗したよ。");
+    } finally {
+      setIsSessionPinPending(false);
+    }
+  };
+
   const handleChangeApproval = async (approvalMode: Session["approvalMode"]) => {
     if (
       !selectedSession ||
@@ -3320,9 +3341,11 @@ export default function AgentSessionWindowApp() {
         onActivateDockPriority: handleActivateDockPriority,
         isSessionHeaderExpanded,
         isEditingTitle,
+        isSessionPinPending,
         titleDraft,
         isSelectedSessionRunning: renderedIsRunning,
         isSelectedSessionReadOnly: activeAuxiliarySession ? true : isSelectedSessionReadOnly,
+        isSelectedSessionPinned: selectedSession.isPinned === true,
         messageListRef,
         pendingRunIndicatorAnnouncement,
         pendingRunIndicatorText,
@@ -3417,6 +3440,7 @@ export default function AgentSessionWindowApp() {
         onCancelTitleEdit: handleCancelTitleEdit,
         onStartTitleEdit: handleStartTitleEdit,
         onDeleteSession: () => void handleDeleteSession(),
+        onToggleSessionPin: () => void handleToggleSessionPin(),
         onOpenSessionExplorer: () => void handleOpenSessionExplorer(),
         onOpenSessionFilesExplorer: () => void handleOpenSessionFilesExplorer(),
         onMessageListScroll: handleMessageListScroll,

--- a/src/HomeApp.tsx
+++ b/src/HomeApp.tsx
@@ -44,6 +44,7 @@ import type { CharacterCatalogEntry } from "./character/character-catalog.js";
 import { HomeAppRouter } from "./home/HomeAppRouter.js";
 import { buildHomeDashboardSlots } from "./home/HomeDashboardSlots.js";
 import { buildHomeRecentSessionsPanelProps } from "./home/home-recent-sessions-panel-props.js";
+import { mergePinnedSessionSummary } from "./home/session-pinning.js";
 import { buildHomeRightPaneProps } from "./home/home-right-pane-props.js";
 import { buildHomeWindowContentSlots } from "./home/HomeWindowContentSlots.js";
 import { getHomeWindowMode } from "./home/home-window-mode.js";
@@ -103,6 +104,7 @@ export default function HomeApp() {
   const openSessionWindowIds = openSessionWindowIdsState.sessionIds;
   const [openCompanionReviewWindowIds, setOpenCompanionReviewWindowIds] = useState<string[]>([]);
   const [sessionSearchText, setSessionSearchText] = useState("");
+  const [pendingSessionPinIds, setPendingSessionPinIds] = useState<string[]>([]);
   const [rightPaneView, setRightPaneView] = useState<HomeRightPaneView>("monitor");
   const [settingsFeedback, setSettingsFeedback] = useState("");
   const [sessionCleanupCutoffDate, setSessionCleanupCutoffDate] = useState("");
@@ -159,6 +161,26 @@ export default function HomeApp() {
 
   const applyLoadedSessionSummaries = (summaries: SessionSummary[]) => {
     setSessionSummariesState({ status: "loaded", summaries });
+  };
+
+  const setSessionPinned = async (sessionId: string, isPinned: boolean) => {
+    const api = getWithMateApi();
+    if (!api) {
+      window.alert("ピン止めはElectronアプリから操作してね。");
+      return;
+    }
+    setPendingSessionPinIds((current) => current.includes(sessionId) ? current : [...current, sessionId]);
+    try {
+      const saved = await api.setSessionPinned({ sessionId, isPinned });
+      setSessionSummariesState((current) => ({
+        ...current,
+        summaries: mergePinnedSessionSummary(current.summaries, saved),
+      }));
+    } catch (error) {
+      window.alert(error instanceof Error ? error.message : "ピン止めの変更に失敗したよ。");
+    } finally {
+      setPendingSessionPinIds((current) => current.filter((id) => id !== sessionId));
+    }
   };
 
   const refreshCharacterEntries = async (
@@ -579,9 +601,11 @@ export default function HomeApp() {
         onChangeSearchText: setSessionSearchText,
         onOpenLaunchDialog: homeLaunchHandlers.onOpenLaunchDialog,
         onOpenSession: (sessionId) => void openSessionWindow(sessionId),
+        onSetSessionPinned: (sessionId, isPinned) => void setSessionPinned(sessionId, isPinned),
         onOpenCompanionReview: (sessionId) => void openCompanionReviewWindow(sessionId),
       },
       canUsePrimaryFeatures,
+      pendingSessionPinIds,
     }),
     rightPane: buildHomeRightPaneProps({
       rightPaneView,

--- a/src/app-state.ts
+++ b/src/app-state.ts
@@ -10,6 +10,7 @@ export {
   normalizeSession,
   normalizeSessionAccessMode,
   normalizeSessionSummary,
+  parseSetSessionPinnedRequest,
   projectSessionSummary,
 } from "./session-state.js";
 export type {
@@ -24,6 +25,7 @@ export type {
   SessionDetail,
   SessionKind,
   SessionSummary,
+  SetSessionPinnedRequest,
   StreamEntry,
 } from "./session-state.js";
 export {

--- a/src/chat/chat-header-actions.tsx
+++ b/src/chat/chat-header-actions.tsx
@@ -37,6 +37,8 @@ export type LiveSessionHeaderPropsInput = {
   titleDraft: string;
   isRunning: boolean;
   isReadOnly?: boolean;
+  isPinned?: boolean;
+  isPinPending?: boolean;
   isAuxiliaryMode?: boolean;
   canViewAuxiliaryAuditLog?: boolean;
   canDeleteSession: boolean;
@@ -52,6 +54,7 @@ export type LiveSessionHeaderPropsInput = {
   onCancelTitleEdit: () => void;
   onStartTitleEdit: () => void;
   onDeleteSession: () => void;
+  onTogglePin?: () => void;
   onOpenWorkspaceExplorer: () => void;
   isWorkspaceExplorerDisabled?: boolean;
   actions?: ReactNode;
@@ -125,6 +128,8 @@ export function buildLiveSessionHeaderProps(input: LiveSessionHeaderPropsInput):
     titleDraft: input.titleDraft,
     isRunning: input.isRunning,
     isReadOnly: input.isReadOnly,
+    isPinned: input.isPinned,
+    isPinPending: input.isPinPending,
     ...resolveChatHeaderVisibility({
       isAuxiliaryMode: input.isAuxiliaryMode,
       canViewAuxiliaryAuditLog: input.canViewAuxiliaryAuditLog,
@@ -144,6 +149,7 @@ export function buildLiveSessionHeaderProps(input: LiveSessionHeaderPropsInput):
     onCancelTitleEdit: input.onCancelTitleEdit,
     onStartTitleEdit: input.onStartTitleEdit,
     onDeleteSession: input.onDeleteSession,
+    onTogglePin: input.onTogglePin,
     actions: input.actions,
     workspaceActions: createWorkspaceExplorerAction({
       disabled: input.isWorkspaceExplorerDisabled,

--- a/src/chat/session-chat-projection.tsx
+++ b/src/chat/session-chat-projection.tsx
@@ -54,6 +54,8 @@ export type AgentSessionChatProjectionInput = {
   titleDraft: string;
   isSelectedSessionRunning: boolean;
   isSelectedSessionReadOnly: boolean;
+  isSelectedSessionPinned: boolean;
+  isSessionPinPending: boolean;
   messageListRef: RefObject<HTMLDivElement | null>;
   pendingRunIndicatorAnnouncement: string;
   pendingRunIndicatorText: string;
@@ -142,6 +144,7 @@ export type AgentSessionChatProjectionInput = {
   onCancelTitleEdit: () => void;
   onStartTitleEdit: () => void;
   onDeleteSession: () => void;
+  onToggleSessionPin: () => void;
   onOpenSessionExplorer: () => void;
   onOpenSessionFilesExplorer: () => void;
   onMessageListScroll: UIEventHandler<HTMLDivElement>;
@@ -223,6 +226,8 @@ export function buildAgentSessionChatWindowProps(input: AgentSessionChatProjecti
     titleDraft: input.titleDraft,
     isRunning: input.isSelectedSessionRunning,
     isReadOnly: input.isSelectedSessionReadOnly,
+    isPinned: input.isSelectedSessionPinned,
+    isPinPending: input.isSessionPinPending,
     isAuxiliaryMode: input.isAuxiliaryMode,
     canViewAuxiliaryAuditLog: true,
     canDeleteSession: true,
@@ -237,6 +242,7 @@ export function buildAgentSessionChatWindowProps(input: AgentSessionChatProjecti
     onCancelTitleEdit: input.onCancelTitleEdit,
     onStartTitleEdit: input.onStartTitleEdit,
     onDeleteSession: input.onDeleteSession,
+    onTogglePin: input.onToggleSessionPin,
     actions: input.headerActions,
     onOpenWorkspaceExplorer: input.onOpenSessionExplorer,
   });

--- a/src/home/HomeRecentSessionsPanel.tsx
+++ b/src/home/HomeRecentSessionsPanel.tsx
@@ -14,7 +14,9 @@ export type HomeRecentSessionsPanelProps = {
   onChangeSearchText: (value: string) => void;
   onOpenLaunchDialog: () => void;
   onOpenSession: (sessionId: string) => void;
+  onSetSessionPinned: (sessionId: string, isPinned: boolean) => void;
   onOpenCompanionReview: (sessionId: string) => void;
+  pendingSessionPinIds?: readonly string[];
   canUsePrimaryFeatures?: boolean;
 };
 
@@ -41,7 +43,9 @@ export function HomeRecentSessionsPanel({
   onChangeSearchText,
   onOpenLaunchDialog,
   onOpenSession,
+  onSetSessionPinned,
   onOpenCompanionReview,
+  pendingSessionPinIds = [],
   canUsePrimaryFeatures = true,
 }: HomeRecentSessionsPanelProps) {
   const openLaunchDialog = () => {
@@ -81,14 +85,19 @@ export function HomeRecentSessionsPanel({
     ...filteredSessionEntries.map((entry) => ({
       kind: "agent" as const,
       updatedAt: entry.session.updatedAt,
+      isPinned: entry.session.isPinned,
       entry,
     })),
     ...visibleCompanionSessions.map((session) => ({
       kind: "companion" as const,
       updatedAt: session.updatedAt,
+      isPinned: false,
       session,
     })),
   ].sort((left, right) => {
+    if (left.isPinned !== right.isPinned) {
+      return left.isPinned ? -1 : 1;
+    }
     const leftTime = Date.parse(left.updatedAt);
     const rightTime = Date.parse(right.updatedAt);
     return (Number.isNaN(rightTime) ? 0 : rightTime) - (Number.isNaN(leftTime) ? 0 : leftTime);
@@ -161,36 +170,51 @@ export function HomeRecentSessionsPanel({
           const { session, state } = item.entry;
           const isReadOnly = isReadOnlySession(session);
           const modeBadge = getAgentSessionModeBadge(session);
+          const isPinPending = pendingSessionPinIds.includes(session.id);
           return (
-            <button
+            <div
               key={`agent-${session.id}`}
-              className="session-card home-session-card"
-              type="button"
+              className={`session-card home-session-card is-pinnable${session.isPinned ? " is-pinned" : ""}`}
               style={buildCardThemeStyle(session.characterThemeColors)}
-              onClick={() => openSession(session.id)}
-              aria-disabled={!canUsePrimaryFeatures}
-              disabled={!canUsePrimaryFeatures}
             >
-              <CharacterAvatar
-                character={{ name: session.character, iconPath: session.characterIconPath }}
-                size="tiny"
-                className="home-session-card-avatar"
-              />
-              <div className="session-card-copy">
-                <div className="session-card-topline home-session-card-topline">
+              <button
+                className="home-session-card-open"
+                type="button"
+                onClick={() => openSession(session.id)}
+                aria-disabled={!canUsePrimaryFeatures}
+                disabled={!canUsePrimaryFeatures}
+              >
+                <CharacterAvatar
+                  character={{ name: session.character, iconPath: session.characterIconPath }}
+                  size="tiny"
+                  className="home-session-card-avatar"
+                />
+                <div className="session-card-copy">
                   <strong>{session.taskTitle}</strong>
-                  <div className="home-session-card-badges">
-                    <span className={modeBadge.className}>{modeBadge.label}</span>
-                    {isReadOnly ? <span className="session-status home-session-status neutral">閲覧専用</span> : null}
-                    <span className={`session-status home-session-status ${state.kind}`.trim()}>{state.label}</span>
+                  <div className="session-card-subline home-session-card-meta">
+                    <span>{`Workspace : ${session.workspacePath || session.workspaceLabel}`}</span>
+                    <span>{`updatedAt: ${session.updatedAt}`}</span>
                   </div>
                 </div>
-                <div className="session-card-subline home-session-card-meta">
-                  <span>{`Workspace : ${session.workspacePath || session.workspaceLabel}`}</span>
-                  <span>{`updatedAt: ${session.updatedAt}`}</span>
+              </button>
+              <div className="home-session-card-actions">
+                <div className="home-session-card-badges">
+                  <span className={modeBadge.className}>{modeBadge.label}</span>
+                  {isReadOnly ? <span className="session-status home-session-status neutral">閲覧専用</span> : null}
+                  <span className={`session-status home-session-status ${state.kind}`.trim()}>{state.label}</span>
                 </div>
+                <button
+                  className={`home-session-pin-button${session.isPinned ? " is-active" : ""}${isPinPending ? " is-pending" : ""}`}
+                  type="button"
+                  aria-pressed={session.isPinned}
+                  aria-label={`${session.taskTitle}を${session.isPinned ? "ピン解除" : "ピン止め"}`}
+                  disabled={!canUsePrimaryFeatures || isPinPending}
+                  onClick={() => onSetSessionPinned(session.id, !session.isPinned)}
+                >
+                  {isPinPending ? "変更中..." : session.isPinned ? "ピン解除" : "ピン止め"}
+                </button>
               </div>
-            </button>
+            </div>
           );
         })}
       </div>

--- a/src/home/home-recent-sessions-panel-props.ts
+++ b/src/home/home-recent-sessions-panel-props.ts
@@ -9,6 +9,7 @@ type HomeRecentSessionsPanelHandlers = {
   onChangeSearchText: (value: string) => void;
   onOpenLaunchDialog: () => void;
   onOpenSession: (sessionId: string) => void;
+  onSetSessionPinned: (sessionId: string, isPinned: boolean) => void;
   onOpenCompanionReview: (sessionId: string) => void;
 };
 
@@ -20,6 +21,7 @@ export type HomeRecentSessionsPanelPropsInput = {
   searchIcon: ReactNode;
   handlers: HomeRecentSessionsPanelHandlers;
   canUsePrimaryFeatures?: boolean;
+  pendingSessionPinIds?: readonly string[];
 };
 
 export function buildHomeRecentSessionsPanelProps({
@@ -30,6 +32,7 @@ export function buildHomeRecentSessionsPanelProps({
   searchIcon,
   handlers,
   canUsePrimaryFeatures,
+  pendingSessionPinIds,
 }: HomeRecentSessionsPanelPropsInput): HomeRecentSessionsPanelProps {
   return {
     filteredSessionEntries,
@@ -40,7 +43,9 @@ export function buildHomeRecentSessionsPanelProps({
     onChangeSearchText: handlers.onChangeSearchText,
     onOpenLaunchDialog: handlers.onOpenLaunchDialog,
     onOpenSession: handlers.onOpenSession,
+    onSetSessionPinned: handlers.onSetSessionPinned,
     onOpenCompanionReview: handlers.onOpenCompanionReview,
     canUsePrimaryFeatures,
+    pendingSessionPinIds,
   };
 }

--- a/src/home/session-pinning.ts
+++ b/src/home/session-pinning.ts
@@ -1,0 +1,12 @@
+import type { SessionSummary } from "../session-state.js";
+
+export function mergePinnedSessionSummary(
+  summaries: readonly SessionSummary[],
+  saved: SessionSummary,
+): SessionSummary[] {
+  return summaries.map((session) => (
+    session.id === saved.id
+      ? { ...session, isPinned: saved.isPinned }
+      : session
+  ));
+}

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -617,6 +617,8 @@ export type SessionHeaderProps = {
   titleDraft: string;
   isRunning: boolean;
   isReadOnly?: boolean;
+  isPinned?: boolean;
+  isPinPending?: boolean;
   showRenameButton?: boolean;
   showAuditLogButton?: boolean;
   showTerminalButton?: boolean;
@@ -624,6 +626,7 @@ export type SessionHeaderProps = {
   workspaceActions?: ReactNode;
   sessionFilesActions?: ReactNode;
   actions?: ReactNode;
+  onTogglePin?: () => void;
   onOpenAuditLog: () => void;
   onOpenTerminal: () => void;
   onTitleDraftChange: (value: string) => void;
@@ -640,6 +643,8 @@ export function SessionHeader({
   titleDraft,
   isRunning,
   isReadOnly = false,
+  isPinned = false,
+  isPinPending = false,
   showRenameButton = true,
   showAuditLogButton = true,
   showTerminalButton = true,
@@ -647,6 +652,7 @@ export function SessionHeader({
   workspaceActions,
   sessionFilesActions,
   actions,
+  onTogglePin,
   onOpenAuditLog,
   onOpenTerminal,
   onTitleDraftChange,
@@ -703,6 +709,17 @@ export function SessionHeader({
               </div>
             ) : null}
             {actions}
+            {onTogglePin ? (
+              <button
+                className={`drawer-toggle compact secondary session-pin-toggle${isPinned ? " is-active" : ""}`}
+                type="button"
+                aria-pressed={isPinned}
+                onClick={onTogglePin}
+                disabled={isPinPending}
+              >
+                {isPinPending ? "変更中..." : isPinned ? "ピン解除" : "ピン止め"}
+              </button>
+            ) : null}
             {showRenameButton || showAuditLogButton || showDeleteButton ? (
               <details className="session-header-more">
                 <summary aria-label="Session actions" title="Session actions">⋯</summary>

--- a/src/session-state.ts
+++ b/src/session-state.ts
@@ -65,6 +65,7 @@ export type Session = {
   taskTitle: string;
   status: "running" | "idle" | "saved";
   updatedAt: string;
+  isPinned: boolean;
   provider: string;
   catalogRevision: number;
   workspaceLabel: string;
@@ -90,7 +91,9 @@ export type Session = {
   stream: StreamEntry[];
 };
 
-export type SessionSummary = Omit<Session, "messages" | "stream" | "characterRuntimeSnapshot">;
+export type SessionSummary = Omit<Session, "messages" | "stream" | "characterRuntimeSnapshot" | "isPinned"> & {
+  isPinned: boolean;
+};
 export type SessionDetail = Session;
 
 export type DiffPreviewPayload = {
@@ -146,6 +149,23 @@ export type CreateSessionRequest = Omit<
 > & {
   workspace: CreateSessionWorkspaceRequest;
 };
+
+export type SetSessionPinnedRequest = {
+  sessionId: string;
+  isPinned: boolean;
+};
+
+export function parseSetSessionPinnedRequest(value: unknown): SetSessionPinnedRequest {
+  if (!value || typeof value !== "object") {
+    throw new Error("ピン止めするセッションの指定が正しくないよ。");
+  }
+  const candidate = value as Partial<SetSessionPinnedRequest>;
+  const sessionId = typeof candidate.sessionId === "string" ? candidate.sessionId.trim() : "";
+  if (!sessionId || typeof candidate.isPinned !== "boolean") {
+    throw new Error("ピン止めするセッションの指定が正しくないよ。");
+  }
+  return { sessionId, isPinned: candidate.isPinned };
+}
 
 export function normalizeSessionAccessMode(value: unknown, fallback: SessionAccessMode = "active"): SessionAccessMode {
   return SESSION_ACCESS_MODE_VALUES.includes(value as SessionAccessMode) ? value as SessionAccessMode : fallback;
@@ -326,6 +346,7 @@ function normalizeSessionSummaryShape(value: unknown): SessionSummary | null {
           ? currentTimestampLabel()
           : candidate.updatedAt
         : currentTimestampLabel(),
+    isPinned: candidate.isPinned === true,
     provider: normalizeProviderId(candidate.provider),
     catalogRevision:
       typeof candidate.catalogRevision === "number" && Number.isInteger(candidate.catalogRevision) && candidate.catalogRevision > 0
@@ -467,6 +488,7 @@ export function buildNewSession(input: CreateSessionInput): Session {
     taskTitle: normalizedTaskTitle,
     status: "idle",
     updatedAt: currentTimestampLabel(),
+    isPinned: false,
     provider: normalizeProviderId(input.provider ?? DEFAULT_PROVIDER_ID),
     catalogRevision:
       typeof input.catalogRevision === "number" && Number.isInteger(input.catalogRevision) && input.catalogRevision > 0
@@ -553,6 +575,7 @@ export function buildSessionSummarySignature(summary: SessionSummary): string {
   return [
     summary.id,
     summary.updatedAt,
+    String(summary.isPinned),
     summary.status,
     summary.runState,
     summary.taskTitle,

--- a/src/styles.css
+++ b/src/styles.css
@@ -740,6 +740,11 @@ button:disabled {
   border: 0;
 }
 
+.session-pin-toggle.is-active {
+  border-color: color-mix(in srgb, var(--character-main) 46%, rgba(203, 213, 225, 0.2));
+  background: color-mix(in srgb, var(--character-main) 18%, rgba(255, 255, 255, 0.04));
+}
+
 .session-title-shell-toggle {
   padding: 0;
   border: 0;
@@ -1471,6 +1476,46 @@ button:disabled {
   min-height: 108px;
 }
 
+.home-page .home-session-card.is-pinnable {
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0;
+  padding: 0;
+  cursor: default;
+}
+
+.home-page .home-session-card-open {
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1fr);
+  gap: 14px;
+  align-items: start;
+  align-self: stretch;
+  min-width: 0;
+  padding: 16px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.home-page .home-session-card-open:focus-visible,
+.home-page .home-session-pin-button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--card-ink, var(--ink)) 72%, transparent);
+  outline-offset: -3px;
+}
+
+.home-page .home-session-card-actions {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 10px;
+  align-self: stretch;
+  padding: 14px 14px 14px 0;
+}
+
 .home-page .home-session-card-avatar {
   align-self: start;
   margin-top: 2px;
@@ -1490,6 +1535,30 @@ button:disabled {
   gap: 6px;
 }
 
+.home-page .home-session-pin-button {
+  min-width: 76px;
+  padding: 6px 10px;
+  border: 1px solid color-mix(in srgb, var(--card-ink, var(--ink)) 22%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--card-ink, var(--ink)) 8%, transparent);
+  color: var(--card-ink, var(--ink));
+  font-size: 0.74rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.home-page .home-session-pin-button:hover:not(:disabled),
+.home-page .home-session-pin-button.is-active {
+  border-color: color-mix(in srgb, var(--card-ink, var(--ink)) 38%, transparent);
+  background: color-mix(in srgb, var(--card-ink, var(--ink)) 16%, transparent);
+}
+
+.home-page .home-session-pin-button.is-pending {
+  cursor: wait;
+  opacity: 0.62;
+}
+
+.home-page .home-session-card-open strong,
 .home-page .home-session-card-topline strong {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/withmate-ipc-channels.ts
+++ b/src/withmate-ipc-channels.ts
@@ -53,6 +53,7 @@ export const WITHMATE_CANCEL_COMPANION_SESSION_RUN_CHANNEL = "withmate:cancel-co
 export const WITHMATE_UPDATE_COMPANION_SESSION_CHANNEL = "withmate:update-companion-session";
 export const WITHMATE_PREVIEW_COMPANION_COMPOSER_INPUT_CHANNEL = "withmate:preview-companion-composer-input";
 export const WITHMATE_UPDATE_SESSION_CHANNEL = "withmate:update-session";
+export const WITHMATE_SET_SESSION_PINNED_CHANNEL = "withmate:set-session-pinned";
 export const WITHMATE_DELETE_SESSION_CHANNEL = "withmate:delete-session";
 export const WITHMATE_DELETE_SESSIONS_LAST_ACTIVE_BEFORE_CHANNEL = "withmate:delete-sessions-last-active-before";
 export const WITHMATE_GET_MATE_STATE_CHANNEL = "withmate:get-mate-state";

--- a/src/withmate-window-api.ts
+++ b/src/withmate-window-api.ts
@@ -25,6 +25,7 @@ import type {
     RunSessionTurnRequest,
     Session,
     SessionSummary,
+    SetSessionPinnedRequest,
 } from "./app-state.js";
 import type { CompanionSession, CompanionSessionSummary, CreateCompanionSessionInput } from "./companion-state.js";
 import type { ChatLayoutPreferenceUpdate } from "./chat/chat-layout-preference.js";
@@ -138,6 +139,7 @@ export type WithMateWindowSessionApi = {
   getSessionMessageArtifact(sessionId: string, messageIndex: number): Promise<MessageArtifact | null>;
   createSession(input: CreateSessionRequest): Promise<Session>;
   updateSession(session: Session): Promise<Session>;
+  setSessionPinned(request: SetSessionPinnedRequest): Promise<SessionSummary>;
   deleteSession(sessionId: string): Promise<void>;
   previewComposerInput(sessionId: string, userMessage: string): Promise<ComposerPreview>;
   listSessionSkills(sessionId: string): Promise<DiscoveredSkill[]>;


### PR DESCRIPTION
## 概要

- Home の SessionList に、カードを開く操作と競合しない個別のピン操作を追加
- ピン済み Session を更新日時順のグループ先頭へ表示
- SessionWindow ヘッダーにピン止め／解除操作を追加
- V6 Session 永続化、IPC、preload、window間broadcastへピン状態を接続
- 通常保存や全件置換、競合する更新でピン状態や新しいSession summaryを巻き戻さないよう保護
- Memory CLI生成物をLF固定として宣言し、Windows build後の偽modified表示を防止

## 検証

- visual-check ElectronでHome／SessionWindowの操作を確認
- pin関連targeted tests: 149 passed
- `npm run typecheck`
- `npm test`: 2190 passed / 0 failed / 1 skipped
- `npm run build`
- `git diff --check`

## レビュー

- `temp/v6.3.18` の最新変更を取り込み済み
- complete-diff review 1回を実施し、検出したblocking findingを修正・targeted closure済み
- 最終Candidateで永続化／並行更新とprojection／UI統合を再確認し、blocking findingなし