### PR TITLE
fix(session): retry表示を最新の依頼に限定

### DIFF
--- a/scripts/tests/retry-state.test.ts
+++ b/scripts/tests/retry-state.test.ts
@@ -11,6 +11,7 @@ import {
   createRetryDraftReplaceConfirmationHandler,
   createRetryEditHandler,
   isRetryActionDisabled,
+  resolveRetryBannerSource,
   resolveRetryBannerKind,
   runRetryResendCommand,
   shouldProtectRetryEditDraft,
@@ -209,6 +210,98 @@ test("resolveRetryBannerKind は session state と terminal audit log から ret
   assert.equal(resolveRetryBannerKind({ runState: "error" }), "failed");
   assert.equal(resolveRetryBannerKind({ runState: "idle", latestTerminalAuditLogPhase: "canceled" }), "canceled");
   assert.equal(resolveRetryBannerKind({ runState: "idle", latestTerminalAuditLogPhase: "completed" }), null);
+});
+
+test("resolveRetryBannerSource は最後の未完了依頼と同じ session / message seq の terminal event だけを使う", () => {
+  const canceled = {
+    id: 10,
+    sessionId: "session-1",
+    createdAt: "2026-08-12T10:00:00.000Z",
+    phase: "canceled" as const,
+    provider: "codex",
+    model: "gpt-5.6",
+    reasoningEffort: "medium" as const,
+    approvalMode: "never" as const,
+    userMessageSeq: 0,
+    assistantMessageSeq: 1,
+    threadId: "thread-1",
+    assistantTextPreview: "キャンセル",
+    operations: [],
+    usage: null,
+    errorMessage: "canceled",
+    detailAvailable: true,
+  };
+  const completed = {
+    ...canceled,
+    id: 11,
+    phase: "completed" as const,
+    userMessageSeq: 2,
+    assistantMessageSeq: 3,
+    assistantTextPreview: "完了",
+    errorMessage: "",
+  };
+  const nextMessages = [
+    { role: "user" as const, text: "古い依頼" },
+    { role: "assistant" as const, text: "キャンセルしたよ" },
+    { role: "user" as const, text: "新しい依頼" },
+  ];
+
+  assert.deepEqual(resolveRetryBannerSource({
+    sessionId: "session-1",
+    messages: nextMessages.slice(0, 2),
+    auditLogs: [canceled],
+    runState: "idle",
+  }), {
+    kind: "canceled",
+    lastRequestText: "古い依頼",
+    terminalAuditLog: canceled,
+  });
+
+  assert.equal(resolveRetryBannerSource({
+    sessionId: "session-1",
+    messages: nextMessages,
+    auditLogs: [canceled],
+    runState: "running",
+  }), null);
+
+  assert.equal(resolveRetryBannerSource({
+    sessionId: "session-1",
+    messages: [...nextMessages, { role: "assistant", text: "完了したよ" }],
+    auditLogs: [completed, canceled],
+    runState: "idle",
+  }), null);
+
+  assert.equal(resolveRetryBannerSource({
+    sessionId: "session-1",
+    messages: [...nextMessages, { role: "assistant", text: "完了したよ" }],
+    auditLogs: [completed, { ...canceled, phase: "failed" }],
+    runState: "idle",
+  }), null);
+
+  assert.equal(resolveRetryBannerSource({
+    sessionId: "session-1",
+    messages: [...nextMessages, { role: "assistant", text: "完了したよ" }],
+    auditLogs: [canceled],
+    runState: "idle",
+  }), null);
+
+  assert.equal(resolveRetryBannerSource({
+    sessionId: "session-1",
+    messages: nextMessages,
+    auditLogs: [{ ...canceled, sessionId: "auxiliary-1", userMessageSeq: 2 }],
+    runState: "idle",
+  }), null);
+
+  assert.deepEqual(resolveRetryBannerSource({
+    sessionId: "session-1",
+    messages: nextMessages,
+    auditLogs: [],
+    runState: "error",
+  }), {
+    kind: "failed",
+    lastRequestText: "新しい依頼",
+    terminalAuditLog: null,
+  });
 });
 
 test("shouldProtectRetryEditDraft は既存 draft の暗黙上書きを避ける", () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -217,7 +217,7 @@ import {
   createRetryDraftReplaceConfirmationHandler,
   createRetryEditHandler,
   isRetryActionDisabled as resolveRetryActionDisabled,
-  resolveRetryBannerKind,
+  resolveRetryBannerSource,
   runRetryResendCommand,
   shouldProtectRetryEditDraft,
   shouldShowRetryBanner,
@@ -1577,16 +1577,11 @@ export default function AgentSessionWindowApp() {
         : null,
     [selectedSession],
   );
-  const lastAssistantMessage = useMemo(
-    () =>
-      selectedSession
-        ? [...selectedSession.messages].reverse().find((message) => message.role === "assistant") ?? null
-        : null,
-    [selectedSession],
-  );
   const latestTerminalAuditLog = useMemo(
-    () => selectedSessionAuditLogs.find((entry) => isTerminalAuditLogPhase(entry.phase)) ?? null,
-    [selectedSessionAuditLogs],
+    () => selectedSessionAuditLogs.find((entry) =>
+      entry.sessionId === activeRunSessionId && isTerminalAuditLogPhase(entry.phase)
+    ) ?? null,
+    [activeRunSessionId, selectedSessionAuditLogs],
   );
   const latestCommandProjection = useMemo(
     () => buildLatestCommandProjection({
@@ -1682,19 +1677,17 @@ export default function AgentSessionWindowApp() {
       return null;
     }
 
-    const retryLastUserMessage = lastUserMessage;
-    if (!retryLastUserMessage) {
-      return null;
-    }
-
-    const kind = resolveRetryBannerKind({
+    const source = resolveRetryBannerSource({
+      sessionId: selectedSession.id,
+      messages: selectedSession.messages,
+      auditLogs: selectedSessionAuditLogs,
       runState: selectedSessionRunState,
-      latestTerminalAuditLogPhase: latestTerminalAuditLog?.phase,
     });
-
-    if (!kind) {
+    if (!source) {
       return null;
     }
+
+    const { kind, lastRequestText, terminalAuditLog } = source;
 
     switch (kind) {
       case "interrupted":
@@ -1705,9 +1698,9 @@ export default function AgentSessionWindowApp() {
             "retry",
             "interrupted",
             selectedSession.id,
-            retryLastUserMessage.text,
+            lastRequestText,
           ]),
-          lastRequestText: retryLastUserMessage.text,
+          lastRequestText,
         };
       case "failed":
         return {
@@ -1717,9 +1710,9 @@ export default function AgentSessionWindowApp() {
             "retry",
             "failed",
             selectedSession.id,
-            retryLastUserMessage.text,
+            lastRequestText,
           ]),
-          lastRequestText: retryLastUserMessage.text,
+          lastRequestText,
         };
       case "canceled":
         return {
@@ -1729,23 +1722,22 @@ export default function AgentSessionWindowApp() {
             "retry",
             "canceled",
             selectedSession.id,
-            retryLastUserMessage.text,
-            latestTerminalAuditLog?.id,
+            lastRequestText,
+            terminalAuditLog?.id,
           ]),
-          lastRequestText: retryLastUserMessage.text,
+          lastRequestText,
         };
       default:
         return null;
     }
   }, [
-    lastAssistantMessage,
     lastUserMessage,
-    latestTerminalAuditLog,
     appSettings.userMicrocopyCatalog,
     selectedSession,
+    selectedSessionAuditLogs,
     selectedSessionCharacter?.name,
+    selectedSessionRunState,
     isSelectedSessionReadOnly,
-    selectedSessionLiveRun,
     activeAuxiliarySession,
   ]);
   const shouldProtectDraftOnRetryEdit = shouldProtectRetryEditDraft({ retryBanner, draft });

--- a/src/chat/retry-state.ts
+++ b/src/chat/retry-state.ts
@@ -1,4 +1,6 @@
 import type { AuditLogSummary } from "../runtime-state.js";
+import type { Message } from "../session-state.js";
+import { isTerminalAuditLogPhase } from "../audit-log-phase.js";
 import { applyComposerDraftChangeCommand } from "./composer-draft-handlers.js";
 
 export type RetryBannerKind = "interrupted" | "failed" | "canceled";
@@ -8,6 +10,12 @@ export type RetryBannerState = {
   badge: string;
   title: string;
   lastRequestText: string;
+};
+
+export type RetryBannerSource = {
+  kind: RetryBannerKind;
+  lastRequestText: string;
+  terminalAuditLog: AuditLogSummary | null;
 };
 
 export type RetryDraftRestoreState = {
@@ -139,6 +147,46 @@ export function resolveRetryBannerKind(input: {
   }
 
   return null;
+}
+
+export function resolveRetryBannerSource(input: {
+  sessionId: string | null | undefined;
+  messages: readonly Message[];
+  auditLogs: readonly AuditLogSummary[];
+  runState: string | null | undefined;
+}): RetryBannerSource | null {
+  if (!input.sessionId || input.runState === "running") {
+    return null;
+  }
+
+  let lastUserMessageSeq = -1;
+  for (let index = input.messages.length - 1; index >= 0; index -= 1) {
+    if (input.messages[index]?.role === "user") {
+      lastUserMessageSeq = index;
+      break;
+    }
+  }
+  if (lastUserMessageSeq < 0) {
+    return null;
+  }
+
+  const terminalAuditLog = input.auditLogs.find((entry) =>
+    entry.sessionId === input.sessionId
+    && entry.userMessageSeq === lastUserMessageSeq
+    && isTerminalAuditLogPhase(entry.phase)
+  ) ?? null;
+  const kind = resolveRetryBannerKind({
+    runState: input.runState,
+    latestTerminalAuditLogPhase: terminalAuditLog?.phase,
+  });
+
+  return kind
+    ? {
+        kind,
+        lastRequestText: input.messages[lastUserMessageSeq]?.text ?? "",
+        terminalAuditLog,
+      }
+    : null;
 }
 
 export function shouldProtectRetryEditDraft(input: {


### PR DESCRIPTION
## 概要

キャンセルまたはエラー後のretry通知が、後続promptの成功後も残留・再表示される問題を修正します。

## 変更内容

- retry表示を、表示対象sessionの最後のuser messageとterminal audit logの `userMessageSeq` が一致する場合に限定
- 新しいturnのrunning中は古いretry表示を抑止
- 後続turn完了後に古いterminal audit logが遅延到着しても再表示しない
- session / Auxiliaryのaudit logが混在しても別turnの状態を採用しない
- cancel→new running→completed、error→new completed、新規failure、stale eventの回帰テストを追加

## 原因

最新のterminal audit logと最後のuser messageを相関確認なしで組み合わせていたため、古いcanceled / failed eventが現在の依頼へ誤って投影されていました。

## 影響

retry bannerと再送・編集操作は、現在の最後の未完了依頼にだけ表示されます。後続turnが成功した場合、古い通知は復活しません。

## 検証

- `node --import tsx --test scripts/tests/retry-state.test.ts scripts/tests/audit-log-refresh.test.ts scripts/tests/session-live-run-subscription.test.ts`（36件成功）
- `npm run typecheck`
- `npm run build`
- lifecycle/concurrency specialist review（blocking findingなし）
