### PR TITLE
feat: Character Affectのコア永続化を実装

### DIFF
--- a/docs/adr/018-character-affect-event-persistence.md
+++ b/docs/adr/018-character-affect-event-persistence.md
@@ -1,0 +1,60 @@
+# ADR 018: Character affectはappend-only eventから投影する
+
+## Status
+
+Accepted
+
+## Context
+
+Character自身の現在感情をsession間で扱うには、Character Definition由来の基調、継続的なrelationship affect、session固有の一時状態、Character Memory episodeを分離する必要がある。状態全体を保存すると、同時sessionの後勝ち上書き、対象の異なる感情の混合、訂正根拠の消失が起きる。
+
+V6 DBは起動時のidempotentなschema ensureとSQLite WALを既存境界とし、Memory V6はrequest fingerprint付きidempotencyとappend/supersede/forget監査を採用している。
+
+## Decision
+
+- baselineはCharacter Definitionから導く入力とし、通常の感情イベントでは更新しない。
+- relationship affectとsession affectは`character_affect_events_v6`へappendする。現在状態はactive eventとreset markerからapplication serviceが投影し、状態スナップショットを正本にしない。
+- session layerの`session_id`はscope ownerとしてsession削除時にeventを削除する。relationship layerは`session_id`を持たず、発生元を`source_session_id`のprovenanceとして`ON DELETE SET NULL`で保持するため、source session削除でrelationship状態を失わない。
+- public projectionでも`sessionId`はscopeだけを表し、relationship eventとそのmutationではnullとする。発生元Sessionは`sourceSessionId`だけで表す。
+- 初期表現はlabelに、`[-1, 1]`のvalence、optional arousal/dimensions、`[0, 1]`のintensityを組み合わせる。分類語彙をenumで固定しない。
+- optional fieldの省略と明示的なundefinedは永続化とrequest fingerprintの前に同じcanonical JSON表現へ正規化する。
+- relationship eventはtargetが`user`または`relationship`の場合だけ許可する。task、bug、artifact、selfへの感情はsession layerに留める。
+- 同じCharacter/user内のidempotency keyはrecord、correct、reset共通のledgerで所有する。operation、訂正対象、監査理由を含むrequest fingerprintが同じ場合だけ再生し、異なる要求での再利用は拒否する。
+- event/reset時刻は辞書順と実時間順が一致するcanonical UTC形式で受理する。
+- 訂正はreplacement eventをappendし、元eventを`corrected`へ遷移させる。resetはscope別markerをappendする。どちらもmutation auditを残す。
+- session eventをrelationshipへ訂正した後にsource sessionが削除された場合、session eventは削除し、relationship replacementと訂正mutationを保持する。参照先削除時は`correction_of_event_id`をnullへ戻し、監査理由はmutationに残す。
+- session指定のinspectionは、そのsession固有のeventに加えて現在状態へ寄与するrelationship eventと監査を返す。
+- Character Memory episodeはMemory V6の正規storage境界へ接続し、`local-user`のbindingとCharacter scopeを`(user, character)`のownerとして扱う。発生元SessionはMemory source provenanceへ保存し、owner scopeには使わない。
+- Affect storage/application境界もsingle-user productの`local-user`だけを受理し、Memory候補の有無でowner制約を変えない。
+- episode writerはapplication構成で必須とし、Memory候補を永続化前にMemory V6 contractで検証する。同じmotifの別eventは別episode、同一event retryは同じderived keyとして扱う。Affect訂正ではreplacement episodeをappendし、元episodeをMemory V6のsupersede境界へ渡す。元episodeがforgottenまたは別scopeの場合は、忘却内容を再生成せずAffect mutation前に訂正を拒否する。
+- Memory appendとAffect linkは別storage transactionである。両方を独自transactionへ統合せず、Memory commit後・link前の失敗を呼び出し側へ返し、event由来の同一idempotency keyによるretryで同じMemory entryへ収束してlinkを完了する。
+- Affect訂正eventは元Memory entry IDも保持する。Affect commit後・replacement Memory commit前に失敗しても、retryは同じpredecessorをMemory V6のsupersede境界へ再送する。初回はactive predecessorを事前検証し、Memory commit後・Affect link前のretryではMemory V6のidempotency replayをpredecessorの状態検証より先に解決する。
+- idempotency replayとconflict rejectionは状態監査と分けたobservationへ記録し、運用metricsで集計する。通常の並行更新はappend-only transactionで直列化し、状態merge conflictを作らない。
+- afterglowは初期版へ含めない。session終了時にsession affectをrelationshipへコピーせず、relationship更新は明示eventだけにする。
+- rollout既定はshadow modeとし、application serviceがmodeをcontextへ明示する。応答への反映強度はcallerが段階的に選ぶ。
+
+## Alternatives
+
+### 現在状態を行単位で更新する
+
+楽観versionを付けても、別targetや別sessionの部分更新を一つのsnapshotへ集約する責務が残り、訂正前の根拠も別途必要になるため採用しない。
+
+### Session終了時にrelationshipへコピーする
+
+bugやtaskへの一時感情までrelationshipへ転写し得るため採用しない。
+
+### afterglowを初期実装へ含める
+
+減衰clock、再起動時評価、relationshipとの優先順位を追加する割に、明示的なsession/relationship分離の検証を弱めるため後続Issueへ分離する。
+
+## Migration and rollback
+
+schema変更はV6 DBへのadditive table/index追加とし、`ensureV6Schema`のsavepoint内で適用する。この機能の既存rowは存在しないためbackfillは不要で、失敗時はtable/index追加をまとめてrollbackする。V6の`user_version`は変更しない。
+
+アプリ版をrollbackした場合、旧版は追加tableを参照せず既存V6 dataを読み続けられる。感情tableを自動dropしないため、再upgrade時にevent履歴を再利用できる。物理削除が必要な場合は、別の明示的なdestructive migrationとして扱う。
+
+## Consequences
+
+- 同時sessionは別session eventをappendするため、現在気分を相互上書きしない。
+- effective state取得時の集約costはevent数に比例する。保持期間やsnapshot最適化は観測結果に基づく後続課題とする。
+- provider/MCP/UIの接続は別Issueでapplication serviceを利用し、独自永続化や独自合成を作らない。

--- a/docs/design/v6-database-foundation.md
+++ b/docs/design/v6-database-foundation.md
@@ -15,6 +15,7 @@ V5以前のsession / legacy Memory / Growth互換を引き継がず、Character-
 - current DB構造の棚卸しは`docs/design/database-schema.md`を参照する。
 - V6 Memoryのdomain contractは`docs/design/v6-memory-foundation.md`を参照する。
 - V6 Session turn の final / interim / provider output / run context 分離は`docs/design/session-turn-storage-v6.md`を参照する。
+- Character affectの追加tableと投影判断は`src-electron/database-schema-v6.ts`、`src-electron/character-affect-storage.ts`、`docs/adr/018-character-affect-event-persistence.md`を参照する。
 - V5 Character catalog / definition / snapshotの意味はV5 source of truthを優先する。
 
 ## Migration Boundary

--- a/docs/plans/20260809-character-affect-persistence/plan.md
+++ b/docs/plans/20260809-character-affect-persistence/plan.md
@@ -2,7 +2,7 @@
 
 - Issue: `ISSUE-251`
 - Draft Issue ID: `WM-AFFECT-CORE`
-- Status: final-closure
+- Status: completed
 - Accepted contract: ISSUE-251本文、ADR 018
 
 ## Scope
@@ -153,3 +153,14 @@ Candidate preflightは`verified`。`contract-schema-projection`と`lifecycle-eff
 2. Affect schema validationが一部CHECKだけを検証し、event `state`などのinvariant-bearing CHECKを欠く既存DBをvalidと判定し得る。
 
 `recordEvent`はcanonical fingerprintとledger replayを先に解決し、新規作成だけsession ownerを検証する。source session削除後も同じrelationship event IDを`created: false`で返し、replay observationを残すcontractを追加した。schema validationは全Character Affect tableのenum、scope、tuple、非空、JSON、range CHECKを検証し、列・index・FKを維持したままevent `state` CHECKだけを欠くDBを拒否するnegative contractを追加した。C6のholistic entryはimmutableな発見記録とし、complete diffの再レビューは行わない。最終Candidateではこの2 familyのdirect check、targeted closure、両specialist lensへのdelta非影響だけを取得する。
+
+### Candidate ISSUE-251-C7 completion
+
+Candidate preflightと最終verificationは`verified`。最終差分では、関連targeted testが86/86、全体testが2210 tests（2209 pass、1 skip）、typecheck、production build、`git diff --check`が成功した。
+
+holistic reviewで検出した2件のfinding familyは、次のtargeted closureで閉じた。
+
+- `ISSUE-251-TC7-CONTRACT`: record replay順序とCharacter Affect CHECK schemaを確認し、blocking finding、accepted risk、validation gapなしでapprove
+- `ISSUE-251-TC7-LIFECYCLE`: source session削除後のrelationship lifecycleと並行appendへの非影響を確認し、blocking finding、accepted risk、validation gapなしでapprove
+
+両reviewはC7のverificationをreview前後に実行し、source identityの一致を確認した。C6のholistic complete-diff reviewは一度だけ実行したimmutableな発見記録として保持し、C7の完了根拠にはdirect checkと上記targeted closureを使用する。ISSUE-251の完了条件に対する未解決項目はない。

--- a/docs/plans/20260809-character-affect-persistence/plan.md
+++ b/docs/plans/20260809-character-affect-persistence/plan.md
@@ -1,0 +1,155 @@
+# Character Affect Persistence Plan
+
+- Issue: `ISSUE-251`
+- Draft Issue ID: `WM-AFFECT-CORE`
+- Status: final-closure
+- Accepted contract: ISSUE-251本文、ADR 018
+
+## Scope
+
+- Character baselineはCharacter Definition由来の入力として扱い、通常イベントでは永続化しない。
+- relationship affectは`(local-user, character)`、session affectは`(local-user, character, session)`でappend-only eventとして永続化する。
+- Character Memory episodeは既存Memory V6のapplication/storage境界で作成、retry、supersede、forgetへ接続する。
+- 初期版ではafterglowを実装しない。provider、MCP、CLI、renderer UI、応答context注入も後続Issueへ分離する。
+
+## Pre-Implementation Closure Plan
+
+Gate status: `ready`
+
+Accepted contract / exact anchors:
+
+- ISSUE-251本文のGoal、target behavior、Done when
+- `docs/adr/018-character-affect-event-persistence.md`
+- `src-electron/memory-v6-storage.ts`の`appendEntry`、`forgetEntries`、idempotency、supersede境界
+- `src-electron/database-schema-v6.ts`のV6 schema ensure、Memory/Affect FK、savepoint境界
+
+Supported scopeはCharacter Affect eventとMemory episodeの作成、retry、訂正、forget後の参照、session reset、別接続の並行appendである。provider、MCP、CLI、renderer UI、afterglow、応答context注入は対象外とする。
+
+Canonical ownerは、Affect event/reset/auditが`CharacterAffectStorage`、Memory episodeのentry/state/relation/audit/idempotencyが`MemoryV6Storage`、両者の順序と収束が`CharacterAffectService`と具体episode writerである。Memory targetはsingle-user productの`local-user`をbinding ownerとし、`character/<characterId>` scopeへ保存する。`sourceSessionId`はMemory source provenanceでありowner scopeに使わない。
+
+Cross-storage mutationは単一SQLite transactionへ統合しない。許可する状態は、Affect eventのみ作成済み、Memory episode作成済みかつAffect link未完了、両方完了である。Memory appendとAffect linkに同一event由来のstable idempotency keyを使い、失敗を返した同一requestのretryで完了状態へ収束させる。
+
+### Invariant Matrix
+
+| Invariant ID | Sibling channel | Coupled values / order | Failure mode / consumer impact | Direct verification | Status |
+| --- | --- | --- | --- | --- | --- |
+| AF-1 | record / read / reset | user, character, session, layer, target | 別sessionまたは別targetの状態が混ざる | storage targeted test | covered |
+| AF-2 | record / correct / reset retry | owner tuple, operation, idempotency key, fingerprint | retryで二重登録、別requestを誤再生 | storage targeted test | covered |
+| AF-3 | correct / reset / inspect | original, replacement/reset marker, audit | 訂正根拠消失、relationshipの誤削除 | storage targeted test | covered |
+| AF-4 | episode create / motif repeat / retry | affect event ID, Memory idempotency key, motif | 同一eventのepisode重複、別eventの反復欠落 | real Memory integration test | covered |
+| AF-5 | fresh / existing / failed ensure | Affect tables, Memory FK, savepoint | 部分schema、既存data破損 | database schema targeted test | covered |
+| AF-6 | replay / conflict / rejection metrics | operation, outcome, audit reason | 抑止・拒否結果を観測不能 | storage/service targeted test | covered |
+| AF-7 | affect correction / Memory supersede | original affect link, replacement event, old/new Memory entry, target tuple | Affectだけ訂正されMemory episodeが旧内容のままactive | real Memory correction/retry test | covered |
+| AF-8 | Memory append / Affect link failure recovery | derived key, Memory commit certainty, link state | Memory成功後のlink失敗で重複または成功誤認 | failure injection + same-request retry test | covered |
+| AF-9 | Memory forget / session reset | Memory state, affect link/audit/effective state, relationship scope | forget/resetが監査または別scopeを破壊 | integration test | covered |
+| AF-10 | concurrent append | separate connection, BEGIN IMMEDIATE, busy timeout, session/relationship scope | overwrite、混線、欠落、不要なSQLITE_BUSY | worker barrierでwrite lockとappendを実際に重ねるtest | covered |
+| AF-11 | service composition | episode candidate, concrete writer availability | writer未設定で候補を黙って破棄 | construction failure + concrete composition test | covered |
+
+Selected trigger matrices:
+
+- Mutation / External Side Effect: Memory commit後・Affect link前のfailureと同一request retryを扱う。
+- Owner / Scope / Projection: `local-user`、Character、Session、Memory target、source provenanceを分離する。
+- Limit / Concurrency / Resource: WAL、busy timeout、別接続transactionの実重複を扱う。
+- Migration / Repair / Existing Data: additive schema ensureとsavepoint rollbackを扱う。
+
+Public IPCや外部protocolは変更せず、UI reactive state、process lifecycle、secret-bearing IPCは対象外のため選択しない。
+
+Triggered review lenses:
+
+- `lifecycle-effect-concurrency`: AF-4、AF-7〜AF-10
+- `contract-schema-projection`: AF-1〜AF-3、AF-5、AF-6、AF-11とowner/scope tuple
+
+Unresolved contract decisions: なし。
+
+## Knowledge Placement
+
+- current implementation: source
+- expectation、failure mode、concurrency overlap: type、schema、targeted test
+- append-only、cross-storage idempotent convergence、Memory supersedeを選ぶ理由: ADR 018
+- architecture document:既存V6 foundation文書はsource/ADR pointerだけを維持する
+- Candidate Definition、Evidence Ledger、review結果:このtask-local planに保持する
+
+## Done
+
+- Memory episodeの作成、同motif反復、retry、訂正時supersede、forget後のAffect監査保持を実Memory V6で確認する。
+- Memory成功後・Affect link前のfailureが同一request retryで重複なく収束する。
+- worker barrierを使い、別接続のtransactionが実際に重なる並行appendを確認する。
+- schema、typecheck、関連test、全体test、production buildが成功する。
+- triggerされた独立reviewを現行Candidateで閉じ、未解決blocking findingを残さない。
+
+## Evidence Ledger
+
+現行Candidateへ含めるsourceとexecutable contractに対し、次を実行した。
+
+| Evidence | Result |
+| --- | --- |
+| `npm run typecheck` | pass |
+| `npx tsx --test scripts/tests/character-affect-storage.test.ts`（連続5回） | 各12/12 pass |
+| `npx tsx --test scripts/tests/character-affect-storage.test.ts scripts/tests/character-affect-service.test.ts scripts/tests/database-schema-v6.test.ts scripts/tests/memory-v6-storage.test.ts scripts/tests/memory-v6-service.test.ts` | 86/86 pass |
+| `npm test` | 2210 tests、2209 pass、1 skip、0 fail |
+| `npm run build` | pass。rendererとElectron main/Memory CLIをproduction build |
+| `git diff --check` | pass |
+
+最初の全体testは並行test worker終了時の待機が無期限になり得るため中断した。worker exit/error検知と10秒timeoutを追加した後、上記の現行Candidate全体testを完走している。レビュー証拠はCandidate Definition作成後に追記する。
+
+### Candidate ISSUE-251-C1 review
+
+Candidate preflightは`verified`。次のspecialist reviewを期限内に完了した。
+
+- `lifecycle-effect-concurrency`: AF-4、AF-7〜AF-10
+- `contract-schema-projection`: AF-1〜AF-3、AF-5、AF-6、AF-11
+
+Finding Promotionでは、5件すべてをsupported scope内で再現可能かつ同じCharacter Affect semantic ownerに属する`current-scope repair`、最終分類`blocking`とした。
+
+1. forgotten Memory episodeの訂正がAffect commit後に恒久失敗する。
+2. source session削除後の訂正retryが保持済みledgerを再生しない。
+3. relationship eventのpublic projectionがscopeとprovenanceを混同する。
+4. optional fieldの明示的undefinedがinvalid JSONまたは別fingerprintになる。
+5. `local-user`制約がMemory候補の有無で変わる。
+
+修正後、Memory統合、storage、schema、Memory V6のtargeted testは84/84 pass、typecheckと`git diff --check`はpass。source変更によりC1はsupersededとし、現行Candidateの全体test、build、specialist closureは新Candidateで取り直す。
+
+### Candidate ISSUE-251-C2 targeted closure
+
+Candidate preflightは`verified`。C1のfinding familyを二つのtargeted closureへ渡し、次の同一owner内blocking findingが残った。
+
+1. Affect訂正commit後・Memory commit前の失敗で、retryがpredecessor Memory IDを失いsupersedeしない。
+2. relationship eventのmutation projectionが発生元Sessionをscope用`sessionId`として公開する。
+
+訂正eventへ`supersedes_memory_entry_id`を永続化し、retryで同じsupersede tupleを復元する。mutationはscope用`session_id`とprovenance用`source_session_id`を分離する。failure injectionとpublic projection assertionを追加し、修正後targeted testは85/85 pass、typecheckはpass。source変更によりC2はsupersededとし、新Candidateでfinding family closureを取り直す。
+
+### Candidate ISSUE-251-C3 targeted closure
+
+Candidate preflightは`verified`。C2の残存familyをtargeted closureへ渡し、次のblocking findingを同じsupported scopeへpromotionした。
+
+1. 訂正Memory commit後・Affect link前のretryがactive predecessor事前検証で遮断される。
+2. mutation provenance列とFKがV6 required schema検証へ含まれず、不完全DBをvalidと判定し得る。
+
+writerの初回事前検証とMemory append時のidempotency replayを分離し、訂正Memory commit後・link前failureの回帰testを追加する。Affectの新しい列とFKをrequired schemaへ追加し、provenance列欠落DBを拒否するnegative testを追加する。source変更によりC3はsupersededとし、現行Candidateでdirect check、closure、holistic reviewを取り直す。
+
+並行testの初期化時に複数workerが同時に`PRAGMA journal_mode=WAL`を実行し、対象transactionが重なる前に`SQLITE_BUSY`となるsetup raceをdirect checkで検出した。append用connectionを順に初期化してから、別connectionのwrite lockと全append transactionをbarrierで重ねる構成へ修正した。修正後のstorage testは連続5回すべて12/12 passであり、write lock保持中にappend結果が返らないことと、解放後の欠落・混線・重複がないことを確認している。
+
+### Candidate ISSUE-251-C4 targeted closure
+
+Candidate preflightは`verified`。`lifecycle-effect-concurrency` closureはAF-7、AF-8、AF-10にblocking finding、accepted risk、validation gapなしで完了した。reviewerによるservice/storageの独立実行は19/19 pass。
+
+`contract-schema-projection` closureでは、required FK検証が参照元列と参照先tableだけを比較し、`ON DELETE` actionを検証しないblocking findingが残った。`source_session_id`を`ON DELETE CASCADE`へ変更したDBをvalidと判定でき、source session削除時にrelationship mutation auditを不可逆に失うため、AF-1、AF-5の`current-scope repair`へpromotionした。
+
+全Character Affect FKを参照元列、参照先table、参照先列、`ON DELETE` actionのtupleで検証し、未列挙だったmutationの`character_id`、`event_id`、`reset_id`とobservationの`session_id`もrequired FKへ追加した。provenance FKを`CASCADE`へ置換したDBを拒否するnegative contractを追加した。修正後、database schema testは13/13、関連targeted testは86/86、typecheck、全体2210 tests（2209 pass、1 skip）、production buildが成功した。source変更によりC4はsupersededとし、最終Candidateで両lensの現行証拠を取り直す。
+
+### Candidate ISSUE-251-C5 targeted closure
+
+Candidate preflightは開始時に`verified`。`contract-schema-projection` closureで、FK欠落fixtureが`source_session_id`列自体も削除してrequired-column検査で先に失敗し、required-FK検査を直接検証していないblocking findingが残った。AF-5のexecutable contract不足として`current-scope repair`へpromotionした。
+
+fixtureは`source_session_id`列を残して対象FKだけを削除し、列の存在とFKの欠落を事前assertしたうえで`isValidV6Database`が拒否する形へ修正した。修正後targeted testは86/86、全体testは2210 tests（2209 pass、1 skip）。C5の`lifecycle-effect-concurrency` reviewerは変更前Candidateの検証後にこのtest差分を検出し、mismatchとして証拠を発行しなかった。C5はsupersededとし、最終Candidateでcontract finding closure、lifecycle delta非影響、holistic reviewを取り直す。
+
+### Candidate ISSUE-251-C6 review
+
+Candidate preflightは`verified`。`contract-schema-projection`と`lifecycle-effect-concurrency`のtargeted closureはいずれもreview前後のidentity一致を確認し、blocking finding、accepted risk、validation gapなしで完了した。
+
+一度だけ実行したfresh holistic complete-diff reviewでは、次の2件をsupported scope内の`current-scope repair`、最終分類`blocking`へpromotionした。
+
+1. relationship eventのrecord idempotency replayがsession owner検証より後にあり、commit後にsource sessionが削除されると同一request retryが失敗する。
+2. Affect schema validationが一部CHECKだけを検証し、event `state`などのinvariant-bearing CHECKを欠く既存DBをvalidと判定し得る。
+
+`recordEvent`はcanonical fingerprintとledger replayを先に解決し、新規作成だけsession ownerを検証する。source session削除後も同じrelationship event IDを`created: false`で返し、replay observationを残すcontractを追加した。schema validationは全Character Affect tableのenum、scope、tuple、非空、JSON、range CHECKを検証し、列・index・FKを維持したままevent `state` CHECKだけを欠くDBを拒否するnegative contractを追加した。C6のholistic entryはimmutableな発見記録とし、complete diffの再レビューは行わない。最終Candidateではこの2 familyのdirect check、targeted closure、両specialist lensへのdelta非影響だけを取得する。

--- a/scripts/tests/character-affect-service.test.ts
+++ b/scripts/tests/character-affect-service.test.ts
@@ -1,0 +1,599 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { describe, it } from "node:test";
+
+import {
+  AFFECT_SCHEMA_VERSION,
+  type AffectEventInput,
+  type AffectEvaluator,
+} from "../../src/character-affect/affect-contract.js";
+import {
+  MemoryV6CharacterAffectEpisodeWriter,
+  createCharacterAffectServiceWithMemory,
+} from "../../src-electron/character-affect-memory-adapter.js";
+import {
+  CharacterAffectService,
+  type CharacterAffectEpisodeWriter,
+} from "../../src-electron/character-affect-service.js";
+import { CharacterAffectStorage } from "../../src-electron/character-affect-storage.js";
+import { ensureV6Schema } from "../../src-electron/database-schema-v6.js";
+import type { MemoryV6ResolvedTarget } from "../../src-electron/memory-v6-schema.js";
+import { MemoryV6Storage } from "../../src-electron/memory-v6-storage.js";
+
+const TARGET: MemoryV6ResolvedTarget = {
+  owner: { type: "character", id: "character-a" },
+  scope: { type: "character", id: "character-a" },
+};
+
+function createFixture(): { directory: string; dbPath: string } {
+  const directory = mkdtempSync(join(tmpdir(), "withmate-affect-service-"));
+  const dbPath = join(directory, "withmate-v6.db");
+  const db = new DatabaseSync(dbPath);
+  try {
+    db.exec("PRAGMA foreign_keys = ON;");
+    ensureV6Schema(db);
+    db.prepare("INSERT INTO characters (id, name, created_at, updated_at) VALUES ('character-a', 'A', ?, ?)")
+      .run("2026-08-09T00:00:00.000Z", "2026-08-09T00:00:00.000Z");
+    db.prepare(`
+      INSERT INTO sessions_v6 (
+        id, title, state, provider_id, catalog_revision, model_id, approval_mode,
+        character_id, character_snapshot_json, created_at, updated_at, last_active_at
+      ) VALUES ('session-a', 'A', 'active', 'codex', 1, 'gpt-5', 'on-request', 'character-a', '{}', ?, ?, ?)
+    `).run("2026-08-09T00:00:00.000Z", "2026-08-09T00:00:00.000Z", "2026-08-09T00:00:00.000Z");
+  } finally {
+    db.close();
+  }
+  return { directory, dbPath };
+}
+
+function episodeEvent(overrides: Partial<AffectEventInput> = {}): AffectEventInput {
+  return {
+    schemaVersion: AFFECT_SCHEMA_VERSION,
+    characterId: "character-a",
+    userId: "local-user",
+    sessionId: "session-a",
+    layer: "session",
+    targetType: "task",
+    targetId: "release",
+    value: { label: "joy", valence: 0.8 },
+    intensity: 0.7,
+    reason: "A release milestone passed.",
+    evidence: "The release passed.",
+    occurredAt: "2026-08-09T01:00:00.000Z",
+    idempotencyKey: "event-day-1",
+    memoryEpisode: {
+      title: "Release milestone",
+      body: "We celebrated another release milestone.",
+      preview: "Release milestone celebration.",
+      motif: "release-celebration",
+      salience: 0.8,
+    },
+    ...overrides,
+  };
+}
+
+function evaluatorFor(getEvent: () => AffectEventInput): AffectEvaluator {
+  return {
+    async evaluate(): Promise<readonly AffectEventInput[]> {
+      return [getEvent()];
+    },
+  };
+}
+
+function serviceInput(summary = "The release passed.") {
+  return {
+    characterId: "character-a",
+    userId: "local-user",
+    characterDefinition: "Cheerful knight.",
+    baseline: [],
+    event: {
+      sessionId: "session-a",
+      summary,
+      occurredAt: "2026-08-09T01:00:00.000Z",
+    },
+  } as const;
+}
+
+class FailOnceLinkStorage extends CharacterAffectStorage {
+  private shouldFail = true;
+
+  override linkMemoryEpisode(eventId: string, memoryEntryId: string): void {
+    if (this.shouldFail) {
+      this.shouldFail = false;
+      throw new Error("Injected failure after Memory append.");
+    }
+    super.linkMemoryEpisode(eventId, memoryEntryId);
+  }
+}
+
+class FailSecondLinkStorage extends CharacterAffectStorage {
+  private linkCount = 0;
+
+  override linkMemoryEpisode(eventId: string, memoryEntryId: string): void {
+    this.linkCount += 1;
+    if (this.linkCount === 2) {
+      throw new Error("Injected failure after correction Memory append.");
+    }
+    super.linkMemoryEpisode(eventId, memoryEntryId);
+  }
+}
+
+class FailOnceCorrectionEpisodeWriter implements CharacterAffectEpisodeWriter {
+  private shouldFail = true;
+
+  constructor(private readonly delegate: CharacterAffectEpisodeWriter) {}
+
+  validateEpisode(input: Parameters<CharacterAffectEpisodeWriter["validateEpisode"]>[0]): void {
+    this.delegate.validateEpisode(input);
+  }
+
+  async writeEpisode(
+    input: Parameters<CharacterAffectEpisodeWriter["writeEpisode"]>[0],
+  ): Promise<{ memoryEntryId: string }> {
+    if (input.supersedesMemoryEntryId && this.shouldFail) {
+      this.shouldFail = false;
+      throw new Error("Injected failure before correction Memory append.");
+    }
+    return this.delegate.writeEpisode(input);
+  }
+}
+
+describe("CharacterAffectService Memory episode lifecycle", () => {
+  it("実Memoryへ同motifの別episodeを保存し、retryと訂正をidempotentにsupersedeする", async () => {
+    const fixture = createFixture();
+    const affectStorage = new CharacterAffectStorage(fixture.dbPath);
+    const memoryStorage = new MemoryV6Storage(fixture.dbPath);
+    let current = episodeEvent();
+    const service = createCharacterAffectServiceWithMemory({
+      affectStorage,
+      memoryStorage,
+      evaluator: evaluatorFor(() => current),
+    });
+    try {
+      const first = await service.evaluateAndRecord(serviceInput());
+      const replay = await service.evaluateAndRecord(serviceInput());
+      assert.equal(replay.events[0]?.id, first.events[0]?.id);
+
+      current = episodeEvent({
+        occurredAt: "2026-08-10T01:00:00.000Z",
+        idempotencyKey: "event-day-2",
+        evidence: "Another release passed.",
+      });
+      await service.evaluateAndRecord({
+        ...serviceInput("Another release passed."),
+        event: { ...serviceInput().event, occurredAt: "2026-08-10T01:00:00.000Z" },
+      });
+
+      const beforeCorrection = memoryStorage.listEntries({
+        target: TARGET,
+        states: ["active", "superseded", "forgotten"],
+        limit: 50,
+      }).items;
+      assert.equal(beforeCorrection.length, 2);
+      assert.notEqual(beforeCorrection[0]?.id, beforeCorrection[1]?.id);
+      assert.ok(beforeCorrection.every((entry) => entry.tags.some(
+        (tag) => tag.type === "motif" && tag.value === "release-celebration",
+      )));
+      assert.ok(beforeCorrection.every((entry) => entry.source.sessionId === "session-a"));
+      assert.ok(beforeCorrection.every(
+        (entry) => entry.owner.type === "character"
+          && entry.owner.id === "character-a"
+          && entry.scope.type === "character"
+          && entry.scope.id === "character-a",
+      ));
+
+      const originalMemoryId = first.events[0]?.memoryEntryId;
+      assert.ok(originalMemoryId);
+      const correction = {
+        eventId: first.events[0]!.id,
+        replacement: episodeEvent({
+          value: { label: "pride", valence: 0.9 },
+          intensity: 0.9,
+          reason: "The milestone mattered more than first recorded.",
+          evidence: "The user confirmed the release impact.",
+          occurredAt: "2026-08-09T01:05:00.000Z",
+          idempotencyKey: "event-day-1-correction",
+          memoryEpisode: {
+            title: "Release milestone correction",
+            body: "We corrected how important the release milestone felt.",
+            preview: "Corrected release milestone episode.",
+            motif: "release-celebration",
+            salience: 0.9,
+          },
+        }),
+        reason: "Corrected the episode salience.",
+      };
+      const corrected = await service.correctEvent(correction);
+      const correctionReplay = await service.correctEvent(correction);
+      assert.equal(correctionReplay.event.id, corrected.event.id);
+      assert.equal(correctionReplay.event.memoryEntryId, corrected.event.memoryEntryId);
+
+      const oldMemory = memoryStorage.getEntry(originalMemoryId);
+      const newMemory = memoryStorage.getEntry(corrected.event.memoryEntryId!);
+      assert.equal(oldMemory?.state, "superseded");
+      assert.equal(oldMemory?.supersededBy, newMemory?.id);
+      assert.equal(newMemory?.state, "active");
+      assert.deepEqual(newMemory?.supersedes, [originalMemoryId]);
+      assert.equal(memoryStorage.listEntries({
+        target: TARGET,
+        states: ["active", "superseded", "forgotten"],
+        limit: 50,
+      }).items.length, 3);
+      assert.equal(service.getMetrics().linkedEpisodes, 3);
+      assert.equal(service.getMetrics().episodeCandidates, 3);
+    } finally {
+      affectStorage.close();
+      memoryStorage.close();
+      rmSync(fixture.directory, { recursive: true, force: true });
+    }
+  });
+
+  it("Memory成功後・Affect link前の失敗を同一request retryで重複なく収束する", async () => {
+    const fixture = createFixture();
+    const affectStorage = new FailOnceLinkStorage(fixture.dbPath);
+    const memoryStorage = new MemoryV6Storage(fixture.dbPath);
+    const service = createCharacterAffectServiceWithMemory({
+      affectStorage,
+      memoryStorage,
+      evaluator: evaluatorFor(() => episodeEvent()),
+    });
+    try {
+      await assert.rejects(
+        () => service.evaluateAndRecord(serviceInput()),
+        /Injected failure after Memory append/,
+      );
+      const afterFailure = service.inspect({ characterId: "character-a", userId: "local-user" });
+      assert.equal(afterFailure.events.length, 1);
+      assert.equal(afterFailure.events[0]?.memoryEntryId, null);
+      assert.equal(memoryStorage.listEntries({ target: TARGET, states: ["active"], limit: 50 }).items.length, 1);
+
+      const retry = await service.evaluateAndRecord(serviceInput());
+      assert.ok(retry.events[0]?.memoryEntryId);
+      assert.equal(memoryStorage.listEntries({
+        target: TARGET,
+        states: ["active", "superseded", "forgotten"],
+        limit: 50,
+      }).items.length, 1);
+      const inspection = service.inspect({ characterId: "character-a", userId: "local-user" });
+      assert.equal(inspection.mutations.filter((item) => item.operation === "episode_candidate").length, 1);
+      assert.equal(inspection.mutations.filter((item) => item.operation === "link_episode").length, 1);
+    } finally {
+      affectStorage.close();
+      memoryStorage.close();
+      rmSync(fixture.directory, { recursive: true, force: true });
+    }
+  });
+
+  it("Affect訂正成功後・Memory commit前の失敗でもpredecessorを保持してretry収束する", async () => {
+    const fixture = createFixture();
+    const affectStorage = new CharacterAffectStorage(fixture.dbPath);
+    const memoryStorage = new MemoryV6Storage(fixture.dbPath);
+    const writer = new FailOnceCorrectionEpisodeWriter(
+      new MemoryV6CharacterAffectEpisodeWriter(memoryStorage),
+    );
+    const service = new CharacterAffectService(
+      affectStorage,
+      evaluatorFor(() => episodeEvent()),
+      writer,
+    );
+    try {
+      const original = (await service.evaluateAndRecord(serviceInput())).events[0]!;
+      const correction = {
+        eventId: original.id,
+        replacement: episodeEvent({
+          idempotencyKey: "correction-memory-precommit-failure",
+          occurredAt: "2026-08-09T01:05:00.000Z",
+          memoryEpisode: {
+            title: "Corrected release episode",
+            body: "The correction must supersede the original after retry.",
+            preview: "Correction retry episode.",
+            motif: "release-celebration",
+            salience: 0.9,
+          },
+        }),
+        reason: "Corrected after a transient Memory failure.",
+      };
+      await assert.rejects(
+        () => service.correctEvent(correction),
+        /Injected failure before correction Memory append/,
+      );
+      const partial = service.inspect({ characterId: "character-a", userId: "local-user" });
+      const unlinkedReplacement = partial.events.find((item) => item.correctionOfEventId === original.id);
+      assert.equal(unlinkedReplacement?.memoryEntryId, null);
+      assert.equal(unlinkedReplacement?.supersedesMemoryEntryId, original.memoryEntryId);
+
+      const replay = await service.correctEvent(correction);
+      assert.equal(replay.created, false);
+      assert.ok(replay.event.memoryEntryId);
+      assert.equal(memoryStorage.getEntry(original.memoryEntryId!)?.state, "superseded");
+      assert.deepEqual(memoryStorage.getEntry(replay.event.memoryEntryId!)?.supersedes, [original.memoryEntryId]);
+      assert.equal(memoryStorage.listEntries({
+        target: TARGET,
+        states: ["active", "superseded", "forgotten"],
+        limit: 50,
+      }).items.length, 2);
+    } finally {
+      affectStorage.close();
+      memoryStorage.close();
+      rmSync(fixture.directory, { recursive: true, force: true });
+    }
+  });
+
+  it("訂正Memory成功後・Affect link前の失敗をidempotent replayで収束する", async () => {
+    const fixture = createFixture();
+    const affectStorage = new FailSecondLinkStorage(fixture.dbPath);
+    const memoryStorage = new MemoryV6Storage(fixture.dbPath);
+    const service = createCharacterAffectServiceWithMemory({
+      affectStorage,
+      memoryStorage,
+      evaluator: evaluatorFor(() => episodeEvent()),
+    });
+    try {
+      const original = (await service.evaluateAndRecord(serviceInput())).events[0]!;
+      const correction = {
+        eventId: original.id,
+        replacement: episodeEvent({
+          idempotencyKey: "correction-link-failure",
+          occurredAt: "2026-08-09T01:05:00.000Z",
+          memoryEpisode: {
+            title: "Correction after link failure",
+            body: "The same Memory append must replay before Affect relinks.",
+            preview: "Correction link retry.",
+            motif: "release-celebration",
+            salience: 0.9,
+          },
+        }),
+        reason: "Corrected with an injected link failure.",
+      };
+      await assert.rejects(
+        () => service.correctEvent(correction),
+        /Injected failure after correction Memory append/,
+      );
+      assert.equal(memoryStorage.getEntry(original.memoryEntryId!)?.state, "superseded");
+      assert.equal(memoryStorage.listEntries({
+        target: TARGET,
+        states: ["active", "superseded", "forgotten"],
+        limit: 50,
+      }).items.length, 2);
+
+      const replay = await service.correctEvent(correction);
+      assert.equal(replay.created, false);
+      assert.ok(replay.event.memoryEntryId);
+      assert.deepEqual(memoryStorage.getEntry(replay.event.memoryEntryId!)?.supersedes, [original.memoryEntryId]);
+      assert.equal(memoryStorage.listEntries({
+        target: TARGET,
+        states: ["active", "superseded", "forgotten"],
+        limit: 50,
+      }).items.length, 2);
+    } finally {
+      affectStorage.close();
+      memoryStorage.close();
+      rmSync(fixture.directory, { recursive: true, force: true });
+    }
+  });
+
+  it("session resetとMemory forget後もrelationship affectのlink、監査、現在状態を保持する", async () => {
+    const fixture = createFixture();
+    const affectStorage = new CharacterAffectStorage(fixture.dbPath);
+    const memoryStorage = new MemoryV6Storage(fixture.dbPath);
+    const relationshipEvent = episodeEvent({
+      layer: "relationship",
+      targetType: "relationship",
+      targetId: "local-user:character-a",
+      value: { label: "trust", valence: 0.7 },
+      idempotencyKey: "relationship-episode",
+    });
+    const service = createCharacterAffectServiceWithMemory({
+      affectStorage,
+      memoryStorage,
+      evaluator: evaluatorFor(() => relationshipEvent),
+    });
+    try {
+      const recorded = await service.evaluateAndRecord(serviceInput());
+      const memoryEntryId = recorded.events[0]?.memoryEntryId;
+      assert.ok(memoryEntryId);
+
+      service.reset({
+        characterId: "character-a",
+        userId: "local-user",
+        layer: "session",
+        sessionId: "session-a",
+        reason: "Reset session mood only.",
+        resetAt: "2026-08-09T02:00:00.000Z",
+        idempotencyKey: "reset-session-a",
+      });
+      assert.equal(memoryStorage.getEntry(memoryEntryId)?.state, "active");
+      assert.ok(service.getEffectiveState({
+        characterId: "character-a",
+        userId: "local-user",
+        sessionId: "session-a",
+      }).components.some((item) => item.label === "trust"));
+
+      const forget = memoryStorage.forgetEntries({
+        target: TARGET,
+        entryIds: [memoryEntryId],
+        reason: "user_request",
+        idempotencyKey: "forget-affect-episode",
+        bindingIdHash: "local-user",
+        sessionId: "session-a",
+      });
+      assert.deepEqual(forget, [{ entryId: memoryEntryId, status: "forgotten" }]);
+      assert.equal(memoryStorage.getEntry(memoryEntryId)?.state, "forgotten");
+
+      await assert.rejects(
+        () => service.correctEvent({
+          eventId: recorded.events[0]!.id,
+          replacement: episodeEvent({
+            layer: "relationship",
+            targetType: "relationship",
+            targetId: "local-user:character-a",
+            idempotencyKey: "forgotten-episode-correction",
+            occurredAt: "2026-08-09T02:05:00.000Z",
+          }),
+          reason: "Attempted correction after forget.",
+        }),
+        /to supersede must be active/,
+      );
+      const afterRejectedCorrection = service.inspect({ characterId: "character-a", userId: "local-user" });
+      assert.equal(afterRejectedCorrection.events.length, 1);
+      assert.equal(afterRejectedCorrection.events[0]?.state, "active");
+      assert.equal(memoryStorage.listEntries({
+        target: TARGET,
+        states: ["active", "superseded", "forgotten"],
+        limit: 50,
+      }).items.length, 1);
+
+      const inspection = service.inspect({ characterId: "character-a", userId: "local-user" });
+      assert.equal(inspection.events[0]?.memoryEntryId, memoryEntryId);
+      assert.ok(inspection.mutations.some((item) => item.operation === "link_episode"));
+      assert.ok(inspection.mutations.some((item) => item.operation === "reset"));
+      assert.ok(service.getEffectiveState({
+        characterId: "character-a",
+        userId: "local-user",
+        sessionId: "session-a",
+      }).components.some((item) => item.label === "trust"));
+    } finally {
+      affectStorage.close();
+      memoryStorage.close();
+      rmSync(fixture.directory, { recursive: true, force: true });
+    }
+  });
+
+  it("source session削除後もMemory付きrelationship訂正のretryを再生する", async () => {
+    const fixture = createFixture();
+    const affectStorage = new CharacterAffectStorage(fixture.dbPath);
+    const memoryStorage = new MemoryV6Storage(fixture.dbPath);
+    const service = createCharacterAffectServiceWithMemory({
+      affectStorage,
+      memoryStorage,
+      evaluator: evaluatorFor(() => episodeEvent()),
+    });
+    try {
+      const original = (await service.evaluateAndRecord(serviceInput())).events[0]!;
+      const correction = {
+        eventId: original.id,
+        replacement: episodeEvent({
+          layer: "relationship" as const,
+          targetType: "relationship" as const,
+          targetId: "local-user:character-a",
+          idempotencyKey: "durable-memory-correction",
+          occurredAt: "2026-08-09T01:05:00.000Z",
+          memoryEpisode: {
+            title: "Durable relationship episode",
+            body: "The corrected affect belongs to the relationship.",
+            preview: "Relationship correction.",
+            motif: "release-celebration",
+            salience: 0.8,
+          },
+        }),
+        reason: "Corrected to relationship scope.",
+      };
+      const corrected = await service.correctEvent(correction);
+
+      const db = new DatabaseSync(fixture.dbPath);
+      try {
+        db.exec("PRAGMA foreign_keys = ON;");
+        db.prepare("DELETE FROM sessions_v6 WHERE id = 'session-a'").run();
+      } finally {
+        db.close();
+      }
+
+      const replay = await service.correctEvent(correction);
+      assert.equal(replay.created, false);
+      assert.equal(replay.event.id, corrected.event.id);
+      assert.equal(replay.event.memoryEntryId, corrected.event.memoryEntryId);
+      assert.equal(memoryStorage.listEntries({
+        target: TARGET,
+        states: ["active", "superseded", "forgotten"],
+        limit: 50,
+      }).items.length, 2);
+    } finally {
+      affectStorage.close();
+      memoryStorage.close();
+      rmSync(fixture.directory, { recursive: true, force: true });
+    }
+  });
+
+  it("episode writer未設定とMemoryを持つeventのepisodeなし訂正を明示的に拒否する", async () => {
+    const fixture = createFixture();
+    const affectStorage = new CharacterAffectStorage(fixture.dbPath);
+    const memoryStorage = new MemoryV6Storage(fixture.dbPath);
+    const evaluator = evaluatorFor(() => episodeEvent());
+    try {
+      assert.throws(
+        () => new CharacterAffectService(affectStorage, evaluator, undefined as never),
+        /Memory episode writer is required/,
+      );
+      const writer = new MemoryV6CharacterAffectEpisodeWriter(memoryStorage);
+      await assert.rejects(
+        () => writer.writeEpisode({
+          characterId: "character-a",
+          userId: "other-user",
+          sourceSessionId: "session-a",
+          sourceEventId: "event-other-user",
+          idempotencyKey: "event-other-user:memory-episode",
+          candidate: episodeEvent().memoryEpisode!,
+        }),
+        /owner must be local-user/,
+      );
+
+      const invalidService = createCharacterAffectServiceWithMemory({
+        affectStorage,
+        memoryStorage,
+        evaluator: evaluatorFor(() => episodeEvent({
+          memoryEpisode: {
+            ...episodeEvent().memoryEpisode!,
+            body: "x".repeat(8_001),
+          },
+        })),
+      });
+      await assert.rejects(
+        () => invalidService.evaluateAndRecord(serviceInput()),
+        /Memory episode is invalid/,
+      );
+      assert.equal(invalidService.inspect({
+        characterId: "character-a",
+        userId: "local-user",
+      }).events.length, 0);
+
+      const service = createCharacterAffectServiceWithMemory({ affectStorage, memoryStorage, evaluator });
+      const noMemoryService = createCharacterAffectServiceWithMemory({
+        affectStorage,
+        memoryStorage,
+        evaluator: evaluatorFor(() => episodeEvent({
+          userId: "other-user",
+          memoryEpisode: undefined,
+          idempotencyKey: "other-user-without-memory",
+        })),
+      });
+      await assert.rejects(
+        () => noMemoryService.evaluateAndRecord({ ...serviceInput(), userId: "other-user" }),
+        /owner must be local-user/,
+      );
+      const recorded = await service.evaluateAndRecord(serviceInput());
+      await assert.rejects(
+        () => service.correctEvent({
+          eventId: recorded.events[0]!.id,
+          replacement: episodeEvent({
+            idempotencyKey: "correction-without-episode",
+            occurredAt: "2026-08-09T01:05:00.000Z",
+            memoryEpisode: undefined,
+          }),
+          reason: "Correction omitted an episode.",
+        }),
+        /must provide a replacement Memory episode/,
+      );
+      assert.equal(service.inspect({
+        characterId: "character-a",
+        userId: "local-user",
+      }).events[0]?.state, "active");
+    } finally {
+      affectStorage.close();
+      memoryStorage.close();
+      rmSync(fixture.directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/tests/character-affect-storage.test.ts
+++ b/scripts/tests/character-affect-storage.test.ts
@@ -1,0 +1,744 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { describe, it } from "node:test";
+import { Worker } from "node:worker_threads";
+
+import { AFFECT_SCHEMA_VERSION, type AffectEventInput } from "../../src/character-affect/affect-contract.js";
+import {
+  CharacterAffectIdempotencyConflictError,
+  CharacterAffectStorage,
+} from "../../src-electron/character-affect-storage.js";
+import { ensureV6Schema } from "../../src-electron/database-schema-v6.js";
+
+function createFixture(): { directory: string; dbPath: string } {
+  const directory = mkdtempSync(join(tmpdir(), "withmate-affect-"));
+  const dbPath = join(directory, "withmate-v6.db");
+  const db = new DatabaseSync(dbPath);
+  try {
+    db.exec("PRAGMA foreign_keys = ON;");
+    ensureV6Schema(db);
+    db.prepare(`
+      INSERT INTO characters (id, name, created_at, updated_at)
+      VALUES ('character-a', 'Character A', '2026-08-09T00:00:00.000Z', '2026-08-09T00:00:00.000Z')
+    `).run();
+    db.prepare(`
+      INSERT INTO characters (id, name, created_at, updated_at)
+      VALUES ('character-b', 'Character B', '2026-08-09T00:00:00.000Z', '2026-08-09T00:00:00.000Z')
+    `).run();
+    const insertSession = db.prepare(`
+      INSERT INTO sessions_v6 (
+        id, title, state, provider_id, catalog_revision, model_id, approval_mode,
+        character_id, character_snapshot_json, created_at, updated_at, last_active_at
+      ) VALUES (?, ?, 'active', 'codex', 1, 'gpt-5', 'on-request', 'character-a', '{}', ?, ?, ?)
+    `);
+    for (const sessionId of ["session-a", "session-b"]) {
+      insertSession.run(
+        sessionId,
+        sessionId,
+        "2026-08-09T00:00:00.000Z",
+        "2026-08-09T00:00:00.000Z",
+        "2026-08-09T00:00:00.000Z",
+      );
+    }
+    db.prepare(`
+      INSERT INTO sessions_v6 (
+        id, title, state, provider_id, catalog_revision, model_id, approval_mode,
+        character_id, character_snapshot_json, created_at, updated_at, last_active_at
+      ) VALUES ('session-other', 'Other', 'active', 'codex', 1, 'gpt-5', 'on-request', 'character-b', '{}', ?, ?, ?)
+    `).run(
+      "2026-08-09T00:00:00.000Z",
+      "2026-08-09T00:00:00.000Z",
+      "2026-08-09T00:00:00.000Z",
+    );
+  } finally {
+    db.close();
+  }
+  return { directory, dbPath };
+}
+
+function event(overrides: Partial<AffectEventInput> = {}): AffectEventInput {
+  return {
+    schemaVersion: AFFECT_SCHEMA_VERSION,
+    characterId: "character-a",
+    userId: "local-user",
+    sessionId: "session-a",
+    layer: "session",
+    targetType: "bug",
+    targetId: "bug-1",
+    value: { label: "frustration", valence: -0.6, arousal: 0.7 },
+    intensity: 0.5,
+    reason: "The same bug recurred.",
+    evidence: "The test failed again.",
+    occurredAt: "2026-08-09T01:00:00.000Z",
+    idempotencyKey: "event-a",
+    ...overrides,
+  };
+}
+
+type WorkerMessage = {
+  type: "locked" | "released" | "ready" | "attempting" | "result" | "error";
+  created?: boolean;
+  eventId?: string;
+  message?: string;
+};
+
+function createMailbox(worker: Worker): { next(type: WorkerMessage["type"]): Promise<WorkerMessage> } {
+  const queued: WorkerMessage[] = [];
+  let exitError: Error | null = null;
+  const waiters: Array<{
+    type: WorkerMessage["type"];
+    resolve(message: WorkerMessage): void;
+    reject(error: Error): void;
+  }> = [];
+  worker.on("message", (message: WorkerMessage) => {
+    if (message.type === "error") {
+      const error = new Error(message.message ?? "Character Affect concurrency worker failed.");
+      const pending = waiters.splice(0);
+      for (const waiter of pending) {
+        waiter.reject(error);
+      }
+      return;
+    }
+    const index = waiters.findIndex((waiter) => waiter.type === message.type);
+    if (index >= 0) {
+      waiters.splice(index, 1)[0]!.resolve(message);
+    } else {
+      queued.push(message);
+    }
+  });
+  worker.on("error", (error) => {
+    exitError = error;
+    const pending = waiters.splice(0);
+    for (const waiter of pending) {
+      waiter.reject(error);
+    }
+  });
+  worker.on("exit", (code) => {
+    if (code === 0 && waiters.length === 0) {
+      return;
+    }
+    exitError = new Error(`Character Affect concurrency worker exited before completing a message (code ${code}).`);
+    const pending = waiters.splice(0);
+    for (const waiter of pending) {
+      waiter.reject(exitError);
+    }
+  });
+  return {
+    next(type) {
+      const index = queued.findIndex((message) => message.type === type);
+      if (index >= 0) {
+        return Promise.resolve(queued.splice(index, 1)[0]!);
+      }
+      if (exitError) {
+        return Promise.reject(exitError);
+      }
+      return new Promise((resolve, reject) => {
+        const waiter = {
+          type,
+          resolve(message: WorkerMessage) {
+            clearTimeout(timeout);
+            resolve(message);
+          },
+          reject(error: Error) {
+            clearTimeout(timeout);
+            reject(error);
+          },
+        };
+        const timeout = setTimeout(() => {
+          const index = waiters.indexOf(waiter);
+          if (index >= 0) {
+            waiters.splice(index, 1);
+          }
+          reject(new Error(`Timed out waiting for Character Affect worker message: ${type}`));
+        }, 10_000);
+        waiters.push(waiter);
+      });
+    },
+  };
+}
+
+async function waitForStarted(counter: Int32Array, count: number): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Atomics.load(counter, 0) < count) {
+    if (Date.now() >= deadline) {
+      throw new Error("Append workers did not reach the concurrency barrier.");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+describe("CharacterAffectStorage", () => {
+  it("別接続のwrite lockと複数Session appendを実際に重ね、busy timeout内で欠落なく直列化する", async () => {
+    const fixture = createFixture();
+    const workerUrl = new URL("./fixtures/character-affect-concurrency-worker.ts", import.meta.url);
+    let blocker: Worker | undefined;
+    const startedBuffer = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT);
+    const started = new Int32Array(startedBuffer);
+    const relationship = event({
+      layer: "relationship",
+      targetType: "relationship",
+      targetId: "local-user:character-a",
+      value: { label: "trust", valence: 0.7 },
+      reason: "Both sessions share relationship trust.",
+      evidence: "The user requested concurrent verification.",
+      occurredAt: "2026-08-09T01:02:00.000Z",
+      idempotencyKey: "concurrent-relationship",
+    });
+    const appendEvents = [
+      event({ idempotencyKey: "concurrent-session-a" }),
+      event({
+        sessionId: "session-b",
+        targetType: "task",
+        targetId: "task-b",
+        value: { label: "satisfaction", valence: 0.8 },
+        reason: "Task B succeeded.",
+        evidence: "Build B passed.",
+        occurredAt: "2026-08-09T01:01:00.000Z",
+        idempotencyKey: "concurrent-session-b",
+      }),
+      relationship,
+      relationship,
+    ];
+    const appendWorkers: Worker[] = [];
+    const appendMailboxes: Array<ReturnType<typeof createMailbox>> = [];
+    try {
+      for (const appendEvent of appendEvents) {
+        const worker = new Worker(workerUrl, {
+          workerData: {
+            mode: "append",
+            dbPath: fixture.dbPath,
+            event: appendEvent,
+            started: startedBuffer,
+          },
+        });
+        const mailbox = createMailbox(worker);
+        appendWorkers.push(worker);
+        appendMailboxes.push(mailbox);
+        await mailbox.next("ready");
+      }
+      blocker = new Worker(workerUrl, { workerData: { mode: "blocker", dbPath: fixture.dbPath } });
+      const blockerMailbox = createMailbox(blocker);
+      await blockerMailbox.next("locked");
+      const resultPromises = appendMailboxes.map((mailbox) => mailbox.next("result"));
+      for (const worker of appendWorkers) {
+        worker.postMessage({ type: "start" });
+      }
+      await Promise.all(appendMailboxes.map((mailbox) => mailbox.next("attempting")));
+      await waitForStarted(started, appendWorkers.length);
+
+      let resultWhileLocked = false;
+      void Promise.race(resultPromises).then(() => {
+        resultWhileLocked = true;
+      });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      assert.equal(resultWhileLocked, false);
+
+      blocker.postMessage({ type: "release" });
+      const results = await Promise.all(resultPromises);
+      await blockerMailbox.next("released");
+      assert.equal(results.filter((result) => result.created === true).length, 3);
+      assert.equal(results.filter((result) => result.created === false).length, 1);
+      assert.equal(new Set(results.map((result) => result.eventId)).size, 3);
+
+      const storage = new CharacterAffectStorage(fixture.dbPath);
+      try {
+        const stateA = storage.getEffectiveState({
+          characterId: "character-a",
+          userId: "local-user",
+          sessionId: "session-a",
+        });
+        const stateB = storage.getEffectiveState({
+          characterId: "character-a",
+          userId: "local-user",
+          sessionId: "session-b",
+        });
+        assert.ok(stateA.components.some((item) => item.targetId === "bug-1"));
+        assert.ok(!stateA.components.some((item) => item.targetId === "task-b"));
+        assert.ok(stateB.components.some((item) => item.targetId === "task-b"));
+        assert.ok(!stateB.components.some((item) => item.targetId === "bug-1"));
+        assert.ok(stateA.components.some((item) => item.label === "trust"));
+        assert.ok(stateB.components.some((item) => item.label === "trust"));
+        assert.equal(storage.getMetrics().idempotencyReplays, 1);
+      } finally {
+        storage.close();
+      }
+
+      const db = new DatabaseSync(fixture.dbPath, { readOnly: true });
+      try {
+        const counts = db.prepare(`
+          SELECT
+            (SELECT COUNT(*) FROM character_affect_events_v6) AS events,
+            (SELECT COUNT(*) FROM character_affect_idempotency_v6) AS idempotency,
+            (SELECT COUNT(*) FROM character_affect_mutations_v6 WHERE operation = 'record') AS records,
+            (SELECT COUNT(*) FROM character_affect_observations_v6 WHERE outcome = 'replayed') AS replays
+        `).get() as { events: number; idempotency: number; records: number; replays: number };
+        assert.deepEqual({ ...counts }, { events: 3, idempotency: 3, records: 3, replays: 1 });
+      } finally {
+        db.close();
+      }
+    } finally {
+      await Promise.allSettled(
+        [...(blocker ? [blocker] : []), ...appendWorkers].map((worker) => worker.terminate()),
+      );
+      rmSync(fixture.directory, { recursive: true, force: true });
+    }
+  });
+
+  it("sessionごとの状態を分離し、relationshipだけを共有する", () => {
+    const fixture = createFixture();
+    const storageA = new CharacterAffectStorage(fixture.dbPath);
+    const storageB = new CharacterAffectStorage(fixture.dbPath);
+    try {
+      storageA.recordEvent(event());
+      storageB.recordEvent(event({
+        sessionId: "session-b",
+        targetId: "task-b",
+        targetType: "task",
+        value: { label: "satisfaction", valence: 0.8 },
+        reason: "Task B succeeded.",
+        evidence: "Build B passed.",
+        occurredAt: "2026-08-09T01:01:00.000Z",
+        idempotencyKey: "event-b",
+      }));
+      storageA.recordEvent(event({
+        layer: "relationship",
+        targetType: "relationship",
+        targetId: "local-user:character-a",
+        value: { label: "trust", valence: 0.7 },
+        reason: "The user checked the result carefully.",
+        evidence: "The user requested a direct verification.",
+        occurredAt: "2026-08-09T01:02:00.000Z",
+        idempotencyKey: "event-relationship",
+      }));
+
+      const stateA = storageA.getEffectiveState({ characterId: "character-a", userId: "local-user", sessionId: "session-a" });
+      const stateB = storageB.getEffectiveState({ characterId: "character-a", userId: "local-user", sessionId: "session-b" });
+      assert.ok(stateA.components.some((item) => item.targetId === "bug-1"));
+      assert.ok(!stateA.components.some((item) => item.targetId === "task-b"));
+      assert.ok(stateB.components.some((item) => item.targetId === "task-b"));
+      assert.ok(!stateB.components.some((item) => item.targetId === "bug-1"));
+      assert.ok(stateA.components.some((item) => item.label === "trust"));
+      assert.ok(stateB.components.some((item) => item.label === "trust"));
+      const sessionBInspection = storageB.inspect({
+        characterId: "character-a",
+        userId: "local-user",
+        sessionId: "session-b",
+      });
+      const relationshipEvent = sessionBInspection.events.find(
+        (item) => item.idempotencyKey === "event-relationship",
+      );
+      assert.ok(relationshipEvent);
+      assert.ok(sessionBInspection.mutations.some((item) => item.eventId === relationshipEvent.id));
+      assert.throws(
+        () => storageA.inspect({
+          characterId: "character-a",
+          userId: "local-user",
+          sessionId: "session-other",
+        }),
+        /does not belong to the Character affect owner/,
+      );
+    } finally {
+      storageA.close();
+      storageB.close();
+      rmSync(fixture.directory, { recursive: true, force: true });
+    }
+  });
+
+  it("retryは二重登録せず、異なるrequestでのkey再利用を拒否する", () => {
+    const fixture = createFixture();
+    const storage = new CharacterAffectStorage(fixture.dbPath);
+    try {
+      const first = storage.recordEvent(event());
+      const replay = storage.recordEvent(event());
+      assert.equal(first.created, true);
+      assert.equal(replay.created, false);
+      assert.equal(replay.event.id, first.event.id);
+      assert.throws(
+        () => storage.recordEvent(event({ reason: "Different request." })),
+        CharacterAffectIdempotencyConflictError,
+      );
+      assert.equal(storage.inspect({ characterId: "character-a", userId: "local-user" }).events.length, 1);
+      assert.equal(storage.getMetrics().idempotencyReplays, 1);
+      assert.equal(storage.getMetrics().idempotencyConflictsRejected, 1);
+    } finally {
+      storage.close();
+      rmSync(fixture.directory, { recursive: true, force: true });
+    }
+  });
+
+  it("optional fieldの省略と明示的undefinedを同じrequestとして扱い、valid JSONを保存する", () => {
+    const fixture = createFixture();
+    const storage = new CharacterAffectStorage(fixture.dbPath);
+    try {
+      const explicitUndefined = event({
+        value: {
+          label: "frustration",
+          valence: -0.4,
+          arousal: undefined,
+          dimensions: undefined,
+        },
+        memoryEpisode: undefined,
+      });
+      const first = storage.recordEvent(explicitUndefined);
+      const replay = storage.recordEvent(event({
+        value: { label: "frustration", valence: -0.4 },
+      }));
+      assert.equal(replay.created, false);
+      assert.equal(replay.event.id, first.event.id);
+      assert.deepEqual(replay.event.value, { label: "frustration", valence: -0.4 });
+    } finally {
+      storage.close();
+      rmSync(fixture.directory, { recursive: true, force: true });
+    }
+  });
+
+  it("idempotency keyを操作横断で所有し、訂正理由も同一request判定へ含める", () => {
+    const fixture = createFixture();
+    const storage = new CharacterAffectStorage(fixture.dbPath);
+    try {
+      const original = storage.recordEvent(event()).event;
+      assert.throws(
+        () => storage.reset({
+          characterId: "character-a",
+          userId: "local-user",
+          layer: "session",
+          sessionId: "session-a",
+          reason: "Conflicting operation.",
+          resetAt: "2026-08-09T02:00:00.000Z",
+          idempotencyKey: "event-a",
+        }),
+        CharacterAffectIdempotencyConflictError,
+      );
+      const correction = {
+        eventId: original.id,
+        replacement: event({ idempotencyKey: "correction-key" }),
+        reason: "First correction reason.",
+      };
+      storage.correctEvent(correction);
+      assert.throws(
+        () => storage.correctEvent({ ...correction, reason: "Different correction reason." }),
+        CharacterAffectIdempotencyConflictError,
+      );
+      assert.equal(storage.getMetrics().idempotencyConflictsRejected, 2);
+    } finally {
+      storage.close();
+      rmSync(fixture.directory, { recursive: true, force: true });
+    }
+  });
+
+  it("schema versionと時系列比較に使えないtimestampをruntime境界で拒否する", () => {
+    const fixture = createFixture();
+    const storage = new CharacterAffectStorage(fixture.dbPath);
+    try {
+      assert.throws(
+        () => storage.recordEvent({ ...event(), schemaVersion: "future-affect" as typeof AFFECT_SCHEMA_VERSION }),
+        /schemaVersion/,
+      );
+      assert.throws(
+        () => storage.recordEvent(event({ occurredAt: "2026-08-09T10:00:00+09:00" })),
+        /canonical UTC timestamp/,
+      );
+      assert.throws(
+        () => storage.reset({
+          characterId: "character-a",
+          userId: "local-user",
+          layer: "session",
+          sessionId: "session-a",
+          reason: "Noncanonical reset.",
+          resetAt: "2026-08-09T11:00:00+09:00",
+          idempotencyKey: "bad-reset-time",
+        }),
+        /canonical UTC timestamp/,
+      );
+    } finally {
+      storage.close();
+      rmSync(fixture.directory, { recursive: true, force: true });
+    }
+  });
+
+  it("baselineと段階的なsession eventを同じownerで合成し、値をclampする", () => {
+    const fixture = createFixture();
+    const storage = new CharacterAffectStorage(fixture.dbPath);
+    try {
+      storage.recordEvent(event({
+        targetType: "self",
+        targetId: "character-a",
+        value: { label: "resolve", valence: 0.8 },
+        intensity: 0.75,
+        idempotencyKey: "resolve-1",
+      }));
+      storage.recordEvent(event({
+        targetType: "self",
+        targetId: "character-a",
+        value: { label: "resolve", valence: 0.8 },
+        intensity: 0.75,
+        occurredAt: "2026-08-09T01:01:00.000Z",
+        idempotencyKey: "resolve-2",
+      }));
+      const state = storage.getEffectiveState({
+        characterId: "character-a",
+        userId: "local-user",
+        sessionId: "session-a",
+        baseline: [{
+          targetType: "self",
+          targetId: "character-a",
+          value: { label: "resolve", valence: 0.6 },
+          intensity: 0.5,
+          reason: "Character baseline.",
+        }],
+      });
+      const resolve = state.components.find((item) => item.label === "resolve");
+      assert.equal(resolve?.valence, 1);
+      assert.equal(resolve?.intensity, 1);
+      assert.deepEqual(resolve?.contributingLayers, ["baseline", "session"]);
+      assert.equal(resolve?.eventIds.length, 2);
+    } finally {
+      storage.close();
+      rmSync(fixture.directory, { recursive: true, force: true });
+    }
+  });
+
+  it("bug targetをrelationshipへ保存できず、session resetはrelationshipを消さない", () => {
+    const fixture = createFixture();
+    const storage = new CharacterAffectStorage(fixture.dbPath);
+    try {
+      assert.throws(
+        () => storage.recordEvent(event({ layer: "relationship" })),
+        /Relationship affect may only target/,
+      );
+      storage.recordEvent(event());
+      const relationship = storage.recordEvent(event({
+        layer: "relationship",
+        targetType: "user",
+        targetId: "local-user",
+        value: { label: "warmth", valence: 0.5 },
+        idempotencyKey: "relationship",
+      })).event;
+      assert.equal(relationship.sessionId, null);
+      assert.equal(relationship.sourceSessionId, "session-a");
+      storage.reset({
+        characterId: "character-a",
+        userId: "local-user",
+        layer: "session",
+        sessionId: "session-a",
+        reason: "User requested a session reset.",
+        resetAt: "2026-08-09T02:00:00.000Z",
+        idempotencyKey: "reset-session-a",
+      });
+      const state = storage.getEffectiveState({ characterId: "character-a", userId: "local-user", sessionId: "session-a" });
+      assert.ok(!state.components.some((item) => item.targetId === "bug-1"));
+      assert.ok(state.components.some((item) => item.label === "warmth"));
+      const inspection = storage.inspect({ characterId: "character-a", userId: "local-user" });
+      const relationshipMutation = inspection.mutations.find(
+        (item) => item.operation === "record" && item.eventId === relationship.id,
+      );
+      assert.equal(relationshipMutation?.sessionId, null);
+      assert.equal(relationshipMutation?.sourceSessionId, "session-a");
+      assert.equal(inspection.events.length, 2);
+      assert.equal(inspection.resets.length, 1);
+      assert.ok(inspection.mutations.some((item) => item.operation === "reset"));
+    } finally {
+      storage.close();
+      rmSync(fixture.directory, { recursive: true, force: true });
+    }
+  });
+
+  it("local-user以外のownerはMemory候補の有無にかかわらず保存しない", () => {
+    const fixture = createFixture();
+    const storage = new CharacterAffectStorage(fixture.dbPath);
+    try {
+      assert.throws(
+        () => storage.recordEvent(event({ userId: "other-user" })),
+        /owner must be local-user/,
+      );
+      assert.equal(storage.getMetrics().events, 0);
+    } finally {
+      storage.close();
+      rmSync(fixture.directory, { recursive: true, force: true });
+    }
+  });
+
+  it("訂正後の投影と元event、mutation auditを同時に確認できる", () => {
+    const fixture = createFixture();
+    const storage = new CharacterAffectStorage(fixture.dbPath);
+    try {
+      const original = storage.recordEvent(event()).event;
+      const replacement = storage.correctEvent({
+        eventId: original.id,
+        replacement: event({
+          value: { label: "determination", valence: 0.4, arousal: 0.5 },
+          intensity: 0.8,
+          reason: "The bug became a solvable task.",
+          evidence: "A reproduction case was isolated.",
+          occurredAt: "2026-08-09T01:05:00.000Z",
+          idempotencyKey: "event-a-correction",
+        }),
+        reason: "Corrected an overstatement.",
+      }).event;
+      const inspection = storage.inspect({ characterId: "character-a", userId: "local-user" });
+      assert.equal(inspection.events.find((item) => item.id === original.id)?.state, "corrected");
+      assert.equal(replacement.correctionOfEventId, original.id);
+      assert.ok(inspection.mutations.some((item) => item.operation === "correct" && item.eventId === replacement.id));
+      const state = storage.getEffectiveState({ characterId: "character-a", userId: "local-user", sessionId: "session-a" });
+      assert.ok(state.components.some((item) => item.label === "determination"));
+      assert.ok(!state.components.some((item) => item.label === "frustration"));
+    } finally {
+      storage.close();
+      rmSync(fixture.directory, { recursive: true, force: true });
+    }
+  });
+
+  it("別sessionのinspectionでもcross-layer correction chainを一式確認できる", () => {
+    const fixture = createFixture();
+    const storage = new CharacterAffectStorage(fixture.dbPath);
+    try {
+      const original = storage.recordEvent(event({
+        layer: "relationship",
+        targetType: "relationship",
+        targetId: "local-user:character-a",
+        value: { label: "trust", valence: 0.6 },
+        idempotencyKey: "relationship-to-correct",
+      })).event;
+      const replacement = storage.correctEvent({
+        eventId: original.id,
+        replacement: event({
+          layer: "session",
+          targetType: "task",
+          targetId: "verification-task",
+          value: { label: "confidence", valence: 0.5 },
+          occurredAt: "2026-08-09T01:05:00.000Z",
+          idempotencyKey: "relationship-to-session-correction",
+        }),
+        reason: "The affect belonged to the task, not the relationship.",
+      }).event;
+
+      const inspection = storage.inspect({
+        characterId: "character-a",
+        userId: "local-user",
+        sessionId: "session-b",
+      });
+      assert.ok(inspection.events.some((item) => item.id === original.id && item.state === "corrected"));
+      assert.ok(inspection.events.some((item) => item.id === replacement.id));
+      assert.ok(inspection.mutations.some(
+        (item) => item.operation === "correct" && item.eventId === replacement.id,
+      ));
+
+      const reverseOriginal = storage.recordEvent(event({
+        targetType: "task",
+        targetId: "relationship-review",
+        value: { label: "caution", valence: -0.2 },
+        occurredAt: "2026-08-09T01:10:00.000Z",
+        idempotencyKey: "session-to-relationship-original",
+      })).event;
+      const reverseReplacement = storage.correctEvent({
+        eventId: reverseOriginal.id,
+        replacement: event({
+          layer: "relationship",
+          targetType: "relationship",
+          targetId: "local-user:character-a",
+          value: { label: "trust", valence: 0.4 },
+          occurredAt: "2026-08-09T01:15:00.000Z",
+          idempotencyKey: "session-to-relationship-correction",
+        }),
+        reason: "The evidence supports relationship trust.",
+      }).event;
+      const reverseInspection = storage.inspect({
+        characterId: "character-a",
+        userId: "local-user",
+        sessionId: "session-b",
+      });
+      assert.ok(reverseInspection.events.some((item) => item.id === reverseOriginal.id));
+      assert.ok(reverseInspection.events.some((item) => item.id === reverseReplacement.id));
+      assert.ok(reverseInspection.mutations.some(
+        (item) => item.operation === "correct" && item.eventId === reverseReplacement.id,
+      ));
+    } finally {
+      storage.close();
+      rmSync(fixture.directory, { recursive: true, force: true });
+    }
+  });
+
+  it("source session削除後もrelationship affectと訂正auditを保持し、session affectだけを削除する", () => {
+    const fixture = createFixture();
+    const storage = new CharacterAffectStorage(fixture.dbPath);
+    try {
+      const relationshipInput = event({
+        layer: "relationship",
+        targetType: "relationship",
+        targetId: "local-user:character-a",
+        value: { label: "trust", valence: 0.7 },
+        idempotencyKey: "durable-relationship",
+      });
+      const relationship = storage.recordEvent(relationshipInput).event;
+      const sessionOriginal = storage.recordEvent(event({
+        targetType: "task",
+        targetId: "shared-work",
+        value: { label: "confidence", valence: 0.3 },
+        occurredAt: "2026-08-09T01:05:00.000Z",
+        idempotencyKey: "session-before-relationship",
+      })).event;
+      const correction = {
+        eventId: sessionOriginal.id,
+        replacement: event({
+          layer: "relationship",
+          targetType: "relationship",
+          targetId: "local-user:character-a",
+          value: { label: "confidence", valence: 0.5 },
+          occurredAt: "2026-08-09T01:10:00.000Z",
+          idempotencyKey: "session-to-durable-relationship",
+        }),
+        reason: "The confidence applies to the relationship.",
+      };
+      const relationshipReplacement = storage.correctEvent(correction).event;
+
+      const db = new DatabaseSync(fixture.dbPath);
+      try {
+        db.exec("PRAGMA foreign_keys = ON;");
+        db.prepare("DELETE FROM sessions_v6 WHERE id = 'session-a'").run();
+        const durableIdempotency = db.prepare(`
+          SELECT COUNT(*) AS count
+          FROM character_affect_idempotency_v6
+          WHERE idempotency_key IN ('durable-relationship', 'session-to-durable-relationship')
+        `).get() as { count: number };
+        assert.equal(durableIdempotency.count, 2);
+      } finally {
+        db.close();
+      }
+
+      const state = storage.getEffectiveState({
+        characterId: "character-a",
+        userId: "local-user",
+        sessionId: "session-b",
+      });
+      assert.ok(state.components.some((item) => item.eventIds.includes(relationship.id)));
+      assert.ok(state.components.some((item) => item.eventIds.includes(relationshipReplacement.id)));
+      const inspection = storage.inspect({ characterId: "character-a", userId: "local-user" });
+      assert.ok(!inspection.events.some((item) => item.id === sessionOriginal.id));
+      assert.equal(inspection.events.find((item) => item.id === relationship.id)?.sourceSessionId, null);
+      assert.equal(
+        inspection.events.find((item) => item.id === relationshipReplacement.id)?.correctionOfEventId,
+        null,
+      );
+      assert.ok(inspection.mutations.some(
+        (item) => item.operation === "correct"
+          && item.eventId === relationshipReplacement.id
+          && item.reason === "The confidence applies to the relationship.",
+      ));
+      assert.equal(storage.getMetrics().relationshipUpdates, 2);
+      assert.equal(storage.getMetrics().sessionUpdates, 0);
+      const delayedRecordReplay = storage.recordEvent(relationshipInput);
+      assert.equal(delayedRecordReplay.created, false);
+      assert.equal(delayedRecordReplay.event.id, relationship.id);
+      const delayedReplay = storage.correctEvent(correction);
+      assert.equal(delayedReplay.created, false);
+      assert.equal(delayedReplay.event.id, relationshipReplacement.id);
+      assert.equal(storage.getMetrics().idempotencyReplays, 2);
+    } finally {
+      storage.close();
+      rmSync(fixture.directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/tests/database-schema-v6.test.ts
+++ b/scripts/tests/database-schema-v6.test.ts
@@ -10,6 +10,7 @@ import {
   APP_DATABASE_V6_SCHEMA_VERSION,
   CREATE_V6_AUDIT_EVENTS_TABLE_SQL,
   CREATE_V6_AUXILIARY_SESSIONS_TABLE_SQL,
+  CREATE_V6_CHARACTER_AFFECT_TABLES_SQL,
   CREATE_V6_CHARACTERS_TABLE_SQL,
   CREATE_V6_MEMORY_PROTECTED_OBJECTS_TABLE_SQL,
   CREATE_V6_PROJECT_SCOPES_TABLE_SQL,
@@ -136,6 +137,16 @@ describe("database-schema-v6", () => {
       };
       assert.equal(row.id, "existing-session");
       assert.equal(row.is_pinned, 0);
+      assert.equal(tableNames(db).includes("character_affect_events_v6"), true);
+      assert.equal(hasForeignKey(db, "character_affect_events_v6", "memory_entry_id", "memory_entries_v6"), true);
+      assert.equal(
+        hasForeignKey(db, "character_affect_events_v6", "supersedes_memory_entry_id", "memory_entries_v6"),
+        true,
+      );
+      assert.equal(
+        hasForeignKey(db, "character_affect_mutations_v6", "source_session_id", "sessions_v6"),
+        true,
+      );
     } finally {
       db.close();
     }
@@ -191,6 +202,77 @@ describe("database-schema-v6", () => {
       legacyMixedDb.exec("CREATE TABLE IF NOT EXISTS project_memory_entries (id TEXT PRIMARY KEY);");
       legacyMixedDb.close();
 
+      const missingAffectProvenanceDir = join(dirPath, "missing-affect-provenance");
+      mkdirSync(missingAffectProvenanceDir);
+      const missingAffectProvenancePath = join(missingAffectProvenanceDir, APP_DATABASE_V6_FILENAME);
+      const missingAffectProvenanceDb = createV6Schema(missingAffectProvenancePath);
+      const mutationSql = tableSql(missingAffectProvenanceDb, "character_affect_mutations_v6");
+      missingAffectProvenanceDb.exec("PRAGMA foreign_keys = OFF;");
+      missingAffectProvenanceDb.exec(mutationSql
+        .replace("CREATE TABLE character_affect_mutations_v6", "CREATE TABLE character_affect_mutations_v6_rebuilt")
+        .replace("    FOREIGN KEY (source_session_id) REFERENCES sessions_v6(id) ON DELETE SET NULL,\n", ""));
+      missingAffectProvenanceDb.exec("DROP TABLE character_affect_mutations_v6;");
+      missingAffectProvenanceDb.exec(
+        "ALTER TABLE character_affect_mutations_v6_rebuilt RENAME TO character_affect_mutations_v6;",
+      );
+      missingAffectProvenanceDb.exec(`
+        CREATE INDEX idx_v6_character_affect_mutations_scope
+        ON character_affect_mutations_v6(character_id, user_id, created_at DESC, id DESC)
+      `);
+      assert.equal(columnNames(missingAffectProvenanceDb, "character_affect_mutations_v6").includes("source_session_id"), true);
+      assert.equal(
+        hasForeignKey(missingAffectProvenanceDb, "character_affect_mutations_v6", "source_session_id", "sessions_v6"),
+        false,
+      );
+      missingAffectProvenanceDb.close();
+
+      const wrongAffectProvenanceDeleteDir = join(dirPath, "wrong-affect-provenance-delete");
+      mkdirSync(wrongAffectProvenanceDeleteDir);
+      const wrongAffectProvenanceDeletePath = join(
+        wrongAffectProvenanceDeleteDir,
+        APP_DATABASE_V6_FILENAME,
+      );
+      const wrongAffectProvenanceDeleteDb = createV6Schema(wrongAffectProvenanceDeletePath);
+      const wrongDeleteMutationSql = tableSql(wrongAffectProvenanceDeleteDb, "character_affect_mutations_v6");
+      wrongAffectProvenanceDeleteDb.exec("PRAGMA foreign_keys = OFF;");
+      wrongAffectProvenanceDeleteDb.exec(wrongDeleteMutationSql
+        .replace("CREATE TABLE character_affect_mutations_v6", "CREATE TABLE character_affect_mutations_v6_rebuilt")
+        .replace(
+          "FOREIGN KEY (source_session_id) REFERENCES sessions_v6(id) ON DELETE SET NULL",
+          "FOREIGN KEY (source_session_id) REFERENCES sessions_v6(id) ON DELETE CASCADE",
+        ));
+      wrongAffectProvenanceDeleteDb.exec("DROP TABLE character_affect_mutations_v6;");
+      wrongAffectProvenanceDeleteDb.exec(
+        "ALTER TABLE character_affect_mutations_v6_rebuilt RENAME TO character_affect_mutations_v6;",
+      );
+      wrongAffectProvenanceDeleteDb.exec(`
+        CREATE INDEX idx_v6_character_affect_mutations_scope
+        ON character_affect_mutations_v6(character_id, user_id, created_at DESC, id DESC)
+      `);
+      wrongAffectProvenanceDeleteDb.close();
+
+      const missingAffectStateCheckDir = join(dirPath, "missing-affect-state-check");
+      mkdirSync(missingAffectStateCheckDir);
+      const missingAffectStateCheckPath = join(missingAffectStateCheckDir, APP_DATABASE_V6_FILENAME);
+      const missingAffectStateCheckDb = createV6Schema(missingAffectStateCheckPath);
+      const affectEventsSql = tableSql(missingAffectStateCheckDb, "character_affect_events_v6");
+      missingAffectStateCheckDb.exec("PRAGMA foreign_keys = OFF;");
+      missingAffectStateCheckDb.exec(affectEventsSql
+        .replace("CREATE TABLE character_affect_events_v6", "CREATE TABLE character_affect_events_v6_rebuilt")
+        .replace("state TEXT NOT NULL DEFAULT 'active' CHECK (state IN ('active', 'corrected'))", "state TEXT NOT NULL DEFAULT 'active'"));
+      missingAffectStateCheckDb.exec("DROP TABLE character_affect_events_v6;");
+      missingAffectStateCheckDb.exec(
+        "ALTER TABLE character_affect_events_v6_rebuilt RENAME TO character_affect_events_v6;",
+      );
+      missingAffectStateCheckDb.exec(`
+        CREATE INDEX idx_v6_character_affect_events_effective
+        ON character_affect_events_v6(character_id, user_id, layer, session_id, state, occurred_at, id);
+
+        CREATE INDEX idx_v6_character_affect_events_target
+        ON character_affect_events_v6(character_id, user_id, target_type, target_id, occurred_at, id)
+      `);
+      missingAffectStateCheckDb.close();
+
       assert.equal(isValidV6Database(validDbPath), true);
       assert.equal(readV6DatabaseUserVersion(validDbPath), APP_DATABASE_V6_SCHEMA_VERSION);
       assert.equal(isValidV6Database(wrongNameDbPath), false);
@@ -199,6 +281,9 @@ describe("database-schema-v6", () => {
       assert.equal(isValidV6Database(partialV6DbPath), false);
       assert.equal(isValidV6Database(malformedV6DbPath), false);
       assert.equal(isValidV6Database(legacyMixedV6DbPath), false);
+      assert.equal(isValidV6Database(missingAffectProvenancePath), false);
+      assert.equal(isValidV6Database(wrongAffectProvenanceDeletePath), false);
+      assert.equal(isValidV6Database(missingAffectStateCheckPath), false);
     } finally {
       rmSync(dirPath, { recursive: true, force: true });
     }
@@ -844,6 +929,7 @@ describe("database-schema-v6", () => {
       for (const statement of CREATE_V6_SCHEMA_SQL) {
         if (
           statement !== CREATE_V6_AUXILIARY_SESSIONS_TABLE_SQL
+          && statement !== CREATE_V6_CHARACTER_AFFECT_TABLES_SQL
           && statement !== CREATE_V6_SESSION_TURNS_TABLE_SQL
           && statement !== CREATE_V6_SESSION_TURN_INTERIMS_TABLE_SQL
           && statement !== CREATE_V6_SESSION_TURN_PROVIDER_OUTPUTS_TABLE_SQL
@@ -927,6 +1013,9 @@ describe("database-schema-v6", () => {
       `);
 
       assert.throws(() => ensureV6Schema(db), /NOT NULL constraint failed/);
+
+      assert.equal(tableNames(db).includes("character_affect_events_v6"), false);
+      assert.equal(tableNames(db).includes("character_affect_idempotency_v6"), false);
 
       assert.deepEqual(columnNames(db, "auxiliary_sessions"), [
         "id",

--- a/scripts/tests/fixtures/character-affect-concurrency-worker.ts
+++ b/scripts/tests/fixtures/character-affect-concurrency-worker.ts
@@ -1,8 +1,8 @@
 import { parentPort, workerData } from "node:worker_threads";
 
 import type { AffectEventInput } from "../../../src/character-affect/affect-contract.js";
-import { CharacterAffectStorage } from "../../../src-electron/character-affect-storage.js";
-import { openAppDatabase } from "../../../src-electron/sqlite-connection.js";
+import { CharacterAffectStorage } from "../../../src-electron/character-affect-storage.ts";
+import { openAppDatabase } from "../../../src-electron/sqlite-connection.ts";
 
 type WorkerData =
   | { mode: "blocker"; dbPath: string }

--- a/scripts/tests/fixtures/character-affect-concurrency-worker.ts
+++ b/scripts/tests/fixtures/character-affect-concurrency-worker.ts
@@ -1,8 +1,16 @@
 import { parentPort, workerData } from "node:worker_threads";
+import { tsImport } from "tsx/esm/api";
 
 import type { AffectEventInput } from "../../../src/character-affect/affect-contract.js";
-import { CharacterAffectStorage } from "../../../src-electron/character-affect-storage.ts";
-import { openAppDatabase } from "../../../src-electron/sqlite-connection.ts";
+
+const { CharacterAffectStorage } = await tsImport(
+  "../../../src-electron/character-affect-storage.ts",
+  import.meta.url,
+) as typeof import("../../../src-electron/character-affect-storage.js");
+const { openAppDatabase } = await tsImport(
+  "../../../src-electron/sqlite-connection.ts",
+  import.meta.url,
+) as typeof import("../../../src-electron/sqlite-connection.js");
 
 type WorkerData =
   | { mode: "blocker"; dbPath: string }

--- a/scripts/tests/fixtures/character-affect-concurrency-worker.ts
+++ b/scripts/tests/fixtures/character-affect-concurrency-worker.ts
@@ -1,0 +1,64 @@
+import { parentPort, workerData } from "node:worker_threads";
+
+import type { AffectEventInput } from "../../../src/character-affect/affect-contract.js";
+import { CharacterAffectStorage } from "../../../src-electron/character-affect-storage.js";
+import { openAppDatabase } from "../../../src-electron/sqlite-connection.js";
+
+type WorkerData =
+  | { mode: "blocker"; dbPath: string }
+  | { mode: "append"; dbPath: string; event: AffectEventInput; started: SharedArrayBuffer };
+
+if (!parentPort) {
+  throw new Error("Character Affect concurrency worker requires a parent port.");
+}
+
+const input = workerData as WorkerData;
+
+if (input.mode === "blocker") {
+  const db = openAppDatabase(input.dbPath);
+  db.exec("BEGIN IMMEDIATE TRANSACTION;");
+  parentPort.postMessage({ type: "locked" });
+  parentPort.once("message", (message: { type?: string }) => {
+    try {
+      if (message.type !== "release") {
+        throw new Error("Unexpected blocker command.");
+      }
+      db.exec("COMMIT;");
+      parentPort.postMessage({ type: "released" });
+    } catch (error) {
+      parentPort.postMessage({
+        type: "error",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      db.close();
+    }
+  });
+} else {
+  const storage = new CharacterAffectStorage(input.dbPath);
+  parentPort.postMessage({ type: "ready" });
+  parentPort.once("message", (message: { type?: string }) => {
+    try {
+      if (message.type !== "start") {
+        throw new Error("Unexpected append command.");
+      }
+      parentPort.postMessage({ type: "attempting" });
+      const started = new Int32Array(input.started);
+      Atomics.add(started, 0, 1);
+      Atomics.notify(started, 0);
+      const result = storage.recordEvent(input.event);
+      parentPort.postMessage({
+        type: "result",
+        created: result.created,
+        eventId: result.event.id,
+      });
+    } catch (error) {
+      parentPort.postMessage({
+        type: "error",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      storage.close();
+    }
+  });
+}

--- a/src-electron/character-affect-memory-adapter.ts
+++ b/src-electron/character-affect-memory-adapter.ts
@@ -1,0 +1,107 @@
+import type { AffectEvaluator } from "../src/character-affect/affect-contract.js";
+import { MEMORY_V6_SCHEMA_VERSION } from "../src/memory-v6/memory-contract.js";
+import { validateMemoryAppendRequest } from "../src/memory-v6/memory-validation.js";
+import {
+  CharacterAffectService,
+  type CharacterAffectEpisodeWriter,
+  type CharacterAffectServiceMode,
+} from "./character-affect-service.js";
+import type { CharacterAffectStorage } from "./character-affect-storage.js";
+import type { MemoryV6ResolvedTarget } from "./memory-v6-schema.js";
+import type { MemoryV6Storage } from "./memory-v6-storage.js";
+
+const LOCAL_USER_ID = "local-user";
+
+export class MemoryV6CharacterAffectEpisodeWriter implements CharacterAffectEpisodeWriter {
+  constructor(private readonly memoryStorage: MemoryV6Storage) {}
+
+  validateEpisode(input: Parameters<CharacterAffectEpisodeWriter["validateEpisode"]>[0]): void {
+    this.validateRequest(input, "character-affect-memory-preflight", true);
+  }
+
+  async writeEpisode(input: Parameters<CharacterAffectEpisodeWriter["writeEpisode"]>[0]): Promise<{ memoryEntryId: string }> {
+    const request = this.validateRequest(input, input.idempotencyKey, false);
+    const target: MemoryV6ResolvedTarget = {
+      owner: { type: "character", id: input.characterId },
+      scope: { type: "character", id: input.characterId },
+    };
+    const result = this.memoryStorage.appendEntry({
+      target,
+      kind: request.kind,
+      title: request.title,
+      body: request.body,
+      preview: request.preview,
+      tags: request.tags,
+      supersedes: request.supersedes,
+      idempotencyKey: request.idempotencyKey,
+      bindingIdHash: LOCAL_USER_ID,
+      source: {
+        type: "agent",
+        sessionId: input.sourceSessionId,
+        messageId: null,
+        providerId: null,
+        appMessageId: null,
+      },
+    });
+    return { memoryEntryId: result.entry.id };
+  }
+
+  private validateRequest(
+    input: Parameters<CharacterAffectEpisodeWriter["validateEpisode"]>[0],
+    idempotencyKey: string,
+    requireActiveSupersedes: boolean,
+  ) {
+    if (input.userId !== LOCAL_USER_ID) {
+      throw new Error("Character Affect Memory episode owner must be local-user.");
+    }
+    if (input.supersedesMemoryEntryId && requireActiveSupersedes) {
+      const predecessor = this.memoryStorage.getEntry(input.supersedesMemoryEntryId);
+      if (
+        !predecessor
+        || predecessor.state !== "active"
+        || predecessor.owner.type !== "character"
+        || predecessor.owner.id !== input.characterId
+        || predecessor.scope.type !== "character"
+        || predecessor.scope.id !== input.characterId
+      ) {
+        throw new Error("Character Affect Memory episode to supersede must be active in the same Character scope.");
+      }
+    }
+    const request = validateMemoryAppendRequest({
+      schemaVersion: MEMORY_V6_SCHEMA_VERSION,
+      target: {
+        owner: "character",
+        scope: "character",
+        character: { type: "id", id: input.characterId },
+      },
+      kind: "context",
+      title: input.candidate.title,
+      body: input.candidate.body,
+      preview: input.candidate.preview,
+      tags: input.candidate.motif
+        ? [{ type: "motif", value: input.candidate.motif }]
+        : [],
+      ...(input.supersedesMemoryEntryId ? { supersedes: [input.supersedesMemoryEntryId] } : {}),
+      idempotencyKey,
+    });
+    if (!request.ok) {
+      throw new Error(`Character Affect Memory episode is invalid: ${request.error.message}`);
+    }
+
+    return request.value;
+  }
+}
+
+export function createCharacterAffectServiceWithMemory(input: {
+  affectStorage: CharacterAffectStorage;
+  memoryStorage: MemoryV6Storage;
+  evaluator: AffectEvaluator;
+  mode?: CharacterAffectServiceMode;
+}): CharacterAffectService {
+  return new CharacterAffectService(
+    input.affectStorage,
+    input.evaluator,
+    new MemoryV6CharacterAffectEpisodeWriter(input.memoryStorage),
+    input.mode,
+  );
+}

--- a/src-electron/character-affect-service.ts
+++ b/src-electron/character-affect-service.ts
@@ -1,0 +1,217 @@
+import {
+  type AffectBaselineComponent,
+  type AffectConversationEvent,
+  type AffectEvaluator,
+  type AffectMemoryEpisodeCandidate,
+  type EffectiveAffectState,
+} from "../src/character-affect/affect-contract.js";
+import {
+  CharacterAffectStorage,
+  type AffectResetInput,
+  type StoredAffectEvent,
+} from "./character-affect-storage.js";
+
+export type CharacterAffectEpisodeWriter = {
+  validateEpisode(input: {
+    characterId: string;
+    userId: string;
+    sourceSessionId: string;
+    candidate: AffectMemoryEpisodeCandidate;
+    supersedesMemoryEntryId?: string;
+  }): void;
+  writeEpisode(input: {
+    characterId: string;
+    userId: string;
+    sourceSessionId: string;
+    sourceEventId: string;
+    idempotencyKey: string;
+    candidate: AffectMemoryEpisodeCandidate;
+    supersedesMemoryEntryId?: string;
+  }): Promise<{ memoryEntryId: string }>;
+};
+
+export type CharacterAffectServiceMode = "shadow" | "active";
+
+export class CharacterAffectService {
+  constructor(
+    private readonly storage: CharacterAffectStorage,
+    private readonly evaluator: AffectEvaluator,
+    private readonly episodeWriter: CharacterAffectEpisodeWriter,
+    private readonly mode: CharacterAffectServiceMode = "shadow",
+  ) {
+    if (!episodeWriter) {
+      throw new Error("Character Affect Memory episode writer is required.");
+    }
+  }
+
+  async evaluateAndRecord(input: {
+    characterId: string;
+    userId: string;
+    characterDefinition: string;
+    baseline: readonly AffectBaselineComponent[];
+    event: AffectConversationEvent;
+  }): Promise<{ mode: CharacterAffectServiceMode; events: StoredAffectEvent[] }> {
+    const current = this.storage.getEffectiveState({
+      characterId: input.characterId,
+      userId: input.userId,
+      sessionId: input.event.sessionId,
+      baseline: input.baseline,
+    });
+    let candidates;
+    try {
+      candidates = await this.evaluator.evaluate({
+        characterId: input.characterId,
+        userId: input.userId,
+        characterDefinition: input.characterDefinition,
+        baseline: input.baseline,
+        current,
+        event: input.event,
+      });
+    } catch (error) {
+      this.storage.recordRejection({
+        characterId: input.characterId,
+        userId: input.userId,
+        sessionId: input.event.sessionId,
+        reason: errorMessage(error),
+      });
+      throw error;
+    }
+
+    const recorded: StoredAffectEvent[] = [];
+    for (const candidate of candidates) {
+      if (
+        candidate.characterId !== input.characterId
+        || candidate.userId !== input.userId
+        || candidate.sessionId !== input.event.sessionId
+      ) {
+        this.storage.recordRejection({
+          characterId: input.characterId,
+          userId: input.userId,
+          sessionId: input.event.sessionId,
+          reason: "Affect evaluator returned a candidate outside the requested owner scope.",
+        });
+        throw new Error("Affect evaluator returned a candidate outside the requested owner scope.");
+      }
+      if (candidate.memoryEpisode) {
+        this.episodeWriter.validateEpisode({
+          characterId: candidate.characterId,
+          userId: candidate.userId,
+          sourceSessionId: candidate.sessionId,
+          candidate: candidate.memoryEpisode,
+        });
+      }
+      let result;
+      try {
+        result = this.storage.recordEvent(candidate);
+      } catch (error) {
+        this.storage.recordRejection({
+          characterId: input.characterId,
+          userId: input.userId,
+          sessionId: input.event.sessionId,
+          reason: errorMessage(error),
+        });
+        throw error;
+      }
+      const event = await this.persistEpisode(result.event, candidate.memoryEpisode);
+      recorded.push(event);
+    }
+    return { mode: this.mode, events: recorded };
+  }
+
+  getEffectiveState(input: {
+    characterId: string;
+    userId: string;
+    sessionId: string;
+    baseline?: readonly AffectBaselineComponent[];
+  }): EffectiveAffectState & { mode: CharacterAffectServiceMode } {
+    return { ...this.storage.getEffectiveState(input), mode: this.mode };
+  }
+
+  async correctEvent(input: Parameters<CharacterAffectStorage["correctEvent"]>[0]) {
+    const original = this.storage.getEvent({
+      eventId: input.eventId,
+      characterId: input.replacement.characterId,
+      userId: input.replacement.userId,
+    });
+    if (!original || original.state !== "active") {
+      const replay = this.storage.correctEvent(input);
+      return {
+        ...replay,
+        event: await this.persistEpisode(
+          replay.event,
+          input.replacement.memoryEpisode,
+          replay.event.supersedesMemoryEntryId ?? undefined,
+        ),
+      };
+    }
+    if (original.memoryEntryId && !input.replacement.memoryEpisode) {
+      throw new Error("Affect correction must provide a replacement Memory episode.");
+    }
+    if (input.replacement.memoryEpisode) {
+      this.episodeWriter.validateEpisode({
+        characterId: input.replacement.characterId,
+        userId: input.replacement.userId,
+        sourceSessionId: input.replacement.sessionId,
+        candidate: input.replacement.memoryEpisode,
+        ...(original.memoryEntryId ? { supersedesMemoryEntryId: original.memoryEntryId } : {}),
+      });
+    }
+    const result = this.storage.correctEvent(input);
+    return {
+      ...result,
+      event: await this.persistEpisode(
+        result.event,
+        input.replacement.memoryEpisode,
+        original.memoryEntryId ?? undefined,
+      ),
+    };
+  }
+
+  reset(input: AffectResetInput) {
+    return this.storage.reset(input);
+  }
+
+  inspect(input: Parameters<CharacterAffectStorage["inspect"]>[0]) {
+    return this.storage.inspect(input);
+  }
+
+  getMetrics() {
+    return this.storage.getMetrics();
+  }
+
+  private async persistEpisode(
+    event: StoredAffectEvent,
+    candidate: AffectMemoryEpisodeCandidate | undefined,
+    supersedesMemoryEntryId?: string,
+  ): Promise<StoredAffectEvent> {
+    if (!candidate) {
+      return event;
+    }
+    this.storage.recordEpisodeCandidate(event.id);
+    if (event.memoryEntryId) {
+      return event;
+    }
+    if (!event.sourceSessionId) {
+      throw new Error("Affect event source session is unavailable for Memory episode creation.");
+    }
+    const episode = await this.episodeWriter.writeEpisode({
+      characterId: event.characterId,
+      userId: event.userId,
+      sourceSessionId: event.sourceSessionId,
+      sourceEventId: event.id,
+      idempotencyKey: `${event.id}:memory-episode`,
+      candidate,
+      ...(supersedesMemoryEntryId ? { supersedesMemoryEntryId } : {}),
+    });
+    this.storage.linkMemoryEpisode(event.id, episode.memoryEntryId);
+    return this.storage.inspect({
+      characterId: event.characterId,
+      userId: event.userId,
+      sessionId: event.sourceSessionId,
+    }).events.find((item) => item.id === event.id)!;
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Unknown affect evaluation rejection.";
+}

--- a/src-electron/character-affect-storage.ts
+++ b/src-electron/character-affect-storage.ts
@@ -1,0 +1,867 @@
+import { createHash, randomUUID } from "node:crypto";
+import { DatabaseSync } from "node:sqlite";
+
+import {
+  AFFECT_SCHEMA_VERSION,
+  assertCanonicalUtcTimestamp,
+  assertValidAffectBaseline,
+  assertValidAffectEvent,
+  type AffectBaselineComponent,
+  type AffectEventInput,
+  type AffectLayer,
+  type AffectTargetType,
+  type AffectValue,
+  type EffectiveAffectComponent,
+  type EffectiveAffectState,
+} from "../src/character-affect/affect-contract.js";
+import { openAppDatabase } from "./sqlite-connection.js";
+
+const LOCAL_USER_ID = "local-user";
+
+export class CharacterAffectIdempotencyConflictError extends Error {
+  constructor() {
+    super("Character affect idempotency key was reused with a different request.");
+    this.name = "CharacterAffectIdempotencyConflictError";
+  }
+}
+
+export type StoredAffectEvent = Omit<AffectEventInput, "sessionId"> & {
+  id: string;
+  sessionId: string | null;
+  sourceSessionId: string | null;
+  state: "active" | "corrected";
+  correctionOfEventId: string | null;
+  memoryEntryId: string | null;
+  supersedesMemoryEntryId: string | null;
+  createdAt: string;
+};
+
+export type AffectResetInput = {
+  characterId: string;
+  userId: string;
+  layer: AffectLayer;
+  sessionId?: string;
+  reason: string;
+  resetAt: string;
+  idempotencyKey: string;
+};
+
+export type AffectMutationRecord = {
+  id: string;
+  operation: "record" | "reject" | "correct" | "reset" | "episode_candidate" | "link_episode";
+  characterId: string;
+  userId: string;
+  sessionId: string | null;
+  sourceSessionId: string | null;
+  eventId: string | null;
+  resetId: string | null;
+  reason: string;
+  createdAt: string;
+};
+
+export type AffectResetRecord = Omit<AffectResetInput, "sessionId"> & {
+  id: string;
+  sessionId: string | null;
+  createdAt: string;
+};
+
+type AffectIdempotencyRow = {
+  operation: "record" | "correct" | "reset";
+  request_fingerprint: string;
+  event_id: string | null;
+  reset_id: string | null;
+};
+
+type AffectEventRow = {
+  id: string;
+  character_id: string;
+  user_id: string;
+  session_id: string | null;
+  source_session_id: string | null;
+  layer: AffectLayer;
+  target_type: AffectTargetType;
+  target_id: string;
+  value_json: string;
+  intensity: number;
+  reason: string;
+  evidence: string;
+  occurred_at: string;
+  idempotency_key: string;
+  request_fingerprint: string;
+  correction_of_event_id: string | null;
+  state: "active" | "corrected";
+  memory_entry_id: string | null;
+  supersedes_memory_entry_id: string | null;
+  created_at: string;
+};
+
+export class CharacterAffectStorage {
+  private readonly db: DatabaseSync;
+
+  constructor(dbPath: string) {
+    this.db = openAppDatabase(dbPath);
+  }
+
+  close(): void {
+    this.db.close();
+  }
+
+  recordEvent(input: AffectEventInput): { event: StoredAffectEvent; created: boolean } {
+    assertValidAffectEvent(input);
+    assertLocalUser(input.userId);
+    const requestFingerprint = fingerprint({ operation: "record", input });
+
+    const outcome = this.transaction(() => {
+      const replay = this.findIdempotency(input.characterId, input.userId, input.idempotencyKey);
+      if (replay) {
+        if (replay.operation !== "record" || replay.request_fingerprint !== requestFingerprint || !replay.event_id) {
+          this.insertObservation("idempotency", "rejected", input, replay.event_id, replay.reset_id, "Conflicting affect request.");
+          return { conflict: true } as const;
+        }
+        this.insertObservation("idempotency", "replayed", input, replay.event_id, null, "Identical affect event replayed.");
+        return { conflict: false, result: { event: toStoredEvent(this.requireEvent(replay.event_id)), created: false } } as const;
+      }
+
+      this.assertSessionOwner(input.sessionId, input.characterId);
+      const eventId = randomUUID();
+      const createdAt = new Date().toISOString();
+      this.insertEvent(eventId, input, requestFingerprint, null, null, createdAt);
+      this.insertIdempotency(input, "record", requestFingerprint, eventId, null, createdAt);
+      this.insertMutation(
+        "record",
+        input.characterId,
+        input.userId,
+        input.layer === "session" ? input.sessionId : null,
+        input.sessionId,
+        eventId,
+        null,
+        input.reason,
+        createdAt,
+      );
+      return { conflict: false, result: { event: toStoredEvent(this.requireEvent(eventId)), created: true } } as const;
+    });
+    if (outcome.conflict) {
+      throw new CharacterAffectIdempotencyConflictError();
+    }
+    return outcome.result;
+  }
+
+  correctEvent(input: {
+    eventId: string;
+    replacement: AffectEventInput;
+    reason: string;
+  }): { event: StoredAffectEvent; created: boolean } {
+    assertValidAffectEvent(input.replacement);
+    assertLocalUser(input.replacement.userId);
+    requireText(input.reason, "reason");
+    const requestFingerprint = fingerprint({
+      operation: "correct",
+      eventId: input.eventId,
+      replacement: input.replacement,
+      reason: input.reason,
+    });
+
+    const outcome = this.transaction(() => {
+      const replay = this.findIdempotency(
+        input.replacement.characterId,
+        input.replacement.userId,
+        input.replacement.idempotencyKey,
+      );
+      if (replay) {
+        if (replay.operation !== "correct" || replay.request_fingerprint !== requestFingerprint || !replay.event_id) {
+          this.insertObservation("idempotency", "rejected", input.replacement, replay.event_id, replay.reset_id, "Conflicting affect correction.");
+          return { conflict: true } as const;
+        }
+        this.insertObservation("idempotency", "replayed", input.replacement, replay.event_id, null, "Identical affect correction replayed.");
+        return { conflict: false, result: { event: toStoredEvent(this.requireEvent(replay.event_id)), created: false } } as const;
+      }
+      this.assertSessionOwner(input.replacement.sessionId, input.replacement.characterId);
+      const original = this.requireEvent(input.eventId);
+      if (
+        original.character_id !== input.replacement.characterId
+        || original.user_id !== input.replacement.userId
+      ) {
+        throw new Error("Correction must remain within the original character and user scope.");
+      }
+      if (original.layer === "session" && original.session_id !== input.replacement.sessionId) {
+        throw new Error("A session affect correction must remain within its original session scope.");
+      }
+      if (original.state !== "active") {
+        throw new Error("Only an active affect event can be corrected.");
+      }
+
+      const eventId = randomUUID();
+      const createdAt = new Date().toISOString();
+      this.insertEvent(
+        eventId,
+        input.replacement,
+        requestFingerprint,
+        original.id,
+        original.memory_entry_id,
+        createdAt,
+      );
+      this.insertIdempotency(input.replacement, "correct", requestFingerprint, eventId, null, createdAt);
+      this.db.prepare("UPDATE character_affect_events_v6 SET state = 'corrected' WHERE id = ?").run(original.id);
+      this.insertMutation(
+        "correct",
+        input.replacement.characterId,
+        input.replacement.userId,
+        input.replacement.layer === "session" ? input.replacement.sessionId : null,
+        input.replacement.sessionId,
+        eventId,
+        null,
+        input.reason,
+        createdAt,
+      );
+      return { conflict: false, result: { event: toStoredEvent(this.requireEvent(eventId)), created: true } } as const;
+    });
+    if (outcome.conflict) {
+      throw new CharacterAffectIdempotencyConflictError();
+    }
+    return outcome.result;
+  }
+
+  reset(input: AffectResetInput): { resetId: string; created: boolean } {
+    requireText(input.characterId, "characterId");
+    requireText(input.userId, "userId");
+    assertLocalUser(input.userId);
+    requireText(input.reason, "reason");
+    requireText(input.idempotencyKey, "idempotencyKey");
+    assertCanonicalUtcTimestamp(input.resetAt, "resetAt");
+    if (input.layer === "session") {
+      requireText(input.sessionId ?? "", "sessionId");
+      this.assertSessionOwner(input.sessionId!, input.characterId);
+    } else if (input.sessionId !== undefined) {
+      throw new Error("Relationship reset must not specify sessionId.");
+    }
+    const requestFingerprint = fingerprint({ operation: "reset", input });
+
+    const outcome = this.transaction(() => {
+      const replay = this.findIdempotency(input.characterId, input.userId, input.idempotencyKey);
+      if (replay) {
+        if (replay.operation !== "reset" || replay.request_fingerprint !== requestFingerprint || !replay.reset_id) {
+          this.insertObservation("idempotency", "rejected", input, replay.event_id, replay.reset_id, "Conflicting affect reset.");
+          return { conflict: true } as const;
+        }
+        this.insertObservation("idempotency", "replayed", input, null, replay.reset_id, "Identical affect reset replayed.");
+        return { conflict: false, result: { resetId: replay.reset_id, created: false } } as const;
+      }
+
+      const resetId = randomUUID();
+      const createdAt = new Date().toISOString();
+      this.db.prepare(`
+        INSERT INTO character_affect_resets_v6 (
+          id, character_id, user_id, session_id, layer, reason, reset_at,
+          idempotency_key, request_fingerprint, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        resetId,
+        input.characterId,
+        input.userId,
+        input.sessionId ?? null,
+        input.layer,
+        input.reason,
+        input.resetAt,
+        input.idempotencyKey,
+        requestFingerprint,
+        createdAt,
+      );
+      this.insertIdempotency(input, "reset", requestFingerprint, null, resetId, createdAt);
+      this.insertMutation(
+        "reset",
+        input.characterId,
+        input.userId,
+        input.sessionId ?? null,
+        input.sessionId ?? null,
+        null,
+        resetId,
+        input.reason,
+        createdAt,
+      );
+      return { conflict: false, result: { resetId, created: true } } as const;
+    });
+    if (outcome.conflict) {
+      throw new CharacterAffectIdempotencyConflictError();
+    }
+    return outcome.result;
+  }
+
+  linkMemoryEpisode(eventId: string, memoryEntryId: string): void {
+    requireText(memoryEntryId, "memoryEntryId");
+    this.transaction(() => {
+      const event = this.requireEvent(eventId);
+      if (event.memory_entry_id && event.memory_entry_id !== memoryEntryId) {
+        throw new Error("Affect event is already linked to another Memory episode.");
+      }
+      if (!event.memory_entry_id) {
+        const changed = this.db.prepare(`
+          UPDATE character_affect_events_v6
+          SET memory_entry_id = ?
+          WHERE id = ?
+        `).run(memoryEntryId, eventId);
+        if (changed.changes !== 1) {
+          throw new Error("Affect event was not found.");
+        }
+        this.insertMutation(
+          "link_episode",
+          event.character_id,
+          event.user_id,
+          event.session_id,
+          event.source_session_id,
+          event.id,
+          null,
+          "Linked Character Memory episode.",
+          new Date().toISOString(),
+        );
+      }
+    });
+  }
+
+  recordEpisodeCandidate(eventId: string): void {
+    this.transaction(() => {
+      const event = this.requireEvent(eventId);
+      const existing = this.db.prepare(`
+        SELECT id FROM character_affect_mutations_v6
+        WHERE operation = 'episode_candidate' AND event_id = ?
+      `).get(eventId);
+      if (!existing) {
+        this.insertMutation(
+          "episode_candidate",
+          event.character_id,
+          event.user_id,
+          event.session_id,
+          event.source_session_id,
+          event.id,
+          null,
+          "Character Memory episode candidate generated.",
+          new Date().toISOString(),
+        );
+      }
+    });
+  }
+
+  recordRejection(input: { characterId: string; userId: string; sessionId: string; reason: string }): void {
+    assertLocalUser(input.userId);
+    this.assertSessionOwner(input.sessionId, input.characterId);
+    this.transaction(() => {
+      this.insertMutation(
+        "reject",
+        input.characterId,
+        input.userId,
+        input.sessionId,
+        input.sessionId,
+        null,
+        null,
+        input.reason,
+        new Date().toISOString(),
+      );
+    });
+  }
+
+  getEvent(input: { eventId: string; characterId: string; userId: string }): StoredAffectEvent | null {
+    assertLocalUser(input.userId);
+    const row = this.db.prepare(`
+      SELECT *
+      FROM character_affect_events_v6
+      WHERE id = ? AND character_id = ? AND user_id = ?
+    `).get(input.eventId, input.characterId, input.userId) as AffectEventRow | undefined;
+    return row ? toStoredEvent(row) : null;
+  }
+
+  getEffectiveState(input: {
+    characterId: string;
+    userId: string;
+    sessionId: string;
+    baseline?: readonly AffectBaselineComponent[];
+  }): EffectiveAffectState {
+    assertLocalUser(input.userId);
+    this.assertSessionOwner(input.sessionId, input.characterId);
+    for (const component of input.baseline ?? []) {
+      assertValidAffectBaseline(component);
+    }
+    const relationshipResetAt = this.latestResetAt(input.characterId, input.userId, "relationship", null);
+    const sessionResetAt = this.latestResetAt(input.characterId, input.userId, "session", input.sessionId);
+    const rows = this.db.prepare(`
+      SELECT *
+      FROM character_affect_events_v6
+      WHERE character_id = ?
+        AND user_id = ?
+        AND state = 'active'
+        AND (
+          (layer = 'relationship' AND occurred_at > ?)
+          OR (layer = 'session' AND session_id = ? AND occurred_at > ?)
+        )
+      ORDER BY occurred_at ASC, id ASC
+    `).all(
+      input.characterId,
+      input.userId,
+      relationshipResetAt,
+      input.sessionId,
+      sessionResetAt,
+    ) as AffectEventRow[];
+
+    const layers = [
+      ...(input.baseline ?? []).map((component) => ({
+        layer: "baseline" as const,
+        targetType: component.targetType,
+        targetId: component.targetId,
+        value: component.value,
+        intensity: component.intensity,
+        reason: component.reason,
+        eventId: null,
+      })),
+      ...rows.map((row) => ({
+        layer: row.layer,
+        targetType: row.target_type,
+        targetId: row.target_id,
+        value: parseValue(row.value_json),
+        intensity: row.intensity,
+        reason: row.reason,
+        eventId: row.id,
+      })),
+    ];
+
+    return {
+      schemaVersion: AFFECT_SCHEMA_VERSION,
+      characterId: input.characterId,
+      userId: input.userId,
+      sessionId: input.sessionId,
+      layers: aggregateComponents(layers, true),
+      components: aggregateComponents(layers, false),
+    };
+  }
+
+  inspect(input: { characterId: string; userId: string; sessionId?: string }): {
+    events: StoredAffectEvent[];
+    resets: AffectResetRecord[];
+    mutations: AffectMutationRecord[];
+  } {
+    assertLocalUser(input.userId);
+    if (input.sessionId) {
+      this.assertSessionOwner(input.sessionId, input.characterId);
+    }
+    const allEvents = this.db.prepare(`
+      SELECT * FROM character_affect_events_v6
+      WHERE character_id = ? AND user_id = ?
+      ORDER BY occurred_at ASC, id ASC
+    `).all(input.characterId, input.userId) as AffectEventRow[];
+    const relevantEventIds = new Set(
+      allEvents
+        .filter((event) => !input.sessionId || event.layer === "relationship" || event.session_id === input.sessionId)
+        .map((event) => event.id),
+    );
+    let expanded = true;
+    while (expanded) {
+      expanded = false;
+      for (const event of allEvents) {
+        const correctionIsRelevant = event.correction_of_event_id
+          ? relevantEventIds.has(event.correction_of_event_id)
+          : false;
+        const originalIsRelevant = event.correction_of_event_id
+          ? relevantEventIds.has(event.id)
+          : false;
+        if (correctionIsRelevant && !relevantEventIds.has(event.id)) {
+          relevantEventIds.add(event.id);
+          expanded = true;
+        }
+        if (originalIsRelevant && !relevantEventIds.has(event.correction_of_event_id!)) {
+          relevantEventIds.add(event.correction_of_event_id!);
+          expanded = true;
+        }
+      }
+    }
+    const events = allEvents.filter((event) => relevantEventIds.has(event.id));
+
+    const allResets = this.db.prepare(`
+      SELECT
+        id,
+        character_id AS characterId,
+        user_id AS userId,
+        session_id AS sessionId,
+        layer,
+        reason,
+        reset_at AS resetAt,
+        idempotency_key AS idempotencyKey,
+        created_at AS createdAt
+      FROM character_affect_resets_v6
+      WHERE character_id = ? AND user_id = ?
+      ORDER BY reset_at ASC, id ASC
+    `).all(input.characterId, input.userId) as AffectResetRecord[];
+    const resets = allResets.filter(
+      (reset) => !input.sessionId || reset.layer === "relationship" || reset.sessionId === input.sessionId,
+    );
+    const relevantResetIds = new Set(resets.map((reset) => reset.id));
+
+    const allMutations = this.db.prepare(`
+      SELECT
+        id,
+        operation,
+        character_id AS characterId,
+        user_id AS userId,
+        session_id AS sessionId,
+        source_session_id AS sourceSessionId,
+        event_id AS eventId,
+        reset_id AS resetId,
+        reason,
+        created_at AS createdAt
+      FROM character_affect_mutations_v6
+      WHERE character_id = ? AND user_id = ?
+      ORDER BY created_at ASC, id ASC
+    `).all(input.characterId, input.userId) as AffectMutationRecord[];
+    const mutations = allMutations.filter(
+      (mutation) => !input.sessionId
+        || mutation.sessionId === input.sessionId
+        || (mutation.eventId ? relevantEventIds.has(mutation.eventId) : false)
+        || (mutation.resetId ? relevantResetIds.has(mutation.resetId) : false),
+    );
+    return { events: events.map(toStoredEvent), resets, mutations };
+  }
+
+  getMetrics(): {
+    events: number;
+    relationshipUpdates: number;
+    sessionUpdates: number;
+    corrections: number;
+    resets: number;
+    linkedEpisodes: number;
+    rejectedEvents: number;
+    episodeCandidates: number;
+    idempotencyReplays: number;
+    idempotencyConflictsRejected: number;
+  } {
+    const eventCounts = this.db.prepare(`
+      SELECT
+        COUNT(*) AS events,
+        SUM(CASE WHEN layer = 'relationship' THEN 1 ELSE 0 END) AS relationshipUpdates,
+        SUM(CASE WHEN layer = 'session' THEN 1 ELSE 0 END) AS sessionUpdates
+      FROM character_affect_events_v6
+    `).get() as { events: number; relationshipUpdates: number | null; sessionUpdates: number | null };
+    const mutationCounts = this.db.prepare(`
+      SELECT
+        SUM(CASE WHEN operation = 'correct' THEN 1 ELSE 0 END) AS corrections,
+        SUM(CASE WHEN operation = 'reset' THEN 1 ELSE 0 END) AS resets,
+        SUM(CASE WHEN operation = 'reject' THEN 1 ELSE 0 END) AS rejectedEvents,
+        SUM(CASE WHEN operation = 'episode_candidate' THEN 1 ELSE 0 END) AS episodeCandidates,
+        SUM(CASE WHEN operation = 'link_episode' THEN 1 ELSE 0 END) AS linkedEpisodes
+      FROM character_affect_mutations_v6
+    `).get() as {
+      corrections: number | null;
+      resets: number | null;
+      rejectedEvents: number | null;
+      episodeCandidates: number | null;
+      linkedEpisodes: number | null;
+    };
+    const observationCounts = this.db.prepare(`
+      SELECT
+        SUM(CASE WHEN kind = 'idempotency' AND outcome = 'replayed' THEN 1 ELSE 0 END) AS replays,
+        SUM(CASE WHEN kind = 'idempotency' AND outcome = 'rejected' THEN 1 ELSE 0 END) AS conflicts
+      FROM character_affect_observations_v6
+    `).get() as { replays: number | null; conflicts: number | null };
+    return {
+      events: eventCounts.events,
+      relationshipUpdates: eventCounts.relationshipUpdates ?? 0,
+      sessionUpdates: eventCounts.sessionUpdates ?? 0,
+      corrections: mutationCounts.corrections ?? 0,
+      resets: mutationCounts.resets ?? 0,
+      rejectedEvents: mutationCounts.rejectedEvents ?? 0,
+      episodeCandidates: mutationCounts.episodeCandidates ?? 0,
+      linkedEpisodes: mutationCounts.linkedEpisodes ?? 0,
+      idempotencyReplays: observationCounts.replays ?? 0,
+      idempotencyConflictsRejected: observationCounts.conflicts ?? 0,
+    };
+  }
+
+  private insertEvent(
+    eventId: string,
+    input: AffectEventInput,
+    requestFingerprint: string,
+    correctionOfEventId: string | null,
+    supersedesMemoryEntryId: string | null,
+    createdAt: string,
+  ): void {
+    this.db.prepare(`
+      INSERT INTO character_affect_events_v6 (
+        id, character_id, user_id, session_id, source_session_id, layer, target_type, target_id,
+        value_json, intensity, reason, evidence, occurred_at, idempotency_key,
+        request_fingerprint, correction_of_event_id, state, memory_entry_id,
+        supersedes_memory_entry_id, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', NULL, ?, ?)
+    `).run(
+      eventId,
+      input.characterId,
+      input.userId,
+      input.layer === "session" ? input.sessionId : null,
+      input.sessionId,
+      input.layer,
+      input.targetType,
+      input.targetId,
+      stableJson(input.value),
+      input.intensity,
+      input.reason,
+      input.evidence,
+      input.occurredAt,
+      input.idempotencyKey,
+      requestFingerprint,
+      correctionOfEventId,
+      supersedesMemoryEntryId,
+      createdAt,
+    );
+  }
+
+  private insertMutation(
+    operation: AffectMutationRecord["operation"],
+    characterId: string,
+    userId: string,
+    sessionId: string | null,
+    sourceSessionId: string | null,
+    eventId: string | null,
+    resetId: string | null,
+    reason: string,
+    createdAt: string,
+  ): void {
+    this.db.prepare(`
+      INSERT INTO character_affect_mutations_v6 (
+        id, operation, character_id, user_id, session_id, source_session_id,
+        event_id, reset_id, reason, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      randomUUID(),
+      operation,
+      characterId,
+      userId,
+      sessionId,
+      sourceSessionId,
+      eventId,
+      resetId,
+      reason,
+      createdAt,
+    );
+  }
+
+  private findIdempotency(characterId: string, userId: string, idempotencyKey: string): AffectIdempotencyRow | undefined {
+    return this.db.prepare(`
+      SELECT operation, request_fingerprint, event_id, reset_id
+      FROM character_affect_idempotency_v6
+      WHERE character_id = ? AND user_id = ? AND idempotency_key = ?
+    `).get(characterId, userId, idempotencyKey) as AffectIdempotencyRow | undefined;
+  }
+
+  private insertIdempotency(
+    input: { characterId: string; userId: string; idempotencyKey: string },
+    operation: AffectIdempotencyRow["operation"],
+    requestFingerprint: string,
+    eventId: string | null,
+    resetId: string | null,
+    createdAt: string,
+  ): void {
+    this.db.prepare(`
+      INSERT INTO character_affect_idempotency_v6 (
+        character_id, user_id, idempotency_key, operation, request_fingerprint,
+        event_id, reset_id, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      input.characterId,
+      input.userId,
+      input.idempotencyKey,
+      operation,
+      requestFingerprint,
+      eventId,
+      resetId,
+      createdAt,
+    );
+  }
+
+  private insertObservation(
+    kind: "idempotency" | "concurrency",
+    outcome: "replayed" | "rejected" | "resolved",
+    input: { characterId: string; userId: string; sessionId?: string },
+    eventId: string | null,
+    resetId: string | null,
+    reason: string,
+  ): void {
+    const sessionId = input.sessionId && this.sessionExists(input.sessionId)
+      ? input.sessionId
+      : null;
+    this.db.prepare(`
+      INSERT INTO character_affect_observations_v6 (
+        id, kind, outcome, character_id, user_id, session_id,
+        event_id, reset_id, reason, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      randomUUID(),
+      kind,
+      outcome,
+      input.characterId,
+      input.userId,
+      sessionId,
+      eventId,
+      resetId,
+      reason,
+      new Date().toISOString(),
+    );
+  }
+
+  private requireEvent(eventId: string): AffectEventRow {
+    const row = this.db.prepare("SELECT * FROM character_affect_events_v6 WHERE id = ?").get(eventId) as
+      | AffectEventRow
+      | undefined;
+    if (!row) {
+      throw new Error("Affect event was not found.");
+    }
+    return row;
+  }
+
+  private latestResetAt(characterId: string, userId: string, layer: AffectLayer, sessionId: string | null): string {
+    const row = this.db.prepare(`
+      SELECT reset_at
+      FROM character_affect_resets_v6
+      WHERE character_id = ? AND user_id = ? AND layer = ? AND session_id IS ?
+      ORDER BY reset_at DESC, id DESC
+      LIMIT 1
+    `).get(characterId, userId, layer, sessionId) as { reset_at: string } | undefined;
+    return row?.reset_at ?? "";
+  }
+
+  private assertSessionOwner(sessionId: string, characterId: string): void {
+    const row = this.db.prepare("SELECT character_id FROM sessions_v6 WHERE id = ?").get(sessionId) as
+      | { character_id: string | null }
+      | undefined;
+    if (!row || row.character_id !== characterId) {
+      throw new Error("Session does not belong to the Character affect owner.");
+    }
+  }
+
+  private sessionExists(sessionId: string): boolean {
+    return Boolean(this.db.prepare("SELECT 1 FROM sessions_v6 WHERE id = ?").get(sessionId));
+  }
+
+  private transaction<T>(run: () => T): T {
+    this.db.exec("BEGIN IMMEDIATE TRANSACTION;");
+    try {
+      const result = run();
+      this.db.exec("COMMIT;");
+      return result;
+    } catch (error) {
+      try {
+        this.db.exec("ROLLBACK;");
+      } catch {
+        // Preserve the original storage failure.
+      }
+      throw error;
+    }
+  }
+}
+
+function toStoredEvent(row: AffectEventRow): StoredAffectEvent {
+  return {
+    schemaVersion: AFFECT_SCHEMA_VERSION,
+    id: row.id,
+    characterId: row.character_id,
+    userId: row.user_id,
+    sessionId: row.session_id,
+    sourceSessionId: row.source_session_id,
+    layer: row.layer,
+    targetType: row.target_type,
+    targetId: row.target_id,
+    value: parseValue(row.value_json),
+    intensity: row.intensity,
+    reason: row.reason,
+    evidence: row.evidence,
+    occurredAt: row.occurred_at,
+    idempotencyKey: row.idempotency_key,
+    state: row.state,
+    correctionOfEventId: row.correction_of_event_id,
+    memoryEntryId: row.memory_entry_id,
+    supersedesMemoryEntryId: row.supersedes_memory_entry_id,
+    createdAt: row.created_at,
+  };
+}
+
+function parseValue(valueJson: string): AffectValue {
+  return JSON.parse(valueJson) as AffectValue;
+}
+
+function aggregateComponents(
+  inputs: Array<{
+    layer: "baseline" | AffectLayer;
+    targetType: AffectTargetType;
+    targetId: string;
+    value: AffectValue;
+    intensity: number;
+    reason: string;
+    eventId: string | null;
+  }>,
+  separateLayers: boolean,
+): EffectiveAffectComponent[] {
+  const groups = new Map<string, EffectiveAffectComponent>();
+  for (const input of inputs) {
+    const key = [separateLayers ? input.layer : "effective", input.targetType, input.targetId, input.value.label].join("\u0000");
+    const current = groups.get(key) ?? {
+      targetType: input.targetType,
+      targetId: input.targetId,
+      label: input.value.label,
+      valence: 0,
+      dimensions: {},
+      intensity: 0,
+      reasons: [],
+      eventIds: [],
+      contributingLayers: [],
+    };
+    current.valence = clamp(current.valence + input.value.valence * input.intensity);
+    if (input.value.arousal !== undefined) {
+      current.arousal = clamp((current.arousal ?? 0) + input.value.arousal * input.intensity);
+    }
+    for (const [dimension, value] of Object.entries(input.value.dimensions ?? {})) {
+      current.dimensions[dimension] = clamp((current.dimensions[dimension] ?? 0) + value * input.intensity);
+    }
+    current.intensity = clamp(current.intensity + input.intensity, 0, 1);
+    current.reasons.push(input.reason);
+    if (input.eventId) {
+      current.eventIds.push(input.eventId);
+    }
+    if (!current.contributingLayers.includes(input.layer)) {
+      current.contributingLayers.push(input.layer);
+    }
+    groups.set(key, current);
+  }
+  return [...groups.values()];
+}
+
+function clamp(value: number, minimum = -1, maximum = 1): number {
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(canonicalJsonValue(value));
+}
+
+function canonicalJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((child) => child === undefined ? null : canonicalJsonValue(child));
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, child]) => child !== undefined)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, child]) => [key, canonicalJsonValue(child)]),
+    );
+  }
+  return value;
+}
+
+function fingerprint(value: unknown): string {
+  return createHash("sha256").update(stableJson(value)).digest("hex");
+}
+
+function requireText(value: string, field: string): void {
+  if (!value.trim()) {
+    throw new Error(`${field} must not be empty.`);
+  }
+}
+
+function assertLocalUser(userId: string): void {
+  if (userId !== LOCAL_USER_ID) {
+    throw new Error("Character affect owner must be local-user.");
+  }
+}

--- a/src-electron/database-schema-v6.ts
+++ b/src-electron/database-schema-v6.ts
@@ -28,6 +28,11 @@ export const REQUIRED_V6_TABLES = [
   "memory_idempotency_forget_results_v6",
   "memory_move_events_v6",
   "memory_protected_objects_v6",
+  "character_affect_events_v6",
+  "character_affect_resets_v6",
+  "character_affect_idempotency_v6",
+  "character_affect_mutations_v6",
+  "character_affect_observations_v6",
 ] as const;
 
 export const FORBIDDEN_V6_TABLES = [
@@ -58,6 +63,11 @@ const REQUIRED_V6_INDEXES = [
   "idx_v6_memory_move_events_idempotency",
   "idx_v6_memory_protected_objects_state",
   "idx_v6_memory_protected_objects_entry",
+  "idx_v6_character_affect_events_effective",
+  "idx_v6_character_affect_events_target",
+  "idx_v6_character_affect_resets_scope",
+  "idx_v6_character_affect_mutations_scope",
+  "idx_v6_character_affect_observations_scope",
 ] as const;
 
 const REQUIRED_V6_TABLE_COLUMNS = {
@@ -207,6 +217,74 @@ const REQUIRED_V6_TABLE_COLUMNS = {
     "updated_at",
     "deleted_at",
   ],
+  character_affect_events_v6: [
+    "id",
+    "character_id",
+    "user_id",
+    "session_id",
+    "source_session_id",
+    "layer",
+    "target_type",
+    "target_id",
+    "value_json",
+    "intensity",
+    "reason",
+    "evidence",
+    "occurred_at",
+    "idempotency_key",
+    "request_fingerprint",
+    "correction_of_event_id",
+    "state",
+    "memory_entry_id",
+    "supersedes_memory_entry_id",
+    "created_at",
+  ],
+  character_affect_resets_v6: [
+    "id",
+    "character_id",
+    "user_id",
+    "session_id",
+    "layer",
+    "reason",
+    "reset_at",
+    "idempotency_key",
+    "request_fingerprint",
+    "created_at",
+  ],
+  character_affect_idempotency_v6: [
+    "character_id",
+    "user_id",
+    "idempotency_key",
+    "operation",
+    "request_fingerprint",
+    "event_id",
+    "reset_id",
+    "created_at",
+  ],
+  character_affect_mutations_v6: [
+    "id",
+    "operation",
+    "character_id",
+    "user_id",
+    "session_id",
+    "source_session_id",
+    "event_id",
+    "reset_id",
+    "reason",
+    "created_at",
+  ],
+  character_affect_observations_v6: [
+    "id",
+    "kind",
+    "outcome",
+    "character_id",
+    "user_id",
+    "session_id",
+    "event_id",
+    "reset_id",
+    "reason",
+    "created_at",
+  ],
 } as const satisfies Record<(typeof REQUIRED_V6_TABLES)[number], readonly string[]>;
 
 export function resolveV6FreshDatabasePath(userDataPath: string): string {
@@ -325,12 +403,24 @@ function hasRequiredIndexes(db: DatabaseSync): boolean {
   return REQUIRED_V6_INDEXES.every((indexName) => indexes.has(indexName));
 }
 
-function hasForeignKey(db: DatabaseSync, tableName: string, fromColumn: string, targetTable: string): boolean {
+function hasForeignKey(
+  db: DatabaseSync,
+  tableName: string,
+  fromColumn: string,
+  targetTable: string,
+  targetColumn = "id",
+  onDelete?: "CASCADE" | "RESTRICT" | "SET NULL",
+): boolean {
   const keys = db.prepare(`PRAGMA foreign_key_list(${tableName})`).all() as Array<{
     from?: unknown;
+    on_delete?: unknown;
     table?: unknown;
+    to?: unknown;
   }>;
-  return keys.some((key) => key.from === fromColumn && key.table === targetTable);
+  return keys.some((key) => key.from === fromColumn
+    && key.table === targetTable
+    && key.to === targetColumn
+    && (onDelete === undefined || key.on_delete === onDelete));
 }
 
 function hasRequiredForeignKeys(db: DatabaseSync): boolean {
@@ -345,7 +435,83 @@ function hasRequiredForeignKeys(db: DatabaseSync): boolean {
     && hasForeignKey(db, "memory_entries_v6", "superseded_by_id", "memory_entries_v6")
     && hasForeignKey(db, "memory_entry_tags_v6", "entry_id", "memory_entries_v6")
     && hasForeignKey(db, "memory_idempotency_keys_v6", "response_entry_id", "memory_entries_v6")
-    && hasForeignKey(db, "memory_protected_objects_v6", "entry_id", "memory_entries_v6");
+    && hasForeignKey(db, "memory_protected_objects_v6", "entry_id", "memory_entries_v6")
+    && hasForeignKey(db, "character_affect_events_v6", "character_id", "characters", "id", "CASCADE")
+    && hasForeignKey(db, "character_affect_events_v6", "session_id", "sessions_v6", "id", "CASCADE")
+    && hasForeignKey(db, "character_affect_events_v6", "source_session_id", "sessions_v6", "id", "SET NULL")
+    && hasForeignKey(
+      db,
+      "character_affect_events_v6",
+      "correction_of_event_id",
+      "character_affect_events_v6",
+      "id",
+      "SET NULL",
+    )
+    && hasForeignKey(db, "character_affect_events_v6", "memory_entry_id", "memory_entries_v6", "id", "SET NULL")
+    && hasForeignKey(
+      db,
+      "character_affect_events_v6",
+      "supersedes_memory_entry_id",
+      "memory_entries_v6",
+      "id",
+      "SET NULL",
+    )
+    && hasForeignKey(db, "character_affect_resets_v6", "character_id", "characters", "id", "CASCADE")
+    && hasForeignKey(db, "character_affect_resets_v6", "session_id", "sessions_v6", "id", "CASCADE")
+    && hasForeignKey(db, "character_affect_idempotency_v6", "character_id", "characters", "id", "CASCADE")
+    && hasForeignKey(
+      db,
+      "character_affect_idempotency_v6",
+      "event_id",
+      "character_affect_events_v6",
+      "id",
+      "CASCADE",
+    )
+    && hasForeignKey(
+      db,
+      "character_affect_idempotency_v6",
+      "reset_id",
+      "character_affect_resets_v6",
+      "id",
+      "CASCADE",
+    )
+    && hasForeignKey(db, "character_affect_mutations_v6", "character_id", "characters", "id", "CASCADE")
+    && hasForeignKey(db, "character_affect_mutations_v6", "session_id", "sessions_v6", "id", "SET NULL")
+    && hasForeignKey(db, "character_affect_mutations_v6", "source_session_id", "sessions_v6", "id", "SET NULL")
+    && hasForeignKey(
+      db,
+      "character_affect_mutations_v6",
+      "event_id",
+      "character_affect_events_v6",
+      "id",
+      "SET NULL",
+    )
+    && hasForeignKey(
+      db,
+      "character_affect_mutations_v6",
+      "reset_id",
+      "character_affect_resets_v6",
+      "id",
+      "SET NULL",
+    )
+    && hasForeignKey(db, "character_affect_observations_v6", "character_id", "characters", "id", "CASCADE")
+    && hasForeignKey(db, "character_affect_observations_v6", "session_id", "sessions_v6", "id", "SET NULL")
+    && hasForeignKey(
+      db,
+      "character_affect_observations_v6",
+      "event_id",
+      "character_affect_events_v6",
+      "id",
+      "SET NULL",
+    )
+    && hasForeignKey(
+      db,
+      "character_affect_observations_v6",
+      "reset_id",
+      "character_affect_resets_v6",
+      "id",
+      "SET NULL",
+    );
 }
 
 function tableSql(db: DatabaseSync, tableName: string): string {
@@ -365,6 +531,11 @@ function hasRequiredCheckConstraints(db: DatabaseSync): boolean {
   const mutationEventsSql = tableSql(db, "memory_mutation_events_v6");
   const idempotencySql = tableSql(db, "memory_idempotency_keys_v6");
   const protectedObjectsSql = tableSql(db, "memory_protected_objects_v6");
+  const affectEventsSql = tableSql(db, "character_affect_events_v6");
+  const affectResetsSql = tableSql(db, "character_affect_resets_v6");
+  const affectIdempotencySql = tableSql(db, "character_affect_idempotency_v6");
+  const affectMutationsSql = tableSql(db, "character_affect_mutations_v6");
+  const affectObservationsSql = tableSql(db, "character_affect_observations_v6");
 
   return sessionsSql.includes("json_valid(character_snapshot_json)")
     && memoryEntriesSql.includes("state IN ('active', 'superseded', 'forgotten')")
@@ -383,7 +554,27 @@ function hasRequiredCheckConstraints(db: DatabaseSync): boolean {
     && protectedObjectsSql.includes("state IN ('active', 'delete_pending', 'deleted')")
     && protectedObjectsSql.includes("role IN ('evidence', 'source', 'snapshot', 'artifact', 'reference', 'other')")
     && protectedObjectsSql.includes("original_bytes >= 0")
-    && protectedObjectsSql.includes("stored_bytes >= 0");
+    && protectedObjectsSql.includes("stored_bytes >= 0")
+    && affectEventsSql.includes("layer IN ('relationship', 'session')")
+    && affectEventsSql.includes("target_type IN ('user', 'relationship', 'task', 'bug', 'artifact', 'self')")
+    && affectEventsSql.includes("json_valid(value_json)")
+    && affectEventsSql.includes("intensity >= 0 AND intensity <= 1")
+    && affectEventsSql.includes("state IN ('active', 'corrected')")
+    && affectEventsSql.includes("user_id <> ''")
+    && affectEventsSql.includes("target_id <> ''")
+    && affectEventsSql.includes("layer <> 'relationship' OR target_type IN ('user', 'relationship')")
+    && affectEventsSql.includes("layer = 'session' AND session_id IS NOT NULL AND source_session_id = session_id")
+    && affectEventsSql.includes("layer = 'relationship' AND session_id IS NULL")
+    && affectResetsSql.includes("layer IN ('relationship', 'session')")
+    && affectResetsSql.includes("layer = 'session' AND session_id IS NOT NULL")
+    && affectResetsSql.includes("layer = 'relationship' AND session_id IS NULL")
+    && affectIdempotencySql.includes("operation IN ('record', 'correct', 'reset')")
+    && affectIdempotencySql.includes("PRIMARY KEY (character_id, user_id, idempotency_key)")
+    && affectIdempotencySql.includes("operation IN ('record', 'correct') AND event_id IS NOT NULL AND reset_id IS NULL")
+    && affectIdempotencySql.includes("operation = 'reset' AND event_id IS NULL AND reset_id IS NOT NULL")
+    && affectMutationsSql.includes("operation IN ('record', 'reject', 'correct', 'reset', 'episode_candidate', 'link_episode')")
+    && affectObservationsSql.includes("kind IN ('idempotency', 'concurrency')")
+    && affectObservationsSql.includes("outcome IN ('replayed', 'rejected', 'resolved')");
 }
 
 function hasNoForeignKeyViolations(db: DatabaseSync): boolean {
@@ -915,6 +1106,131 @@ export const CREATE_V6_MEMORY_MOVE_EVENTS_TABLE_SQL = `
     ON memory_move_events_v6(entry_id, created_at DESC);
 `;
 
+export const CREATE_V6_CHARACTER_AFFECT_TABLES_SQL = `
+  CREATE TABLE IF NOT EXISTS character_affect_events_v6 (
+    id TEXT PRIMARY KEY,
+    character_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    session_id TEXT,
+    source_session_id TEXT,
+    layer TEXT NOT NULL CHECK (layer IN ('relationship', 'session')),
+    target_type TEXT NOT NULL CHECK (target_type IN ('user', 'relationship', 'task', 'bug', 'artifact', 'self')),
+    target_id TEXT NOT NULL,
+    value_json TEXT NOT NULL CHECK (json_valid(value_json)),
+    intensity REAL NOT NULL CHECK (intensity >= 0 AND intensity <= 1),
+    reason TEXT NOT NULL,
+    evidence TEXT NOT NULL,
+    occurred_at TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    request_fingerprint TEXT NOT NULL,
+    correction_of_event_id TEXT,
+    state TEXT NOT NULL DEFAULT 'active' CHECK (state IN ('active', 'corrected')),
+    memory_entry_id TEXT,
+    supersedes_memory_entry_id TEXT,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (character_id) REFERENCES characters(id) ON DELETE CASCADE,
+    FOREIGN KEY (session_id) REFERENCES sessions_v6(id) ON DELETE CASCADE,
+    FOREIGN KEY (source_session_id) REFERENCES sessions_v6(id) ON DELETE SET NULL,
+    FOREIGN KEY (correction_of_event_id) REFERENCES character_affect_events_v6(id) ON DELETE SET NULL,
+    FOREIGN KEY (memory_entry_id) REFERENCES memory_entries_v6(id) ON DELETE SET NULL,
+    FOREIGN KEY (supersedes_memory_entry_id) REFERENCES memory_entries_v6(id) ON DELETE SET NULL,
+    UNIQUE (character_id, user_id, idempotency_key),
+    CHECK (user_id <> ''),
+    CHECK (target_id <> ''),
+    CHECK (layer <> 'relationship' OR target_type IN ('user', 'relationship')),
+    CHECK (
+      (layer = 'session' AND session_id IS NOT NULL AND source_session_id = session_id)
+      OR (layer = 'relationship' AND session_id IS NULL)
+    )
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_v6_character_affect_events_effective
+    ON character_affect_events_v6(character_id, user_id, layer, session_id, state, occurred_at, id);
+
+  CREATE INDEX IF NOT EXISTS idx_v6_character_affect_events_target
+    ON character_affect_events_v6(character_id, user_id, target_type, target_id, occurred_at, id);
+
+  CREATE TABLE IF NOT EXISTS character_affect_resets_v6 (
+    id TEXT PRIMARY KEY,
+    character_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    session_id TEXT,
+    layer TEXT NOT NULL CHECK (layer IN ('relationship', 'session')),
+    reason TEXT NOT NULL,
+    reset_at TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    request_fingerprint TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (character_id) REFERENCES characters(id) ON DELETE CASCADE,
+    FOREIGN KEY (session_id) REFERENCES sessions_v6(id) ON DELETE CASCADE,
+    UNIQUE (character_id, user_id, idempotency_key),
+    CHECK ((layer = 'session' AND session_id IS NOT NULL) OR (layer = 'relationship' AND session_id IS NULL))
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_v6_character_affect_resets_scope
+    ON character_affect_resets_v6(character_id, user_id, layer, session_id, reset_at DESC, id DESC);
+
+  CREATE TABLE IF NOT EXISTS character_affect_idempotency_v6 (
+    character_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    operation TEXT NOT NULL CHECK (operation IN ('record', 'correct', 'reset')),
+    request_fingerprint TEXT NOT NULL,
+    event_id TEXT,
+    reset_id TEXT,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (character_id, user_id, idempotency_key),
+    FOREIGN KEY (character_id) REFERENCES characters(id) ON DELETE CASCADE,
+    FOREIGN KEY (event_id) REFERENCES character_affect_events_v6(id) ON DELETE CASCADE,
+    FOREIGN KEY (reset_id) REFERENCES character_affect_resets_v6(id) ON DELETE CASCADE,
+    CHECK (
+      (operation IN ('record', 'correct') AND event_id IS NOT NULL AND reset_id IS NULL)
+      OR (operation = 'reset' AND event_id IS NULL AND reset_id IS NOT NULL)
+    )
+  );
+
+  CREATE TABLE IF NOT EXISTS character_affect_mutations_v6 (
+    id TEXT PRIMARY KEY,
+    operation TEXT NOT NULL CHECK (operation IN ('record', 'reject', 'correct', 'reset', 'episode_candidate', 'link_episode')),
+    character_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    session_id TEXT,
+    source_session_id TEXT,
+    event_id TEXT,
+    reset_id TEXT,
+    reason TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (character_id) REFERENCES characters(id) ON DELETE CASCADE,
+    FOREIGN KEY (session_id) REFERENCES sessions_v6(id) ON DELETE SET NULL,
+    FOREIGN KEY (source_session_id) REFERENCES sessions_v6(id) ON DELETE SET NULL,
+    FOREIGN KEY (event_id) REFERENCES character_affect_events_v6(id) ON DELETE SET NULL,
+    FOREIGN KEY (reset_id) REFERENCES character_affect_resets_v6(id) ON DELETE SET NULL
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_v6_character_affect_mutations_scope
+    ON character_affect_mutations_v6(character_id, user_id, created_at DESC, id DESC);
+
+  CREATE TABLE IF NOT EXISTS character_affect_observations_v6 (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL CHECK (kind IN ('idempotency', 'concurrency')),
+    outcome TEXT NOT NULL CHECK (outcome IN ('replayed', 'rejected', 'resolved')),
+    character_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    session_id TEXT,
+    event_id TEXT,
+    reset_id TEXT,
+    reason TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (character_id) REFERENCES characters(id) ON DELETE CASCADE,
+    FOREIGN KEY (session_id) REFERENCES sessions_v6(id) ON DELETE SET NULL,
+    FOREIGN KEY (event_id) REFERENCES character_affect_events_v6(id) ON DELETE SET NULL,
+    FOREIGN KEY (reset_id) REFERENCES character_affect_resets_v6(id) ON DELETE SET NULL
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_v6_character_affect_observations_scope
+    ON character_affect_observations_v6(character_id, user_id, created_at DESC, id DESC);
+`;
+
 export const CREATE_V6_SCHEMA_SQL = [
   CREATE_V6_APP_SETTINGS_TABLE_SQL,
   CREATE_V6_MODEL_CATALOG_TABLES_SQL,
@@ -935,6 +1251,7 @@ export const CREATE_V6_SCHEMA_SQL = [
   CREATE_V6_MEMORY_IDEMPOTENCY_FORGET_RESULTS_TABLE_SQL,
   CREATE_V6_MEMORY_MOVE_EVENTS_TABLE_SQL,
   CREATE_V6_MEMORY_PROTECTED_OBJECTS_TABLE_SQL,
+  CREATE_V6_CHARACTER_AFFECT_TABLES_SQL,
   `PRAGMA user_version = ${APP_DATABASE_V6_SCHEMA_VERSION};`,
 ] as const;
 

--- a/src/character-affect/affect-contract.ts
+++ b/src/character-affect/affect-contract.ts
@@ -1,0 +1,156 @@
+export const AFFECT_SCHEMA_VERSION = "withmate-affect-v1" as const;
+
+export type AffectLayer = "relationship" | "session";
+export type AffectTargetType = "user" | "relationship" | "task" | "bug" | "artifact" | "self";
+
+export type AffectValue = {
+  label: string;
+  valence: number;
+  arousal?: number;
+  dimensions?: Record<string, number>;
+};
+
+export type AffectBaselineComponent = {
+  targetType: "self" | "relationship";
+  targetId: string;
+  value: AffectValue;
+  intensity: number;
+  reason: string;
+};
+
+export type AffectEventInput = {
+  schemaVersion: typeof AFFECT_SCHEMA_VERSION;
+  characterId: string;
+  userId: string;
+  sessionId: string;
+  layer: AffectLayer;
+  targetType: AffectTargetType;
+  targetId: string;
+  value: AffectValue;
+  intensity: number;
+  reason: string;
+  evidence: string;
+  occurredAt: string;
+  idempotencyKey: string;
+  memoryEpisode?: AffectMemoryEpisodeCandidate;
+};
+
+export type AffectMemoryEpisodeCandidate = {
+  title: string;
+  body: string;
+  preview: string;
+  motif?: string;
+  salience: number;
+};
+
+export type AffectConversationEvent = {
+  sessionId: string;
+  summary: string;
+  occurredAt: string;
+  sourceMessageId?: string;
+};
+
+export type AffectEvaluationContext = {
+  characterId: string;
+  userId: string;
+  characterDefinition: string;
+  baseline: readonly AffectBaselineComponent[];
+  current: EffectiveAffectState;
+  event: AffectConversationEvent;
+};
+
+export type AffectEvaluator = {
+  evaluate(context: AffectEvaluationContext): Promise<readonly AffectEventInput[]>;
+};
+
+export type EffectiveAffectComponent = {
+  targetType: AffectTargetType;
+  targetId: string;
+  label: string;
+  valence: number;
+  arousal?: number;
+  dimensions: Record<string, number>;
+  intensity: number;
+  reasons: string[];
+  eventIds: string[];
+  contributingLayers: Array<"baseline" | AffectLayer>;
+};
+
+export type EffectiveAffectState = {
+  schemaVersion: typeof AFFECT_SCHEMA_VERSION;
+  characterId: string;
+  userId: string;
+  sessionId: string;
+  layers: EffectiveAffectComponent[];
+  components: EffectiveAffectComponent[];
+};
+
+export function assertValidAffectEvent(input: AffectEventInput): void {
+  if (input.schemaVersion !== AFFECT_SCHEMA_VERSION) {
+    throw new Error(`schemaVersion must be ${AFFECT_SCHEMA_VERSION}.`);
+  }
+  requireNonEmpty(input.characterId, "characterId");
+  requireNonEmpty(input.userId, "userId");
+  requireNonEmpty(input.sessionId, "sessionId");
+  requireNonEmpty(input.targetId, "targetId");
+  requireNonEmpty(input.value.label, "value.label");
+  requireNonEmpty(input.reason, "reason");
+  requireNonEmpty(input.evidence, "evidence");
+  requireNonEmpty(input.idempotencyKey, "idempotencyKey");
+  assertFiniteRange(input.value.valence, -1, 1, "value.valence");
+  if (input.value.arousal !== undefined) {
+    assertFiniteRange(input.value.arousal, -1, 1, "value.arousal");
+  }
+  for (const [key, value] of Object.entries(input.value.dimensions ?? {})) {
+    requireNonEmpty(key, "value.dimensions key");
+    assertFiniteRange(value, -1, 1, `value.dimensions.${key}`);
+  }
+  assertFiniteRange(input.intensity, 0, 1, "intensity");
+  assertCanonicalUtcTimestamp(input.occurredAt, "occurredAt");
+  if (input.layer === "relationship" && input.targetType !== "user" && input.targetType !== "relationship") {
+    throw new Error("Relationship affect may only target the user or relationship.");
+  }
+  if (input.memoryEpisode) {
+    requireNonEmpty(input.memoryEpisode.title, "memoryEpisode.title");
+    requireNonEmpty(input.memoryEpisode.body, "memoryEpisode.body");
+    requireNonEmpty(input.memoryEpisode.preview, "memoryEpisode.preview");
+    if (input.memoryEpisode.motif !== undefined) {
+      requireNonEmpty(input.memoryEpisode.motif, "memoryEpisode.motif");
+    }
+    assertFiniteRange(input.memoryEpisode.salience, 0, 1, "memoryEpisode.salience");
+  }
+}
+
+export function assertValidAffectBaseline(component: AffectBaselineComponent): void {
+  requireNonEmpty(component.targetId, "baseline.targetId");
+  requireNonEmpty(component.value.label, "baseline.value.label");
+  requireNonEmpty(component.reason, "baseline.reason");
+  assertFiniteRange(component.value.valence, -1, 1, "baseline.value.valence");
+  if (component.value.arousal !== undefined) {
+    assertFiniteRange(component.value.arousal, -1, 1, "baseline.value.arousal");
+  }
+  for (const [key, value] of Object.entries(component.value.dimensions ?? {})) {
+    requireNonEmpty(key, "baseline.value.dimensions key");
+    assertFiniteRange(value, -1, 1, `baseline.value.dimensions.${key}`);
+  }
+  assertFiniteRange(component.intensity, 0, 1, "baseline.intensity");
+}
+
+export function assertCanonicalUtcTimestamp(value: string, field: string): void {
+  const timestamp = new Date(value);
+  if (!Number.isFinite(timestamp.getTime()) || timestamp.toISOString() !== value) {
+    throw new Error(`${field} must be a canonical UTC timestamp.`);
+  }
+}
+
+function requireNonEmpty(value: string, field: string): void {
+  if (!value.trim()) {
+    throw new Error(`${field} must not be empty.`);
+  }
+}
+
+function assertFiniteRange(value: number, minimum: number, maximum: number, field: string): void {
+  if (!Number.isFinite(value) || value < minimum || value > maximum) {
+    throw new Error(`${field} must be between ${minimum} and ${maximum}.`);
+  }
+}


### PR DESCRIPTION
## 概要

Characterごとの感情状態をbaseline、relationship、sessionの各layerへ分離し、append-only eventとしてV6 DBへ永続化します。Character Memory episodeは既存Memory V6の正規境界へ接続し、作成、retry、訂正、forgetのライフサイクルを一貫して扱います。

## 主な変更

- Character Affectの型、validation、storage、application serviceを追加
- Memory V6 episode adapterとidempotentな部分成功リカバリを追加
- scope、provenance、監査、訂正、resetの永続化schemaを追加
- 別SQLite接続のtransactionを実際に重ねるworker barrier testを追加
- 永続化、並行更新、cross-storage収束の判断をADR 018へ記録
- ISSUE-251の完了証拠をtask-local planへ記録

## 検証

- Character Affect / Memory V6 targeted tests: 86/86 pass
- Character Affect storage tests: 12/12 pass
- database-schema-v6 tests: 13/13 pass
- `npm run typecheck`: pass
- `npm test`: 2210 tests、2209 pass、1 skip、0 fail
- `npm run build`: pass
- `git diff --check`: pass

## Review

- holistic complete-diff review: 1回実施
- 最終Candidateのtargeted closure: 2件ともapprove
- 未解決blocking finding、accepted risk、validation gap: なし

Draft Issue ID: `WM-AFFECT-CORE`