### PR TITLE
fix(markdown): Markdownリンクのコピー操作を追加

### DIFF
--- a/docs/design/message-rich-text.md
+++ b/docs/design/message-rich-text.md
@@ -14,6 +14,9 @@ Session message と Markdown file preview に同じ rich text renderer を使い
 - ローカル path link に `#L10` などの fragment が付いている場合は、少なくとも path 本体を開けるように fragment を無視して扱う。`:10` または `:10:4` 形式は、指定された path が存在しない場合だけ行番号または行番号と列番号として扱う
 - Markdown file preview の相対 link と相対 image は、その file の親 directory と同じ認可済み root の中で解決する
 - OS の既定アプリで file を開けない場合は理由を表示し、通常の Open から Explorer 表示へ自動で切り替えない
+- render 済み link の context menu は「リンクをコピー」を提供し、表示 label ではなく通常の Open と同じ `href` target を clipboard へ渡す。encoded URL / path は decode・normalizeしない
+- HTTP / HTTPS、`mailto:`、workspace 相対 path、`file:`、Windows absolute pathをcopy対象とし、unsafe schemeで除去されたlinkと同一pageの`#` anchorは対象にしない
+- context menuはmouseの右clickに加え、focusしたlinkからShift+F10またはContext Menu keyで到達できるnative menuとする。dismissはcopy成功として通知しない
 - detached preview の navigation と root authorization は `docs/adr/020-file-preview-window-navigation.md` を正本とする
 
 ## Image Handling

--- a/scripts/tests/main-ipc-registration.test.ts
+++ b/scripts/tests/main-ipc-registration.test.ts
@@ -44,6 +44,7 @@ import {
   WITHMATE_GET_SESSION_FILE_PREVIEW_WINDOW_PAYLOAD_CHANNEL,
   WITHMATE_COPY_SESSION_FILE_PREVIEW_IMAGE_CHANNEL,
   WITHMATE_SHOW_SESSION_FILE_PREVIEW_IMAGE_CONTEXT_MENU_CHANNEL,
+  WITHMATE_SHOW_MARKDOWN_LINK_CONTEXT_MENU_CHANNEL,
   WITHMATE_LIST_FILE_ROOT_CHANGES_CHANNEL,
   WITHMATE_GET_FILE_ROOT_DIFF_CHANNEL,
   WITHMATE_OPEN_CHARACTER_EDITOR_WINDOW_CHANNEL,
@@ -149,6 +150,7 @@ test("registerMainIpcHandlers は保持する public IPC だけを登録する",
   assert.ok(handlers.has(WITHMATE_LIST_SESSION_SUMMARIES_CHANNEL));
   assert.ok(handlers.has(WITHMATE_COPY_SESSION_FILE_PREVIEW_IMAGE_CHANNEL));
   assert.ok(handlers.has(WITHMATE_SHOW_SESSION_FILE_PREVIEW_IMAGE_CONTEXT_MENU_CHANNEL));
+  assert.ok(handlers.has(WITHMATE_SHOW_MARKDOWN_LINK_CONTEXT_MENU_CHANNEL));
   assert.ok(handlers.has(WITHMATE_LIST_FILE_ROOT_CHANGES_CHANNEL));
   assert.ok(handlers.has(WITHMATE_GET_FILE_ROOT_DIFF_CHANNEL));
   assert.ok(handlers.has(WITHMATE_GET_APP_SETTINGS_CHANNEL));
@@ -708,6 +710,51 @@ test("画像copy IPCはowning Session windowと非負の整数座標だけを受
     () => handlers.get(WITHMATE_COPY_SESSION_FILE_PREVIEW_IMAGE_CHANNEL)?.({}, request) as Promise<unknown>,
     /owning Session window/,
   );
+});
+
+test("Markdown link context menu IPCはtarget文字列と非負の整数座標を変換せず渡す", async () => {
+  const { ipcMain, handlers } = createIpcMainStub();
+  const sourceWindow = createWindowStub("file:///session.html?sessionId=session-1");
+  let currentWindow: ReturnType<typeof createWindowStub> | null = sourceWindow;
+  const requests: unknown[] = [];
+  const { deps } = createDeps({
+    resolveEventWindow: () => currentWindow,
+    showMarkdownLinkContextMenu: async (_event: unknown, request: unknown) => {
+      requests.push(request);
+      return { status: "copied" };
+    },
+  });
+  registerMainIpcHandlers(ipcMain, deps);
+  const request = {
+    target: "file:///C:/tmp/candidate-source%20final.json",
+    point: { x: 24, y: 48 },
+  };
+
+  assert.deepEqual(
+    await handlers.get(WITHMATE_SHOW_MARKDOWN_LINK_CONTEXT_MENU_CHANNEL)?.({}, request),
+    { status: "copied" },
+  );
+  assert.deepEqual(requests, [request]);
+
+  for (const invalidRequest of [
+    null,
+    { target: "", point: { x: 1, y: 2 } },
+    { target: "docs/review-brief.md", point: { x: -1, y: 2 } },
+    { target: "docs/review-brief.md", point: { x: 1.5, y: 2 } },
+  ]) {
+    await assert.rejects(
+      () => handlers.get(WITHMATE_SHOW_MARKDOWN_LINK_CONTEXT_MENU_CHANNEL)?.({}, invalidRequest) as Promise<unknown>,
+      /Markdown link context menu request is invalid/,
+    );
+  }
+  assert.deepEqual(requests, [request]);
+
+  currentWindow = null;
+  await assert.rejects(
+    () => handlers.get(WITHMATE_SHOW_MARKDOWN_LINK_CONTEXT_MENU_CHANNEL)?.({}, request) as Promise<unknown>,
+    /only available from a WithMate window/,
+  );
+  assert.deepEqual(requests, [request]);
 });
 
 test("registerMainIpcHandlers は Mate 未作成時でも session runtime IPC を block しない", async () => {

--- a/scripts/tests/markdown-link-context-menu-service.test.ts
+++ b/scripts/tests/markdown-link-context-menu-service.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { MarkdownLinkContextMenuService } from "../../src-electron/markdown-link-context-menu-service.js";
+
+function createHarness(writeText: (target: string) => void = () => undefined) {
+  let menuTemplate: Array<{ label?: string; click?: () => void }> = [];
+  let popupOptions: { callback?: () => void; x?: number; y?: number; window?: unknown } | undefined;
+  const service = new MarkdownLinkContextMenuService({
+    buildMenu(template) {
+      menuTemplate = template as Array<{ label?: string; click?: () => void }>;
+      return {
+        popup(options) {
+          popupOptions = options;
+        },
+      };
+    },
+    writeText,
+  });
+  return {
+    service,
+    getMenuTemplate: () => menuTemplate,
+    getPopupOptions: () => popupOptions,
+  };
+}
+
+test("Markdown link context menuは選択時だけtargetをそのままclipboardへ渡す", async () => {
+  const copied: string[] = [];
+  const harness = createHarness((target) => copied.push(target));
+  const request = {
+    target: "docs/candidate-source%20final.json",
+    point: { x: 120, y: 240 },
+  };
+  const resultPromise = harness.service.showContextMenu({} as never, request);
+
+  assert.equal(harness.getMenuTemplate()[0]?.label, "リンクをコピー");
+  assert.deepEqual(harness.getPopupOptions(), {
+    window: {},
+    x: 120,
+    y: 240,
+    callback: harness.getPopupOptions()?.callback,
+  });
+  assert.deepEqual(copied, []);
+
+  harness.getMenuTemplate()[0]?.click?.();
+  assert.deepEqual(await resultPromise, { status: "copied" });
+  assert.deepEqual(copied, [request.target]);
+});
+
+test("Markdown link context menuはdismissとcopy失敗を成功扱いしない", async () => {
+  const dismissed = createHarness();
+  const dismissResult = dismissed.service.showContextMenu({} as never, {
+    target: "docs/review-brief.md",
+    point: { x: 1, y: 2 },
+  });
+  dismissed.getPopupOptions()?.callback?.();
+  assert.deepEqual(await dismissResult, { status: "dismissed" });
+
+  const failed = createHarness(() => {
+    throw new Error("clipboard unavailable");
+  });
+  const failedResult = failed.service.showContextMenu({} as never, {
+    target: "docs/review-brief.md",
+    point: { x: 1, y: 2 },
+  });
+  failed.getMenuTemplate()[0]?.click?.();
+  assert.deepEqual(await failedResult, {
+    status: "failed",
+    message: "リンクをコピーできませんでした。",
+  });
+});

--- a/scripts/tests/message-rich-text.test.ts
+++ b/scripts/tests/message-rich-text.test.ts
@@ -8,6 +8,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import {
   handleMarkdownLinkClick,
+  handleMarkdownLinkContextMenu,
   MessageRichText,
   resolveMessageMarkdownRenderMode,
 } from "../../src/MessageRichText.js";
@@ -33,6 +34,31 @@ function clickMarkdownLink(target: string) {
   );
 
   return { defaultPrevented, opened };
+}
+
+async function openMarkdownLinkContextMenu(target: string) {
+  const requests: Array<{ target: string; point: { x: number; y: number } }> = [];
+  let defaultPrevented = false;
+
+  const result = await handleMarkdownLinkContextMenu(
+    {
+      clientX: 120,
+      clientY: 240,
+      currentTarget: {
+        getBoundingClientRect: () => ({ left: 10, bottom: 20 }),
+      },
+      preventDefault: () => {
+        defaultPrevented = true;
+      },
+    },
+    target,
+    async (request) => {
+      requests.push(request);
+      return { status: "copied" };
+    },
+  );
+
+  return { defaultPrevented, requests, result };
 }
 
 function installDomGlobals(dom: JSDOM): () => void {
@@ -135,6 +161,111 @@ test("handleMarkdownLinkClick は encoded local link を decode せず openPath 
 
   assert.equal(defaultPrevented, true);
   assert.deepEqual(opened, ["docs/my%20file-%E4%BB%95%E6%A7%98.md"]);
+});
+
+test("handleMarkdownLinkContextMenu は openPath と同じ各種targetを変換せずmenuへ渡す", async () => {
+  const targets = [
+    "https://example.test/docs/my%20file.md?raw=%2F#intro",
+    "mailto:alice+docs@example.test",
+    "docs/review-brief%20final.md",
+    "file:///C:/tmp/candidate-source%20final.json",
+    "C:%5Cworkspace%5Creview-brief.md",
+  ];
+
+  for (const target of targets) {
+    const { defaultPrevented, requests, result } = await openMarkdownLinkContextMenu(target);
+    assert.equal(defaultPrevented, true);
+    assert.deepEqual(requests, [{ target, point: { x: 120, y: 240 } }]);
+    assert.deepEqual(result, { status: "copied" });
+  }
+});
+
+test("handleMarkdownLinkContextMenu は unsafe link と同一ページanchorをcopy対象にしない", async () => {
+  for (const target of ["javascript:alert(1)", "#message-footnote-example-fn-1", ""]) {
+    const { defaultPrevented, requests, result } = await openMarkdownLinkContextMenu(target);
+    assert.equal(defaultPrevented, false);
+    assert.deepEqual(requests, []);
+    assert.equal(result, null);
+  }
+});
+
+test("handleMarkdownLinkContextMenu はkeyboard起点のmenu位置をanchorから解決する", async () => {
+  let request: { target: string; point: { x: number; y: number } } | null = null;
+  await handleMarkdownLinkContextMenu(
+    {
+      clientX: 0,
+      clientY: 0,
+      currentTarget: {
+        getBoundingClientRect: () => ({ left: 32.4, bottom: 48.6 }),
+      },
+      preventDefault: () => undefined,
+    },
+    "docs/review-brief.md",
+    async (input) => {
+      request = input;
+      return { status: "dismissed" };
+    },
+  );
+
+  assert.deepEqual(request, {
+    target: "docs/review-brief.md",
+    point: { x: 32, y: 49 },
+  });
+});
+
+test("MessageRichText はrender済みlinkの右clickでtargetをcopy menuへ渡しfeedbackを表示する", async () => {
+  const dom = new JSDOM("<!doctype html><div id=\"root\"></div>", {
+    pretendToBeVisual: true,
+    url: "http://localhost/",
+  });
+  const requests: Array<{ target: string; point: { x: number; y: number } }> = [];
+  Object.defineProperty(dom.window, "withmate", {
+    configurable: true,
+    value: {
+      async showMarkdownLinkContextMenu(request: { target: string; point: { x: number; y: number } }) {
+        requests.push(request);
+        return { status: "copied" } as const;
+      },
+    },
+  });
+  const restoreGlobals = installDomGlobals(dom);
+  const container = dom.window.document.getElementById("root");
+  let root: Root | null = null;
+
+  try {
+    assert.ok(container);
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(React.createElement(MessageRichText, {
+        text: "[candidate](docs/candidate-source%20final.json)",
+        forceFullRender: true,
+      }));
+    });
+    const anchor = container.querySelector("a");
+    assert.ok(anchor);
+
+    await act(async () => {
+      anchor.dispatchEvent(new dom.window.MouseEvent("contextmenu", {
+        bubbles: true,
+        cancelable: true,
+        clientX: 80,
+        clientY: 160,
+      }));
+      await Promise.resolve();
+    });
+
+    assert.deepEqual(requests, [{
+      target: "docs/candidate-source%20final.json",
+      point: { x: 80, y: 160 },
+    }]);
+    assert.equal(container.querySelector(".message-link-copy-toast")?.textContent, "リンクをコピーしました。");
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    restoreGlobals();
+    dom.window.close();
+  }
 });
 
 test("MessageRichText は local/file href の encode を保持して render する", () => {

--- a/scripts/tests/preload-api.test.ts
+++ b/scripts/tests/preload-api.test.ts
@@ -265,6 +265,14 @@ test("createWithMateWindowApi は invoke 系 API を domain ごとに束ねる",
     channel: "withmate:show-session-file-preview-image-context-menu",
     args: [imageActionRequest],
   });
+  const markdownLinkRequest = {
+    target: "docs/review-brief%20final.md",
+    point: { x: 80, y: 160 },
+  };
+  assert.deepEqual(await api.showMarkdownLinkContextMenu(markdownLinkRequest), {
+    channel: "withmate:show-markdown-link-context-menu",
+    args: [markdownLinkRequest],
+  });
   assert.deepEqual(await api.listFileRootChanges({ sessionId: "session-1", rootId: "workspace" }), {
     channel: "withmate:list-file-root-changes",
     args: [{ sessionId: "session-1", rootId: "workspace" }],
@@ -439,6 +447,7 @@ test("createWithMateWindowApi は current public API の key を揃えて expose
     "setMateAvatar",
     "setSessionPinned",
     "showSessionFilePreviewImageContextMenu",
+    "showMarkdownLinkContextMenu",
     "startCharacterAuthoringSession",
     "stashCompanionTargetChanges",
     "subscribeAppSettings",

--- a/src-electron/main-ipc-deps.ts
+++ b/src-electron/main-ipc-deps.ts
@@ -20,6 +20,10 @@ import type {
   SessionSummary,
 } from "../src/app-state.js";
 import type { AppDatabaseDiagnostics } from "../src/app-database-diagnostics-state.js";
+import type {
+  MarkdownLinkContextMenuRequest,
+  MarkdownLinkContextMenuResult,
+} from "../src/markdown-link-context-menu.js";
 import type { MemoryV6Diagnostics } from "../src/memory-v6/memory-diagnostics-state.js";
 import type { MemoryForgetReason, MemoryV6ReviewSearchRequest } from "../src/memory-v6/memory-contract.js";
 import type { MemoryFileUsageResponse } from "../src/memory-v6/memory-response-contract.js";
@@ -155,6 +159,10 @@ export type MainIpcWindowDepsArgs = {
     event: IpcMainInvokeEvent,
     request: SessionFilePreviewImageActionRequest,
   ): Awaitable<SessionFilePreviewImageContextMenuResult>;
+  showMarkdownLinkContextMenu(
+    event: IpcMainInvokeEvent,
+    request: MarkdownLinkContextMenuRequest,
+  ): Awaitable<MarkdownLinkContextMenuResult>;
   openPathTarget(target: string, options?: OpenPathOptions): Promise<OpenPathResult>;
   openAppLogFolder(): Promise<void>;
   openCrashDumpFolder(): Promise<void>;
@@ -413,6 +421,7 @@ export function createMainIpcRegistrationDeps(
     openSessionFilesTerminal: args.window.openSessionFilesTerminal,
     copySessionFilePreviewImage: args.window.copySessionFilePreviewImage,
     showSessionFilePreviewImageContextMenu: args.window.showSessionFilePreviewImageContextMenu,
+    showMarkdownLinkContextMenu: args.window.showMarkdownLinkContextMenu,
     openPathTarget: args.window.openPathTarget,
     openAppLogFolder: args.window.openAppLogFolder,
     openCrashDumpFolder: args.window.openCrashDumpFolder,

--- a/src-electron/main-ipc-registration.ts
+++ b/src-electron/main-ipc-registration.ts
@@ -1,6 +1,10 @@
 import type { BrowserWindow, IpcMain, IpcMainInvokeEvent } from "electron";
 
 import type { RendererLogInput } from "../src/app-log-types.js";
+import type {
+  MarkdownLinkContextMenuRequest,
+  MarkdownLinkContextMenuResult,
+} from "../src/markdown-link-context-menu.js";
 import type { AppDatabaseDiagnostics } from "../src/app-database-diagnostics-state.js";
 import type { MemoryV6Diagnostics } from "../src/memory-v6/memory-diagnostics-state.js";
 import type { MemoryForgetReason, MemoryV6ReviewSearchRequest } from "../src/memory-v6/memory-contract.js";
@@ -161,6 +165,7 @@ import {
   WITHMATE_GET_SESSION_FILE_PREVIEW_WINDOW_PAYLOAD_CHANNEL,
   WITHMATE_COPY_SESSION_FILE_PREVIEW_IMAGE_CHANNEL,
   WITHMATE_SHOW_SESSION_FILE_PREVIEW_IMAGE_CONTEXT_MENU_CHANNEL,
+  WITHMATE_SHOW_MARKDOWN_LINK_CONTEXT_MENU_CHANNEL,
   WITHMATE_LIST_FILE_ROOT_CHANGES_CHANNEL,
   WITHMATE_GET_FILE_ROOT_DIFF_CHANNEL,
   WITHMATE_GET_SESSION_CONTEXT_TELEMETRY_CHANNEL,
@@ -379,6 +384,10 @@ export type MainIpcRegistrationDeps = {
     event: IpcSenderEvent,
     request: SessionFilePreviewImageActionRequest,
   ): Awaitable<SessionFilePreviewImageContextMenuResult>;
+  showMarkdownLinkContextMenu(
+    event: IpcSenderEvent,
+    request: MarkdownLinkContextMenuRequest,
+  ): Awaitable<MarkdownLinkContextMenuResult>;
   listFileRootChanges(request: FileRootChangesRequest): Awaitable<FileRootChangesResult>;
   getFileRootDiff(request: FileRootFileDiffRequest): Awaitable<FileRootFileDiffResult>;
   getSessionMessageArtifact(sessionId: string, messageIndex: number): Awaitable<MessageArtifact | null>;
@@ -590,6 +599,7 @@ type MainIpcSessionQueryDeps = Pick<
   | "getSessionFilePreviewWindowPayload"
   | "copySessionFilePreviewImage"
   | "showSessionFilePreviewImageContextMenu"
+  | "showMarkdownLinkContextMenu"
   | "listFileRootChanges"
   | "getFileRootDiff"
   | "getSessionMessageArtifact"
@@ -872,6 +882,30 @@ function parseSessionFilePreviewImageActionRequest(
   }
   return {
     sessionId: candidate.sessionId,
+    point: { x: point.x, y: point.y },
+  };
+}
+
+function parseMarkdownLinkContextMenuRequest(input: unknown): MarkdownLinkContextMenuRequest {
+  if (!input || typeof input !== "object") {
+    throw new TypeError("Markdown link context menu request is invalid.");
+  }
+  const candidate = input as Partial<MarkdownLinkContextMenuRequest>;
+  const point = candidate.point;
+  if (
+    typeof candidate.target !== "string"
+    || !candidate.target
+    || !point
+    || typeof point !== "object"
+    || !Number.isSafeInteger(point.x)
+    || point.x < 0
+    || !Number.isSafeInteger(point.y)
+    || point.y < 0
+  ) {
+    throw new TypeError("Markdown link context menu request is invalid.");
+  }
+  return {
+    target: candidate.target,
     point: { x: point.x, y: point.y },
   };
 }
@@ -1341,6 +1375,13 @@ function registerSessionQueryHandlers(ipcMain: IpcHandleRegistrar, deps: MainIpc
     const request = parseSessionFilePreviewImageActionRequest(input);
     await assertSessionFileExplorerSender(event, request.sessionId, deps);
     return deps.showSessionFilePreviewImageContextMenu(event, request);
+  });
+  ipcMain.handle(WITHMATE_SHOW_MARKDOWN_LINK_CONTEXT_MENU_CHANNEL, (event, input: unknown) => {
+    const request = parseMarkdownLinkContextMenuRequest(input);
+    if (!deps.resolveEventWindow(event)) {
+      throw new TypeError("Markdown link context menu is only available from a WithMate window.");
+    }
+    return deps.showMarkdownLinkContextMenu(event, request);
   });
   ipcMain.handle(WITHMATE_LIST_FILE_ROOT_CHANGES_CHANNEL, async (event, request: FileRootChangesRequest) => {
     if (

--- a/src-electron/main.ts
+++ b/src-electron/main.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import {
   app,
   BrowserWindow,
+  clipboard,
   crashReporter,
   dialog,
   ipcMain,
@@ -144,6 +145,7 @@ import { WindowDialogService } from "./window-dialog-service.js";
 import { SessionMemorySupportService } from "./session-memory-support-service.js";
 import { SessionFileExplorerService, type SessionFileExplorerContext } from "./session-file-explorer-service.js";
 import { SessionFilePreviewImageCopyService } from "./session-file-preview-image-copy-service.js";
+import { MarkdownLinkContextMenuService } from "./markdown-link-context-menu-service.js";
 import { FileRootGitChangesService } from "./file-root-git-changes-service.js";
 import {
   appendSessionFilesDirectory,
@@ -276,6 +278,10 @@ const bundledMemorySkillPath = app.isPackaged
 const trayIconPath = path.resolve(currentDir, "../../build/icon.ico");
 const sessionFilePreviewImageCopyService = new SessionFilePreviewImageCopyService({
   buildMenu: (template) => Menu.buildFromTemplate(template),
+});
+const markdownLinkContextMenuService = new MarkdownLinkContextMenuService({
+  buildMenu: (template) => Menu.buildFromTemplate(template),
+  writeText: (target) => clipboard.writeText(target),
 });
 const codexAdapter = new CodexAdapter((input) => writeAppLog({
   ...input,
@@ -1349,6 +1355,11 @@ function requireMainInfrastructureRegistry(): MainInfrastructureRegistry<
                     BrowserWindow.fromWebContents(event.sender) ?? null,
                     event.sender,
                     request.point,
+                  ),
+                showMarkdownLinkContextMenu: (event, request) =>
+                  markdownLinkContextMenuService.showContextMenu(
+                    BrowserWindow.fromWebContents(event.sender) ?? null,
+                    request,
                   ),
                 openPathTarget,
                 openAppLogFolder: () => openDirectory(appLogsPath),

--- a/src-electron/markdown-link-context-menu-service.ts
+++ b/src-electron/markdown-link-context-menu-service.ts
@@ -1,0 +1,63 @@
+import type { BrowserWindow, Menu, MenuItemConstructorOptions } from "electron";
+
+import type {
+  MarkdownLinkContextMenuRequest,
+  MarkdownLinkContextMenuResult,
+} from "../src/markdown-link-context-menu.js";
+
+type LinkContextMenu = Pick<Menu, "popup">;
+
+export type MarkdownLinkContextMenuServiceDeps = {
+  buildMenu(template: MenuItemConstructorOptions[]): LinkContextMenu;
+  writeText(target: string): void;
+};
+
+const LINK_COPY_FAILED_MESSAGE = "リンクをコピーできませんでした。";
+const LINK_CONTEXT_MENU_FAILED_MESSAGE = "リンクのメニューを開けませんでした。";
+
+export class MarkdownLinkContextMenuService {
+  constructor(private readonly deps: MarkdownLinkContextMenuServiceDeps) {}
+
+  private copyTarget(target: string): MarkdownLinkContextMenuResult {
+    try {
+      this.deps.writeText(target);
+      return { status: "copied" };
+    } catch {
+      return { status: "failed", message: LINK_COPY_FAILED_MESSAGE };
+    }
+  }
+
+  showContextMenu(
+    window: BrowserWindow | null,
+    request: MarkdownLinkContextMenuRequest,
+  ): Promise<MarkdownLinkContextMenuResult> {
+    if (!window) {
+      return Promise.resolve({ status: "failed", message: LINK_CONTEXT_MENU_FAILED_MESSAGE });
+    }
+
+    return new Promise((resolve) => {
+      let settled = false;
+      const settle = (result: MarkdownLinkContextMenuResult) => {
+        if (!settled) {
+          settled = true;
+          resolve(result);
+        }
+      };
+
+      try {
+        const menu = this.deps.buildMenu([{
+          label: "リンクをコピー",
+          click: () => settle(this.copyTarget(request.target)),
+        }]);
+        menu.popup({
+          window,
+          x: request.point.x,
+          y: request.point.y,
+          callback: () => settle({ status: "dismissed" }),
+        });
+      } catch {
+        settle({ status: "failed", message: LINK_CONTEXT_MENU_FAILED_MESSAGE });
+      }
+    });
+  }
+}

--- a/src-electron/preload-api.ts
+++ b/src-electron/preload-api.ts
@@ -78,6 +78,7 @@ import {
   WITHMATE_GET_SESSION_FILE_PREVIEW_WINDOW_PAYLOAD_CHANNEL,
   WITHMATE_COPY_SESSION_FILE_PREVIEW_IMAGE_CHANNEL,
   WITHMATE_SHOW_SESSION_FILE_PREVIEW_IMAGE_CONTEXT_MENU_CHANNEL,
+  WITHMATE_SHOW_MARKDOWN_LINK_CONTEXT_MENU_CHANNEL,
   WITHMATE_LIST_FILE_ROOT_CHANGES_CHANNEL,
   WITHMATE_GET_FILE_ROOT_DIFF_CHANNEL,
   WITHMATE_GET_SESSION_CONTEXT_TELEMETRY_CHANNEL,
@@ -258,6 +259,9 @@ function createWindowApi(ipcRenderer: IpcRendererLike): WithMateWindowNavigation
     },
     openPath(target, options) {
       return ipcRenderer.invoke(WITHMATE_OPEN_PATH_CHANNEL, target, options ?? null);
+    },
+    showMarkdownLinkContextMenu(request) {
+      return ipcRenderer.invoke(WITHMATE_SHOW_MARKDOWN_LINK_CONTEXT_MENU_CHANNEL, request);
     },
     openAppLogFolder() {
       return ipcRenderer.invoke(WITHMATE_OPEN_APP_LOG_FOLDER_CHANNEL);

--- a/src/MessageRichText.tsx
+++ b/src/MessageRichText.tsx
@@ -1,4 +1,15 @@
-import { Children, isValidElement, memo, useEffect, useId, useMemo, useState, type MouseEvent, type ReactNode } from "react";
+import {
+  Children,
+  isValidElement,
+  memo,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
 import ReactMarkdown, { defaultUrlTransform, type Components, type UrlTransform } from "react-markdown";
 import rehypeKatex from "rehype-katex";
 import remarkGfm from "remark-gfm";
@@ -8,6 +19,10 @@ import type { PluggableList } from "unified";
 import { getWithMateApi } from "./renderer-withmate-api.js";
 import { toLocalFileUrl } from "./local-file-url.js";
 import { resolveOpenPathFeedback, showOpenPathFeedback } from "./open-path-result.js";
+import type {
+  MarkdownLinkContextMenuRequest,
+  MarkdownLinkContextMenuResult,
+} from "./markdown-link-context-menu.js";
 
 export type MessageViewMode = "preview" | "source";
 
@@ -193,6 +208,50 @@ export function handleMarkdownLinkClick(
 
   event.preventDefault();
   openMarkdownLink(target, onOpenPath);
+}
+
+type MarkdownLinkContextMenuEvent = {
+  clientX: number;
+  clientY: number;
+  currentTarget: {
+    getBoundingClientRect(): Pick<DOMRect, "bottom" | "left">;
+  };
+  preventDefault(): void;
+};
+
+type ShowMarkdownLinkContextMenu = (
+  request: MarkdownLinkContextMenuRequest,
+) => Promise<MarkdownLinkContextMenuResult>;
+
+export async function handleMarkdownLinkContextMenu(
+  event: MarkdownLinkContextMenuEvent,
+  target: string,
+  showContextMenu?: ShowMarkdownLinkContextMenu,
+): Promise<MarkdownLinkContextMenuResult | null> {
+  if (!target || target.startsWith("#") || hasUnsupportedUrlScheme(target)) {
+    return null;
+  }
+
+  const showMenu = showContextMenu ?? getWithMateApi()?.showMarkdownLinkContextMenu;
+  if (!showMenu) {
+    return null;
+  }
+
+  const anchorRect = event.currentTarget.getBoundingClientRect();
+  const keyboardTriggered = event.clientX === 0 && event.clientY === 0;
+  const point = keyboardTriggered
+    ? { x: Math.max(0, Math.round(anchorRect.left)), y: Math.max(0, Math.round(anchorRect.bottom)) }
+    : { x: Math.max(0, Math.round(event.clientX)), y: Math.max(0, Math.round(event.clientY)) };
+
+  event.preventDefault();
+  try {
+    return await showMenu({ target, point });
+  } catch (error) {
+    return {
+      status: "failed",
+      message: error instanceof Error ? error.message : "リンクのメニューを開けませんでした。",
+    };
+  }
 }
 
 function replaceFootnoteLabelReference(value: unknown, footnoteLabelId: string) {
@@ -499,6 +558,7 @@ function createMarkdownComponents(
   onOpenPath?: (target: string) => void,
   options?: {
     enableMermaid?: boolean;
+    onLinkContextMenuResult?: (result: MarkdownLinkContextMenuResult) => void;
     resolveImageSource?: (target: string) => Promise<string | null>;
   },
 ): Components {
@@ -519,9 +579,16 @@ function createMarkdownComponents(
       const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
         handleMarkdownLinkClick(event, target, onOpenPath);
       };
+      const handleContextMenu = (event: MouseEvent<HTMLAnchorElement>) => {
+        void handleMarkdownLinkContextMenu(event, target).then((result) => {
+          if (result && result.status !== "dismissed") {
+            options?.onLinkContextMenuResult?.(result);
+          }
+        });
+      };
 
       return (
-        <a {...props} href={href} onClick={handleClick}>
+        <a {...props} href={href} onClick={handleClick} onContextMenu={handleContextMenu}>
           {children}
         </a>
       );
@@ -552,15 +619,30 @@ function MessageMarkdownPreview({
   const footnotePrefix = useMemo(() => `message-footnote-${reactId.replace(/[^a-zA-Z0-9_-]/g, "")}-`, [reactId]);
   const footnoteLabelId = `${footnotePrefix}footnote-label`;
   const shouldDefer = !forceFullRender && shouldDeferRichMarkdownRender();
+  const [linkCopyFeedback, setLinkCopyFeedback] = useState<{
+    message: string;
+    tone: "error" | "success";
+  } | null>(null);
   const [renderState, setRenderState] = useState<{ text: string; mode: MarkdownRenderMode }>(() => ({
     text,
     mode: shouldDefer ? "light" : "full",
   }));
   const renderMode = resolveMessageMarkdownRenderMode(forceFullRender, text, renderState, shouldDefer);
   const isFullRender = renderMode === "full";
+  const handleLinkContextMenuResult = useCallback((result: MarkdownLinkContextMenuResult) => {
+    setLinkCopyFeedback(result.status === "copied"
+      ? { message: "リンクをコピーしました。", tone: "success" }
+      : result.status === "failed"
+        ? { message: result.message, tone: "error" }
+        : null);
+  }, []);
   const components = useMemo(
-    () => createMarkdownComponents(onOpenPath, { enableMermaid: isFullRender, resolveImageSource }),
-    [isFullRender, onOpenPath, resolveImageSource],
+    () => createMarkdownComponents(onOpenPath, {
+      enableMermaid: isFullRender,
+      onLinkContextMenuResult: handleLinkContextMenuResult,
+      resolveImageSource,
+    }),
+    [handleLinkContextMenuResult, isFullRender, onOpenPath, resolveImageSource],
   );
   const rehypePlugins = useMemo<PluggableList>(
     () => (isFullRender ? [rehypeKatex, createFootnoteLabelIdPlugin(footnoteLabelId)] : []),
@@ -587,6 +669,14 @@ function MessageMarkdownPreview({
     });
   }, [shouldDefer, text]);
 
+  useEffect(() => {
+    if (!linkCopyFeedback) {
+      return;
+    }
+    const timeout = window.setTimeout(() => setLinkCopyFeedback(null), 2_400);
+    return () => window.clearTimeout(timeout);
+  }, [linkCopyFeedback]);
+
   return (
     <div className={`${className} rich-text`.trim()} data-markdown-render-mode={renderMode}>
       <ReactMarkdown
@@ -598,6 +688,16 @@ function MessageMarkdownPreview({
       >
         {text}
       </ReactMarkdown>
+      {linkCopyFeedback ? (
+        <span
+          className={`message-link-copy-toast ${linkCopyFeedback.tone}`}
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          {linkCopyFeedback.message}
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/src/markdown-link-context-menu.ts
+++ b/src/markdown-link-context-menu.ts
@@ -1,0 +1,14 @@
+export type MarkdownLinkContextMenuPoint = {
+  x: number;
+  y: number;
+};
+
+export type MarkdownLinkContextMenuRequest = {
+  target: string;
+  point: MarkdownLinkContextMenuPoint;
+};
+
+export type MarkdownLinkContextMenuResult =
+  | { status: "copied" }
+  | { status: "dismissed" }
+  | { status: "failed"; message: string };

--- a/src/styles.css
+++ b/src/styles.css
@@ -10356,6 +10356,28 @@ button:disabled {
   color: #933c3c;
 }
 
+.message-link-copy-toast {
+  position: fixed;
+  right: 18px;
+  bottom: 18px;
+  z-index: 50;
+  max-width: min(520px, calc(100vw - 36px));
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  padding: 10px 12px;
+  background: var(--surface-strong);
+  color: var(--ink);
+  box-shadow: var(--shadow);
+}
+
+.message-link-copy-toast.success {
+  border-color: var(--teal);
+}
+
+.message-link-copy-toast.error {
+  border-color: var(--danger, #fca5a5);
+}
+
 .companion-review-toast {
   border-color: rgba(203, 213, 225, 0.12);
   background: rgba(15, 19, 26, 0.96);

--- a/src/withmate-ipc-channels.ts
+++ b/src/withmate-ipc-channels.ts
@@ -20,6 +20,7 @@ export const WITHMATE_GET_SESSION_FILE_PREVIEW_WINDOW_PAYLOAD_CHANNEL =
 export const WITHMATE_COPY_SESSION_FILE_PREVIEW_IMAGE_CHANNEL = "withmate:copy-session-file-preview-image";
 export const WITHMATE_SHOW_SESSION_FILE_PREVIEW_IMAGE_CONTEXT_MENU_CHANNEL =
   "withmate:show-session-file-preview-image-context-menu";
+export const WITHMATE_SHOW_MARKDOWN_LINK_CONTEXT_MENU_CHANNEL = "withmate:show-markdown-link-context-menu";
 export const WITHMATE_LIST_FILE_ROOT_CHANGES_CHANNEL = "withmate:list-file-root-changes";
 export const WITHMATE_GET_FILE_ROOT_DIFF_CHANNEL = "withmate:get-file-root-diff";
 export const WITHMATE_GET_SESSION_MESSAGE_ARTIFACT_CHANNEL = "withmate:get-session-message-artifact";

--- a/src/withmate-window-api.ts
+++ b/src/withmate-window-api.ts
@@ -43,6 +43,10 @@ import type {
 } from "./companion-review-state.js";
 import type { ModelCatalogDocument, ModelCatalogSnapshot } from "./model-catalog.js";
 import type { RendererLogInput } from "./app-log-types.js";
+import type {
+  MarkdownLinkContextMenuRequest,
+  MarkdownLinkContextMenuResult,
+} from "./markdown-link-context-menu.js";
 import type { AppBootStatus } from "./app-boot-state.js";
 import type { AppDatabaseDiagnostics } from "./app-database-diagnostics-state.js";
 import type { MemoryV6Diagnostics } from "./memory-v6/memory-diagnostics-state.js";
@@ -116,6 +120,9 @@ export type WithMateWindowNavigationApi = {
   openCompanionReviewWindow(sessionId: string): Promise<void>;
   openCompanionMergeWindow(sessionId: string): Promise<void>;
   openPath(target: string, options?: OpenPathOptions): Promise<OpenPathResult>;
+  showMarkdownLinkContextMenu(
+    request: MarkdownLinkContextMenuRequest,
+  ): Promise<MarkdownLinkContextMenuResult>;
   openAppLogFolder(): Promise<void>;
   openCrashDumpFolder(): Promise<void>;
   openSessionTerminal(sessionId: string): Promise<void>;


### PR DESCRIPTION
## 概要

render済みMarkdownリンクから、native context menuの「リンクをコピー」を選んでリンクtargetをコピーできるようにします。

## 変更内容

- 右クリックおよびShift+F10 / Context Menuキーからコピー操作へ到達可能にする
- 表示labelではなく、既存のopenPath経路と同じtargetをdecode・normalizeせずclipboardへ渡す
- unsafe hrefと同一ページアンカーをcopy対象から除外する
- 成功・失敗を小さな一時feedbackで表示する
- renderer、preload / IPC、menu serviceの契約テストを追加する
- Markdown rich text設計文書へcopy契約を追記する

## 検証

- `npx tsx --test scripts/tests/main-ipc-registration.test.ts scripts/tests/message-rich-text.test.ts scripts/tests/markdown-link-context-menu-service.test.ts scripts/tests/preload-api.test.ts`（73件成功）
- `npm run typecheck`
- `npm test`（2323件成功、1件skip、失敗0）
- `npm run build`
- `npm run build:electron`

## 未実施

- 実Electron上でのnative menu位置、Shift+F10、OS clipboardのvisual smoke