### PR TITLE
fix: Sessionの応答重複描画とスクロールのカクつきを修正

### DIFF
--- a/scripts/tests/auxiliary-session-message-projection.test.ts
+++ b/scripts/tests/auxiliary-session-message-projection.test.ts
@@ -367,6 +367,50 @@ test("resolveLiveAssistantMessageIndex は target session の次 assistant index
   );
 });
 
+test("resolveLiveAssistantMessageIndex は保存済み末尾へ遅延 live final を同じ行として収束させる", () => {
+  assert.equal(
+    resolveLiveAssistantMessageIndex(
+      [
+        { role: "user", text: "main prompt" },
+        { role: "assistant", text: "final response\n\nFailure notice" },
+      ],
+      [],
+      "session-1",
+      "session-1",
+      "final response",
+    ),
+    1,
+  );
+
+  assert.equal(
+    resolveLiveAssistantMessageIndex(
+      [
+        { role: "assistant", text: "same response" },
+        { role: "user", text: "next prompt" },
+      ],
+      [],
+      "session-1",
+      "session-1",
+      "same response",
+    ),
+    2,
+  );
+
+  assert.equal(
+    resolveLiveAssistantMessageIndex(
+      [{ role: "assistant", text: "main response" }],
+      [createAuxiliarySession([
+        { role: "user", text: "aux prompt" },
+        { role: "assistant", text: "aux final response" },
+      ], { id: "aux-1" })],
+      "aux-1",
+      "session-1",
+      "aux final response",
+    ),
+    1,
+  );
+});
+
 test("shouldProjectLiveAssistantBridge は live run が消えて persisted assistant もなければ bridge を投影しない", () => {
   assert.equal(
     shouldProjectLiveAssistantBridge({

--- a/scripts/tests/session-message-column.test.ts
+++ b/scripts/tests/session-message-column.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { JSDOM } from "jsdom";
-import React, { createRef, useState, type ComponentType } from "react";
+import React, { createRef, useState, type ComponentType, type ProfilerOnRenderCallback } from "react";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -272,6 +272,7 @@ async function mountSessionMessageColumn(options: {
   pendingMessageGroupId?: string | null;
   pendingMessageText?: string;
   messageViewMode?: SessionMessageColumnProps["messageViewMode"];
+  onRender?: ProfilerOnRenderCallback;
 }): Promise<MountedSessionMessageColumn> {
   const previousWindow = globalThis.window;
   const previousDocument = globalThis.document;
@@ -423,8 +424,7 @@ async function mountSessionMessageColumn(options: {
     messageViewMode?: SessionMessageColumnProps["messageViewMode"];
   }) => {
     await act(async () => {
-      root.render(
-        React.createElement(MessageColumn, {
+      const messageColumn = React.createElement(MessageColumn, {
           sessionId: "session-1",
           character,
           messages: callbacks.messages ?? options.messages,
@@ -453,8 +453,10 @@ async function mountSessionMessageColumn(options: {
           onCopyMessageText: callbacks.onCopyMessageText,
           onQuoteMessageText: callbacks.onQuoteMessageText,
           messageViewMode: callbacks.messageViewMode ?? options.messageViewMode,
-        }),
-      );
+        });
+      root.render(options.onRender
+        ? React.createElement(React.Profiler, { id: "session-message-column", onRender: options.onRender }, messageColumn)
+        : messageColumn);
     });
   };
 
@@ -961,7 +963,11 @@ test("SessionMessageColumn は上側rowの可変高再計測後も表示位置�
       mounted.container.querySelectorAll<HTMLElement>(".session-message-virtual-row"),
     );
     const rowAboveViewport = renderedRows.find((row) => {
-      const start = Number.parseFloat(row.style.transform.match(/translateY\(([^p]+)px\)/)?.[1] ?? "0");
+      const start = Number.parseFloat(
+        row.style.transform.match(/translate3d\(0,\s*([^p]+)px/)?.[1]
+          ?? row.style.transform.match(/translateY\(([^p]+)px\)/)?.[1]
+          ?? "0",
+      );
       return start < messageList.scrollTop;
     });
     assert.ok(rowAboveViewport);
@@ -996,6 +1002,9 @@ test("SessionMessageColumn は末尾追従中だけappend後も末尾へ追従�
       isMessageListFollowing: true,
       messages: appendedMessages,
     });
+    await act(async () => {
+      await new Promise<void>((resolve) => mounted.dom.window.requestAnimationFrame(() => resolve()));
+    });
 
     assert.ok(messageList.scrollTop > followingScrollTop);
     assert.match(mounted.container.textContent ?? "", /appended at end/);
@@ -1011,6 +1020,41 @@ test("SessionMessageColumn は末尾追従中だけappend後も末尾へ追従�
     });
 
     assert.equal(messageList.scrollTop, nonFollowingScrollTop);
+  } finally {
+    await mounted.cleanup();
+  }
+});
+
+test("SessionMessageColumn は同じ仮想範囲内の連続scrollでmessageを再描画しない", async () => {
+  let renderCount = 0;
+  const messages = Array.from({ length: 100 }, (_, index) => ({
+    role: index % 2 === 0 ? "user" as const : "assistant" as const,
+    text: `message ${index + 1}`,
+  }));
+  const mounted = await mountSessionMessageColumn({
+    messages,
+    onRender: () => {
+      renderCount += 1;
+    },
+  });
+
+  try {
+    const messageList = mounted.messageListRef.current;
+    assert.ok(messageList);
+    await act(async () => {
+      messageList.scrollTop = 3_000;
+      messageList.dispatchEvent(new mounted.dom.window.Event("scroll"));
+    });
+    const rendersAfterFirstScroll = renderCount;
+
+    for (const scrollTop of [3_002, 3_004, 3_006, 3_008, 3_010]) {
+      await act(async () => {
+        messageList.scrollTop = scrollTop;
+        messageList.dispatchEvent(new mounted.dom.window.Event("scroll"));
+      });
+    }
+
+    assert.equal(renderCount, rendersAfterFirstScroll);
   } finally {
     await mounted.cleanup();
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1149,9 +1149,10 @@ export default function AgentSessionWindowApp() {
           projectedAuxiliarySessions,
           activeRunSessionId,
           selectedSession?.id,
+          liveRunAssistantText,
         )
         : 0,
-    [activeRunSessionId, displayedMessages, projectedAuxiliarySessions, selectedSession?.id],
+    [activeRunSessionId, displayedMessages, liveRunAssistantText, projectedAuxiliarySessions, selectedSession?.id],
   );
   const hasPersistedLiveAssistantBridge = useMemo(
     () =>

--- a/src/CompanionReviewApp.tsx
+++ b/src/CompanionReviewApp.tsx
@@ -716,6 +716,7 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
   const activeComposerText = activeAuxiliarySession?.composerDraft ?? composerText;
   const selectedSessionLiveRun =
     activeRunSessionId !== null && liveRunState.ownerSessionId === activeRunSessionId ? liveRunState.state : null;
+  const liveRunAssistantText = selectedSessionLiveRun?.assistantText ?? "";
   const projectedAuxiliarySessions = useMessageListAuxiliarySessions(
     closedAuxiliarySessions,
     activeAuxiliarySession,
@@ -728,9 +729,10 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
           projectedAuxiliarySessions,
           activeRunSessionId,
           snapshot?.session.id,
+          liveRunAssistantText,
         )
         : 0,
-    [activeRunSessionId, projectedAuxiliarySessions, snapshot?.session.id, snapshot?.session.messages],
+    [activeRunSessionId, liveRunAssistantText, projectedAuxiliarySessions, snapshot?.session.id, snapshot?.session.messages],
   );
   const hasPersistedLiveAssistantBridge = useMemo(
     () =>
@@ -750,7 +752,6 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
       return null;
     }
 
-    const liveRunAssistantText = selectedSessionLiveRun?.assistantText ?? "";
     const liveThreadId = selectedSessionLiveRun?.threadId ?? null;
     const bridgeMessageIndex =
       liveAssistantBridge?.sessionId === activeRunSessionId &&
@@ -782,7 +783,7 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
     liveAssistantBridge,
     liveAssistantMessageIndex,
     selectedSessionLiveRun,
-    selectedSessionLiveRun?.assistantText,
+    liveRunAssistantText,
     selectedSessionLiveRun?.threadId,
   ]);
   const messageListProjection = useMemo(

--- a/src/auxiliary-session-message-projection.ts
+++ b/src/auxiliary-session-message-projection.ts
@@ -260,13 +260,21 @@ export function resolveLiveAssistantMessageIndex(
   auxiliarySessions: AuxiliaryMessageLookupSession[],
   targetSessionId: string,
   sessionId = "session",
+  assistantText = "",
 ): number {
-  if (targetSessionId === sessionId) {
-    return sessionMessages.length;
+  const targetMessages = targetSessionId === sessionId
+    ? sessionMessages
+    : auxiliarySessions.find((auxiliarySession) => auxiliarySession.id === targetSessionId)?.messages ?? [];
+  const persistedTailIndex = targetMessages.length - 1;
+  const persistedTail = targetMessages[persistedTailIndex];
+  if (
+    assistantText.length > 0 &&
+    persistedTail?.role === "assistant"
+  ) {
+    return persistedTailIndex;
   }
 
-  const targetAuxiliarySession = auxiliarySessions.find((auxiliarySession) => auxiliarySession.id === targetSessionId);
-  return targetAuxiliarySession?.messages.length ?? 0;
+  return targetMessages.length;
 }
 
 export function shouldProjectLiveAssistantBridge({

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -2474,7 +2474,8 @@ export function SessionMessageColumn({
       0,
       messages.length * SESSION_MESSAGE_ESTIMATED_ROW_HEIGHT - SESSION_MESSAGE_FALLBACK_VIEWPORT_HEIGHT,
     ),
-    useFlushSync: false,
+    directDomUpdates: true,
+    directDomUpdatesMode: "transform",
   });
   const virtualMessages = messageVirtualizer.getVirtualItems();
   const hasPendingMessageText =
@@ -2884,8 +2885,9 @@ export function SessionMessageColumn({
         {messages.length > 0 || isRunning ? (
           <div className="session-message-list-window">
             <div
+              ref={messageVirtualizer.containerRef}
               className="session-message-list-window-items"
-              style={{ height: messageVirtualizer.getTotalSize(), position: "relative" }}
+              style={{ position: "relative" }}
             >
           {virtualMessages.map((virtualMessage) => {
             const absoluteIndex = virtualMessage.index;
@@ -2931,7 +2933,6 @@ export function SessionMessageColumn({
                   doesMessageGroupContinue ? " auxiliary-message-group-continues" : ""
                 }${absoluteIndex === messages.length - 1 ? " session-message-virtual-row-end" : ""}`}
                 data-index={absoluteIndex}
-                style={{ transform: `translateY(${virtualMessage.start}px)` }}
               >
                 {isMessageGroupStart && messageGroup ? (
                   <div


### PR DESCRIPTION
## 概要

Sessionで同じassistantレスポンスが一時的に二重描画される問題と、メッセージ一覧のスクロールがカクつく問題を修正します。

## 原因

- persisted finalがlive responseより先に反映された場合、live projectionへ次のmessage indexが割り当てられ、一時的に別行として描画されていました。
- 仮想リストのscroll offset更新がReactのmessage tree再描画を伴っていました。

## 変更内容

- persisted finalと遅延live responseを、本文差分がある場合も同じassistant行へ収束させました。
- Session、Companion Review、Auxiliaryで共通のprojection境界を更新しました。
- 仮想リストの位置とcontainer sizeを直接DOM更新し、同じvirtual range内のscroll-only更新でmessage treeを再描画しないようにしました。
- 重複描画、別ターンの同文レスポンス、スクロール時の再描画、末尾追従に回帰テストを追加しました。

## 影響

応答確定時の一時的な二重表示を防ぎ、長いSessionのスクロールを滑らかにします。既存の末尾追従と可変高メッセージの位置補正は維持します。

## 検証

- `npx tsx --test scripts/tests/auxiliary-session-message-projection.test.ts scripts/tests/session-message-column.test.ts scripts/tests/session-chat-layout-hooks.test.tsx`（59 passed）
- `npm test`（2314 passed / 1 skipped / 0 failed）
- `npm run typecheck`
- `npm run build`
- 独立specialist reviewと修正後targeted closure（blockingなし）

Closes #258