### PR TITLE
feat(chat): 貼り付け画像をMarkdown表示する

### DIFF
--- a/docs/design/session-local-files.md
+++ b/docs/design/session-local-files.md
@@ -6,7 +6,7 @@
 ## Goal
 
 WithMate の Session ごとに、repo へ入れない一時資料を置ける managed directory を用意する。
-ユーザーは composer への paste や picker から画像・ファイルを追加し、保存された path をそのまま prompt reference として使える。
+ユーザーは composer への paste や picker から画像・ファイルを追加し、保存された path を prompt reference として使える。
 
 ## Position
 
@@ -33,7 +33,7 @@ New Session の `SessionFolder` 選択は directory を作成しない。`Start 
 
 Session local files directory は次の経路で常に effective allowed directory に含める。
 
-- composer preview の `@path` 解決
+- composer preview の `@path` と local Markdown image 解決
 - provider prompt composition の `additionalDirectories`
 - Codex thread options
 - Copilot session config / attachment roots
@@ -64,8 +64,8 @@ attachment popover の `Session files` sectionにある `File` action は sessio
 composer textarea の paste は次のように扱う。
 
 - text only: 通常 paste
-- image: PNG として保存し、保存先 reference を挿入する
-- file: session local files directory へコピーし、保存先 reference を挿入する
+- image: PNG、JPEG、GIF、WebP、BMP、SVG は保存し、absolute path の Markdown image を挿入する
+- file: session local files directory へコピーし、保存先を `@path` として挿入する。AVIF、TIFF、ICO もこの扱いとする
 - mixed: browser / Electron が提供する file item を優先し、保存できた reference を挿入する
 
 保存時の basename 衝突は `name-2.ext` のように採番する。
@@ -84,8 +84,8 @@ main process が managed directory を作成し、copy / write を担当する�
 - `openSessionFilesDirectory(sessionId)`
 - `openSessionFilesTerminal(sessionId)`
 
-戻り値は保存済み absolute path の配列とする。
-composer は戻り値を既存の `@path` reference 挿入処理へ渡す。
+保存 API は保存済み absolute path を返す。
+renderer は clipboard file の MIME type と拡張子から表示形式を決め、対応画像を Markdown image、それ以外を `@path` として caret 位置へ挿入する。
 
 ## Cleanup
 
@@ -98,7 +98,8 @@ legacy MateTalk は永続 session record を持たないため、window ごと�
 
 ## Validation
 
-- paste image が session local files directory に保存され、composer に reference が挿入される
+- paste image が session local files directory に保存され、composer に Markdown image が挿入される
+- paste image の Markdown image が preview と provider image attachment の同じ file identity へ解決される
 - `Session` action で選んだ file がコピーされ、コピー先 reference が挿入される
 - preview で session local files が outside workspace attachment として認識される
 - Codex / Copilot runtime に session local files directory が additional directory として渡る

--- a/scripts/tests/composer-attachments.test.ts
+++ b/scripts/tests/composer-attachments.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { resolveComposerPreview } from "../../src-electron/composer-attachments.js";
+import { formatMarkdownImageReference } from "../../src/composer-image-reference.js";
+
+test("resolveComposerPreview はMarkdown画像をprovider画像添付として解決する", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "withmate-markdown-image-"));
+  const workspacePath = path.join(root, "workspace");
+  const sessionFilesPath = path.join(root, "session-files");
+  const imagePath = path.join(sessionFilesPath, "pasted image (1).png");
+  await mkdir(workspacePath, { recursive: true });
+  await mkdir(sessionFilesPath, { recursive: true });
+  await writeFile(imagePath, new Uint8Array([1, 2, 3]));
+
+  try {
+    const preview = await resolveComposerPreview(
+      { workspacePath, allowedAdditionalDirectories: [sessionFilesPath] },
+      formatMarkdownImageReference(imagePath),
+    );
+
+    assert.deepEqual(preview.errors, []);
+    assert.equal(preview.attachments.length, 1);
+    assert.equal(preview.attachments[0]?.kind, "image");
+    assert.equal(preview.attachments[0]?.source, "markdown-image");
+    assert.equal(preview.attachments[0]?.absolutePath, imagePath);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("resolveComposerPreview は同じ画像のMarkdownと@pathを一つの添付へ集約する", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "withmate-markdown-image-dedupe-"));
+  const workspacePath = path.join(root, "workspace");
+  const imagePath = path.join(workspacePath, "image.png");
+  await mkdir(workspacePath, { recursive: true });
+  await writeFile(imagePath, new Uint8Array([1]));
+
+  try {
+    const preview = await resolveComposerPreview(
+      { workspacePath, allowedAdditionalDirectories: [] },
+      `${formatMarkdownImageReference(imagePath)} @image.png`,
+    );
+    assert.deepEqual(preview.errors, []);
+    assert.equal(preview.attachments.length, 1);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/tests/composer-image-reference.test.ts
+++ b/scripts/tests/composer-image-reference.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  extractMarkdownImageReferenceCandidates,
+  findMarkdownImageReferences,
+  formatMarkdownImageReference,
+  isSupportedComposerImagePath,
+  removeMarkdownImageReferences,
+} from "../../src/composer-image-reference.js";
+
+test("formatMarkdownImageReference は local path を安全な Markdown image にする", () => {
+  assert.equal(
+    formatMarkdownImageReference("C:\\Users\\A Name\\shot [1] (copy).png"),
+    "![shot \\[1\\] (copy).png](C:/Users/A%20Name/shot%20%5B1%5D%20%28copy%29.png)",
+  );
+  assert.equal(
+    formatMarkdownImageReference("\\\\server\\shared files\\shot (1).png"),
+    "![shot (1).png](file://server/shared%20files/shot%20%281%29.png)",
+  );
+});
+
+test("Markdown image reference は Windows path と file URL を local path として抽出する", () => {
+  const markdown = [
+    "![first](C:/Users/A%20Name/first.png)",
+    "![second](file:///C:/Users/A%20Name/second.webp)",
+    "![shared](file://server/shared%20files/third.gif)",
+    "![remote](https://example.test/remote.png)",
+    "![unsupported](C:/Users/A/image.avif)",
+  ].join("\n");
+
+  assert.deepEqual(extractMarkdownImageReferenceCandidates(markdown), [
+    "C:/Users/A Name/first.png",
+    "C:/Users/A Name/second.webp",
+    "//server/shared files/third.gif",
+  ]);
+  assert.deepEqual(
+    findMarkdownImageReferences(markdown).map(({ path }) => path),
+    ["C:/Users/A Name/first.png", "C:/Users/A Name/second.webp", "//server/shared files/third.gif"],
+  );
+});
+
+test("isSupportedComposerImagePath は既存7形式だけを画像として扱う", () => {
+  for (const extension of ["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg"]) {
+    assert.equal(isSupportedComposerImagePath(`C:/images/sample.${extension}`), true);
+  }
+  for (const extension of ["avif", "tiff", "tif", "ico", "txt"]) {
+    assert.equal(isSupportedComposerImagePath(`C:/images/sample.${extension}`), false);
+  }
+});
+
+test("removeMarkdownImageReferences は一致する画像だけを削除する", () => {
+  const first = formatMarkdownImageReference("C:/images/first image (1).png");
+  const second = formatMarkdownImageReference("C:/images/second.png");
+
+  assert.equal(
+    removeMarkdownImageReferences(`確認 ${first} と ${second}`, ["C:\\images\\first image (1).png"]),
+    `確認  と ${second}`,
+  );
+});

--- a/scripts/tests/composer-paste-handlers.test.ts
+++ b/scripts/tests/composer-paste-handlers.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   collectPastedClipboardFiles,
+  collectPastedSessionAttachments,
   collectPastedSessionAttachmentPaths,
   createPastedSessionAttachmentHandler,
   type PastedClipboardFile,
@@ -13,6 +14,13 @@ function createPastedFile(name: string, content: string): PastedClipboardFile {
   return {
     name,
     arrayBuffer: async () => new TextEncoder().encode(content).buffer,
+  };
+}
+
+function createTypedPastedFile(name: string, content: string, type: string): PastedClipboardFile {
+  return {
+    ...createPastedFile(name, content),
+    type,
   };
 }
 
@@ -78,11 +86,35 @@ test("collectPastedSessionAttachmentPaths は pasted files を保存して path 
   assert.equal(prevented, true);
   assert.deepEqual(saved, [
     { sessionId: "session-1", fileName: "pasted.png", dataText: "named" },
-    { sessionId: "session-1", fileName: "pasted-2026-06-05T12-34-56.000Z.png", dataText: "fallback" },
+    { sessionId: "session-1", fileName: "pasted-2026-06-05T12-34-56.000Z.bin", dataText: "fallback" },
   ]);
   assert.deepEqual(savedPaths, [
     "session-files/pasted.png",
-    "session-files/pasted-2026-06-05T12-34-56.000Z.png",
+    "session-files/pasted-2026-06-05T12-34-56.000Z.bin",
+  ]);
+});
+
+test("collectPastedSessionAttachments は空名を MIME が対応画像の場合だけ画像として扱う", async () => {
+  let timestampIndex = 0;
+  const attachments = await collectPastedSessionAttachments({
+    clipboardData: {
+      files: [
+        createTypedPastedFile("", "png", "image/png"),
+        createTypedPastedFile(" ", "avif", "image/avif"),
+        createPastedFile("", "unknown"),
+      ],
+      items: [],
+    },
+    currentTimestampLabel: () => `stamp-${timestampIndex += 1}`,
+    preventDefault: () => {},
+    savePastedSessionFile: async ({ fileName }) => `C:/session-files/${fileName}`,
+    sessionId: "session-empty-name",
+  });
+
+  assert.deepEqual(attachments, [
+    { path: "C:/session-files/pasted-stamp-1.png", presentation: "image" },
+    { path: "C:/session-files/pasted-stamp-2.bin", presentation: "path" },
+    { path: "C:/session-files/pasted-stamp-3.bin", presentation: "path" },
   ]);
 });
 
@@ -151,7 +183,7 @@ test("createPastedSessionAttachmentHandler は item file paste を保存して�
     getAsFile: () => itemFile,
   };
   const saved: Array<{ sessionId: string; fileName: string; dataText: string }> = [];
-  const insertedPaths: string[][] = [];
+  const insertedAttachments: Array<Array<{ path: string; presentation: "image" | "path" }>> = [];
   let prevented = false;
 
   const handlePaste = createPastedSessionAttachmentHandler({
@@ -170,8 +202,8 @@ test("createPastedSessionAttachmentHandler は item file paste を保存して�
       return `session-files/${fileName}`;
     },
     getSessionId: () => "session-3",
-    insertReferencePaths: (referencePaths) => {
-      insertedPaths.push(referencePaths);
+    insertAttachments: (attachments) => {
+      insertedAttachments.push(attachments);
     },
   });
 
@@ -190,7 +222,44 @@ test("createPastedSessionAttachmentHandler は item file paste を保存して�
   assert.deepEqual(saved, [
     { sessionId: "session-3", fileName: "from-items.png", dataText: "items" },
   ]);
-  assert.deepEqual(insertedPaths, [["session-files/from-items.png"]]);
+  assert.deepEqual(insertedAttachments, [[{
+    path: "session-files/from-items.png",
+    presentation: "image",
+  }]]);
+});
+
+test("createPastedSessionAttachmentHandler は対応画像と通常ファイルを表示形式つきで挿入する", async () => {
+  const inserted: Array<Array<{ path: string; presentation: "image" | "path" }>> = [];
+  const handlePaste = createPastedSessionAttachmentHandler({
+    alertError: () => {
+      throw new Error("unexpected alert");
+    },
+    canPaste: () => true,
+    currentTimestampLabel: () => "unused",
+    fallbackErrorMessage: "fallback",
+    getSavePastedSessionFile: () => async ({ fileName }) => `C:/session-files/${fileName}`,
+    getSessionId: () => "session-mixed",
+    insertAttachments: (attachments) => inserted.push(attachments),
+  });
+
+  const handled = await handlePaste({
+    clipboardData: {
+      files: [
+        createTypedPastedFile("capture", "image", "image/png"),
+        createTypedPastedFile("archive.avif", "unsupported image", "image/avif"),
+        createPastedFile("notes.txt", "text"),
+      ],
+      items: [],
+    },
+    preventDefault: () => {},
+  });
+
+  assert.equal(handled, true);
+  assert.deepEqual(inserted, [[
+    { path: "C:/session-files/capture.png", presentation: "image" },
+    { path: "C:/session-files/archive.avif", presentation: "path" },
+    { path: "C:/session-files/notes.txt", presentation: "path" },
+  ]]);
 });
 
 test("createPastedSessionAttachmentHandler は paste 不可なら保存も挿入も行わない", async () => {
@@ -211,7 +280,7 @@ test("createPastedSessionAttachmentHandler は paste 不可なら保存も挿入
       return "unused";
     },
     getSessionId: () => "session-4",
-    insertReferencePaths: () => {
+    insertAttachments: () => {
       inserted = true;
     },
   });
@@ -247,7 +316,7 @@ test("createPastedSessionAttachmentHandler は API や session id がなけれ�
     fallbackErrorMessage: "fallback",
     getSavePastedSessionFile: input.getSavePastedSessionFile,
     getSessionId: input.getSessionId,
-    insertReferencePaths: () => {
+    insertAttachments: () => {
       inserted = true;
     },
   });
@@ -321,7 +390,7 @@ test("createPastedSessionAttachmentHandler は保存失敗時に通知して挿�
       throw new Error("save failed");
     },
     getSessionId: () => "session-5",
-    insertReferencePaths: () => {
+    insertAttachments: () => {
       inserted = true;
     },
   });
@@ -354,7 +423,7 @@ test("createPastedSessionAttachmentHandler は保存失敗が Error でない場
       throw "non-error failure";
     },
     getSessionId: () => "session-6",
-    insertReferencePaths: () => {
+    insertAttachments: () => {
       throw new Error("unexpected insertion");
     },
   });

--- a/scripts/tests/message-rich-text.test.ts
+++ b/scripts/tests/message-rich-text.test.ts
@@ -466,6 +466,27 @@ test("MessageRichText は local / data / external Markdown image を既定表示
   assert.match(html, /src="https:\/\/cdn\.example\.test\/image\.png"/);
 });
 
+test("MessageRichText は local image を優先読込し external image は遅延読込する", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(MessageRichText, {
+      text: [
+        "![local](file:///C:/tmp/local.png)",
+        "![embedded](data:image/png;base64,AAAA)",
+        "![remote](https://example.test/image.png)",
+      ].join("\n"),
+    }),
+  );
+  const dom = new JSDOM(html);
+  const images = Array.from(dom.window.document.querySelectorAll("img"));
+
+  assert.equal(images[0]?.getAttribute("loading"), "eager");
+  assert.equal(images[0]?.getAttribute("fetchpriority"), "high");
+  assert.equal(images[1]?.getAttribute("loading"), "eager");
+  assert.equal(images[1]?.getAttribute("fetchpriority"), "high");
+  assert.equal(images[2]?.getAttribute("loading"), "lazy");
+  assert.equal(images[2]?.getAttribute("fetchpriority"), "auto");
+});
+
 test("MessageRichText は直接 image を表示しながら load 完了後に loading 表示を消す", async () => {
   const dom = new JSDOM("<!doctype html><div id=\"root\"></div>", {
     pretendToBeVisual: true,

--- a/scripts/tests/path-reference.test.ts
+++ b/scripts/tests/path-reference.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   buildTextReferenceCandidateState,
+  extractComposerAttachmentReferenceCandidates,
   extractTextReferenceCandidates,
   TEXT_PATH_REFERENCE_SIGNATURE_SEPARATOR,
 } from "../../src/path-reference.js";
@@ -28,4 +29,18 @@ test("buildTextReferenceCandidateState は候補有無と signature を返す", 
     hasCandidates: false,
     signature: "",
   });
+});
+
+test("extractComposerAttachmentReferenceCandidates は @path と local Markdown image を区別して返す", () => {
+  assert.deepEqual(
+    extractComposerAttachmentReferenceCandidates([
+      "確認 @src/App.tsx",
+      "![pasted](C:/session-files/pasted%20image.png)",
+      "![remote](https://example.test/image.png)",
+    ].join("\n")),
+    [
+      { path: "src/App.tsx", source: "text" },
+      { path: "C:/session-files/pasted image.png", source: "markdown-image", kind: "image" },
+    ],
+  );
 });

--- a/scripts/tests/session-composer-paths.test.ts
+++ b/scripts/tests/session-composer-paths.test.ts
@@ -5,6 +5,7 @@ import {
   appendMissingPathReferenceAttachments,
   buildAdditionalDirectoryItems,
   buildComposerAttachmentItems,
+  buildComposerReferenceInsertionState,
   buildPathReferenceAttachmentItems,
   buildPathReferenceInsertionState,
   buildPathReferenceRemovalState,
@@ -50,6 +51,19 @@ test("buildPathReferenceInsertionState は空白を含む path reference を quo
 
 test("buildPathReferenceInsertionState は reference path が空なら null を返す", () => {
   assert.equal(buildPathReferenceInsertionState("draft", 0, []), null);
+});
+
+test("buildComposerReferenceInsertionState は画像Markdownと通常pathを同じcaretへ挿入する", () => {
+  assert.deepEqual(
+    buildComposerReferenceInsertionState("確認後", "確認".length, [
+      { path: "C:/session-files/cover image.png", presentation: "image" },
+      { path: "C:/session-files/note.txt", presentation: "path" },
+    ]),
+    {
+      draft: "確認 ![cover image.png](C:/session-files/cover%20image.png) @C:/session-files/note.txt 後",
+      caret: "確認 ![cover image.png](C:/session-files/cover%20image.png) @C:/session-files/note.txt ".length,
+    },
+  );
 });
 
 test("buildSelectedPathReferenceInsertionState は選択 path を解決して挿入 state を作る", () => {
@@ -311,6 +325,16 @@ test("removePathReferenceTokensFromDraft は複数 token と句読点境界を�
       ["src/App.tsx", "docs/my note.md"],
     ),
     "確認 (), !",
+  );
+});
+
+test("removePathReferenceTokensFromDraft は対応するMarkdown画像全体を削除する", () => {
+  assert.equal(
+    removePathReferenceTokensFromDraft(
+      "確認 ![cover image.png](C:/session-files/cover%20image.png) して",
+      ["C:\\session-files\\cover image.png"],
+    ),
+    "確認 して",
   );
 });
 

--- a/scripts/tests/session-shell-handlers.test.ts
+++ b/scripts/tests/session-shell-handlers.test.ts
@@ -7,6 +7,7 @@ import {
   applyAgentPickerToggleCommand,
   applyCancelTitleEditCommand,
   applyComposerSubmitKeyCommand,
+  applyComposerReferenceInsertionCommand,
   applyContextPaneTabCycleCommand,
   applyActionDockCollapseCommand,
   applyActionDockExpandCommand,
@@ -1162,6 +1163,32 @@ describe("applySelectedPathReferenceInsertionCommand", () => {
     assert.deepEqual(events, [
       "apply:16:see @src/App.tsx here",
       "restore:none:16",
+    ]);
+  });
+});
+
+describe("applyComposerReferenceInsertionCommand", () => {
+  it("paste attachment の表示形式を保って挿入し、caret を復元する", () => {
+    const events: string[] = [];
+    const textarea = { selectionStart: 0 } as HTMLTextAreaElement;
+
+    assert.equal(
+      applyComposerReferenceInsertionCommand({
+        draft: "",
+        fallbackCaret: 0,
+        references: [
+          { path: "C:/session-files/image one.png", presentation: "image" },
+          { path: "C:/session-files/note.txt", presentation: "path" },
+        ],
+        textarea,
+        applyInsertion: (state) => events.push(`apply:${state.draft}`),
+        restoreComposerTextareaFocusAndCaret: (_textarea, caret) => events.push(`caret:${caret}`),
+      }),
+      true,
+    );
+    assert.deepEqual(events, [
+      "apply:![image one.png](C:/session-files/image%20one.png) @C:/session-files/note.txt",
+      "caret:77",
     ]);
   });
 });

--- a/src-electron/composer-attachments.ts
+++ b/src-electron/composer-attachments.ts
@@ -2,7 +2,7 @@ import { stat } from "node:fs/promises";
 import path from "node:path";
 
 import type { ComposerAttachment, ComposerAttachmentInput, ComposerAttachmentKind, ComposerPreview, Session } from "../src/app-state.js";
-import { extractTextReferenceCandidates } from "../src/path-reference.js";
+import { extractComposerAttachmentReferenceCandidates } from "../src/path-reference.js";
 import { isPathWithinAnyDirectory, normalizeAllowedAdditionalDirectories } from "./additional-directories.js";
 
 const IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"]);
@@ -101,11 +101,7 @@ export async function resolveComposerPreview(
   session: ComposerPreviewSessionContext,
   userMessage: string,
 ): Promise<ComposerPreview> {
-  const textCandidates = extractTextReferenceCandidates(userMessage).map<ComposerAttachmentInput>((entry) => ({
-    path: entry,
-    source: "text",
-  }));
-  const candidates = [...textCandidates];
+  const candidates = extractComposerAttachmentReferenceCandidates(userMessage);
   const attachments: ComposerAttachment[] = [];
   const errors: string[] = [];
   const seenIds = new Set<string>();

--- a/src-electron/main-query-service.ts
+++ b/src-electron/main-query-service.ts
@@ -17,7 +17,7 @@ import {
   cloneSessions,
 } from "../src/app-state.js";
 import { getProviderAppSettings, resolveProviderSkillRootPath, type AppSettings } from "../src/provider-settings-state.js";
-import { extractTextReferenceCandidates } from "../src/path-reference.js";
+import { extractComposerAttachmentReferenceCandidates } from "../src/path-reference.js";
 import type { Awaitable } from "./persistent-store-lifecycle-service.js";
 
 type MainQueryServiceDeps = {
@@ -147,7 +147,7 @@ export class MainQueryService {
   }
 
   async previewComposerInput(sessionId: string, userMessage: string): Promise<ComposerPreview> {
-    if (extractTextReferenceCandidates(userMessage).length === 0) {
+    if (extractComposerAttachmentReferenceCandidates(userMessage).length === 0) {
       return { attachments: [], errors: [] };
     }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -124,6 +124,7 @@ import {
   buildComposerAttachmentItems,
   pickComposerReferencePath,
   type ComposerPathPickerKind,
+  type ComposerReferenceInput,
 } from "./session-composer-paths.js";
 import {
   applyComposerDraftClearCommand,
@@ -263,6 +264,7 @@ import {
 import {
   applyPickedAdditionalDirectoryUiStateCommand,
   applyPickedComposerReferencePathCommand,
+  applyComposerReferenceInsertionCommand,
   applySelectedPathReferenceInsertionCommand,
   applySkillPromptInsertionCommand,
   applySessionFilesReferencePathsCommand,
@@ -2833,6 +2835,35 @@ export default function AgentSessionWindowApp() {
     insertReferencePaths([selectedPath]);
   };
 
+  const insertPastedAttachments = (references: ComposerReferenceInput[]) => {
+    const textarea = composerTextareaRef.current;
+    const targetAuxiliarySession = activeAuxiliarySession;
+    const currentDraft = targetAuxiliarySession ? targetAuxiliarySession.composerDraft : draft;
+    applyComposerReferenceInsertionCommand({
+      draft: currentDraft,
+      fallbackCaret: composerCaret,
+      references,
+      textarea,
+      applyInsertion: ({ draft: nextDraft, caret: nextCaret }) => {
+        if (targetAuxiliarySession) {
+          void handleAuxiliaryDraftChange(nextDraft, nextCaret);
+          setComposerCaret(nextCaret);
+        } else {
+          applyComposerDraftChangeCommand({
+            value: nextDraft,
+            selectionStart: nextCaret,
+            setDraft,
+            setComposerCaret,
+            syncMainComposerCaret: (selectionStart) => {
+              mainComposerCaretRef.current = selectionStart;
+            },
+          });
+        }
+      },
+      restoreComposerTextareaFocusAndCaret,
+    });
+  };
+
   const handleRemoveAttachmentReference = createPathReferenceRemovalHandler({
     getDraft: () => activeAuxiliarySession ? activeAuxiliarySession.composerDraft : draft,
     applyRemoval: (nextState) => {
@@ -2971,7 +3002,7 @@ export default function AgentSessionWindowApp() {
       return withmateApi ? (request) => withmateApi.savePastedSessionFile(request) : null;
     },
     getSessionId: () => selectedSession?.id,
-    insertReferencePaths,
+    insertAttachments: insertPastedAttachments,
   });
 
   const handleAddAdditionalDirectory = async () => {

--- a/src/CompanionReviewApp.tsx
+++ b/src/CompanionReviewApp.tsx
@@ -171,6 +171,7 @@ import {
   buildComposerAttachmentItems,
   pickComposerReferencePath,
   type ComposerPathPickerKind,
+  type ComposerReferenceInput,
 } from "./session-composer-paths.js";
 import {
   useChatLayoutPresentation,
@@ -262,6 +263,7 @@ import {
 import {
   applyPickedAdditionalDirectoryUiStateCommand,
   applyPickedComposerReferencePathCommand,
+  applyComposerReferenceInsertionCommand,
   applySelectedPathReferenceInsertionCommand,
   applySkillPromptInsertionCommand,
   applySessionFilesReferencePathsCommand,
@@ -1619,6 +1621,30 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
     insertReferencePaths([selectedPath]);
   }
 
+  function insertPastedAttachments(references: ComposerReferenceInput[]): void {
+    const textarea = composerTextareaRef.current;
+    applyComposerReferenceInsertionCommand({
+      draft: activeComposerText,
+      fallbackCaret: composerCaret,
+      references,
+      textarea,
+      applyInsertion: ({ draft: nextDraft, caret: nextCaret }) => {
+        if (activeAuxiliarySession) {
+          setComposerCaret(nextCaret);
+          void handleAuxiliaryDraftChange(nextDraft, nextCaret);
+        } else {
+          applyComposerDraftChangeCommand({
+            value: nextDraft,
+            selectionStart: nextCaret,
+            setDraft: setComposerText,
+            setComposerCaret,
+          });
+        }
+      },
+      restoreComposerTextareaFocusAndCaret,
+    });
+  }
+
   async function pickAndInsertPath(kind: ComposerPathPickerKind): Promise<void> {
     const withmateApi = getWithMateApi();
     if (!withmateApi || !snapshot || runDisabled) {
@@ -1726,7 +1752,7 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
       return withmateApi ? (request) => withmateApi.savePastedSessionFile(request) : null;
     },
     getSessionId: () => snapshot?.session.id,
-    insertReferencePaths,
+    insertAttachments: insertPastedAttachments,
   });
 
   async function handleAddAdditionalDirectory(): Promise<void> {

--- a/src/MessageRichText.tsx
+++ b/src/MessageRichText.tsx
@@ -138,6 +138,10 @@ function isDirectMarkdownImageSource(target: string): boolean {
   );
 }
 
+function shouldLoadMarkdownImageEagerly(target: string): boolean {
+  return /^(?:file:|data:image\/|blob:)/i.test(target);
+}
+
 const markdownUrlTransform: UrlTransform = (url, key) => {
   if (key === "src") {
     if (!isAllowedMarkdownImageSource(url)) {
@@ -377,6 +381,7 @@ type MarkdownImageProps = {
 
 function MarkdownImage({ source, alt, title, resolveImageSource }: MarkdownImageProps) {
   const canLoadDirectly = !resolveImageSource && isDirectMarkdownImageSource(source);
+  const shouldLoadEagerly = shouldLoadMarkdownImageEagerly(source);
   const [resolvedSource, setResolvedSource] = useState(canLoadDirectly ? source : "");
   const [loadStatus, setLoadStatus] = useState<"resolving" | "loading" | "ready" | "error">(
     resolveImageSource ? "resolving" : canLoadDirectly ? "loading" : "error",
@@ -439,7 +444,8 @@ function MarkdownImage({ source, alt, title, resolveImageSource }: MarkdownImage
           src={resolvedSource}
           alt={alt ?? ""}
           title={title}
-          loading="lazy"
+          loading={shouldLoadEagerly ? "eager" : "lazy"}
+          fetchPriority={shouldLoadEagerly ? "high" : "auto"}
           onLoad={() => setLoadStatus("ready")}
           onError={() => setLoadStatus("error")}
         />

--- a/src/chat/composer-paste-handlers.ts
+++ b/src/chat/composer-paste-handlers.ts
@@ -1,6 +1,23 @@
 import type { WithMateWindowPickerApi } from "../withmate-window-api.js";
+import { isSupportedComposerImagePath } from "../composer-image-reference.js";
+import type { ComposerReferenceInput } from "../session-composer-paths.js";
 
-export type PastedClipboardFile = Pick<File, "arrayBuffer" | "name">;
+const SUPPORTED_IMAGE_MIME_EXTENSIONS = new Map([
+  ["image/png", "png"],
+  ["image/jpeg", "jpg"],
+  ["image/gif", "gif"],
+  ["image/webp", "webp"],
+  ["image/bmp", "bmp"],
+  ["image/svg+xml", "svg"],
+]);
+
+export type PastedClipboardFile = {
+  arrayBuffer(): Promise<ArrayBuffer>;
+  name: string;
+  type?: string;
+};
+
+export type PastedSessionAttachment = ComposerReferenceInput;
 
 export type PastedClipboardFileItem = {
   kind: string;
@@ -38,25 +55,65 @@ export async function collectPastedSessionAttachmentPaths(input: {
   savePastedSessionFile: WithMateWindowPickerApi["savePastedSessionFile"];
   sessionId: string;
 }): Promise<string[]> {
+  return (await collectPastedSessionAttachments(input)).map((attachment) => attachment.path);
+}
+
+function resolvePastedFileName(input: {
+  currentTimestampLabel: () => string;
+  file: PastedClipboardFile;
+}): string {
+  const trimmedName = input.file.name.trim();
+  const mimeExtension = SUPPORTED_IMAGE_MIME_EXTENSIONS.get(input.file.type?.toLocaleLowerCase() ?? "");
+  if (trimmedName) {
+    if (mimeExtension && !isSupportedComposerImagePath(trimmedName)) {
+      return `${trimmedName}.${mimeExtension}`;
+    }
+    return trimmedName;
+  }
+
+  const fallbackExtension = mimeExtension ?? "bin";
+  return `pasted-${input.currentTimestampLabel().replace(/[:/\\\s]+/g, "-")}.${fallbackExtension}`;
+}
+
+function resolvePastedAttachmentPresentation(
+  file: PastedClipboardFile,
+  fileName: string,
+): PastedSessionAttachment["presentation"] {
+  const mimeType = file.type?.toLocaleLowerCase() ?? "";
+  return SUPPORTED_IMAGE_MIME_EXTENSIONS.has(mimeType) || isSupportedComposerImagePath(fileName)
+    ? "image"
+    : "path";
+}
+
+export async function collectPastedSessionAttachments(input: {
+  clipboardData: PastedSessionFileClipboardData;
+  currentTimestampLabel: () => string;
+  preventDefault: () => void;
+  savePastedSessionFile: WithMateWindowPickerApi["savePastedSessionFile"];
+  sessionId: string;
+}): Promise<PastedSessionAttachment[]> {
   const pastedFiles = collectPastedClipboardFiles(input.clipboardData);
   if (pastedFiles.length === 0) {
     return [];
   }
 
   input.preventDefault();
-  const savedPaths: string[] = [];
+  const savedAttachments: PastedSessionAttachment[] = [];
   for (const file of pastedFiles) {
     const buffer = await file.arrayBuffer();
-    const fileName = file.name.trim() || `pasted-${input.currentTimestampLabel().replace(/[:/\\\s]+/g, "-")}.png`;
+    const fileName = resolvePastedFileName({ file, currentTimestampLabel: input.currentTimestampLabel });
     const savedPath = await input.savePastedSessionFile({
       sessionId: input.sessionId,
       fileName,
       data: buffer,
     });
-    savedPaths.push(savedPath);
+    savedAttachments.push({
+      path: savedPath,
+      presentation: resolvePastedAttachmentPresentation(file, fileName),
+    });
   }
 
-  return savedPaths;
+  return savedAttachments;
 }
 
 export function createPastedSessionAttachmentHandler(input: {
@@ -66,7 +123,7 @@ export function createPastedSessionAttachmentHandler(input: {
   fallbackErrorMessage: string;
   getSavePastedSessionFile: () => WithMateWindowPickerApi["savePastedSessionFile"] | null | undefined;
   getSessionId: () => string | null | undefined;
-  insertReferencePaths: (referencePaths: string[]) => void;
+  insertAttachments: (attachments: PastedSessionAttachment[]) => void;
 }): (event: PastedSessionAttachmentEvent) => Promise<boolean> {
   return async (event) => {
     if (!input.canPaste()) {
@@ -80,18 +137,18 @@ export function createPastedSessionAttachmentHandler(input: {
     }
 
     try {
-      const savedPaths = await collectPastedSessionAttachmentPaths({
+      const savedAttachments = await collectPastedSessionAttachments({
         clipboardData: event.clipboardData,
         currentTimestampLabel: input.currentTimestampLabel,
         preventDefault: () => event.preventDefault(),
         savePastedSessionFile,
         sessionId,
       });
-      if (savedPaths.length === 0) {
+      if (savedAttachments.length === 0) {
         return false;
       }
 
-      input.insertReferencePaths(savedPaths);
+      input.insertAttachments(savedAttachments);
       return true;
     } catch (error) {
       input.alertError(error instanceof Error ? error.message : input.fallbackErrorMessage);

--- a/src/chat/session-shell-handlers.ts
+++ b/src/chat/session-shell-handlers.ts
@@ -9,11 +9,13 @@ import {
 } from "../session-composer-selection.js";
 import { createQuotedMessageInsertionFromComposer } from "./message-text-actions.js";
 import {
+  buildComposerReferenceInsertionState,
   buildPathReferenceRemovalState,
   buildSelectedPathReferenceInsertionState,
   resolvePickedPathBaseDirectory,
   toDirectoryPath,
   type ComposerPathPickerKind,
+  type ComposerReferenceInput,
   type PathReferenceInsertionState,
 } from "../session-composer-paths.js";
 import {
@@ -566,6 +568,31 @@ export function applySelectedPathReferenceInsertionCommand(input: {
     selectedPaths: input.selectedPaths,
     workspacePath: input.workspacePath,
   });
+  if (!insertionState) {
+    return false;
+  }
+
+  input.applyInsertion(insertionState);
+  input.restoreComposerTextareaFocusAndCaret(input.textarea, insertionState.caret);
+  return true;
+}
+
+export function applyComposerReferenceInsertionCommand(input: {
+  draft: string;
+  fallbackCaret: number;
+  references: ComposerReferenceInput[];
+  textarea: HTMLTextAreaElement | null;
+  applyInsertion: (state: PathReferenceInsertionState) => void;
+  restoreComposerTextareaFocusAndCaret: (
+    textarea: HTMLTextAreaElement | null,
+    caret: number,
+  ) => void;
+}): boolean {
+  const insertionState = buildComposerReferenceInsertionState(
+    input.draft,
+    input.textarea?.selectionStart ?? input.fallbackCaret,
+    input.references,
+  );
   if (!insertionState) {
     return false;
   }

--- a/src/composer-image-reference.ts
+++ b/src/composer-image-reference.ts
@@ -1,0 +1,139 @@
+const SUPPORTED_IMAGE_EXTENSIONS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "bmp",
+  "svg",
+]);
+
+const MARKDOWN_IMAGE_PATTERN = /!\[(?:\\.|[^\]\\])*\]\(\s*(?:<([^>\r\n]+)>|((?:\\.|[^)\s])+))(?:\s+(?:"(?:\\.|[^"])*"|'(?:\\.|[^'])*'|\((?:\\.|[^)])*\)))?\s*\)/g;
+
+export type MarkdownImageReferenceMatch = {
+  end: number;
+  path: string;
+  start: number;
+};
+
+function normalizeSlash(filePath: string): string {
+  return filePath.replace(/\\/g, "/");
+}
+
+function decodePathComponent(value: string): string | null {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+}
+
+function decodeLocalImageTarget(target: string): string | null {
+  const trimmedTarget = target.trim();
+  if (/^file:/i.test(trimmedTarget)) {
+    try {
+      const url = new URL(trimmedTarget);
+      if (url.protocol !== "file:") {
+        return null;
+      }
+
+      const decodedPath = decodePathComponent(url.pathname);
+      if (decodedPath === null) {
+        return null;
+      }
+
+      if (url.hostname) {
+        return `//${url.hostname}${decodedPath}`;
+      }
+
+      return decodedPath.replace(/^\/(?=[A-Za-z]:\/)/, "");
+    } catch {
+      return null;
+    }
+  }
+
+  const decodedTarget = decodePathComponent(trimmedTarget);
+  if (decodedTarget === null) {
+    return null;
+  }
+
+  const normalizedTarget = normalizeSlash(decodedTarget);
+  return /^(?:[A-Za-z]:\/|\/\/)/.test(normalizedTarget) ? normalizedTarget : null;
+}
+
+function normalizePathIdentity(filePath: string): string {
+  return normalizeSlash(filePath).toLocaleLowerCase();
+}
+
+function escapeMarkdownAltText(value: string): string {
+  return value.replace(/([\\\[\]])/g, "\\$1");
+}
+
+function encodeMarkdownPathSegment(value: string): string {
+  return encodeURIComponent(value).replace(/[()]/g, (character) => (
+    character === "(" ? "%28" : "%29"
+  ));
+}
+
+export function isSupportedComposerImagePath(filePath: string): boolean {
+  const normalizedPath = normalizeSlash(filePath).split(/[?#]/, 1)[0] ?? "";
+  const extensionMatch = normalizedPath.match(/\.([^.\/]+)$/);
+  return extensionMatch !== null && SUPPORTED_IMAGE_EXTENSIONS.has(extensionMatch[1].toLocaleLowerCase());
+}
+
+export function formatMarkdownImageReference(filePath: string): string {
+  const normalizedPath = normalizeSlash(filePath);
+  const basename = normalizedPath.slice(normalizedPath.lastIndexOf("/") + 1) || "image";
+  const encodedPath = normalizedPath.startsWith("//")
+    ? `file://${normalizedPath.slice(2).split("/").map(encodeMarkdownPathSegment).join("/")}`
+    : normalizedPath
+      .split("/")
+      .map(encodeMarkdownPathSegment)
+      .join("/")
+      .replace(/^([A-Za-z])%3A\//, "$1:/");
+  return `![${escapeMarkdownAltText(basename)}](${encodedPath})`;
+}
+
+export function findLocalMarkdownImageReferences(text: string): MarkdownImageReferenceMatch[] {
+  const matches: MarkdownImageReferenceMatch[] = [];
+  const expression = new RegExp(MARKDOWN_IMAGE_PATTERN);
+  for (const match of text.matchAll(expression)) {
+    const target = match[1] ?? match[2] ?? "";
+    const localPath = decodeLocalImageTarget(target);
+    if (match.index === undefined || localPath === null || !isSupportedComposerImagePath(localPath)) {
+      continue;
+    }
+
+    matches.push({
+      start: match.index,
+      end: match.index + match[0].length,
+      path: localPath,
+    });
+  }
+  return matches;
+}
+
+export function extractLocalMarkdownImagePaths(text: string): string[] {
+  return findLocalMarkdownImageReferences(text).map((match) => match.path);
+}
+
+export const findMarkdownImageReferences = findLocalMarkdownImageReferences;
+export const extractMarkdownImageReferenceCandidates = extractLocalMarkdownImagePaths;
+
+export function removeLocalMarkdownImageReferences(
+  text: string,
+  referencePaths: readonly string[],
+): string {
+  const removablePaths = new Set(referencePaths.map(normalizePathIdentity));
+  const matches = findLocalMarkdownImageReferences(text)
+    .filter((match) => removablePaths.has(normalizePathIdentity(match.path)))
+    .sort((left, right) => right.start - left.start);
+
+  let nextText = text;
+  for (const match of matches) {
+    nextText = `${nextText.slice(0, match.start)}${nextText.slice(match.end)}`;
+  }
+  return nextText;
+}
+
+export const removeMarkdownImageReferences = removeLocalMarkdownImageReferences;

--- a/src/path-reference.ts
+++ b/src/path-reference.ts
@@ -1,3 +1,6 @@
+import { extractLocalMarkdownImagePaths } from "./composer-image-reference.js";
+import type { ComposerAttachmentInput } from "./runtime-state.js";
+
 export const TEXT_PATH_REFERENCE_PATTERN = /(^|[\s(])@(?:"([^"\r\n]+)"|([^\s@]+))/gm;
 export const TEXT_PATH_REFERENCE_SIGNATURE_SEPARATOR = "\u001f";
 
@@ -21,6 +24,20 @@ export function extractTextReferenceCandidates(text: string): string[] {
   }
 
   return candidates;
+}
+
+export function extractComposerAttachmentReferenceCandidates(text: string): ComposerAttachmentInput[] {
+  return [
+    ...extractTextReferenceCandidates(text).map((path): ComposerAttachmentInput => ({
+      path,
+      source: "text",
+    })),
+    ...extractLocalMarkdownImagePaths(text).map((path): ComposerAttachmentInput => ({
+      kind: "image",
+      path,
+      source: "markdown-image",
+    })),
+  ];
 }
 
 export function buildTextReferenceCandidateState(text: string): TextReferenceCandidateState {

--- a/src/runtime-state.ts
+++ b/src/runtime-state.ts
@@ -322,7 +322,7 @@ export type DiscoveredCustomAgent = {
 
 export type ComposerAttachmentKind = "file" | "folder" | "image";
 
-export type ComposerAttachmentSource = "text";
+export type ComposerAttachmentSource = "text" | "markdown-image";
 
 export type ComposerAttachmentInput = {
   path: string;

--- a/src/session-composer-paths.ts
+++ b/src/session-composer-paths.ts
@@ -1,4 +1,8 @@
 import type { ComposerAttachment } from "./runtime-state.js";
+import {
+  formatMarkdownImageReference,
+  removeLocalMarkdownImageReferences,
+} from "./composer-image-reference.js";
 
 export type ComposerAttachmentDisplay = {
   kindLabel: string;
@@ -36,6 +40,11 @@ export type PathReferenceInsertionState = {
   draft: string;
 };
 
+export type ComposerReferenceInput = {
+  path: string;
+  presentation: "image" | "path";
+};
+
 export type ComposerPathPickerKind = "file" | "folder" | "image";
 
 export type ComposerReferencePathPicker = {
@@ -71,11 +80,34 @@ export function buildPathReferenceInsertionState(
   };
 }
 
+export function buildComposerReferenceInsertionState(
+  draft: string,
+  caret: number,
+  references: readonly ComposerReferenceInput[],
+): PathReferenceInsertionState | null {
+  if (references.length === 0) {
+    return null;
+  }
+
+  const referenceTokens = references.map((reference) => (
+    reference.presentation === "image"
+      ? formatMarkdownImageReference(reference.path)
+      : formatPathReference(reference.path)
+  ));
+  const leadingSpacer = caret > 0 && !/\s/.test(draft[caret - 1] ?? "") ? " " : "";
+  const trailingSpacer = draft.length > caret && !/\s/.test(draft[caret] ?? "") ? " " : "";
+  const insertion = `${leadingSpacer}${referenceTokens.join(" ")}${trailingSpacer}`;
+  return {
+    draft: `${draft.slice(0, caret)}${insertion}${draft.slice(caret)}`,
+    caret: caret + insertion.length,
+  };
+}
+
 export function removePathReferenceTokensFromDraft(
   draft: string,
   referencePaths: readonly string[],
 ): string {
-  let nextDraft = draft;
+  let nextDraft = removeLocalMarkdownImageReferences(draft, referencePaths);
   const escapedTokens = referencePaths
     .map((referencePath) => formatPathReference(referencePath))
     .map(escapeRegExpPattern);


### PR DESCRIPTION
## 概要

- チャットへ貼り付けた対応画像をMarkdown埋め込みとしてcomposerへ挿入
- Markdown画像をprovider添付として解決し、重複する参照を集約
- PNG、JPEG、GIF、WebP、BMP、SVGを画像表示対象とし、その他は従来のpath参照を維持
- ローカル画像を優先読み込みし、送信直後の表示待ちを短縮

## 検証

- targeted tests: 158 passed
- npm test: 2226 passed / 1 skipped / 0 failed
- npm run typecheck
- npm run build
- git diff --check