### PR TITLE
fix(chat): 選択操作をActionDockより前面に表示

### DIFF
--- a/docs/design/message-rich-text.md
+++ b/docs/design/message-rich-text.md
@@ -37,6 +37,7 @@ Session message と Markdown file preview に同じ rich text renderer を使い
 - message と file preview は同じ component mapping を使う
 - 呼び出し元は path open と local image resolution の context だけを注入する
 - Quote を提供する共通 chat window は Preview を既定とし、ActionDock の表示切替で message column 全体を Source にできる。Source は元 Markdown を plain text として表示し、選択、Quote、検索は表示中の source text を対象にする
+- assistant response の選択 action は Session chat root が overlay と stacking context を所有し、message surface や ActionDock の局所 stacking context から分離する。位置と lifecycle の executable contract は `src/chat/selection-action-overlay.ts` と `scripts/tests/session-message-column.test.ts` を正本とする
 - message の表示 mode は window mount 中だけ保持し、永続化しない。切替時は既存の selection を解除する
 - Markdown file preview は Preview を既定とし、Source は file preview 側が切り替える
 

--- a/scripts/tests/session-context-pane-style.test.ts
+++ b/scripts/tests/session-context-pane-style.test.ts
@@ -65,6 +65,23 @@ test("Session header menu は固定高の Header Dock に切られず中央領�
   );
 });
 
+test("selection action overlay は Session layout の stacking context 内で surface と modal の間を所有する", async () => {
+  const stylesSource = await readFile("src/styles.css", "utf8");
+
+  assert.match(
+    stylesSource,
+    /\.session-chat-layout\s*{[\s\S]*?isolation:\s*isolate;[\s\S]*?}/,
+  );
+  assert.match(
+    stylesSource,
+    /\.session-selection-action-overlay\s*{\s*position:\s*fixed;\s*z-index:\s*35;\s*inset:\s*0;\s*pointer-events:\s*none;\s*}/,
+  );
+  assert.match(
+    stylesSource,
+    /\.message-response-actions\s*{[\s\S]*?position:\s*fixed;[\s\S]*?pointer-events:\s*auto;[\s\S]*?}/,
+  );
+});
+
 test("左右ペインは固定 track 構成の幅と内容を滑らかに開閉する", async () => {
   const stylesSource = await readFile("src/styles.css", "utf8");
 

--- a/scripts/tests/session-message-column.test.ts
+++ b/scripts/tests/session-message-column.test.ts
@@ -10,6 +10,7 @@ import {
   SessionActionDockCompactRow,
   SessionContextPane,
   SessionComposerExpanded,
+  SessionChatScreen,
   SessionMessageColumn,
   shouldAdjustSessionMessageScrollPosition,
   type SessionMessageColumnProps,
@@ -19,6 +20,7 @@ import { useCompanionCharacterProfile } from "../../src/companion-character-prof
 import type { CompanionSession } from "../../src/companion-state.js";
 import { buildContextPaneProjection } from "../../src/session-ui-projection.js";
 import type { CharacterProfile, LiveApprovalRequest, LiveElicitationRequest, Message } from "../../src/app-state.js";
+import { resolveSelectionActionOverlayPosition } from "../../src/chat/selection-action-overlay.js";
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -360,6 +362,9 @@ async function mountSessionMessageColumn(options: {
   };
 
   dom.window.HTMLElement.prototype.getBoundingClientRect = function getBoundingClientRect() {
+    if (this.classList.contains("session-selection-action-overlay")) {
+      return createRect({ left: 0, top: 0, width: 960, height: 720 });
+    }
     if (this.classList.contains("session-message-list")) {
       return createRect({ left: 0, top: 0, width: 960, height: 720 });
     }
@@ -455,9 +460,22 @@ async function mountSessionMessageColumn(options: {
           onQuoteMessageText: callbacks.onQuoteMessageText,
           messageViewMode: callbacks.messageViewMode ?? options.messageViewMode,
         });
-      root.render(options.onRender
+      const profiledMessageColumn = options.onRender
         ? React.createElement(React.Profiler, { id: "session-message-column", onRender: options.onRender }, messageColumn)
-        : messageColumn);
+        : messageColumn;
+      root.render(React.createElement(SessionChatScreen, {
+        mode: "agent",
+        header: null,
+        headerSplitter: null,
+        isHeaderVisible: false,
+        messageColumn: profiledMessageColumn,
+        actionDock: null,
+        actionDockSplitter: null,
+        isActionDockExpanded: false,
+        layoutPriority: "dock-first",
+        splitter: null,
+        rightPane: null,
+      }));
     });
   };
 
@@ -1213,6 +1231,41 @@ test("SessionMessageColumn は artifact 展開と diff 起動に必要な表示�
   assert.match(html, /snapshot files/);
 });
 
+test("selection action geometry は viewport と ActionDock 境界内で flip と左右 clamp を行う", () => {
+  const overlayRect = createRect({ left: 0, top: 0, width: 360, height: 640 });
+  const sourceRect = createRect({ left: 12, top: 80, width: 336, height: 500 });
+  const actionDockRect = createRect({ left: 12, top: 580, width: 336, height: 48 });
+  const toolbarRect = { width: 112, height: 32 };
+
+  const nearDock = resolveSelectionActionOverlayPosition({
+    anchorRect: createRect({ left: 150, top: 566, width: 60, height: 12 }),
+    actionDockRect,
+    overlayRect,
+    sourceRect,
+    toolbarRect,
+  });
+  assert.deepEqual(nearDock, { left: 124, maxWidth: 320, top: 526 });
+  assert.ok((nearDock?.top as number) + toolbarRect.height < actionDockRect.top);
+
+  const leftEdge = resolveSelectionActionOverlayPosition({
+    anchorRect: createRect({ left: -20, top: 120, width: 20, height: 20 }),
+    actionDockRect,
+    overlayRect,
+    sourceRect,
+    toolbarRect,
+  });
+  assert.equal(leftEdge?.left, 20);
+
+  const rightEdge = resolveSelectionActionOverlayPosition({
+    anchorRect: createRect({ left: 350, top: 120, width: 20, height: 20 }),
+    actionDockRect,
+    overlayRect,
+    sourceRect,
+    toolbarRect,
+  });
+  assert.equal(rightEdge?.left, 228);
+});
+
 test("SessionMessageColumn は未選択時に response action を描画しない", () => {
   const html = renderSessionMessageColumn({
     messages: [
@@ -1232,9 +1285,10 @@ test("SessionMessageColumn は未選択時に response action を描画しない
 test("SessionMessageColumn は選択範囲にだけ response action toolbar を表示する", async () => {
   const copiedTexts: string[] = [];
   const quotedTexts: string[] = [];
+  const assistantMessage = "assistant result text\n\n```text\nnested code text\n```";
   const mounted = await mountSessionMessageColumn({
     messages: [
-      { role: "assistant", text: "assistant result text" },
+      { role: "assistant", text: assistantMessage },
       { role: "user", text: "user prompt text" },
     ],
     onCopyMessageText: (text) => copiedTexts.push(text),
@@ -1277,10 +1331,13 @@ test("SessionMessageColumn は選択範囲にだけ response action toolbar を�
       value: () => selection,
     });
 
-    const selectText = async (body: Element, text: string, rect: DOMRect) => {
-      const paragraph = body.querySelector(".message-paragraph");
-      assert.ok(paragraph?.firstChild);
-      selectionNode = paragraph.firstChild;
+    const selectText = async (body: Element, text: string, rect: DOMRect, targetSelector?: string) => {
+      const target = targetSelector
+        ? body.querySelector(targetSelector)
+        : body.querySelector(".message-paragraph") ?? body.querySelector(".message-body");
+      const textNode = target?.firstChild;
+      assert.ok(textNode);
+      selectionNode = textNode;
       selectedText = text;
       isCollapsed = false;
       anchorRect = rect;
@@ -1302,6 +1359,7 @@ test("SessionMessageColumn は選択範囲にだけ response action toolbar を�
 
     let toolbar = container.querySelector(".message-response-actions") as HTMLElement | null;
     assert.ok(toolbar);
+    assert.ok(toolbar.parentElement?.classList.contains("session-selection-action-overlay"));
     assert.equal(toolbar.style.left, "74px");
     assert.equal(toolbar.style.top, "60px");
 
@@ -1340,6 +1398,23 @@ test("SessionMessageColumn は選択範囲にだけ response action toolbar を�
     assert.equal(toolbar.style.left, "224px");
     assert.equal(toolbar.style.top, "220px");
 
+    const nestedScrollOwner = assistantBody.querySelector(".message-code-block");
+    assert.ok(nestedScrollOwner);
+    await selectText(
+      assistantBody,
+      "nested code text",
+      createRect({ left: 180, top: 280, width: 80, height: 20 }),
+      ".message-code-block code",
+    );
+    anchorRect = createRect({ left: 120, top: 280, width: 80, height: 20 });
+    await act(async () => {
+      nestedScrollOwner.dispatchEvent(new dom.window.Event("scroll", { bubbles: false }));
+    });
+    toolbar = container.querySelector(".message-response-actions") as HTMLElement | null;
+    assert.ok(toolbar);
+    assert.equal(toolbar.style.left, "104px");
+    assert.equal(toolbar.style.top, "240px");
+
     anchorRect = createRect({ left: 520, top: 520, width: 40, height: 20 });
     await act(async () => {
       messageList.dispatchEvent(new dom.window.Event("scroll"));
@@ -1356,8 +1431,25 @@ test("SessionMessageColumn は選択範囲にだけ response action toolbar を�
     assert.equal(container.querySelector(".message-response-actions"), null);
     assert.equal(
       container.querySelector("[data-message-text-actions='true']")?.textContent,
-      "assistant result text",
+      assistantMessage,
     );
+
+    const currentAssistantBody = container.querySelector("[data-message-text-actions='true']");
+    assert.ok(currentAssistantBody);
+    await selectText(
+      currentAssistantBody,
+      "assistant result",
+      createRect({ left: 100, top: 100, width: 60, height: 20 }),
+    );
+    assert.ok(container.querySelector(".message-response-actions"));
+    await mounted.rerender({
+      messages: [],
+      onCopyMessageText: (text) => copiedTexts.push(text),
+      onQuoteMessageText: (text) => quotedTexts.push(text),
+      messageViewMode: "source",
+    });
+    await act(async () => Promise.resolve());
+    assert.equal(container.querySelector(".message-response-actions"), null);
     await clearSelection();
   } finally {
     mounted.cleanup();

--- a/src/chat/selection-action-overlay.ts
+++ b/src/chat/selection-action-overlay.ts
@@ -1,0 +1,59 @@
+import type { CSSProperties } from "react";
+
+type Rect = Pick<DOMRect, "bottom" | "height" | "left" | "right" | "top" | "width">;
+
+export type SelectionActionOverlayPositionInput = {
+  anchorRect: Rect;
+  actionDockRect?: Rect | null;
+  overlayRect: Rect;
+  sourceRect: Rect;
+  toolbarRect: Pick<Rect, "height" | "width">;
+  padding?: number;
+};
+
+export function resolveSelectionActionOverlayPosition(
+  input: SelectionActionOverlayPositionInput,
+): CSSProperties | null {
+  const padding = input.padding ?? 8;
+  const boundaryLeft = Math.max(input.overlayRect.left, input.sourceRect.left);
+  const boundaryRight = Math.min(input.overlayRect.right, input.sourceRect.right);
+  const boundaryTop = Math.max(input.overlayRect.top, input.sourceRect.top);
+  let boundaryBottom = Math.min(input.overlayRect.bottom, input.sourceRect.bottom);
+
+  const dockOverlapsHorizontally = !!input.actionDockRect
+    && input.actionDockRect.left < boundaryRight
+    && input.actionDockRect.right > boundaryLeft;
+  if (dockOverlapsHorizontally && input.actionDockRect) {
+    boundaryBottom = Math.min(boundaryBottom, input.actionDockRect.top);
+  }
+
+  const availableWidth = boundaryRight - boundaryLeft - padding * 2;
+  const availableHeight = boundaryBottom - boundaryTop - padding * 2;
+  if (availableWidth <= 0 || availableHeight <= 0) {
+    return null;
+  }
+
+  const toolbarWidth = Math.min(input.toolbarRect.width || 112, availableWidth);
+  const toolbarHeight = Math.min(input.toolbarRect.height || 32, availableHeight);
+  const preferredLeft = input.anchorRect.left + (input.anchorRect.width - toolbarWidth) / 2;
+  const aboveTop = input.anchorRect.top - toolbarHeight - padding;
+  const belowTop = input.anchorRect.bottom + padding;
+  const top = aboveTop >= boundaryTop + padding
+    ? aboveTop
+    : belowTop + toolbarHeight <= boundaryBottom - padding
+      ? belowTop
+      : Math.min(
+          boundaryBottom - toolbarHeight - padding,
+          Math.max(boundaryTop + padding, aboveTop),
+        );
+  const left = Math.min(
+    boundaryRight - toolbarWidth - padding,
+    Math.max(boundaryLeft + padding, preferredLeft),
+  );
+
+  return {
+    left,
+    maxWidth: availableWidth,
+    top,
+  };
+}

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -1,4 +1,5 @@
-import { Component, Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ClipboardEventHandler, type CSSProperties, type Dispatch, type ErrorInfo, type KeyboardEventHandler, type ReactNode, type RefObject, type SetStateAction, type UIEventHandler } from "react";
+import { Component, Fragment, createContext, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState, type ClipboardEventHandler, type CSSProperties, type Dispatch, type ErrorInfo, type KeyboardEventHandler, type ReactNode, type RefObject, type SetStateAction, type UIEventHandler } from "react";
+import { createPortal } from "react-dom";
 import { useVirtualizer } from "@tanstack/react-virtual";
 
 import type {
@@ -47,6 +48,7 @@ import { getWithMateApi } from "./renderer-withmate-api.js";
 import { SessionContentFindBar } from "./session-content-find-bar.js";
 import { clampFindMatchIndex, findTextMatches } from "./find-text-matches.js";
 import { ComposerAttachmentMenu } from "./chat/composer-attachment-menu.js";
+import { resolveSelectionActionOverlayPosition } from "./chat/selection-action-overlay.js";
 import {
   isMessageRenderedSearchTextNode,
   projectMessageRenderedSearchText,
@@ -816,6 +818,22 @@ export type SessionChatScreenProps = {
   modals?: ReactNode;
 };
 
+const SelectionActionOverlayContext = createContext<HTMLDivElement | null>(null);
+
+function SelectionActionOverlayBoundary({ children }: { children: ReactNode }) {
+  const [overlayElement, setOverlayElement] = useState<HTMLDivElement | null>(null);
+
+  return (
+    <SelectionActionOverlayContext.Provider value={overlayElement}>
+      {children}
+      <div
+        ref={setOverlayElement}
+        className="session-selection-action-overlay"
+      />
+    </SelectionActionOverlayContext.Provider>
+  );
+}
+
 export function SessionChatScreen({
   mode,
   className = "",
@@ -866,6 +884,7 @@ export function SessionChatScreen({
       style={layoutStyle}
       data-session-mode={mode}
     >
+      <SelectionActionOverlayBoundary>
       <div
         id={SESSION_HEADER_DOCK_ID}
         ref={headerDockRef}
@@ -921,6 +940,7 @@ export function SessionChatScreen({
       </div>
 
       {modals}
+      </SelectionActionOverlayBoundary>
     </div>
   );
 }
@@ -2454,6 +2474,7 @@ export function SessionMessageColumn({
   isContentActive = true,
   messageViewMode = "preview",
 }: SessionMessageColumnProps) {
+  const selectionActionOverlay = useContext(SelectionActionOverlayContext);
   const [openArtifactFolds, setOpenArtifactFolds] = useState<Record<string, boolean>>({});
   const [loadedArtifactDetails, setLoadedArtifactDetails] = useState<Record<string, MessageArtifact>>({});
   const [loadingArtifactDetails, setLoadingArtifactDetails] = useState<Record<string, boolean>>({});
@@ -2593,28 +2614,45 @@ export function SessionMessageColumn({
   const updateSelectionToolbar = useCallback(() => {
     const messageListElement = messageListRef.current;
     const selectionDetails = getSelectionDetailsWithinMessageList(messageListElement);
-    const boundaryRect = messageListElement?.getBoundingClientRect() ?? null;
+    const sourceRect = messageListElement?.getBoundingClientRect() ?? null;
+    const overlayRect = selectionActionOverlay?.getBoundingClientRect() ?? null;
+    const actionDockRect = document.getElementById(SESSION_ACTION_DOCK_ID)?.getBoundingClientRect() ?? null;
     const toolbarRect =
       selectionToolbarRef.current?.getBoundingClientRect() ??
       { width: 112, height: 32 };
     if (
       !selectionDetails ||
-      !boundaryRect ||
-      !rectsIntersect(selectionDetails.anchorRect, boundaryRect)
+      !sourceRect ||
+      !overlayRect ||
+      !rectsIntersect(selectionDetails.anchorRect, sourceRect)
     ) {
       setSelectionToolbar(null);
       return;
     }
 
+    const style = resolveSelectionActionOverlayPosition({
+      actionDockRect,
+      anchorRect: selectionDetails.anchorRect,
+      overlayRect,
+      sourceRect,
+      toolbarRect,
+    });
+    if (!style) {
+      setSelectionToolbar(null);
+      return;
+    }
+
     setSelectionToolbar({
-      style: clampToolbarPosition({
-        anchorRect: selectionDetails.anchorRect,
-        boundaryRect,
-        toolbarRect,
-      }),
+      style,
       text: selectionDetails.text,
     });
-  }, [messageListRef]);
+  }, [messageListRef, selectionActionOverlay]);
+
+  useLayoutEffect(() => {
+    if (selectionToolbar) {
+      updateSelectionToolbar();
+    }
+  }, [selectionToolbar?.text, updateSelectionToolbar]);
 
   useEffect(() => {
     if (typeof document === "undefined" || typeof window === "undefined") {
@@ -2624,14 +2662,43 @@ export function SessionMessageColumn({
     document.addEventListener("selectionchange", updateSelectionToolbar);
     window.addEventListener("resize", updateSelectionToolbar);
     const messageListElement = messageListRef.current;
-    messageListElement?.addEventListener("scroll", updateSelectionToolbar, { passive: true });
+    messageListElement?.addEventListener("scroll", updateSelectionToolbar, {
+      capture: true,
+      passive: true,
+    });
+    const actionDockElement = document.getElementById(SESSION_ACTION_DOCK_ID);
+    const resizeObserver = typeof window.ResizeObserver === "undefined"
+      ? null
+      : new window.ResizeObserver(updateSelectionToolbar);
+    if (messageListElement) {
+      resizeObserver?.observe(messageListElement);
+    }
+    if (selectionActionOverlay) {
+      resizeObserver?.observe(selectionActionOverlay);
+    }
+    if (actionDockElement) {
+      resizeObserver?.observe(actionDockElement);
+    }
+    const mutationObserver = messageListElement && typeof window.MutationObserver !== "undefined"
+      ? new window.MutationObserver(updateSelectionToolbar)
+      : null;
+    if (messageListElement) {
+      mutationObserver?.observe(messageListElement, {
+        attributeFilter: ["data-index", "style"],
+        attributes: true,
+        childList: true,
+        subtree: true,
+      });
+    }
 
     return () => {
       document.removeEventListener("selectionchange", updateSelectionToolbar);
       window.removeEventListener("resize", updateSelectionToolbar);
-      messageListElement?.removeEventListener("scroll", updateSelectionToolbar);
+      messageListElement?.removeEventListener("scroll", updateSelectionToolbar, { capture: true });
+      resizeObserver?.disconnect();
+      mutationObserver?.disconnect();
     };
-  }, [messageListRef, updateSelectionToolbar]);
+  }, [messageListRef, selectionActionOverlay, updateSelectionToolbar]);
 
   useEffect(() => {
     setCurrentFindMatch(0);
@@ -3157,14 +3224,15 @@ export function SessionMessageColumn({
             <div className="message-list-bottom-anchor" aria-hidden="true" />
           </div>
         ) : null}
-        {selectionToolbar ? (
+        {selectionToolbar && selectionActionOverlay ? createPortal(
           <MessageResponseActions
             actionText={selectionToolbar.text}
             onCopyMessageText={onCopyMessageText}
             onQuoteMessageText={onQuoteMessageText}
             style={selectionToolbar.style}
             toolbarRef={selectionToolbarRef}
-          />
+          />,
+          selectionActionOverlay,
         ) : null}
       </div>
     </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -162,6 +162,7 @@ button:disabled {
   --session-action-dock-row-height: var(--session-action-dock-compact-height, 54px);
   --session-left-pane-track-width: 0px;
   --session-right-pane-track-width: 0px;
+  isolation: isolate;
   grid-template-rows:
     var(--session-header-dock-row-height)
     var(--session-dock-splitter-size)
@@ -171,6 +172,13 @@ button:disabled {
   transition:
     grid-template-rows var(--session-dock-motion-duration) var(--session-dock-motion-easing),
     grid-template-columns var(--session-dock-motion-duration) var(--session-dock-motion-easing);
+}
+
+.session-selection-action-overlay {
+  position: fixed;
+  z-index: 35;
+  inset: 0;
+  pointer-events: none;
 }
 
 .session-chat-layout.layout-priority-side-pane {
@@ -6091,6 +6099,7 @@ button:disabled {
 .message-response-actions {
   position: fixed;
   z-index: 3;
+  box-sizing: border-box;
   display: inline-flex;
   justify-content: flex-end;
   gap: 6px;


### PR DESCRIPTION
## 概要

- assistant responseの選択Copy/QuoteをSession root所有のoverlayへ移動
- viewport・message list・ActionDock境界に応じて上下flipと左右clampを適用
- selection変更、scroll、resize、layout変更、virtualizationで位置を再計算または破棄
- 既存のclipboard、Quote挿入、keyboard、focus、pointer selection契約を維持

## 検証

- `npx tsx --test scripts/tests/session-message-column.test.ts scripts/tests/message-text-actions.test.ts scripts/tests/session-context-pane-style.test.ts scripts/tests/chat-window.test.ts` — 67件成功
- `npm test` — 成功
- `npm run typecheck` — 成功
- `npm run build` — 成功
- `git diff --check` — 成功

## 補足

分離したvisual-check用Electronの起動までは確認しました。画面操作用native pipeが利用できず、自動操作によるドラッグ選択とスクリーンショット確認は未実施です。