### PR TITLE
style(chat): スプリッター周囲の余白を広げる

### DIFF
--- a/scripts/tests/session-chat-layout-hooks.test.tsx
+++ b/scripts/tests/session-chat-layout-hooks.test.tsx
@@ -34,7 +34,7 @@ test("vertical dock height は比率上限と中央領域の最小高を優先�
     minHeight: 180,
     maxHeightRatio: 0.4,
     oppositeDockHeight: 64,
-  }), 52);
+  }), 36);
 });
 
 test("vertical dock layout は border-box から padding と border を除いた高さを使う", () => {
@@ -68,7 +68,7 @@ test("vertical dock layout は border-box から padding と border を除いた
       minHeight: 180,
       maxHeightRatio: 0.4,
       oppositeDockHeight: 64,
-    }), 207);
+    }), 191);
   } finally {
     dom.window.close();
     Object.defineProperty(globalThis, "window", { configurable: true, value: previousWindow });

--- a/scripts/tests/session-context-pane-style.test.ts
+++ b/scripts/tests/session-context-pane-style.test.ts
@@ -104,7 +104,7 @@ test("splitter が選んだ優先軸に応じて side pane または上下 dock 
   assert.match(stylesSource, /\.session-chat-layout\.is-header-visible\s*{[\s\S]*?--session-header-dock-row-height:\s*64px;/);
   assert.match(
     stylesSource,
-    /\.session-chat-layout\.is-action-dock-expanded\s*{[\s\S]*?--session-action-dock-row-height:\s*max\([\s\S]*?min\([\s\S]*?var\(--session-action-dock-height, 320px\),[\s\S]*?40dvh,[\s\S]*?calc\(100dvh - var\(--session-header-dock-row-height\) - 326px\)/,
+    /\.session-chat-layout\.is-action-dock-expanded\s*{[\s\S]*?--session-action-dock-row-height:\s*max\([\s\S]*?min\([\s\S]*?var\(--session-action-dock-height, 320px\),[\s\S]*?40dvh,[\s\S]*?calc\(100dvh - var\(--session-header-dock-row-height\) - 342px\)/,
   );
   assert.match(chatWindowSource, /session-action-dock-content session-action-dock-expanded-content/);
   assert.match(stylesSource, /\.session-action-dock-slot\.is-expanded \.composer > :not\(\.composer-input-row\)\s*{[\s\S]*?flex:\s*0 0 auto;/);
@@ -117,6 +117,30 @@ test("splitter が選んだ優先軸に応じて side pane または上下 dock 
 test("splitter の枠は各 track に収まり、modal より背面に残る", async () => {
   const stylesSource = await readFile("src/styles.css", "utf8");
 
+  assert.match(
+    stylesSource,
+    /\.session-chat-layout\s*{[\s\S]*?--session-dock-splitter-size:\s*20px;[\s\S]*?grid-template-rows:[\s\S]*?var\(--session-dock-splitter-size\)[\s\S]*?minmax\(280px,\s*1fr\)[\s\S]*?var\(--session-dock-splitter-size\);/,
+  );
+  assert.match(
+    stylesSource,
+    /\.session-chat-layout\.layout-priority-side-pane\s*{[\s\S]*?grid-template-columns:[\s\S]*?var\(--session-dock-splitter-size\)[\s\S]*?minmax\(0,\s*1fr\)[\s\S]*?var\(--session-dock-splitter-size\);/,
+  );
+  assert.match(
+    stylesSource,
+    /\.session-dock-splitter\.edge-left,[\s\S]*?\.session-dock-splitter\.edge-right\s*{[\s\S]*?width:\s*var\(--session-dock-splitter-size\);/,
+  );
+  assert.match(
+    stylesSource,
+    /\.session-dock-splitter\.edge-top,[\s\S]*?\.session-dock-splitter\.edge-bottom\s*{[\s\S]*?height:\s*var\(--session-dock-splitter-size\);/,
+  );
+  assert.match(
+    stylesSource,
+    /\.session-dock-splitter::before\s*{[\s\S]*?inset:\s*8px;/,
+  );
+  assert.match(
+    stylesSource,
+    /\.session-dock-splitter\.edge-top::before,[\s\S]*?\.session-dock-splitter\.edge-bottom::before\s*{[\s\S]*?inset:\s*8px;/,
+  );
   assert.match(
     stylesSource,
     /\.session-dock-splitter-chevron\s*{[\s\S]*?box-sizing:\s*border-box;[\s\S]*?width:\s*12px;[\s\S]*?height:\s*24px;/,
@@ -150,7 +174,7 @@ test("Header と ActionDock は中央・左右ペインの外側に全幅 dock �
   assert.match(stylesSource, /\.session-chat-layout\.is-header-visible\s*{[\s\S]*?--session-header-dock-row-height:\s*64px;/);
   assert.match(
     stylesSource,
-    /\.session-chat-layout\.is-action-dock-expanded\s*{[\s\S]*?--session-action-dock-row-height:\s*max\([\s\S]*?min\([\s\S]*?var\(--session-action-dock-height, 320px\),[\s\S]*?40dvh,[\s\S]*?calc\(100dvh - var\(--session-header-dock-row-height\) - 326px\)/,
+    /\.session-chat-layout\.is-action-dock-expanded\s*{[\s\S]*?--session-action-dock-row-height:\s*max\([\s\S]*?min\([\s\S]*?var\(--session-action-dock-height, 320px\),[\s\S]*?40dvh,[\s\S]*?calc\(100dvh - var\(--session-header-dock-row-height\) - 342px\)/,
   );
   assert.match(chatWindowSource, /session-action-dock-content session-action-dock-expanded-content/);
   assert.match(stylesSource, /\.session-action-dock-slot\.is-expanded \.composer > :not\(\.composer-input-row\)\s*{[\s\S]*?flex:\s*0 0 auto;/);

--- a/src/session-chat-layout-hooks.ts
+++ b/src/session-chat-layout-hooks.ts
@@ -29,7 +29,7 @@ const SESSION_ACTION_DOCK_COMPACT_DEFAULT_HEIGHT = 54;
 const SESSION_ACTION_DOCK_MIN_HEIGHT = 260;
 const SESSION_ACTION_DOCK_MAX_HEIGHT_RATIO = 0.4;
 const SESSION_CENTRAL_SURFACE_MIN_HEIGHT = 280;
-const SESSION_VERTICAL_SPLITTER_TOTAL_HEIGHT = 24;
+const SESSION_VERTICAL_SPLITTER_TOTAL_HEIGHT = 40;
 
 function scrollMessageListElementToBottom(messageListElement: HTMLDivElement): void {
   const bottomAnchor = messageListElement.querySelector<HTMLElement>(".message-list-bottom-anchor");

--- a/src/styles.css
+++ b/src/styles.css
@@ -148,15 +148,16 @@ button:disabled {
 .session-chat-layout {
   --session-dock-motion-duration: 220ms;
   --session-dock-motion-easing: cubic-bezier(0.22, 1, 0.36, 1);
+  --session-dock-splitter-size: 20px;
   --session-header-dock-row-height: 0px;
   --session-action-dock-row-height: var(--session-action-dock-compact-height, 54px);
   --session-left-pane-track-width: 0px;
   --session-right-pane-track-width: 0px;
   grid-template-rows:
     var(--session-header-dock-row-height)
-    12px
+    var(--session-dock-splitter-size)
     minmax(280px, 1fr)
-    12px
+    var(--session-dock-splitter-size)
     var(--session-action-dock-row-height);
   transition:
     grid-template-rows var(--session-dock-motion-duration) var(--session-dock-motion-easing),
@@ -166,9 +167,9 @@ button:disabled {
 .session-chat-layout.layout-priority-side-pane {
   grid-template-columns:
     var(--session-left-pane-track-width)
-    12px
+    var(--session-dock-splitter-size)
     minmax(0, 1fr)
-    12px
+    var(--session-dock-splitter-size)
     var(--session-right-pane-track-width);
   grid-template-areas:
     "left-pane left-split header right-split right-pane"
@@ -194,9 +195,9 @@ button:disabled {
 .session-chat-layout.layout-priority-dock {
   grid-template-columns:
     var(--session-left-pane-track-width)
-    12px
+    var(--session-dock-splitter-size)
     minmax(0, 1fr)
-    12px
+    var(--session-dock-splitter-size)
     var(--session-right-pane-track-width);
   grid-template-areas:
     "header header header header header"
@@ -265,7 +266,7 @@ button:disabled {
     min(
       var(--session-action-dock-height, 320px),
       40dvh,
-      calc(100dvh - var(--session-header-dock-row-height) - 326px)
+      calc(100dvh - var(--session-header-dock-row-height) - 342px)
     )
   );
 }
@@ -5242,14 +5243,14 @@ button:disabled {
 
 .session-dock-splitter.edge-left,
 .session-dock-splitter.edge-right {
-  width: 12px;
+  width: var(--session-dock-splitter-size);
   cursor: col-resize;
 }
 
 .session-dock-splitter.edge-top,
 .session-dock-splitter.edge-bottom {
   width: 100%;
-  height: 12px;
+  height: var(--session-dock-splitter-size);
   cursor: row-resize;
 }
 
@@ -5261,7 +5262,7 @@ button:disabled {
 .session-dock-splitter::before {
   content: "";
   position: absolute;
-  inset: 8px 4px;
+  inset: 8px;
   border-radius: 999px;
   background: rgba(203, 213, 225, 0.14);
   transition: background 160ms ease;
@@ -5269,7 +5270,7 @@ button:disabled {
 
 .session-dock-splitter.edge-top::before,
 .session-dock-splitter.edge-bottom::before {
-  inset: 4px 8px;
+  inset: 8px;
 }
 
 .session-dock-splitter:hover::before,
@@ -10829,7 +10830,9 @@ button:disabled {
   .session-chat-layout.layout-priority-side-pane,
   .session-chat-layout.layout-priority-dock {
     grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: auto auto 0px 16px minmax(220px, 1fr) 16px 0px auto auto;
+    grid-template-rows:
+      auto auto 0px var(--session-dock-splitter-size) minmax(220px, 1fr)
+      var(--session-dock-splitter-size) 0px auto auto;
     grid-template-areas:
       "header"
       "top-split"
@@ -10848,7 +10851,9 @@ button:disabled {
   .session-chat-layout.layout-priority-side-pane.is-left-pane-visible,
   .session-chat-layout.layout-priority-dock.is-left-pane-visible {
     grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: auto auto minmax(300px, 42vh) 16px minmax(220px, 1fr) 16px 0px auto auto;
+    grid-template-rows:
+      auto auto minmax(300px, 42vh) var(--session-dock-splitter-size) minmax(220px, 1fr)
+      var(--session-dock-splitter-size) 0px auto auto;
     grid-template-areas:
       "header"
       "top-split"
@@ -10864,7 +10869,9 @@ button:disabled {
   .session-chat-layout.layout-priority-side-pane.is-right-pane-visible,
   .session-chat-layout.layout-priority-dock.is-right-pane-visible {
     grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: auto auto 0px 16px minmax(220px, 1fr) 16px minmax(300px, 42vh) auto auto;
+    grid-template-rows:
+      auto auto 0px var(--session-dock-splitter-size) minmax(220px, 1fr)
+      var(--session-dock-splitter-size) minmax(300px, 42vh) auto auto;
     grid-template-areas:
       "header"
       "top-split"
@@ -10880,7 +10887,9 @@ button:disabled {
   .session-chat-layout.layout-priority-side-pane.is-left-pane-visible.is-right-pane-visible,
   .session-chat-layout.layout-priority-dock.is-left-pane-visible.is-right-pane-visible {
     grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: auto auto minmax(300px, 42vh) 16px minmax(220px, 1fr) 16px minmax(300px, 42vh) auto auto;
+    grid-template-rows:
+      auto auto minmax(300px, 42vh) var(--session-dock-splitter-size) minmax(220px, 1fr)
+      var(--session-dock-splitter-size) minmax(300px, 42vh) auto auto;
     grid-template-areas:
       "header"
       "top-split"
@@ -10924,7 +10933,7 @@ button:disabled {
   .session-dock-splitter.edge-right {
     display: block;
     width: 100%;
-    min-height: 16px;
+    min-height: var(--session-dock-splitter-size);
     cursor: pointer;
   }
 
@@ -10935,7 +10944,7 @@ button:disabled {
 
   .session-dock-splitter.edge-left::before,
   .session-dock-splitter.edge-right::before {
-    inset: 6px 8px;
+    inset: 8px;
   }
 
   .session-dock-splitter.edge-left .session-dock-splitter-chevron,


### PR DESCRIPTION
## 概要

- チャット共通レイアウトの上下左右スプリッター領域を 12px から 20px に拡張
- 表示線は 4px のまま維持し、線と隣接要素の余白を片側 8px に調整
- 狭いウィンドウを含むレイアウト計算と ActionDock の高さ上限を新しい領域幅へ同期
- スプリッターの配置・線幅・高さ計算を確認する回帰テストを更新

## Validation

- npx tsx --test scripts/tests/chat-window.test.ts scripts/tests/session-context-pane-style.test.ts scripts/tests/session-chat-layout-hooks.test.tsx
- npm run typecheck
- npm run build
- scripts/start-withmate-visual-check.ps1 による上下左右・展開状態の目視確認

## Related

- ISSUE-236