### PR TITLE
feat(changes): 読み込み状態を視覚表示する

### DIFF
--- a/scripts/tests/workspace-changes-pane.test.tsx
+++ b/scripts/tests/workspace-changes-pane.test.tsx
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { JSDOM } from "jsdom";
 import React, { act } from "react";
@@ -380,4 +381,171 @@ test("FileRootChangesPane は大量の変更を constrained viewport 内で仮�
     }
     dom.window.close();
   }
+});
+
+test("FileRootChangesPane は loading state を競合させず stale request を無視する", async () => {
+  const previousActEnvironment = (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT;
+  const previousWindow = globalThis.window;
+  const previousDocument = globalThis.document;
+  const previousHTMLElement = globalThis.HTMLElement;
+  const previousElement = globalThis.Element;
+  const previousNode = globalThis.Node;
+  const previousNavigator = globalThis.navigator;
+  const dom = new JSDOM("<!doctype html><html><body><div id=\"root\"></div></body></html>", {
+    pretendToBeVisual: true,
+  });
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  Object.defineProperty(globalThis, "window", { configurable: true, value: dom.window });
+  Object.defineProperty(globalThis, "document", { configurable: true, value: dom.window.document });
+  Object.defineProperty(globalThis, "HTMLElement", { configurable: true, value: dom.window.HTMLElement });
+  Object.defineProperty(globalThis, "Element", { configurable: true, value: dom.window.Element });
+  Object.defineProperty(globalThis, "Node", { configurable: true, value: dom.window.Node });
+  Object.defineProperty(globalThis, "navigator", { configurable: true, value: dom.window.navigator });
+  const { FileRootChangesPane } = await import("../../src/file-explorer/FileRootChangesPane.js");
+
+  type ChangesResult = { status: "ok"; entries: FileRootGitChangeEntry[] };
+  const pendingRequests: Array<(result: ChangesResult) => void> = [];
+  const testApi = {
+    listSessionFileRoots: async () => [
+      { id: "workspace", kind: "workspace" as const, label: "Workspace", displayPath: "C:/repo" },
+    ],
+    listFileRootChanges: async () => new Promise<ChangesResult>((resolve) => pendingRequests.push(resolve)),
+  };
+  const baseProps = {
+    api: testApi,
+    sessionId: "session-1",
+    enabled: true,
+    rootsRevision: "roots-1",
+    refreshRevision: 0,
+    onOpenFile: () => undefined,
+    onOpenDiff: async () => null,
+  };
+  const entries = (count: number): FileRootGitChangeEntry[] => Array.from({ length: count }, (_, index) => ({
+    relativePath: `file-${index}.txt`,
+    previousRelativePath: null,
+    scopes: ["working-tree"],
+    kinds: { "working-tree": "modified" },
+  }));
+  let root: Root | null = null;
+  try {
+    await act(async () => {
+      root = createRoot(dom.window.document.getElementById("root") as HTMLElement);
+      root.render(React.createElement(FileRootChangesPane, baseProps));
+      await Promise.resolve();
+    });
+    const changesPane = dom.window.document.querySelector<HTMLElement>(".workspace-changes-pane");
+    const initialLoading = dom.window.document.querySelector<HTMLElement>(".workspace-changes-loading");
+    assert.equal(pendingRequests.length, 1);
+    assert.equal(changesPane?.getAttribute("aria-busy"), "true");
+    assert.equal(initialLoading?.getAttribute("role"), "status");
+    assert.equal(initialLoading?.className, "workspace-changes-loading");
+    assert.equal(initialLoading?.getAttribute("aria-live"), "polite");
+    assert.equal(initialLoading?.querySelector(".visually-hidden")?.textContent?.trim(), "Loading changes");
+    assert.ok(initialLoading?.querySelector(".workspace-changes-spinner[aria-hidden='true']"));
+    assert.equal(dom.window.document.querySelector(".workspace-changes-empty"), null);
+
+    await act(async () => {
+      pendingRequests[0]?.({ status: "ok", entries: entries(1) });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    assert.equal(changesPane?.getAttribute("aria-busy"), "false");
+    assert.equal(dom.window.document.querySelector(".workspace-changes-loading"), null);
+    assert.equal(dom.window.document.querySelector(".workspace-changes-root-count")?.textContent, "1");
+
+    await act(async () => {
+      root?.render(React.createElement(FileRootChangesPane, { ...baseProps, refreshRevision: 1 }));
+      await Promise.resolve();
+    });
+    const refreshLoading = dom.window.document.querySelector<HTMLElement>(".workspace-changes-loading");
+    assert.equal(pendingRequests.length, 2);
+    assert.equal(changesPane?.getAttribute("aria-busy"), "true");
+    assert.equal(refreshLoading?.className, "workspace-changes-loading");
+    assert.equal(refreshLoading?.querySelector(".visually-hidden")?.textContent?.trim(), "Refreshing changes");
+    assert.equal(dom.window.document.querySelector(".workspace-changes-root-count")?.textContent, "1");
+
+    await act(async () => {
+      root?.render(React.createElement(FileRootChangesPane, { ...baseProps, refreshRevision: 2 }));
+      await Promise.resolve();
+    });
+    assert.equal(pendingRequests.length, 3);
+    await act(async () => {
+      pendingRequests[1]?.({ status: "ok", entries: entries(2) });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    assert.equal(changesPane?.getAttribute("aria-busy"), "true");
+    assert.equal(dom.window.document.querySelector(".workspace-changes-root-count")?.textContent, "1");
+
+    await act(async () => {
+      pendingRequests[2]?.({ status: "ok", entries: entries(3) });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    assert.equal(changesPane?.getAttribute("aria-busy"), "false");
+    assert.equal(dom.window.document.querySelector(".workspace-changes-loading"), null);
+    assert.equal(dom.window.document.querySelector(".workspace-changes-root-count")?.textContent, "3");
+
+    await act(async () => {
+      root?.render(React.createElement(FileRootChangesPane, {
+        ...baseProps,
+        api: {
+          listSessionFileRoots: async () => {
+            throw new Error("Initial root failure.");
+          },
+          listFileRootChanges: async () => ({ status: "ok" as const, entries: [] }),
+        },
+        sessionId: "session-error",
+        rootsRevision: "roots-error",
+      }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    assert.match(dom.window.document.querySelector("[role='alert']")?.textContent ?? "", /Initial root failure/);
+    assert.equal(dom.window.document.querySelector(".workspace-changes-empty"), null);
+    assert.equal(dom.window.document.querySelector(".workspace-changes-loading"), null);
+
+    await act(async () => {
+      root?.render(React.createElement(FileRootChangesPane, {
+        ...baseProps,
+        api: {
+          listSessionFileRoots: async () => [],
+          listFileRootChanges: async () => ({ status: "ok" as const, entries: [] }),
+        },
+        sessionId: "session-empty",
+        rootsRevision: "roots-empty",
+      }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    assert.ok(dom.window.document.querySelector(".workspace-changes-empty"));
+    assert.equal(dom.window.document.querySelector("[role='alert']"), null);
+    assert.equal(dom.window.document.querySelector(".workspace-changes-loading"), null);
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+    Object.defineProperty(globalThis, "window", { configurable: true, value: previousWindow });
+    Object.defineProperty(globalThis, "document", { configurable: true, value: previousDocument });
+    Object.defineProperty(globalThis, "HTMLElement", { configurable: true, value: previousHTMLElement });
+    Object.defineProperty(globalThis, "Element", { configurable: true, value: previousElement });
+    Object.defineProperty(globalThis, "Node", { configurable: true, value: previousNode });
+    Object.defineProperty(globalThis, "navigator", { configurable: true, value: previousNavigator });
+    dom.window.close();
+  }
+});
+
+test("Changes loading indicator は既存内容より明瞭で reduced motion に配慮する", async () => {
+  const styles = await readFile(new URL("../../src/styles.css", import.meta.url), "utf8");
+
+  assert.match(
+    styles,
+    /\.workspace-changes-loading\s*{[^}]*background:\s*color-mix\(in srgb, var\(--surface-deep\) 72%, transparent\);[^}]*color:\s*var\(--ink\);/s,
+  );
+  assert.match(
+    styles,
+    /\.workspace-changes-spinner\s*{[^}]*width:\s*24px;[^}]*height:\s*24px;[^}]*border:\s*3px solid/s,
+  );
+  assert.match(styles, /\.workspace-changes-spinner\s*{[^}]*animation:\s*workspace-changes-spin\s+720ms\s+linear\s+infinite;/s);
+  assert.match(
+    styles,
+    /@media \(prefers-reduced-motion:\s*reduce\)\s*{[\s\S]*?\.workspace-changes-spinner\s*{[^}]*animation:\s*none;/,
+  );
 });

--- a/src/file-explorer/FileRootChangesPane.tsx
+++ b/src/file-explorer/FileRootChangesPane.tsx
@@ -170,6 +170,19 @@ export function FileRootChangesPane({
   return (
     <div className="workspace-changes-pane" aria-busy={loading}>
       {message ? <p className="workspace-changes-message" role="alert">{message}</p> : null}
+      {loading ? (
+        <div
+          className="workspace-changes-loading"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          <span className="workspace-changes-spinner" aria-hidden="true" />
+          <span className="visually-hidden">
+            {rootChanges.length > 0 ? "Refreshing changes" : "Loading changes"}
+          </span>
+        </div>
+      ) : null}
       {rootChanges.length > 0 ? (
         <div className="workspace-changes-groups" role="list" aria-label="File root changes">
           {rootChanges.map((rootChange) => (
@@ -184,7 +197,7 @@ export function FileRootChangesPane({
             />
           ))}
         </div>
-      ) : !loading ? (
+      ) : !loading && !message ? (
         <p className="workspace-changes-empty">No Git repositories.</p>
       ) : null}
     </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -4919,6 +4919,7 @@ button:disabled {
 }
 
 .workspace-changes-pane {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 6px;
@@ -4926,6 +4927,34 @@ button:disabled {
   height: 100%;
   overflow: hidden;
   padding: 8px;
+}
+
+.workspace-changes-loading {
+  position: absolute;
+  inset: 8px;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--surface-deep) 72%, transparent);
+  color: var(--ink);
+  pointer-events: none;
+}
+
+.workspace-changes-spinner {
+  width: 24px;
+  height: 24px;
+  box-sizing: border-box;
+  border: 3px solid color-mix(in srgb, currentColor 24%, transparent);
+  border-top-color: currentColor;
+  border-radius: 50%;
+  animation: workspace-changes-spin 720ms linear infinite;
+}
+
+@keyframes workspace-changes-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .workspace-changes-group-header {
@@ -11126,6 +11155,10 @@ button:disabled {
 @media (prefers-reduced-motion: reduce) {
   .session-chat-layout {
     --session-dock-motion-duration: 0ms;
+  }
+
+  .workspace-changes-spinner {
+    animation: none;
   }
 }
 


### PR DESCRIPTION
## 概要

Changesペインの初回読み込みと明示的な再読み込みで、領域中央にローディング表示を出します。

## 変更内容

- 初回読み込みと再読み込みで同じ位置にスピナーを表示
- 再読み込み中も既存の変更一覧とスクロール位置を保持
- 半透明オーバーレイと24pxのスピナーで、既存内容の上でも読み込み状態を明確化
- `aria-busy`、politeなstatus通知、reduced motion対応を追加
- loading、loaded、empty、error、stale requestの状態遷移をcomponent testで検証

## 背景

Changesの取得中に一覧が空だと何も表示されず、処理中かどうか判断できませんでした。また、初回と再読み込みで表示位置が変わると一貫性がないため、領域中央の同じ表示へ統一しています。

## 検証

- `tsx --test scripts/tests/workspace-changes-pane.test.tsx`
- `npm run typecheck`
- `git diff --check`