### PR TITLE
fix: Session上スクロールの末尾フォールバックを防止

### DIFF
--- a/docs/design/desktop-ui.md
+++ b/docs/design/desktop-ui.md
@@ -247,8 +247,9 @@ Electron デスクトップアプリとして、`Home Window` / `Character Edito
 - 中央 live Git Diff は Split を既定表示とし、Inline へ切り替えられる。両表示は同じ unified patch と検索modelを投影し、Split でも表示rowをvirtualizeする
 - work surface は外側 card を持たず、padding / gap を抑えて message viewport を優先する
 - message list は条件付き follow mode で動かす
-  - viewport bottom gap が 80px 以下のときは末尾追従を許可する
-  - 80px を超えて上へ読んでいる間は位置を維持する
+  - viewport bottom gap が 80px 以下で、上方向へ読み始めていないときは末尾追従を許可する
+  - 上方向への scroll を検出した時点で追従を止め、80px 以内でも遅延描画や行高再計測によって末尾側へ戻さない
+  - 80px を超えて上へ読んでいる間も位置を維持する
   - `selectedSession.id` 切替時は follow / unread state をリセットする
   - 追従停止中は `新着あり` / `読み返し中` の最小 banner を表示し、`末尾へ移動` で復帰できる
 - pending 中の live activity / streaming response

--- a/docs/design/v6-memory-foundation.md
+++ b/docs/design/v6-memory-foundation.md
@@ -862,7 +862,7 @@ search監査は件数・latency・strategy程度に抑え、private query全文�
 ## Skill Distribution
 
 - Skillはglobal provider skill rootへ配置する。
-- current実装では、Settingsで解決できるprovider skill rootへ起動時と設定保存後に`withmate-memory`を同期する。provider skill root未設定時はskipする。
+- current実装では、packaged appだけがSettingsで解決できるprovider skill rootへ起動時と設定保存後に`withmate-memory`を同期する。source checkoutからの開発起動はglobal provider skill rootを変更せず、provider skill root未設定時もskipする。
 - WithMateが管理する場合はmanaged marker / versionを持つ。current実装では`.withmate-managed-skill.json`を持つ`withmate-memory`だけをapp version単位で更新する。
 - user-created同名Skillを無断上書きしない。
 - packaged CLI pathまたはshimをSkillが利用できるようにする。packaged CLI helperはbuild時に`scripts/withmate-memory.ts`から生成し、canonical CLIと別実装として保守しない。current実装ではWindowsのproviderへ同期するmanaged Skillは`SKILL.md`、`reference/`、managed markerを持ち、`bin/`は省略してinstalled app側のpackaged resourceをPATH shim経由で呼ぶ。Windowsではinstall rootの`withmate-memory.cmd`に加え、user PATH既定の`Microsoft\WindowsApps\withmate-memory.cmd` aliasをinstallerが作成する。installerはuser `Path` registry値を直接編集しない。macOS / LinuxではSettings > Diagnosticsから`~/.local/bin/withmate-memory` shimをinstall / uninstallできる。`~/.local/bin`がapp processの`PATH`に含まれてshimがusableな場合も、providerへ同期するmanaged Skillは`SKILL.md`、`reference/`、managed markerを持ち、`bin/`だけを省略する。
@@ -884,7 +884,7 @@ foundationではMemory Management Windowを戻さない。
 最小UI:
 
 - Settings DiagnosticsにMemory API状態を表示する。current実装ではruntime APIのrunning / stopped / failed、baseUrl、DB path、discovery file path、secret有無だけをread-onlyで返す。
-- global Skill install状態を表示する。current実装では直近managed Skill sync結果をproviderごとに表示し、collision / failed / unconfiguredを区別する。
+- global Skill install状態を表示する。current実装では直近managed Skill sync結果をproviderごとに表示し、unpackaged / collision / failed / unconfiguredを区別する。
 - last error summaryを表示する。current実装ではruntime起動/停止とSkill sync失敗の直近errorを最大3件保持する。
 - runtime API secret、discovery documentのsecret値はdiagnostics stateへ含めない。UIにはsecret値を表示しない。
 - Settings Diagnosticsにprovider instruction sampleを表示し、clipboard copy導線を置く。このsampleはユーザーが必要なprovider instruction fileへ手動で貼り付けるための補助であり、WithMateはinstruction fileを自動同期しない。
@@ -976,6 +976,7 @@ npm run build
 - `current` target、`--session-project`、`memory.resolve_context`を拒否する
 - Codex / Copilot adapterがMemory bindingなしでprovider client / session cacheを再利用する
 - user-created同名`withmate-memory` Skillを上書きせずcollisionとしてskipする
+- source checkoutからの開発起動ではmanaged Skillを新規作成も更新もしない
 - Settings DiagnosticsからMemory Review windowを開き、active entryの検索、full body閲覧、forgetを実行できる
 - Settings Diagnosticsでprovider instruction sampleを確認し、clipboardへcopyできる
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "withmate",
-  "version": "6.3.19",
+  "version": "6.3.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "withmate",
-      "version": "6.3.19",
+      "version": "6.3.20",
       "license": "ISC",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withmate",
-  "version": "6.3.19",
+  "version": "6.3.20",
   "description": "キャラクターロールプレイ対応 coding agent デスクトップアプリ",
   "private": true,
   "main": "dist-electron/src-electron/main.js",

--- a/resources/skills/withmate-memory/reference/character-context.md
+++ b/resources/skills/withmate-memory/reference/character-context.md
@@ -1,6 +1,6 @@
 # WithMate Character Context MCP and CLI Reference
 
-This reference describes the Character context interface bundled by WithMate. The installed managed Skill's `.withmate-managed-skill.json` contains `bundleVersion`, which identifies the WithMate release that supplied the Skill. In a source checkout, `package.json` is the release version anchor.
+This reference describes the Character context interface bundled by WithMate. The installed managed Skill's `.withmate-managed-skill.json` contains `bundleVersion`, which identifies the packaged WithMate release that supplied the Skill. Development runs from a source checkout do not install or update the global managed Skill.
 
 ## Contract versions
 

--- a/scripts/tests/managed-memory-skill-service.test.ts
+++ b/scripts/tests/managed-memory-skill-service.test.ts
@@ -101,6 +101,7 @@ describe("ManagedMemorySkillService", () => {
         bundledSkillPath: bundlePath,
         getAppSettings: () => settings,
         getAppVersion: () => "6.3.19-test",
+        isPackagedApp: () => true,
         platform: "win32",
       });
 
@@ -141,6 +142,7 @@ describe("ManagedMemorySkillService", () => {
         bundledSkillPath: bundlePath,
         getAppSettings: () => settings,
         getAppVersion: () => "5.0.0-test",
+        isPackagedApp: () => true,
         platform: "win32",
       });
 
@@ -177,6 +179,7 @@ describe("ManagedMemorySkillService", () => {
         bundledSkillPath: bundlePath,
         getAppSettings: () => settings,
         getAppVersion: () => "5.0.0-test",
+        isPackagedApp: () => true,
         platform: "win32",
       });
 
@@ -204,6 +207,7 @@ describe("ManagedMemorySkillService", () => {
         bundledSkillPath: bundlePath,
         getAppSettings: () => settings,
         getAppVersion: () => "5.0.0-test",
+        isPackagedApp: () => true,
         platform: "win32",
       });
 
@@ -237,6 +241,7 @@ describe("ManagedMemorySkillService", () => {
         bundledSkillPath: bundlePath,
         getAppSettings: () => settings,
         getAppVersion: () => "5.0.0-test",
+        isPackagedApp: () => true,
         platform: "win32",
       });
 
@@ -273,6 +278,7 @@ describe("ManagedMemorySkillService", () => {
         bundledSkillPath: bundlePath,
         getAppSettings: () => settings,
         getAppVersion: () => "5.0.0-test",
+        isPackagedApp: () => true,
         platform: "win32",
       });
 
@@ -309,6 +315,7 @@ describe("ManagedMemorySkillService", () => {
         bundledSkillPath: bundlePath,
         getAppSettings: () => settings,
         getAppVersion: () => "5.0.0-test",
+        isPackagedApp: () => true,
         platform: "win32",
       });
 
@@ -352,6 +359,7 @@ describe("ManagedMemorySkillService", () => {
           return settings;
         },
         getAppVersion: () => "5.0.0-test",
+        isPackagedApp: () => true,
         platform: "win32",
       });
 
@@ -365,6 +373,50 @@ describe("ManagedMemorySkillService", () => {
     }
   });
 
+  it("同期を許可しない runtime では provider skill root を変更しない", async () => {
+    const bundlePath = await createBundle();
+    const rootPath = await mkdtemp(path.join(tmpdir(), "withmate-memory-skill-root-"));
+    const directRootPath = await mkdtemp(path.join(tmpdir(), "withmate-memory-skill-direct-root-"));
+    try {
+      const settings = createDefaultAppSettings();
+      settings.codingProviderSettings.codex = {
+        enabled: true,
+        apiKey: "",
+        skillRootPath: rootPath,
+        skillRelativePath: "skills",
+        instructionRelativePath: "",
+      };
+      const existingSkillPath = path.join(rootPath, "skills", WITHMATE_MEMORY_SKILL_NAME);
+      await mkdir(existingSkillPath, { recursive: true });
+      await writeFile(path.join(existingSkillPath, "sentinel.txt"), "keep", "utf8");
+      let appVersionReadCount = 0;
+      const service = new ManagedMemorySkillService({
+        bundledSkillPath: bundlePath,
+        getAppSettings: () => settings,
+        getAppVersion: () => {
+          appVersionReadCount += 1;
+          return "43.1.0-test";
+        },
+        isPackagedApp: () => false,
+        platform: "win32",
+      });
+
+      const configuredResult = (await service.syncConfiguredProviderSkills())[0];
+      const directResult = await service.syncProviderSkill("direct", directRootPath);
+
+      assert.equal(configuredResult?.status, "skipped-unpackaged");
+      assert.equal(directResult.status, "skipped-unpackaged");
+      assert.equal(await readFile(path.join(existingSkillPath, "sentinel.txt"), "utf8"), "keep");
+      assert.equal(await pathExists(path.join(existingSkillPath, ".withmate-managed-skill.json")), false);
+      assert.equal(await pathExists(path.join(directRootPath, WITHMATE_MEMORY_SKILL_NAME)), false);
+      assert.equal(appVersionReadCount, 0);
+    } finally {
+      await rm(bundlePath, { recursive: true, force: true });
+      await rm(rootPath, { recursive: true, force: true });
+      await rm(directRootPath, { recursive: true, force: true });
+    }
+  });
+
   it("skill root 未設定 provider は skipped-unconfigured にする", async () => {
     const bundlePath = await createBundle();
     try {
@@ -372,6 +424,7 @@ describe("ManagedMemorySkillService", () => {
         bundledSkillPath: bundlePath,
         getAppSettings: () => createDefaultAppSettings(),
         getAppVersion: () => "5.0.0-test",
+        isPackagedApp: () => true,
         platform: "win32",
       });
 
@@ -400,6 +453,7 @@ describe("ManagedMemorySkillService", () => {
         bundledSkillPath: bundlePath,
         getAppSettings: () => settings,
         getAppVersion: () => "5.0.0-test",
+        isPackagedApp: () => true,
         platform: "darwin",
       });
 
@@ -433,6 +487,7 @@ describe("ManagedMemorySkillService", () => {
         bundledSkillPath: bundlePath,
         getAppSettings: () => settings,
         getAppVersion: () => "5.0.0-test",
+        isPackagedApp: () => true,
         platform: "darwin",
         shouldSyncSkillMarkdownOnly: () => true,
       });

--- a/scripts/tests/session-chat-layout-hooks.test.tsx
+++ b/scripts/tests/session-chat-layout-hooks.test.tsx
@@ -312,7 +312,7 @@ test("ActionDock compact height は展開時の外枠高ではなく compact row
   }
 });
 
-test("useSessionMessageListFollowing は非表示から復帰した chat を末尾追従へ戻す", async () => {
+test("useSessionMessageListFollowing は上方向scrollで追従を止め、非表示からの復帰時に戻す", async () => {
   const previousActEnvironment = (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
     .IS_REACT_ACT_ENVIRONMENT;
   const previousWindow = globalThis.window;
@@ -381,6 +381,30 @@ test("useSessionMessageListFollowing は非表示から復帰した chat を末�
     Object.defineProperty(messageList, "scrollHeight", { configurable: true, value: 1_000 });
     Object.defineProperty(messageList, "clientHeight", { configurable: true, value: 200 });
     await act(async () => {
+      messageList.scrollTop = 800;
+      messageList.dispatchEvent(new dom.window.Event("scroll", { bubbles: true }));
+      messageList.scrollTop = 760;
+      messageList.dispatchEvent(new dom.window.Event("scroll", { bubbles: true }));
+    });
+    assert.equal(following.textContent, "false");
+
+    await act(async () => {
+      root?.render(React.createElement(Harness, { enabled: true, scrollSignature: "while-reading" }));
+    });
+    assert.equal(scrollToBottomCount, 1);
+
+    await act(async () => {
+      messageList.scrollTop = 800;
+      messageList.dispatchEvent(new dom.window.Event("scroll", { bubbles: true }));
+    });
+    assert.equal(following.textContent, "true");
+
+    await act(async () => {
+      root?.render(React.createElement(Harness, { enabled: true, scrollSignature: "at-bottom-update" }));
+    });
+    assert.equal(scrollToBottomCount, 2);
+
+    await act(async () => {
       messageList.scrollTop = 300;
       messageList.dispatchEvent(new dom.window.Event("scroll", { bubbles: true }));
     });
@@ -389,12 +413,12 @@ test("useSessionMessageListFollowing は非表示から復帰した chat を末�
     await act(async () => {
       root?.render(React.createElement(Harness, { enabled: false, scrollSignature: "preview-update" }));
     });
-    assert.equal(scrollToBottomCount, 1);
+    assert.equal(scrollToBottomCount, 2);
 
     await act(async () => {
       root?.render(React.createElement(Harness, { enabled: true, scrollSignature: "preview-update" }));
     });
-    assert.equal(scrollToBottomCount, 1);
+    assert.equal(scrollToBottomCount, 2);
     assert.equal(following.textContent, "true");
   } finally {
     await act(async () => root?.unmount());

--- a/scripts/tests/session-message-column.test.ts
+++ b/scripts/tests/session-message-column.test.ts
@@ -11,6 +11,7 @@ import {
   SessionContextPane,
   SessionComposerExpanded,
   SessionMessageColumn,
+  shouldAdjustSessionMessageScrollPosition,
   type SessionMessageColumnProps,
 } from "../../src/session-components.js";
 import { StableSessionMessageColumn } from "../../src/chat/chat-window.js";
@@ -980,6 +981,24 @@ test("SessionMessageColumn は上側rowの可変高再計測後も表示位置�
   } finally {
     await mounted.cleanup();
   }
+});
+
+test("SessionMessageColumn は上方向scroll中のrow計測補正だけを抑止する", () => {
+  assert.equal(shouldAdjustSessionMessageScrollPosition({
+    itemStart: 1_000,
+    scrollOffset: 4_000,
+    scrollDirection: "backward",
+  }), false);
+  assert.equal(shouldAdjustSessionMessageScrollPosition({
+    itemStart: 1_000,
+    scrollOffset: 4_000,
+    scrollDirection: null,
+  }), true);
+  assert.equal(shouldAdjustSessionMessageScrollPosition({
+    itemStart: 5_000,
+    scrollOffset: 4_000,
+    scrollDirection: null,
+  }), false);
 });
 
 test("SessionMessageColumn は末尾追従中だけappend後も末尾へ追従する", async () => {

--- a/src-electron/main.ts
+++ b/src-electron/main.ts
@@ -1941,6 +1941,7 @@ function requireManagedMemorySkillService(): ManagedMemorySkillService {
       bundledSkillPath: bundledMemorySkillPath,
       getAppSettings: () => requireAppSettingsStorage().getSettings(),
       getAppVersion: () => app.getVersion(),
+      isPackagedApp: () => app.isPackaged,
       shouldSyncSkillMarkdownOnly: () => requireMemoryCliShimService().isPathShimUsable(),
     });
   }

--- a/src-electron/managed-memory-skill-service.ts
+++ b/src-electron/managed-memory-skill-service.ts
@@ -14,6 +14,7 @@ export type ManagedMemorySkillSyncStatus =
   | "installed"
   | "updated"
   | "unchanged"
+  | "skipped-unpackaged"
   | "skipped-unconfigured"
   | "skipped-collision"
   | "failed";
@@ -38,6 +39,7 @@ export type ManagedMemorySkillServiceDeps = {
   bundledSkillPath: string;
   getAppSettings(): AppSettings;
   getAppVersion(): string;
+  isPackagedApp(): boolean;
   platform?: NodeJS.Platform;
   shouldSyncSkillMarkdownOnly?: () => boolean | Promise<boolean>;
 };
@@ -67,6 +69,15 @@ export class ManagedMemorySkillService {
 
     const resolvedSkillRootPath = path.resolve(normalizedSkillRootPath);
     const skillPath = path.join(resolvedSkillRootPath, WITHMATE_MEMORY_SKILL_NAME);
+    if (!this.deps.isPackagedApp()) {
+      return {
+        providerId,
+        skillRootPath: resolvedSkillRootPath,
+        skillPath,
+        status: "skipped-unpackaged",
+      };
+    }
+
     try {
       const marker = await this.readMarker(skillPath);
       if (marker === "unmanaged") {

--- a/src/memory-v6/memory-diagnostics-state.ts
+++ b/src/memory-v6/memory-diagnostics-state.ts
@@ -14,6 +14,7 @@ export type MemoryV6SkillSyncDiagnostics = {
     | "installed"
     | "updated"
     | "unchanged"
+    | "skipped-unpackaged"
     | "skipped-unconfigured"
     | "skipped-collision"
     | "failed"

--- a/src/session-chat-layout-hooks.ts
+++ b/src/session-chat-layout-hooks.ts
@@ -30,6 +30,7 @@ const SESSION_ACTION_DOCK_MIN_HEIGHT = 260;
 const SESSION_ACTION_DOCK_MAX_HEIGHT_RATIO = 0.4;
 const SESSION_CENTRAL_SURFACE_MIN_HEIGHT = 280;
 const SESSION_VERTICAL_SPLITTER_TOTAL_HEIGHT = 40;
+const SESSION_MESSAGE_BOTTOM_EPSILON = 1;
 
 function scrollMessageListElementToBottom(messageListElement: HTMLDivElement): void {
   const bottomAnchor = messageListElement.querySelector<HTMLElement>(".message-list-bottom-anchor");
@@ -432,6 +433,7 @@ export function useSessionMessageListFollowing({
   const messageListSignatureRef = useRef("");
   const messageListOwnerKeyRef = useRef<string | null>(null);
   const messageListEnabledRef = useRef(enabled);
+  const previousMessageListScrollTopRef = useRef<number | null>(null);
   const [isMessageListFollowing, setIsMessageListFollowing] = useState(true);
 
   const scrollMessageListToBottom = useCallback(() => {
@@ -441,6 +443,10 @@ export function useSessionMessageListFollowing({
     }
 
     scrollMessageListElementToBottom(messageListElement);
+    previousMessageListScrollTopRef.current = Math.max(
+      0,
+      messageListElement.scrollHeight - messageListElement.clientHeight,
+    );
   }, []);
 
   useLayoutEffect(() => {
@@ -453,6 +459,7 @@ export function useSessionMessageListFollowing({
     if (!enabled) {
       messageListOwnerKeyRef.current = ownerKey;
       messageListSignatureRef.current = currentSignature;
+      previousMessageListScrollTopRef.current = null;
       return;
     }
 
@@ -460,12 +467,14 @@ export function useSessionMessageListFollowing({
     if (!messageListElement) {
       messageListOwnerKeyRef.current = ownerKey;
       messageListSignatureRef.current = currentSignature;
+      previousMessageListScrollTopRef.current = null;
       return;
     }
 
     if (!wasEnabled) {
       messageListOwnerKeyRef.current = ownerKey;
       messageListSignatureRef.current = currentSignature;
+      previousMessageListScrollTopRef.current = messageListElement.scrollTop;
       setIsMessageListFollowing(true);
       return;
     }
@@ -474,7 +483,7 @@ export function useSessionMessageListFollowing({
       messageListOwnerKeyRef.current = ownerKey;
       messageListSignatureRef.current = currentSignature;
       setIsMessageListFollowing(true);
-      scrollMessageListElementToBottom(messageListElement);
+      scrollMessageListToBottom();
       return;
     }
 
@@ -485,9 +494,9 @@ export function useSessionMessageListFollowing({
     messageListSignatureRef.current = currentSignature;
 
     if (isMessageListFollowing) {
-      scrollMessageListElementToBottom(messageListElement);
+      scrollMessageListToBottom();
     }
-  }, [enabled, isMessageListFollowing, ownerKey, scrollSignature]);
+  }, [enabled, isMessageListFollowing, ownerKey, scrollMessageListToBottom, scrollSignature]);
 
   const handleMessageListScroll = useCallback(() => {
     const messageListElement = messageListRef.current;
@@ -495,8 +504,14 @@ export function useSessionMessageListFollowing({
       return;
     }
 
-    const bottomGap = Math.max(0, messageListElement.scrollHeight - messageListElement.clientHeight - messageListElement.scrollTop);
-    const nextFollowing = bottomGap <= bottomThreshold;
+    const currentScrollTop = messageListElement.scrollTop;
+    const maxScrollTop = Math.max(0, messageListElement.scrollHeight - messageListElement.clientHeight);
+    const previousScrollTop = previousMessageListScrollTopRef.current ?? maxScrollTop;
+    previousMessageListScrollTopRef.current = currentScrollTop;
+    const bottomGap = Math.max(0, maxScrollTop - currentScrollTop);
+    const isScrollingUp = currentScrollTop < previousScrollTop;
+    const isAtBottom = bottomGap <= SESSION_MESSAGE_BOTTOM_EPSILON;
+    const nextFollowing = isAtBottom || (!isScrollingUp && bottomGap <= bottomThreshold);
 
     setIsMessageListFollowing((current) => (current === nextFollowing ? current : nextFollowing));
   }, [bottomThreshold]);

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -495,6 +495,14 @@ const SESSION_MESSAGE_FALLBACK_VIEWPORT_HEIGHT = 720;
 const SESSION_MESSAGE_OVERSCAN = 6;
 const SESSION_MESSAGE_SCROLL_END_THRESHOLD = 80;
 
+export function shouldAdjustSessionMessageScrollPosition(input: {
+  itemStart: number;
+  scrollOffset: number;
+  scrollDirection: "forward" | "backward" | null;
+}): boolean {
+  return input.scrollDirection !== "backward" && input.itemStart < input.scrollOffset;
+}
+
 type MessageArtifactFoldSection = "files" | "operation";
 
 function messageArtifactFoldKey(artifactKey: string, section: MessageArtifactFoldSection, index?: number): string {
@@ -2466,8 +2474,8 @@ export function SessionMessageColumn({
     estimateSize: () => SESSION_MESSAGE_ESTIMATED_ROW_HEIGHT,
     getItemKey: getMessageKey,
     overscan: SESSION_MESSAGE_OVERSCAN,
-    anchorTo: "end",
-    followOnAppend: true,
+    anchorTo: isMessageListFollowing ? "end" : "start",
+    followOnAppend: isMessageListFollowing,
     scrollEndThreshold: SESSION_MESSAGE_SCROLL_END_THRESHOLD,
     initialRect: { width: 0, height: SESSION_MESSAGE_FALLBACK_VIEWPORT_HEIGHT },
     initialOffset: Math.max(
@@ -2477,6 +2485,13 @@ export function SessionMessageColumn({
     directDomUpdates: true,
     directDomUpdatesMode: "transform",
   });
+  messageVirtualizer.shouldAdjustScrollPositionOnItemSizeChange = (item, _delta, instance) => (
+    shouldAdjustSessionMessageScrollPosition({
+      itemStart: item.start,
+      scrollOffset: instance.scrollOffset ?? 0,
+      scrollDirection: instance.scrollDirection,
+    })
+  );
   const virtualMessages = messageVirtualizer.getVirtualItems();
   const hasPendingMessageText =
     !hasLiveRunAssistantText &&


### PR DESCRIPTION
## 概要

- Sessionで上方向へスクロールした際、仮想化行の再計測によって末尾方向へ戻される挙動を抑止
- 上方向のユーザー操作を検出した時点で末尾追従を解除
- source checkoutからの開発起動ではglobal managed Skillを新規作成・更新しない
- アプリバージョンを6.3.20へ更新

## 検証

- `npm run typecheck`
- `npm test`（2316 pass / 1 skip / 0 fail）
- `npm run build`
- 「WithMate v6.3.18」Sessionでスクロール挙動を目視確認