### PR TITLE
fix(session): ヘッダーメニューを外側操作で閉じる

### DIFF
--- a/docs/manual-test-checklist.md
+++ b/docs/manual-test-checklist.md
@@ -111,7 +111,8 @@ npm run electron:start
 | MT-023C1 | Session narrow layout reachability | viewport を `1400px` 未満まで狭めた Session Window を開く | 保存された layout priority にかかわらず、Header、File Explorer（active 時）、中央 surface、Context pane（active 時）、ActionDock の順で縦 stack になり、`Latest Command` と provider に応じた `Tasks` / `Context` へ到達できる |
 | MT-023C2 | Session minimum width guardrail | Session Window を最小幅近くまで縮める | Header、中央 surface、active side pane、ActionDock へ scroll を含めて到達でき、最小幅でも window が不自然に固定されない |
 | MT-023D | Session header hidden state | Session Window を開いて上 splitter を見る | 通常 state では Header が hidden で、中央 surface の上に再表示用 splitter だけが残る |
-| MT-023D1 | Session header expanded state | 上 splitter を押して Header を展開し、splitter をドラッグする | Header が1行分の固定高の full-width strip として表示され、`Rename / Audit Log / Terminal / Delete` が見える。`Close` と `More` は出ず、drag しても高さは変わらない |
+| MT-023D1 | Session header expanded state | 上 splitter を押して Header を展開し、splitter をドラッグする | Header が1行分の固定高の full-width strip として表示され、Workspace / Session 操作と `Session actions` の `⋯` menuへ到達できる。`Close` は出ず、drag しても高さは変わらない |
+| MT-023D1A | Session header actions menu dismiss | expanded Header の `⋯` menuを開き、外側をpointer操作する。もう一度開いて`Escape`、triggerの再クリック、各menu項目の実行も試す | 外側操作、triggerの再クリック、項目実行でmenuが閉じる。`Escape`ではmenuが閉じてtriggerへfocusが戻り、pin / rename / audit / deleteの各操作は従来どおり実行される |
 | MT-023D2 | Session terminal launch | expanded header の `Terminal` を押す | session の `workspacePath` を作業ディレクトリにした外部 terminal が開く |
 | MT-023D3 | Session header recollapse | expanded Header の上 splitterを押す | Header が閉じ、中央 surface の上に再表示用 splitterだけが残る |
 | MT-023D4 | Additional directory manage UI | Session Window の composer toolbar を確認し、`Add Directory` と `Dirs` を操作する | `Add Directory` が `Skill` と同じ列に並ぶ。`Dirs` は既定では閉じており、開いた後に現在の許可リストが表示され、provider が `Codex` の時だけ `×` で削除できる |

--- a/scripts/tests/chat-header-actions.test.tsx
+++ b/scripts/tests/chat-header-actions.test.tsx
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { JSDOM } from "jsdom";
 import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { SessionHeader } from "../../src/session-components.js";
@@ -11,9 +14,9 @@ import {
   createWorkspaceExplorerAction,
   resolveAuxiliaryHeaderActionState,
 } from "../../src/chat/chat-header-actions.js";
-import { SessionHeader } from "../../src/session-components.js";
-
 const noop = () => {};
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 test("SessionHeader は低頻度の管理操作を menu にまとめる", () => {
   const html = renderToStaticMarkup(
@@ -35,11 +38,110 @@ test("SessionHeader は低頻度の管理操作を menu にまとめる", () => 
   );
 
   assert.match(html, /<summary aria-label="Session actions"/);
+  assert.match(html, /aria-haspopup="menu"/);
+  assert.match(html, /aria-expanded="false"/);
   assert.match(html, /role="menu"/);
   assert.match(html, /role="menuitem" aria-pressed="false">ピン止め<\/button>/);
   assert.match(html, /role="menuitem">Rename<\/button>/);
   assert.match(html, /role="menuitem">Audit Log<\/button>/);
   assert.match(html, /role="menuitem">Delete<\/button>/);
+});
+
+test("SessionHeader menu は外側操作、Escape、項目実行、trigger 再クリックで閉じる", async () => {
+  const previousGlobals = {
+    window: globalThis.window,
+    document: globalThis.document,
+    Node: globalThis.Node,
+    HTMLElement: globalThis.HTMLElement,
+    Event: globalThis.Event,
+    MouseEvent: globalThis.MouseEvent,
+    KeyboardEvent: globalThis.KeyboardEvent,
+    PointerEvent: globalThis.PointerEvent,
+  };
+  const dom = new JSDOM("<!doctype html><html><body><div id=\"root\"></div><button id=\"outside\">Outside</button></body></html>", {
+    pretendToBeVisual: true,
+  });
+  const container = dom.window.document.getElementById("root") as HTMLElement;
+  const root = createRoot(container);
+  const actions: string[] = [];
+
+  Object.defineProperties(globalThis, {
+    window: { configurable: true, value: dom.window },
+    document: { configurable: true, value: dom.window.document },
+    Node: { configurable: true, value: dom.window.Node },
+    HTMLElement: { configurable: true, value: dom.window.HTMLElement },
+    Event: { configurable: true, value: dom.window.Event },
+    MouseEvent: { configurable: true, value: dom.window.MouseEvent },
+    KeyboardEvent: { configurable: true, value: dom.window.KeyboardEvent },
+    PointerEvent: { configurable: true, value: dom.window.PointerEvent ?? dom.window.MouseEvent },
+  });
+
+  try {
+    await act(async () => root.render(
+      <SessionHeader
+        taskTitle="Session"
+        isEditingTitle={false}
+        titleDraft="Session"
+        isRunning={false}
+        onOpenAuditLog={() => actions.push("audit")}
+        onOpenTerminal={noop}
+        onTitleDraftChange={noop}
+        onTitleInputKeyDown={noop}
+        onSaveTitle={noop}
+        onCancelTitleEdit={noop}
+        onStartTitleEdit={() => actions.push("rename")}
+        onDeleteSession={() => actions.push("delete")}
+        onTogglePin={() => actions.push("pin")}
+      />,
+    ));
+
+    const details = container.querySelector<HTMLDetailsElement>("details.session-header-more");
+    const trigger = container.querySelector<HTMLElement>("summary[aria-label=\"Session actions\"]");
+    assert.ok(details);
+    assert.ok(trigger);
+
+    await act(async () => trigger.click());
+    assert.equal(details.open, true);
+    await act(async () => trigger.click());
+    assert.equal(details.open, false);
+
+    await act(async () => trigger.click());
+    await act(async () => {
+      dom.window.document.getElementById("outside")?.dispatchEvent(new dom.window.Event("pointerdown", { bubbles: true }));
+    });
+    assert.equal(details.open, false);
+
+    await act(async () => trigger.click());
+    container.querySelector<HTMLButtonElement>("[role=\"menuitem\"]")?.focus();
+    await act(async () => {
+      details.dispatchEvent(new dom.window.KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    assert.equal(details.open, false);
+    assert.equal(dom.window.document.activeElement, trigger);
+
+    for (const [label, action] of [["ピン止め", "pin"], ["Rename", "rename"], ["Audit Log", "audit"], ["Delete", "delete"]]) {
+      await act(async () => trigger.click());
+      const item = [...container.querySelectorAll<HTMLButtonElement>("[role=\"menuitem\"]")]
+        .find((button) => button.textContent === label);
+      assert.ok(item);
+      await act(async () => item.click());
+      assert.equal(details.open, false);
+      assert.equal(actions.at(-1), action);
+    }
+  } finally {
+    await act(async () => root.unmount());
+    dom.window.close();
+    Object.defineProperties(globalThis, {
+      window: { configurable: true, value: previousGlobals.window },
+      document: { configurable: true, value: previousGlobals.document },
+      Node: { configurable: true, value: previousGlobals.Node },
+      HTMLElement: { configurable: true, value: previousGlobals.HTMLElement },
+      Event: { configurable: true, value: previousGlobals.Event },
+      MouseEvent: { configurable: true, value: previousGlobals.MouseEvent },
+      KeyboardEvent: { configurable: true, value: previousGlobals.KeyboardEvent },
+      PointerEvent: { configurable: true, value: previousGlobals.PointerEvent },
+    });
+  }
 });
 
 test("createWorkspaceExplorerAction は共通の workspace Explorer action を描画する", () => {

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -670,6 +670,30 @@ export function SessionHeader({
   onStartTitleEdit,
   onDeleteSession,
 }: SessionHeaderProps) {
+  const sessionActionsRef = useRef<HTMLDetailsElement | null>(null);
+  const sessionActionsTriggerRef = useRef<HTMLElement | null>(null);
+  const [isSessionActionsOpen, setIsSessionActionsOpen] = useState(false);
+
+  useEffect(() => {
+    if (!isSessionActionsOpen) {
+      return;
+    }
+
+    const closeOnOutsidePointerDown = (event: PointerEvent) => {
+      if (event.target && !sessionActionsRef.current?.contains(event.target as Node)) {
+        setIsSessionActionsOpen(false);
+      }
+    };
+
+    document.addEventListener("pointerdown", closeOnOutsidePointerDown);
+    return () => document.removeEventListener("pointerdown", closeOnOutsidePointerDown);
+  }, [isSessionActionsOpen]);
+
+  const runSessionAction = (action: () => void) => {
+    setIsSessionActionsOpen(false);
+    action();
+  };
+
   return (
     <header className="session-window-bar session-top-bar rise-1">
       <div className={`session-top-bar-row${isEditingTitle ? " is-editing-title" : ""}`}>
@@ -718,8 +742,33 @@ export function SessionHeader({
             ) : null}
             {actions}
             {onTogglePin || showRenameButton || showAuditLogButton || showDeleteButton ? (
-              <details className="session-header-more">
-                <summary aria-label="Session actions" title="Session actions">⋯</summary>
+              <details
+                ref={sessionActionsRef}
+                className="session-header-more"
+                open={isSessionActionsOpen}
+                onKeyDown={(event) => {
+                  if (event.key !== "Escape" || !isSessionActionsOpen) {
+                    return;
+                  }
+                  event.preventDefault();
+                  event.stopPropagation();
+                  setIsSessionActionsOpen(false);
+                  sessionActionsTriggerRef.current?.focus();
+                }}
+              >
+                <summary
+                  ref={sessionActionsTriggerRef}
+                  aria-label="Session actions"
+                  aria-haspopup="menu"
+                  aria-expanded={isSessionActionsOpen}
+                  title="Session actions"
+                  onClick={(event) => {
+                    event.preventDefault();
+                    setIsSessionActionsOpen((open) => !open);
+                  }}
+                >
+                  ⋯
+                </summary>
                 <div className="session-header-more-menu" role="menu">
                   {onTogglePin ? (
                     <button
@@ -727,24 +776,24 @@ export function SessionHeader({
                       type="button"
                       role="menuitem"
                       aria-pressed={isPinned}
-                      onClick={onTogglePin}
+                      onClick={() => runSessionAction(onTogglePin)}
                       disabled={isPinPending}
                     >
                       {isPinPending ? "変更中..." : isPinned ? "ピン解除" : "ピン止め"}
                     </button>
                   ) : null}
                   {showRenameButton ? (
-                    <button type="button" role="menuitem" onClick={onStartTitleEdit} disabled={isRunning || isReadOnly}>
+                    <button type="button" role="menuitem" onClick={() => runSessionAction(onStartTitleEdit)} disabled={isRunning || isReadOnly}>
                       Rename
                     </button>
                   ) : null}
                   {showAuditLogButton ? (
-                    <button type="button" role="menuitem" onClick={onOpenAuditLog}>
+                    <button type="button" role="menuitem" onClick={() => runSessionAction(onOpenAuditLog)}>
                       Audit Log
                     </button>
                   ) : null}
                   {showDeleteButton ? (
-                    <button className="danger" type="button" role="menuitem" onClick={onDeleteSession} disabled={isRunning}>
+                    <button className="danger" type="button" role="menuitem" onClick={() => runSessionAction(onDeleteSession)} disabled={isRunning}>
                       Delete
                     </button>
                   ) : null}


### PR DESCRIPTION
## 概要

SessionヘッダーのSession actionsメニューを、トリガーの再クリック以外でも自然に閉じられるようにします。

## 変更内容

- メニュー外のpointer操作で閉じる
- Escapeで閉じてトリガーへfocusを戻す
- pin / rename / audit / delete実行後に閉じる
- aria-expandedとaria-haspopupを追加する
- component testとmanual test checklistを更新する

## 検証

- npx tsx --test scripts/tests/chat-header-actions.test.tsx
- npm run typecheck
- git diff --check

## 未実施

- Electron分離起動による目視確認