### PR TITLE
feat(home): Workspaceパスの手入力に対応

### DIFF
--- a/scripts/tests/home-components.test.tsx
+++ b/scripts/tests/home-components.test.tsx
@@ -6,6 +6,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { HomeLaunchDialog } from "../../src/home/HomeLaunchDialog.js";
+import type { HomeLaunchWorkspaceValidationState } from "../../src/home/home-launch-state.js";
 import { filterCharactersByName } from "../../src/home/HomeCharactersPanel.js";
 import { HomeMonitorContent } from "../../src/home/HomeMonitorContent.js";
 import { HomeRecentSessionsPanel } from "../../src/home/HomeRecentSessionsPanel.js";
@@ -553,13 +554,16 @@ describe("HomeLaunchDialog", () => {
     options = characterOptions,
     charactersLoaded = true,
     randomCharacterSelected = false,
+    workspaceValidation: HomeLaunchWorkspaceValidationState = "idle",
   ) => renderToStaticMarkup(
     <HomeLaunchDialog
       open={true}
       title="demo"
-      workspaceSelected={false}
       sessionFolderSelected={false}
       launchWorkspacePathLabel="workspace"
+      workspacePathInput="C:\\work space\\"
+      workspaceValidation={workspaceValidation}
+      workspaceValidationMessage={workspaceValidation === "invalid" ? "Path not found." : ""}
       enabledLaunchProviders={[{ id: "codex", label: "Codex" }]}
       selectedLaunchProviderId="codex"
       characterOptions={options}
@@ -571,6 +575,7 @@ describe("HomeLaunchDialog", () => {
       launchStarting={false}
       onClose={noOp}
       onChangeTitle={noOp}
+      onChangeWorkspacePath={noOp}
       onBrowseWorkspace={noOp}
       onSelectSessionFolder={noOp}
       onSelectProvider={noOp}
@@ -601,6 +606,32 @@ describe("HomeLaunchDialog", () => {
     assert.ok(html.indexOf("ランダム") < html.indexOf("Mia"));
     assert.ok(html.includes("最近使っていないCharacterを優先"));
     assert.ok(html.indexOf("Browse") < html.indexOf("SessionFolder"));
+  });
+
+  it("Workspace input と invalid 理由を field 近傍へ表示する", () => {
+    const idle = renderHomeLaunchDialog();
+    const html = renderHomeLaunchDialog(characterOptions, true, false, "invalid");
+
+    assert.match(idle, /<span id="launch-workspace-path-error"[^>]*><\/span>/);
+    assert.ok(html.includes("launch-workspace-path"));
+    assert.ok(html.includes('value="C:'));
+    assert.ok(html.includes("work space"));
+    assert.ok(html.includes('aria-invalid="true"'));
+    assert.ok(html.includes("Path not found."));
+  });
+
+  it("Workspace validation は debounce 開始から filesystem 確認完了まで spinner を表示する", () => {
+    const debouncing = renderHomeLaunchDialog(characterOptions, true, false, "debouncing");
+    const pending = renderHomeLaunchDialog(characterOptions, true, false, "pending");
+
+    assert.ok(debouncing.includes("workspace-validation-spinner"));
+    assert.ok(debouncing.includes('aria-busy="true"'));
+    assert.ok(debouncing.includes("Workspace パスを確認しています"));
+    assert.ok(!debouncing.includes("確認中"));
+    assert.ok(pending.includes("workspace-validation-spinner"));
+    assert.ok(pending.includes('aria-busy="true"'));
+    assert.ok(pending.includes("Workspace パスを確認しています"));
+    assert.ok(!pending.includes(">確認中<"));
   });
 
   it("random選択時は一覧先頭のランダムcardだけを選択状態にする", () => {

--- a/scripts/tests/home-launch-handlers.test.ts
+++ b/scripts/tests/home-launch-handlers.test.ts
@@ -40,6 +40,7 @@ describe("home-launch-handlers", () => {
       createCharacterEntry({ id: "new-character", name: "New Character" }),
     ];
     const feedback: string[] = [];
+    const scheduledWorkspacePaths: string[] = [];
     let refreshCount = 0;
 
     const handlers = buildHomeLaunchHandlers({
@@ -64,7 +65,9 @@ describe("home-launch-handlers", () => {
       setLaunchDraft: (updater) => {
         draft = typeof updater === "function" ? updater(draft) : updater;
       },
-      pickWorkspaceDirectory: async () => null,
+      pickWorkspaceDirectory: async () => "C:\\browse workspace\\",
+      scheduleWorkspaceValidation: (targetPath) => scheduledWorkspacePaths.push(targetPath),
+      cancelWorkspaceValidation: () => {},
       openSessionWindow: async () => undefined,
       openCompanionReviewWindow: async () => undefined,
       createSession: async () => null,
@@ -93,6 +96,15 @@ describe("home-launch-handlers", () => {
 
     handlers.onSelectSessionFolder();
     assert.deepEqual(draft.workspace, { kind: "session-folder" });
+    assert.equal(draft.workspacePathInput, "");
+
+    handlers.onChangeWorkspacePath("\\\\server\\share\\manual workspace\\");
+    handlers.onBrowseWorkspace();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.deepEqual(scheduledWorkspacePaths, [
+      "\\\\server\\share\\manual workspace\\",
+      "C:\\browse workspace\\",
+    ]);
 
     handlers.onChangeMode("companion");
     assert.equal(draft.mode, "companion");
@@ -128,6 +140,8 @@ describe("home-launch-handlers", () => {
         draft = typeof updater === "function" ? updater(draft) : updater;
       },
       pickWorkspaceDirectory: async () => null,
+      scheduleWorkspaceValidation: () => {},
+      cancelWorkspaceValidation: () => {},
       openSessionWindow: async () => undefined,
       openCompanionReviewWindow: async () => undefined,
       createSession: async () => null,

--- a/scripts/tests/home-launch-state.test.ts
+++ b/scripts/tests/home-launch-state.test.ts
@@ -5,6 +5,9 @@ import type { CharacterCatalogEntry } from "../../src/character/character-catalo
 import {
   buildCreateCompanionSessionInputFromLaunchDraft,
   buildCreateSessionRequestFromLaunchDraft,
+  applyLaunchWorkspacePathValidation,
+  beginLaunchWorkspacePathValidation,
+  markLaunchWorkspacePathValidationPending,
   closeLaunchDraft,
   createClosedLaunchDraft,
   openLaunchDraft,
@@ -73,6 +76,9 @@ describe("home-launch-state", () => {
       open: true,
       mode: "session",
       title: "",
+      workspacePathInput: "",
+      workspaceValidation: "idle",
+      workspaceValidationMessage: "",
       workspace: null,
       providerId: "codex",
       characterSelectionMode: "random",
@@ -83,6 +89,9 @@ describe("home-launch-state", () => {
       open: false,
       mode: "session",
       title: "",
+      workspacePathInput: "",
+      workspaceValidation: "idle",
+      workspaceValidationMessage: "",
       workspace: null,
       providerId: "",
       characterSelectionMode: "random",
@@ -98,6 +107,82 @@ describe("home-launch-state", () => {
       path: "F:/work/demo",
       branch: "",
     });
+    assert.equal(draft.workspacePathInput, "F:/work/demo");
+    assert.equal(draft.workspaceValidation, "valid");
+  });
+
+  it("manual workspace は valid response のときだけ raw path から canonical tuple を作る", () => {
+    const targetPath = "C:\\work space\\demo\\";
+    const debouncing = beginLaunchWorkspacePathValidation(createClosedLaunchDraft(), targetPath);
+    assert.equal(debouncing.workspace, null);
+    assert.equal(debouncing.workspaceValidation, "debouncing");
+    const pending = markLaunchWorkspacePathValidationPending(debouncing, targetPath);
+    assert.equal(pending.workspaceValidation, "pending");
+
+    const invalid = applyLaunchWorkspacePathValidation(pending, targetPath, {
+      valid: false,
+      reason: "not-directory",
+    });
+    assert.equal(invalid.workspace, null);
+    assert.equal(invalid.workspaceValidationMessage, "Not a directory.");
+
+    const valid = applyLaunchWorkspacePathValidation(pending, targetPath, { valid: true });
+    assert.deepEqual(valid.workspace, {
+      label: "demo",
+      path: targetPath,
+      branch: "",
+    });
+  });
+
+  it("manual workspace validation は別入力の stale response を無視する", () => {
+    const current = beginLaunchWorkspacePathValidation(createClosedLaunchDraft(), "C:\\new");
+    assert.equal(
+      markLaunchWorkspacePathValidationPending(current, "C:\\old"),
+      current,
+    );
+    assert.equal(
+      applyLaunchWorkspacePathValidation(current, "C:\\old", { valid: true }),
+      current,
+    );
+  });
+
+  it("validated manual workspace は session / companion request に同じ path を投影する", () => {
+    const targetPath = "\\\\server\\share\\work space\\";
+    const draft = {
+      ...applyLaunchWorkspacePathValidation(
+        markLaunchWorkspacePathValidationPending(
+          beginLaunchWorkspacePathValidation(createClosedLaunchDraft(), targetPath),
+          targetPath,
+        ),
+        targetPath,
+        { valid: true } as const,
+      ),
+      open: true,
+      title: "task",
+      providerId: "codex",
+    };
+
+    const sessionRequest = buildCreateSessionRequestFromLaunchDraft({
+      draft,
+      mateProfile: null,
+      selectedProviderId: "codex",
+    });
+    const companionRequest = buildCreateCompanionSessionInputFromLaunchDraft({
+      draft: { ...draft, mode: "companion" },
+      mateProfile: null,
+      selectedProviderId: "codex",
+    });
+
+    assert.equal(sessionRequest?.workspace.kind, "directory");
+    if (sessionRequest?.workspace.kind === "directory") {
+      assert.deepEqual(sessionRequest.workspace, {
+        kind: "directory",
+        label: "work space",
+        path: targetPath,
+        branch: "",
+      });
+    }
+    assert.equal(companionRequest?.workspacePath, targetPath);
   });
 
   it("provider 選択時に launch draft の providerId を更新する", () => {

--- a/scripts/tests/home-launch-style.test.ts
+++ b/scripts/tests/home-launch-style.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("Workspace validation error は表示有無で field の高さを変えない", async () => {
+  const [componentSource, stylesSource] = await Promise.all([
+    readFile("src/home/HomeLaunchDialog.tsx", "utf8"),
+    readFile("src/styles.css", "utf8"),
+  ]);
+  const errorRule = stylesSource.match(/\.home-page \.launch-field-error\s*{([^}]*)}/)?.[1];
+
+  assert.match(
+    componentSource,
+    /<div className="launch-field-heading">[\s\S]*?launch-workspace-path-error[\s\S]*?<\/div>\s*<div className="launch-field-input-shell/,
+  );
+  assert.ok(errorRule);
+  assert.match(errorRule, /height:\s*1rem;/);
+  assert.match(errorRule, /line-height:\s*1rem;/);
+  assert.match(errorRule, /overflow:\s*hidden;/);
+  assert.match(errorRule, /white-space:\s*nowrap;/);
+});
+
+test("Workspace validation spinner は debounce 中から遅延なく描画する", async () => {
+  const stylesSource = await readFile("src/styles.css", "utf8");
+  const spinnerRule = stylesSource.match(/\.workspace-validation-spinner\s*{([^}]*)}/)?.[1];
+
+  assert.ok(spinnerRule);
+  assert.match(spinnerRule, /animation:\s*workspace-validation-spin\s+0\.7s\s+linear\s+infinite;/);
+  assert.doesNotMatch(spinnerRule, /opacity:\s*0;/);
+  assert.doesNotMatch(spinnerRule, /animation-delay:/);
+});

--- a/scripts/tests/home-launch-workspace-validation.test.ts
+++ b/scripts/tests/home-launch-workspace-validation.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { it } from "node:test";
+
+import { createHomeLaunchWorkspaceValidationController } from "../../src/home/home-launch-workspace-validation.js";
+import {
+  applyLaunchWorkspacePathValidation,
+  beginLaunchWorkspacePathValidation,
+  createClosedLaunchDraft,
+  markLaunchWorkspacePathValidationPending,
+  setLaunchWorkspaceToSessionFolder,
+} from "../../src/home/home-launch-state.js";
+import type { WorkspaceDirectoryValidationResult } from "../../src/workspace-directory-validation.js";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+it("workspace validation は debounce 中の keystroke ごとに filesystem 境界を呼ばない", async () => {
+  const calls: string[] = [];
+  const scheduled: string[] = [];
+  const started: string[] = [];
+  const controller = createHomeLaunchWorkspaceValidationController({
+    delayMs: 15,
+    validate: async (targetPath) => {
+      calls.push(targetPath);
+      return { valid: true };
+    },
+    onScheduled: (targetPath) => scheduled.push(targetPath),
+    onValidationStart: (targetPath) => started.push(targetPath),
+    onResult: () => {},
+  });
+
+  controller.schedule("C:\\w");
+  controller.schedule("C:\\wo");
+  controller.schedule("C:\\work");
+  assert.deepEqual(calls, []);
+  assert.deepEqual(scheduled, ["C:\\w", "C:\\wo", "C:\\work"]);
+  assert.deepEqual(started, []);
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.deepEqual(calls, ["C:\\work"]);
+  assert.deepEqual(started, ["C:\\work"]);
+});
+
+it("workspace validation は古い response と cancel 後の response を反映しない", async () => {
+  const first = deferred<WorkspaceDirectoryValidationResult>();
+  const second = deferred<WorkspaceDirectoryValidationResult>();
+  const cancelled = deferred<WorkspaceDirectoryValidationResult>();
+  const results: string[] = [];
+  const controller = createHomeLaunchWorkspaceValidationController({
+    delayMs: 0,
+    validate: (targetPath) => targetPath.endsWith("first")
+      ? first.promise
+      : targetPath.endsWith("cancelled")
+        ? cancelled.promise
+        : second.promise,
+    onScheduled: () => {},
+    onValidationStart: () => {},
+    onResult: (targetPath) => results.push(targetPath),
+  });
+
+  controller.schedule("C:\\first");
+  await flush();
+  controller.schedule("C:\\second");
+  await flush();
+  second.resolve({ valid: true });
+  first.resolve({ valid: false, reason: "missing" });
+  await flush();
+  assert.deepEqual(results, ["C:\\second"]);
+
+  controller.schedule("C:\\cancelled");
+  await flush();
+  controller.cancel();
+  cancelled.resolve({ valid: true });
+  await flush();
+  assert.deepEqual(results, ["C:\\second"]);
+});
+
+it("SessionFolder への切替後は in-flight validation が workspace draft を上書きしない", async () => {
+  const validation = deferred<WorkspaceDirectoryValidationResult>();
+  let draft = createClosedLaunchDraft();
+  const controller = createHomeLaunchWorkspaceValidationController({
+    delayMs: 0,
+    validate: () => validation.promise,
+    onScheduled: (targetPath) => {
+      draft = beginLaunchWorkspacePathValidation(draft, targetPath);
+    },
+    onValidationStart: (targetPath) => {
+      draft = markLaunchWorkspacePathValidationPending(draft, targetPath);
+    },
+    onResult: (targetPath, result) => {
+      draft = applyLaunchWorkspacePathValidation(draft, targetPath, result);
+    },
+  });
+
+  controller.schedule("C:\\old-workspace");
+  await flush();
+  assert.equal(draft.workspaceValidation, "pending");
+
+  controller.cancel();
+  draft = setLaunchWorkspaceToSessionFolder(draft);
+  validation.resolve({ valid: true });
+  await flush();
+
+  assert.deepEqual(draft.workspace, { kind: "session-folder" });
+  assert.equal(draft.workspaceValidation, "idle");
+  assert.equal(draft.workspacePathInput, "");
+});

--- a/scripts/tests/main-ipc-deps.test.ts
+++ b/scripts/tests/main-ipc-deps.test.ts
@@ -52,6 +52,9 @@ test("createMainIpcRegistrationDeps は残存する window / mate delegate を�
       async pickDirectory() {
         return null;
       },
+      async validateWorkspaceDirectory() {
+        return { valid: true };
+      },
       async pickFile() {
         return null;
       },

--- a/scripts/tests/main-ipc-registration.test.ts
+++ b/scripts/tests/main-ipc-registration.test.ts
@@ -12,6 +12,7 @@ import {
   WITHMATE_CREATE_AUXILIARY_SESSION_CHANNEL,
   WITHMATE_CREATE_CHARACTER_CHANNEL,
   WITHMATE_CREATE_MATE_CHANNEL,
+  WITHMATE_CREATE_COMPANION_SESSION_CHANNEL,
   WITHMATE_CREATE_SESSION_CHANNEL,
   WITHMATE_CREATE_PROMPT_TEMPLATE_CHANNEL,
   WITHMATE_DELETE_SESSION_CHANNEL,
@@ -51,6 +52,7 @@ import {
   WITHMATE_OPEN_SESSION_CHANNEL,
   WITHMATE_OPEN_SETTINGS_WINDOW_CHANNEL,
   WITHMATE_PICK_IMAGE_FILE_CHANNEL,
+  WITHMATE_VALIDATE_WORKSPACE_DIRECTORY_CHANNEL,
   WITHMATE_RESET_APP_DATABASE_CHANNEL,
   WITHMATE_RESOLVE_LAUNCH_CHARACTER_CHANNEL,
   WITHMATE_RUN_AUXILIARY_SESSION_TURN_CHANNEL,
@@ -138,6 +140,17 @@ function createAuxiliarySessionStub(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function createSessionRequest(workspace: Record<string, unknown>) {
+  return {
+    taskTitle: "Task",
+    characterId: "character-1",
+    character: "Character",
+    characterIconPath: "",
+    characterThemeColors: { main: "#111111", sub: "#222222" },
+    workspace,
+  };
+}
+
 test("registerMainIpcHandlers は保持する public IPC だけを登録する", () => {
   const { ipcMain, handlers } = createIpcMainStub();
   const { deps } = createDeps();
@@ -147,6 +160,7 @@ test("registerMainIpcHandlers は保持する public IPC だけを登録する",
   assert.ok(handlers.has(WITHMATE_OPEN_SESSION_CHANNEL));
   assert.ok(handlers.has(WITHMATE_OPEN_SETTINGS_WINDOW_CHANNEL));
   assert.ok(handlers.has(WITHMATE_OPEN_CHARACTER_EDITOR_WINDOW_CHANNEL));
+  assert.ok(handlers.has(WITHMATE_VALIDATE_WORKSPACE_DIRECTORY_CHANNEL));
   assert.ok(handlers.has(WITHMATE_LIST_SESSION_SUMMARIES_CHANNEL));
   assert.ok(handlers.has(WITHMATE_COPY_SESSION_FILE_PREVIEW_IMAGE_CHANNEL));
   assert.ok(handlers.has(WITHMATE_SHOW_SESSION_FILE_PREVIEW_IMAGE_CONTEXT_MENU_CHANNEL));
@@ -205,6 +219,125 @@ test("registerMainIpcHandlers は保持する public IPC だけを登録する",
   for (const channel of removedChannels) {
     assert.equal(handlers.has(channel), false, `${channel} should not be registered`);
   }
+});
+
+test("workspace validation IPC は Home window だけから validation service を呼べる", async () => {
+  const { ipcMain, handlers } = createIpcMainStub();
+  const homeWindow = createWindowStub("http://localhost:5173/");
+  const otherWindow = createWindowStub("http://localhost:5173/?mode=settings");
+  let eventWindow = homeWindow;
+  const validatedPaths: unknown[] = [];
+  const { deps } = createDeps({
+    resolveEventWindow: () => eventWindow,
+    resolveHomeWindow: () => homeWindow,
+    validateWorkspaceDirectory: async (targetPath: unknown) => {
+      validatedPaths.push(targetPath);
+      return { valid: true };
+    },
+  });
+  registerMainIpcHandlers(ipcMain, deps);
+  const handler = handlers.get(WITHMATE_VALIDATE_WORKSPACE_DIRECTORY_CHANNEL);
+
+  assert.deepEqual(await handler?.({}, "C:\\workspace"), { valid: true });
+  eventWindow = otherWindow;
+  await assert.rejects(
+    () => handler?.({}, "C:\\private") as Promise<unknown>,
+    /only available from the Home window/,
+  );
+  assert.deepEqual(validatedPaths, ["C:\\workspace"]);
+});
+
+test("Session/Companion 作成 IPC は Home だけを許可し、作成直前に同じ workspace validation を通す", async () => {
+  const { ipcMain, handlers } = createIpcMainStub();
+  const homeWindow = createWindowStub("http://localhost:5173/");
+  const otherWindow = createWindowStub("http://localhost:5173/?mode=settings");
+  let eventWindow = homeWindow;
+  const validatedPaths: unknown[] = [];
+  const created: string[] = [];
+  const { deps } = createDeps({
+    resolveEventWindow: () => eventWindow,
+    resolveHomeWindow: () => homeWindow,
+    validateWorkspaceDirectory: async (targetPath: unknown) => {
+      validatedPaths.push(targetPath);
+      return targetPath === "C:\\valid" ? { valid: true } : { valid: false, reason: "missing" };
+    },
+    createSession: async () => {
+      created.push("session");
+      return {};
+    },
+    createCompanionSession: async () => {
+      created.push("companion");
+      return {};
+    },
+  });
+  registerMainIpcHandlers(ipcMain, deps);
+  const createSession = handlers.get(WITHMATE_CREATE_SESSION_CHANNEL);
+  const createCompanion = handlers.get(WITHMATE_CREATE_COMPANION_SESSION_CHANNEL);
+  const validSession = createSessionRequest({
+    kind: "directory",
+    label: "valid",
+    path: "C:\\valid",
+    branch: "main",
+  });
+
+  await createSession?.({}, validSession);
+  await createCompanion?.({}, { workspacePath: "C:\\valid" });
+  assert.deepEqual(created, ["session", "companion"]);
+
+  await assert.rejects(
+    () => createSession?.({}, createSessionRequest({
+      kind: "directory",
+      label: "missing",
+      path: "C:\\missing",
+      branch: "",
+    })) as Promise<unknown>,
+    /Path not found\./,
+  );
+  await assert.rejects(
+    () => createCompanion?.({}, { workspacePath: "C:\\missing" }) as Promise<unknown>,
+    /Path not found\./,
+  );
+  assert.deepEqual(created, ["session", "companion"]);
+
+  eventWindow = otherWindow;
+  await assert.rejects(
+    () => createSession?.({}, validSession) as Promise<unknown>,
+    /only available from the Home window/,
+  );
+  await assert.rejects(
+    () => createCompanion?.({}, { workspacePath: "C:\\valid" }) as Promise<unknown>,
+    /only available from the Home window/,
+  );
+  assert.deepEqual(validatedPaths, ["C:\\valid", "C:\\valid", "C:\\missing", "C:\\missing"]);
+  assert.deepEqual(created, ["session", "companion"]);
+});
+
+test("SessionFolder 作成 IPC は filesystem validation を行わず Home から作成できる", async () => {
+  const { ipcMain, handlers } = createIpcMainStub();
+  const homeWindow = createWindowStub("http://localhost:5173/");
+  let validationCount = 0;
+  let creationCount = 0;
+  const { deps } = createDeps({
+    resolveEventWindow: () => homeWindow,
+    resolveHomeWindow: () => homeWindow,
+    validateWorkspaceDirectory: async () => {
+      validationCount += 1;
+      return { valid: true };
+    },
+    createSession: async () => {
+      creationCount += 1;
+      return {};
+    },
+  });
+  registerMainIpcHandlers(ipcMain, deps);
+
+  await handlers.get(WITHMATE_CREATE_SESSION_CHANNEL)?.(
+    {},
+    createSessionRequest({ kind: "session-folder" }),
+  );
+
+  assert.equal(validationCount, 0);
+  assert.equal(creationCount, 1);
 });
 
 test("prompt template IPC は CRUD payload を専用 dependency へ渡す", async () => {

--- a/scripts/tests/preload-api.test.ts
+++ b/scripts/tests/preload-api.test.ts
@@ -189,6 +189,10 @@ test("createWithMateWindowApi は invoke 系 API を domain ごとに束ねる",
     channel: "withmate:pick-files",
     args: ["C:/seed"],
   });
+  assert.deepEqual(await api.validateWorkspaceDirectory("C:/workspace"), {
+    channel: "withmate:validate-workspace-directory",
+    args: ["C:/workspace"],
+  });
   assert.deepEqual(await api.pickSessionFiles("session-1"), {
     channel: "withmate:pick-session-files",
     args: ["session-1"],
@@ -419,6 +423,7 @@ test("createWithMateWindowApi は current public API の key を揃えて expose
     "openSettingsWindow",
     "openMemoryV6ReviewWindow",
     "openTerminalAtPath",
+    "validateWorkspaceDirectory",
     "pickDirectory",
     "pickFile",
     "pickFiles",

--- a/scripts/tests/workspace-directory-validation-service.test.ts
+++ b/scripts/tests/workspace-directory-validation-service.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { WorkspaceDirectoryValidationService } from "../../src-electron/workspace-directory-validation-service.js";
+import { resolveWorkspaceDirectoryValidationMessage } from "../../src/workspace-directory-validation.js";
+
+function createService({
+  absolute = true,
+  directory = true,
+  statError,
+  accessError,
+}: {
+  absolute?: boolean;
+  directory?: boolean;
+  statError?: unknown;
+  accessError?: unknown;
+} = {}) {
+  const calls: string[] = [];
+  return {
+    calls,
+    service: new WorkspaceDirectoryValidationService({
+      isAbsolute(targetPath) {
+        calls.push(`absolute:${targetPath}`);
+        return absolute;
+      },
+      async stat(targetPath) {
+        calls.push(`stat:${targetPath}`);
+        if (statError) throw statError;
+        return { isDirectory: () => directory };
+      },
+      async access(targetPath) {
+        calls.push(`access:${targetPath}`);
+        if (accessError) throw accessError;
+      },
+    }),
+  };
+}
+
+describe("WorkspaceDirectoryValidationService", () => {
+  it("入力文字列を変更せず absolute directory の利用可能性を確認する", async () => {
+    const { service, calls } = createService();
+    const targetPath = "C:\\work space\\repo\\";
+
+    assert.deepEqual(await service.validate(targetPath), { valid: true });
+    assert.deepEqual(calls, [
+      `absolute:${targetPath}`,
+      `stat:${targetPath}`,
+      `access:${targetPath}`,
+    ]);
+  });
+
+  it("relative path、missing、file、unavailable を区別する", async () => {
+    assert.deepEqual(await createService({ absolute: false }).service.validate("repo"), {
+      valid: false,
+      reason: "not-absolute",
+    });
+    assert.deepEqual(await createService({
+      statError: Object.assign(new Error("missing"), { code: "ENOENT" }),
+    }).service.validate("C:\\missing"), { valid: false, reason: "missing" });
+    assert.deepEqual(await createService({ directory: false }).service.validate("C:\\file.txt"), {
+      valid: false,
+      reason: "not-directory",
+    });
+    assert.deepEqual(await createService({ accessError: new Error("denied") }).service.validate("C:\\private"), {
+      valid: false,
+      reason: "unavailable",
+    });
+  });
+
+  it("unknown input は filesystem へ渡さない", async () => {
+    const { service, calls } = createService();
+    assert.deepEqual(await service.validate(null), { valid: false, reason: "empty" });
+    assert.deepEqual(calls, []);
+  });
+});
+
+describe("workspace directory validation messages", () => {
+  it("短い英語の recovery message を返し、empty では表示しない", () => {
+    assert.equal(resolveWorkspaceDirectoryValidationMessage({ valid: false, reason: "empty" }), "");
+    assert.equal(
+      resolveWorkspaceDirectoryValidationMessage({ valid: false, reason: "not-absolute" }),
+      "Enter an absolute path.",
+    );
+    assert.equal(resolveWorkspaceDirectoryValidationMessage({ valid: false, reason: "missing" }), "Path not found.");
+    assert.equal(
+      resolveWorkspaceDirectoryValidationMessage({ valid: false, reason: "not-directory" }),
+      "Not a directory.",
+    );
+    assert.equal(
+      resolveWorkspaceDirectoryValidationMessage({ valid: false, reason: "unavailable" }),
+      "Directory unavailable.",
+    );
+  });
+});

--- a/src-electron/main-ipc-deps.ts
+++ b/src-electron/main-ipc-deps.ts
@@ -108,6 +108,7 @@ import type {
   UpdateMateInput,
 } from "../src/mate/mate-state.js";
 import type { Awaitable } from "./persistent-store-lifecycle-service.js";
+import type { WorkspaceDirectoryValidationResult } from "../src/workspace-directory-validation.js";
 import type {
   CreatePromptTemplateInput,
   PromptTemplate,
@@ -137,6 +138,7 @@ export type MainIpcWindowDepsArgs = {
   openCompanionReviewWindow(sessionId: string): Promise<BrowserWindow>;
   openCompanionMergeWindow(sessionId: string): Promise<BrowserWindow>;
   pickDirectory(targetWindow: MaybeWindow, initialPath: string | null): Promise<string | null>;
+  validateWorkspaceDirectory(targetPath: unknown): Promise<WorkspaceDirectoryValidationResult>;
   pickFile(targetWindow: MaybeWindow, initialPath: string | null): Promise<string | null>;
   pickFiles(targetWindow: MaybeWindow, initialPath: string | null): Promise<string[]>;
   pickSessionFiles(targetWindow: MaybeWindow, sessionId: string): Promise<string[]>;
@@ -409,6 +411,7 @@ export function createMainIpcRegistrationDeps(
       await args.window.openCompanionMergeWindow(sessionId);
     },
     pickDirectory: args.window.pickDirectory,
+    validateWorkspaceDirectory: args.window.validateWorkspaceDirectory,
     pickFile: args.window.pickFile,
     pickFiles: args.window.pickFiles,
     pickSessionFiles: args.window.pickSessionFiles,

--- a/src-electron/main-ipc-registration.ts
+++ b/src-electron/main-ipc-registration.ts
@@ -113,6 +113,11 @@ import type {
 } from "../src/session-state.js";
 import type { Awaitable } from "./persistent-store-lifecycle-service.js";
 import {
+  resolveWorkspaceDirectoryValidationMessage,
+  type WorkspaceDirectoryValidationResult,
+} from "../src/workspace-directory-validation.js";
+import { parseCreateSessionRequest } from "./create-session-request.js";
+import {
   WITHMATE_CANCEL_SESSION_RUN_CHANNEL,
   WITHMATE_CANCEL_COMPANION_SESSION_RUN_CHANNEL,
   WITHMATE_ARCHIVE_CHARACTER_CHANNEL,
@@ -215,6 +220,7 @@ import {
   WITHMATE_OPEN_TERMINAL_AT_PATH_CHANNEL,
   WITHMATE_MERGE_COMPANION_SELECTED_FILES_CHANNEL,
   WITHMATE_PICK_DIRECTORY_CHANNEL,
+  WITHMATE_VALIDATE_WORKSPACE_DIRECTORY_CHANNEL,
   WITHMATE_PICK_FILE_CHANNEL,
   WITHMATE_PICK_FILES_CHANNEL,
   WITHMATE_PICK_SESSION_FILES_CHANNEL,
@@ -440,6 +446,7 @@ export type MainIpcRegistrationDeps = {
   resolveLaunchCharacter(input?: ResolveLaunchCharacterInput | null): Awaitable<CharacterDetail | null>;
   startCharacterAuthoringSession(input: StartCharacterAuthoringSessionInput): Awaitable<CharacterAuthoringSessionStartResult>;
   pickDirectory(targetWindow: MaybeWindow, initialPath: string | null): Promise<string | null>;
+  validateWorkspaceDirectory(targetPath: unknown): Promise<WorkspaceDirectoryValidationResult>;
   pickFile(targetWindow: MaybeWindow, initialPath: string | null): Promise<string | null>;
   pickFiles(targetWindow: MaybeWindow, initialPath: string | null): Promise<string[]>;
   pickSessionFiles(targetWindow: MaybeWindow, sessionId: string): Promise<string[]>;
@@ -485,6 +492,7 @@ type MainIpcWindowDeps = Pick<
   | "openSessionTerminal"
   | "openTerminalAtPath"
   | "pickDirectory"
+  | "validateWorkspaceDirectory"
   | "pickFile"
   | "pickFiles"
   | "pickSessionFiles"
@@ -609,6 +617,9 @@ type MainIpcSessionQueryDeps = Pick<
 
 type MainIpcCompanionDeps = Pick<
   MainIpcRegistrationDeps,
+  | "resolveEventWindow"
+  | "resolveHomeWindow"
+  | "validateWorkspaceDirectory"
   | "createCompanionSession"
   | "getCompanionSession"
   | "getCompanionMessageArtifact"
@@ -629,6 +640,7 @@ type MainIpcSessionRuntimeDeps = Pick<
   MainIpcRegistrationDeps,
   | "resolveEventWindow"
   | "resolveHomeWindow"
+  | "validateWorkspaceDirectory"
   | "resolveSessionWindow"
   | "isSettingsWindow"
   | "getLiveSessionRun"
@@ -645,6 +657,16 @@ type MainIpcSessionRuntimeDeps = Pick<
   | "runSessionTurn"
   | "cancelSessionRun"
 >;
+
+async function assertUsableWorkspaceDirectory(
+  targetPath: unknown,
+  deps: Pick<MainIpcRegistrationDeps, "validateWorkspaceDirectory">,
+): Promise<void> {
+  const result = await deps.validateWorkspaceDirectory(targetPath);
+  if (!result.valid) {
+    throw new Error(resolveWorkspaceDirectoryValidationMessage(result));
+  }
+}
 
 type MainIpcMateDeps = Pick<
   MainIpcRegistrationDeps,
@@ -697,6 +719,17 @@ function assertSettingsWindowSender(
     return;
   }
   throw new Error("Settings IPC is only available from the Settings window.");
+}
+
+function assertHomeWindowSender(
+  event: IpcMainInvokeEvent,
+  deps: Pick<MainIpcRegistrationDeps, "resolveEventWindow" | "resolveHomeWindow">,
+): void {
+  const window = deps.resolveEventWindow(event);
+  if (window && deps.resolveHomeWindow() === window) {
+    return;
+  }
+  throw new Error("Workspace validation IPC is only available from the Home window.");
 }
 
 function assertSessionDeleteSender(
@@ -1008,6 +1041,10 @@ function registerWindowHandlers(ipcMain: IpcHandleRegistrar, deps: MainIpcWindow
   ipcMain.handle(WITHMATE_PICK_DIRECTORY_CHANNEL, async (event, initialPath: string | null) =>
     deps.pickDirectory(resolveTargetWindow(event, deps), initialPath),
   );
+  ipcMain.handle(WITHMATE_VALIDATE_WORKSPACE_DIRECTORY_CHANNEL, async (event, targetPath: unknown) => {
+    assertHomeWindowSender(event, deps);
+    return deps.validateWorkspaceDirectory(targetPath);
+  });
   ipcMain.handle(WITHMATE_PICK_FILE_CHANNEL, async (event, initialPath: string | null) =>
     deps.pickFile(resolveTargetWindow(event, deps), initialPath),
   );
@@ -1496,9 +1533,11 @@ function registerCompanionHandlers(ipcMain: IpcHandleRegistrar, deps: MainIpcCom
   ipcMain.handle(WITHMATE_PREVIEW_COMPANION_COMPOSER_INPUT_CHANNEL, async (_event, sessionId: string, userMessage: string) =>
     deps.previewCompanionComposerInput(sessionId, userMessage),
   );
-  ipcMain.handle(WITHMATE_CREATE_COMPANION_SESSION_CHANNEL, async (_event, input: CreateCompanionSessionInput) =>
-    deps.createCompanionSession(input),
-  );
+  ipcMain.handle(WITHMATE_CREATE_COMPANION_SESSION_CHANNEL, async (event, input: CreateCompanionSessionInput) => {
+    assertHomeWindowSender(event, deps);
+    await assertUsableWorkspaceDirectory(input?.workspacePath, deps);
+    return deps.createCompanionSession(input);
+  });
   ipcMain.handle(WITHMATE_RUN_COMPANION_SESSION_TURN_CHANNEL, async (_event, sessionId: string, request: RunSessionTurnRequest) =>
     deps.runCompanionSessionTurn(sessionId, request),
   );
@@ -1547,7 +1586,14 @@ function registerSessionRuntimeHandlers(ipcMain: IpcHandleRegistrar, deps: MainI
       deps.resolveLiveElicitation(sessionId, requestId, response);
     },
   );
-  ipcMain.handle(WITHMATE_CREATE_SESSION_CHANNEL, (_event, input: CreateSessionRequest) => deps.createSession(input));
+  ipcMain.handle(WITHMATE_CREATE_SESSION_CHANNEL, async (event, input: CreateSessionRequest) => {
+    assertHomeWindowSender(event, deps);
+    const { workspace } = parseCreateSessionRequest(input);
+    if (workspace.kind === "directory") {
+      await assertUsableWorkspaceDirectory(workspace.path, deps);
+    }
+    return deps.createSession(input);
+  });
   ipcMain.handle(WITHMATE_UPDATE_SESSION_CHANNEL, (_event, session: Session) => deps.updateSession(session));
   ipcMain.handle(
     WITHMATE_SET_SESSION_PINNED_CHANNEL,

--- a/src-electron/main.ts
+++ b/src-electron/main.ts
@@ -142,6 +142,7 @@ import { SessionApprovalService } from "./session-approval-service.js";
 import { SessionElicitationService } from "./session-elicitation-service.js";
 import { WindowBroadcastService } from "./window-broadcast-service.js";
 import { WindowDialogService } from "./window-dialog-service.js";
+import { WorkspaceDirectoryValidationService } from "./workspace-directory-validation-service.js";
 import { SessionMemorySupportService } from "./session-memory-support-service.js";
 import { SessionFileExplorerService, type SessionFileExplorerContext } from "./session-file-explorer-service.js";
 import { SessionFilePreviewImageCopyService } from "./session-file-preview-image-copy-service.js";
@@ -361,6 +362,7 @@ let mainSessionCommandFacade: MainSessionCommandFacade | null = null;
 let mainSessionPersistenceFacade: MainSessionPersistenceFacade | null = null;
 let sessionLaunchSelectionService: SessionLaunchSelectionService | null = null;
 const providerRuntimeOperationCoordinator = new ProviderRuntimeOperationCoordinator();
+const workspaceDirectoryValidationService = new WorkspaceDirectoryValidationService();
 let mainWindowFacade: MainWindowFacade | null = null;
 let mainQueryService: MainQueryService | null = null;
 let appTrayService: AppTrayService | null = null;
@@ -1335,6 +1337,8 @@ function requireMainInfrastructureRegistry(): MainInfrastructureRegistry<
                 openCompanionMergeWindow,
                 pickDirectory: (targetWindow, initialPath) =>
                   requireWindowDialogService().pickDirectory(targetWindow, initialPath),
+                validateWorkspaceDirectory: (targetPath) =>
+                  workspaceDirectoryValidationService.validate(targetPath),
                 pickFile: (targetWindow, initialPath) =>
                   requireWindowDialogService().pickFile(targetWindow, initialPath),
                 pickFiles: (targetWindow, initialPath) =>

--- a/src-electron/preload-api.ts
+++ b/src-electron/preload-api.ts
@@ -121,6 +121,7 @@ import {
   WITHMATE_OPEN_MEMORY_V6_REVIEW_WINDOW_CHANNEL,
   WITHMATE_OPEN_TERMINAL_AT_PATH_CHANNEL,
   WITHMATE_PICK_DIRECTORY_CHANNEL,
+  WITHMATE_VALIDATE_WORKSPACE_DIRECTORY_CHANNEL,
   WITHMATE_PICK_FILE_CHANNEL,
   WITHMATE_PICK_FILES_CHANNEL,
   WITHMATE_PICK_SESSION_FILES_CHANNEL,
@@ -668,6 +669,9 @@ function createMemoryV6ReviewApi(ipcRenderer: IpcRendererLike): Pick<
 
 function createPickerApi(ipcRenderer: IpcRendererLike): WithMateWindowPickerApi {
   return {
+    validateWorkspaceDirectory(targetPath) {
+      return ipcRenderer.invoke(WITHMATE_VALIDATE_WORKSPACE_DIRECTORY_CHANNEL, targetPath);
+    },
     pickDirectory(initialPath) {
       return ipcRenderer.invoke(WITHMATE_PICK_DIRECTORY_CHANNEL, initialPath ?? null);
     },

--- a/src-electron/workspace-directory-validation-service.ts
+++ b/src-electron/workspace-directory-validation-service.ts
@@ -1,0 +1,48 @@
+import { constants } from "node:fs";
+import { access, stat } from "node:fs/promises";
+import path from "node:path";
+
+import type { WorkspaceDirectoryValidationResult } from "../src/workspace-directory-validation.js";
+
+type WorkspaceDirectoryValidationServiceDeps = {
+  isAbsolute(targetPath: string): boolean;
+  stat(targetPath: string): Promise<{ isDirectory(): boolean }>;
+  access(targetPath: string, mode: number): Promise<void>;
+};
+
+const DEFAULT_DEPS: WorkspaceDirectoryValidationServiceDeps = {
+  isAbsolute: path.isAbsolute,
+  stat,
+  access,
+};
+
+function isMissingPathError(error: unknown): boolean {
+  return !!error && typeof error === "object" && "code" in error && error.code === "ENOENT";
+}
+
+export class WorkspaceDirectoryValidationService {
+  constructor(private readonly deps: WorkspaceDirectoryValidationServiceDeps = DEFAULT_DEPS) {}
+
+  async validate(targetPath: unknown): Promise<WorkspaceDirectoryValidationResult> {
+    if (typeof targetPath !== "string" || targetPath.length === 0) {
+      return { valid: false, reason: "empty" };
+    }
+    if (!this.deps.isAbsolute(targetPath)) {
+      return { valid: false, reason: "not-absolute" };
+    }
+
+    try {
+      const stats = await this.deps.stat(targetPath);
+      if (!stats.isDirectory()) {
+        return { valid: false, reason: "not-directory" };
+      }
+      await this.deps.access(targetPath, constants.R_OK | constants.X_OK);
+      return { valid: true };
+    } catch (error) {
+      return {
+        valid: false,
+        reason: isMissingPathError(error) ? "missing" : "unavailable",
+      };
+    }
+  }
+}

--- a/src/HomeApp.tsx
+++ b/src/HomeApp.tsx
@@ -24,9 +24,16 @@ import {
 import { buildHomeLaunchDialogProps } from "./home/home-launch-dialog-props.js";
 import {
   createClosedLaunchDraft,
+  applyLaunchWorkspacePathValidation,
+  beginLaunchWorkspacePathValidation,
+  markLaunchWorkspacePathValidationPending,
   resolveLaunchCharacterId,
   type HomeLaunchDraft,
 } from "./home/home-launch-state.js";
+import {
+  createHomeLaunchWorkspaceValidationController,
+  type HomeLaunchWorkspaceValidationController,
+} from "./home/home-launch-workspace-validation.js";
 import { resolveSelectedLaunchProviderDraftId } from "./launch/launch-provider-selection.js";
 import { type CompanionSessionSummary } from "./companion-state.js";
 import { startCompanionSessionSummariesSubscription } from "./companion-session-summary-subscription.js";
@@ -130,6 +137,26 @@ export default function HomeApp() {
   const [mateProfileEditorOpen, setMateProfileEditorOpen] = useState(false);
   const settingsDirtyRef = useRef(false);
   const settingsHydratedRef = useRef(!isSettingsWindowMode);
+  const workspaceValidationControllerRef = useRef<HomeLaunchWorkspaceValidationController | null>(null);
+  if (workspaceValidationControllerRef.current === null) {
+    workspaceValidationControllerRef.current = createHomeLaunchWorkspaceValidationController({
+      validate: async (targetPath) => (
+        await withWithMateApi((api) => api.validateWorkspaceDirectory(targetPath))
+        ?? { valid: false, reason: "unavailable" }
+      ),
+      onScheduled: (targetPath) => {
+        setLaunchDraft((current) => beginLaunchWorkspacePathValidation(current, targetPath));
+      },
+      onValidationStart: (targetPath) => {
+        setLaunchDraft((current) => markLaunchWorkspacePathValidationPending(current, targetPath));
+      },
+      onResult: (targetPath, result) => {
+        setLaunchDraft((current) => applyLaunchWorkspacePathValidation(current, targetPath, result));
+      },
+    });
+  }
+
+  useEffect(() => () => workspaceValidationControllerRef.current?.cancel(), []);
 
   const applyIncomingAppSettings = (settings: AppSettings, options?: { force?: boolean }) => {
     setAppSettings(settings);
@@ -390,6 +417,9 @@ export default function HomeApp() {
       launchMode: "session",
       launchTitle: launchDraft.title,
       launchWorkspace: launchDraft.workspace,
+      workspacePathInput: launchDraft.workspacePathInput,
+      workspaceValidation: launchDraft.workspaceValidation,
+      workspaceValidationMessage: launchDraft.workspaceValidationMessage,
       launchCharacterId: launchDraft.characterId,
       launchCharacterSelectionMode: launchDraft.characterSelectionMode,
       characterEntries,
@@ -445,6 +475,8 @@ export default function HomeApp() {
     setLaunchStarting,
     setLaunchDraft,
     pickWorkspaceDirectory: async () => withWithMateApi((api) => api.pickDirectory()),
+    scheduleWorkspaceValidation: (targetPath) => workspaceValidationControllerRef.current?.schedule(targetPath),
+    cancelWorkspaceValidation: () => workspaceValidationControllerRef.current?.cancel(),
     openSessionWindow,
     openCompanionReviewWindow,
     createSession: async (input) => await withWithMateApi((api) => api.createSession(input)),
@@ -634,6 +666,7 @@ export default function HomeApp() {
       launchStarting,
       onClose: homeLaunchHandlers.onCloseLaunchDialog,
       onChangeTitle: homeLaunchHandlers.onChangeTitle,
+      onChangeWorkspacePath: homeLaunchHandlers.onChangeWorkspacePath,
       onBrowseWorkspace: () => void homeLaunchHandlers.onBrowseWorkspace(),
       onSelectSessionFolder: homeLaunchHandlers.onSelectSessionFolder,
       onSelectProvider: homeLaunchHandlers.onSelectLaunchProvider,

--- a/src/home/HomeLaunchDialog.tsx
+++ b/src/home/HomeLaunchDialog.tsx
@@ -7,13 +7,16 @@ import { buildCharacterThemeStyle } from "../theme-utils.js";
 import { CharacterAvatar } from "../ui-utils.js";
 import type { CharacterCatalogEntry } from "../character/character-catalog.js";
 import { DEFAULT_CHARACTER_THEME_COLORS } from "../character-state.js";
+import type { HomeLaunchWorkspaceValidationState } from "./home-launch-state.js";
 
 export type HomeLaunchDialogProps = {
   open: boolean;
   title: string;
-  workspaceSelected: boolean;
   sessionFolderSelected: boolean;
   launchWorkspacePathLabel: string;
+  workspacePathInput: string;
+  workspaceValidation: HomeLaunchWorkspaceValidationState;
+  workspaceValidationMessage: string;
   enabledLaunchProviders: Array<{ id: string; label: string }>;
   selectedLaunchProviderId: string | null;
   characterOptions: CharacterCatalogEntry[];
@@ -25,6 +28,7 @@ export type HomeLaunchDialogProps = {
   launchStarting: boolean;
   onClose: () => void;
   onChangeTitle: (value: string) => void;
+  onChangeWorkspacePath: (value: string) => void;
   onBrowseWorkspace: () => void;
   onSelectSessionFolder: () => void;
   onSelectProvider: (providerId: string) => void;
@@ -36,9 +40,11 @@ export type HomeLaunchDialogProps = {
 export function HomeLaunchDialog({
   open,
   title,
-  workspaceSelected,
   sessionFolderSelected,
   launchWorkspacePathLabel,
+  workspacePathInput,
+  workspaceValidation,
+  workspaceValidationMessage,
   enabledLaunchProviders,
   selectedLaunchProviderId,
   characterOptions,
@@ -50,6 +56,7 @@ export function HomeLaunchDialog({
   launchStarting,
   onClose,
   onChangeTitle,
+  onChangeWorkspacePath,
   onBrowseWorkspace,
   onSelectSessionFolder,
   onSelectProvider,
@@ -67,6 +74,8 @@ export function HomeLaunchDialog({
   if (!open) {
     return null;
   }
+
+  const workspaceValidationActive = workspaceValidation === "debouncing" || workspaceValidation === "pending";
 
   return (
     <LaunchDialogShell
@@ -100,6 +109,43 @@ export function HomeLaunchDialog({
       </section>
 
       <section className="launch-section workspace-picker minimal">
+        <div className="launch-field">
+          <div className="launch-field-heading">
+            <label className="launch-field-label" htmlFor="launch-workspace-path">
+              Workspace
+            </label>
+            <span
+              id="launch-workspace-path-error"
+              className="launch-field-error"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              title={workspaceValidationMessage || undefined}
+            >
+              {workspaceValidationMessage}
+            </span>
+          </div>
+          <div className="launch-field-input-shell workspace-validation-input" aria-busy={workspaceValidationActive}>
+            <input
+              id="launch-workspace-path"
+              className="launch-field-input"
+              type="text"
+              value={workspacePathInput}
+              placeholder="C:\\path\\to\\workspace"
+              aria-invalid={workspaceValidation === "invalid"}
+              aria-describedby={workspaceValidationMessage ? "launch-workspace-path-error" : undefined}
+              onChange={(event) => onChangeWorkspacePath(event.target.value)}
+            />
+            {workspaceValidationActive ? (
+              <span className="workspace-validation-spinner" aria-hidden="true" />
+            ) : null}
+          </div>
+          {workspaceValidationActive ? (
+            <span className="visually-hidden" role="status" aria-live="polite">
+              Workspace パスを確認しています
+            </span>
+          ) : null}
+        </div>
         <div className="section-head compact-actions workspace-picker-actions">
           <button className="browse-button" type="button" onClick={onBrowseWorkspace}>
             Browse
@@ -113,7 +159,9 @@ export function HomeLaunchDialog({
             SessionFolder
           </button>
         </div>
-        <p className={`launch-path${workspaceSelected ? " selected" : ""}`}>{launchWorkspacePathLabel}</p>
+        {sessionFolderSelected ? (
+          <p className="launch-path selected">{launchWorkspacePathLabel}</p>
+        ) : null}
       </section>
 
       <ProviderLaunchField

--- a/src/home/home-launch-dialog-props.ts
+++ b/src/home/home-launch-dialog-props.ts
@@ -10,6 +10,7 @@ type HomeLaunchDialogPropsInput = {
   launchStarting: boolean;
   onClose: () => void;
   onChangeTitle: (value: string) => void;
+  onChangeWorkspacePath: (value: string) => void;
   onBrowseWorkspace: () => void;
   onSelectSessionFolder: () => void;
   onSelectProvider: (providerId: string) => void;
@@ -26,6 +27,7 @@ export function buildHomeLaunchDialogProps({
   launchStarting,
   onClose,
   onChangeTitle,
+  onChangeWorkspacePath,
   onBrowseWorkspace,
   onSelectSessionFolder,
   onSelectProvider,
@@ -36,9 +38,11 @@ export function buildHomeLaunchDialogProps({
   return {
     open: draft.open,
     title: draft.title,
-    workspaceSelected: projection.workspaceSelected,
     sessionFolderSelected: projection.sessionFolderSelected,
     launchWorkspacePathLabel: projection.launchWorkspacePathLabel,
+    workspacePathInput: projection.workspacePathInput,
+    workspaceValidation: projection.workspaceValidation,
+    workspaceValidationMessage: projection.workspaceValidationMessage,
     enabledLaunchProviders: projection.enabledLaunchProviders,
     selectedLaunchProviderId: projection.selectedLaunchProvider?.id ?? null,
     characterOptions: projection.characterOptions,
@@ -50,6 +54,7 @@ export function buildHomeLaunchDialogProps({
     launchStarting,
     onClose,
     onChangeTitle,
+    onChangeWorkspacePath,
     onBrowseWorkspace,
     onSelectSessionFolder,
     onSelectProvider,

--- a/src/home/home-launch-handlers.ts
+++ b/src/home/home-launch-handlers.ts
@@ -10,7 +10,6 @@ import type { HomeLaunchDraft } from "./home-launch-state.js";
 import {
   closeLaunchDraft,
   openLaunchDraft,
-  setLaunchWorkspaceFromPath,
   setLaunchWorkspaceToSessionFolder,
   updateLaunchDraftForCharacterSelection,
   updateLaunchDraftForProviderSelection,
@@ -37,6 +36,8 @@ type HomeLaunchHandlersContext = {
   setLaunchStarting: (launchStarting: boolean) => void;
   setLaunchDraft: (updater: HomeLaunchDraft | ((draft: HomeLaunchDraft) => HomeLaunchDraft)) => void;
   pickWorkspaceDirectory: () => Promise<string | null> | string | null;
+  scheduleWorkspaceValidation: (targetPath: string) => void;
+  cancelWorkspaceValidation: () => void;
   openSessionWindow: (sessionId: string) => Promise<void>;
   openCompanionReviewWindow: (sessionId: string) => Promise<void>;
   createSession: (input: CreateSessionRequest) => Promise<SessionSummary | null>;
@@ -55,6 +56,7 @@ export type HomeLaunchHandlers = {
   onSelectRandomLaunchCharacter: () => void;
   onChangeMode: (mode: HomeLaunchDraft["mode"]) => void;
   onChangeTitle: (value: string) => void;
+  onChangeWorkspacePath: (value: string) => void;
   onStartSession: (mode?: HomeLaunchDraft["mode"]) => void;
 };
 
@@ -76,6 +78,8 @@ export function buildHomeLaunchHandlers({
   setLaunchStarting,
   setLaunchDraft,
   pickWorkspaceDirectory,
+  scheduleWorkspaceValidation,
+  cancelWorkspaceValidation,
   openSessionWindow,
   openCompanionReviewWindow,
   createSession,
@@ -90,10 +94,11 @@ export function buildHomeLaunchHandlers({
     }
 
     setLaunchFeedback("");
-    setLaunchDraft((current) => setLaunchWorkspaceFromPath(current, selectedPath));
+    scheduleWorkspaceValidation(selectedPath);
   };
 
   const onOpenLaunchDialog = async () => {
+    cancelWorkspaceValidation();
     setLaunchFeedback("");
     await refreshCharacterEntries().catch((error) => {
       setCharactersLoaded(false);
@@ -109,6 +114,7 @@ export function buildHomeLaunchHandlers({
   };
 
   const onCloseLaunchDialog = () => {
+    cancelWorkspaceValidation();
     setLaunchFeedback("");
     setLaunchStarting(false);
     setLaunchDraft((current) => closeLaunchDraft(current));
@@ -147,6 +153,7 @@ export function buildHomeLaunchHandlers({
   return {
     onBrowseWorkspace: () => void onBrowseWorkspace(),
     onSelectSessionFolder: () => {
+      cancelWorkspaceValidation();
       setLaunchFeedback("");
       setLaunchDraft((current) => setLaunchWorkspaceToSessionFolder(current));
     },
@@ -174,6 +181,10 @@ export function buildHomeLaunchHandlers({
     onChangeTitle: (value) => {
       setLaunchFeedback("");
       setLaunchDraft((current) => ({ ...current, title: value }));
+    },
+    onChangeWorkspacePath: (value) => {
+      setLaunchFeedback("");
+      scheduleWorkspaceValidation(value);
     },
     onStartSession: (mode) => void onStartSession(mode),
   };

--- a/src/home/home-launch-projection.ts
+++ b/src/home/home-launch-projection.ts
@@ -4,6 +4,7 @@ import { getProviderAppSettings, type AppSettings } from "../provider-settings-s
 import { resolveSelectedLaunchProviderId } from "../launch/launch-provider-selection.js";
 import {
   resolveLaunchCharacterId,
+  type HomeLaunchWorkspaceValidationState,
   type LaunchCharacterSelectionMode,
 } from "./home-launch-state.js";
 import {
@@ -22,6 +23,9 @@ export type HomeLaunchProjection = {
   randomCharacterSelected: boolean;
   charactersLoaded: boolean;
   launchWorkspacePathLabel: string;
+  workspacePathInput: string;
+  workspaceValidation: HomeLaunchWorkspaceValidationState;
+  workspaceValidationMessage: string;
   sessionFolderSelected: boolean;
   workspaceSelected: boolean;
   canStartSession: boolean;
@@ -32,6 +36,9 @@ export function buildHomeLaunchProjection({
   launchMode,
   launchTitle,
   launchWorkspace,
+  workspacePathInput = "",
+  workspaceValidation = "idle",
+  workspaceValidationMessage = "",
   launchCharacterId,
   launchCharacterSelectionMode = "random",
   characterEntries = [],
@@ -43,6 +50,9 @@ export function buildHomeLaunchProjection({
   launchMode?: "session" | "companion";
   launchTitle: string;
   launchWorkspace: LaunchWorkspaceSelection | null;
+  workspacePathInput?: string;
+  workspaceValidation?: HomeLaunchWorkspaceValidationState;
+  workspaceValidationMessage?: string;
   launchCharacterId?: string;
   launchCharacterSelectionMode?: LaunchCharacterSelectionMode;
   characterEntries?: readonly CharacterCatalogEntry[];
@@ -74,6 +84,9 @@ export function buildHomeLaunchProjection({
     launchWorkspacePathLabel: sessionFolderSelected
       ? "SessionFolder"
       : launchWorkspace?.path ?? "workspace",
+    workspacePathInput,
+    workspaceValidation,
+    workspaceValidationMessage,
     sessionFolderSelected,
     workspaceSelected: !!launchWorkspace,
     canStartSession:

--- a/src/home/home-launch-state.ts
+++ b/src/home/home-launch-state.ts
@@ -10,6 +10,10 @@ import {
 } from "./home-launch-workspace.js";
 import { LAUNCH_NO_PROVIDER_SELECTED_MESSAGE } from "../launch/launch-feedback.js";
 import type { MateProfile, MateStorageState } from "../mate/mate-state.js";
+import {
+  resolveWorkspaceDirectoryValidationMessage,
+  type WorkspaceDirectoryValidationResult,
+} from "../workspace-directory-validation.js";
 
 const NEUTRAL_CHARACTER_ID = "withmate-neutral-character";
 const NEUTRAL_CHARACTER_NAME = "WithMate";
@@ -25,11 +29,15 @@ type LaunchCharacterSnapshot = {
 type CharacterUsageSessionSource = Pick<SessionSummary, "characterId" | "sessionKind">;
 
 export type LaunchCharacterSelectionMode = "specific" | "random";
+export type HomeLaunchWorkspaceValidationState = "idle" | "debouncing" | "pending" | "valid" | "invalid";
 
 export type HomeLaunchDraft = {
   open: boolean;
   mode: "session" | "companion";
   title: string;
+  workspacePathInput: string;
+  workspaceValidation: HomeLaunchWorkspaceValidationState;
+  workspaceValidationMessage: string;
   workspace: LaunchWorkspaceSelection | null;
   providerId: string;
   characterSelectionMode: LaunchCharacterSelectionMode;
@@ -41,6 +49,9 @@ export function createClosedLaunchDraft(): HomeLaunchDraft {
     open: false,
     mode: "session",
     title: "",
+    workspacePathInput: "",
+    workspaceValidation: "idle",
+    workspaceValidationMessage: "",
     workspace: null,
     providerId: "",
     characterSelectionMode: "random",
@@ -58,6 +69,9 @@ export function openLaunchDraft(
     open: true,
     mode,
     title: "",
+    workspacePathInput: "",
+    workspaceValidation: "idle",
+    workspaceValidationMessage: "",
     workspace: null,
     providerId: defaultProviderId,
     characterSelectionMode: "random",
@@ -115,6 +129,9 @@ export function closeLaunchDraft(draft: HomeLaunchDraft): HomeLaunchDraft {
     ...draft,
     open: false,
     title: "",
+    workspacePathInput: "",
+    workspaceValidation: "idle",
+    workspaceValidationMessage: "",
     workspace: null,
     providerId: "",
     characterSelectionMode: "random",
@@ -125,13 +142,64 @@ export function closeLaunchDraft(draft: HomeLaunchDraft): HomeLaunchDraft {
 export function setLaunchWorkspaceFromPath(draft: HomeLaunchDraft, selectedPath: string): HomeLaunchDraft {
   return {
     ...draft,
+    workspacePathInput: selectedPath,
+    workspaceValidation: "valid",
+    workspaceValidationMessage: "",
     workspace: inferWorkspaceFromPath(selectedPath),
+  };
+}
+
+export function beginLaunchWorkspacePathValidation(
+  draft: HomeLaunchDraft,
+  targetPath: string,
+): HomeLaunchDraft {
+  return {
+    ...draft,
+    workspacePathInput: targetPath,
+    workspaceValidation: targetPath.length > 0 ? "debouncing" : "idle",
+    workspaceValidationMessage: "",
+    workspace: null,
+  };
+}
+
+export function markLaunchWorkspacePathValidationPending(
+  draft: HomeLaunchDraft,
+  targetPath: string,
+): HomeLaunchDraft {
+  if (draft.workspacePathInput !== targetPath) {
+    return draft;
+  }
+  return {
+    ...draft,
+    workspaceValidation: "pending",
+  };
+}
+
+export function applyLaunchWorkspacePathValidation(
+  draft: HomeLaunchDraft,
+  targetPath: string,
+  result: WorkspaceDirectoryValidationResult,
+): HomeLaunchDraft {
+  if (draft.workspacePathInput !== targetPath || draft.workspaceValidation !== "pending") {
+    return draft;
+  }
+  if (result.valid) {
+    return setLaunchWorkspaceFromPath(draft, targetPath);
+  }
+  return {
+    ...draft,
+    workspaceValidation: "invalid",
+    workspaceValidationMessage: resolveWorkspaceDirectoryValidationMessage(result),
+    workspace: null,
   };
 }
 
 export function setLaunchWorkspaceToSessionFolder(draft: HomeLaunchDraft): HomeLaunchDraft {
   return {
     ...draft,
+    workspacePathInput: "",
+    workspaceValidation: "idle",
+    workspaceValidationMessage: "",
     workspace: { kind: "session-folder" },
   };
 }

--- a/src/home/home-launch-workspace-validation.ts
+++ b/src/home/home-launch-workspace-validation.ts
@@ -1,0 +1,69 @@
+import type { WorkspaceDirectoryValidationResult } from "../workspace-directory-validation.js";
+
+export const HOME_LAUNCH_WORKSPACE_VALIDATION_DEBOUNCE_MS = 300;
+
+type TimeoutHandle = ReturnType<typeof setTimeout>;
+
+type HomeLaunchWorkspaceValidationControllerOptions = {
+  validate: (targetPath: string) => Promise<WorkspaceDirectoryValidationResult>;
+  onScheduled: (targetPath: string) => void;
+  onValidationStart: (targetPath: string) => void;
+  onResult: (targetPath: string, result: WorkspaceDirectoryValidationResult) => void;
+  delayMs?: number;
+  setTimer?: (callback: () => void, delayMs: number) => TimeoutHandle;
+  clearTimer?: (handle: TimeoutHandle) => void;
+};
+
+export type HomeLaunchWorkspaceValidationController = {
+  schedule(targetPath: string): void;
+  cancel(): void;
+};
+
+export function createHomeLaunchWorkspaceValidationController({
+  validate,
+  onScheduled,
+  onValidationStart,
+  onResult,
+  delayMs = HOME_LAUNCH_WORKSPACE_VALIDATION_DEBOUNCE_MS,
+  setTimer = setTimeout,
+  clearTimer = clearTimeout,
+}: HomeLaunchWorkspaceValidationControllerOptions): HomeLaunchWorkspaceValidationController {
+  let generation = 0;
+  let timeout: TimeoutHandle | null = null;
+
+  const cancel = () => {
+    generation += 1;
+    if (timeout !== null) {
+      clearTimer(timeout);
+      timeout = null;
+    }
+  };
+
+  return {
+    schedule(targetPath) {
+      cancel();
+      onScheduled(targetPath);
+      if (targetPath.length === 0) {
+        return;
+      }
+
+      const requestGeneration = generation;
+      timeout = setTimer(() => {
+        timeout = null;
+        onValidationStart(targetPath);
+        void validate(targetPath)
+          .then((result) => {
+            if (requestGeneration === generation) {
+              onResult(targetPath, result);
+            }
+          })
+          .catch(() => {
+            if (requestGeneration === generation) {
+              onResult(targetPath, { valid: false, reason: "unavailable" });
+            }
+          });
+      }, delayMs);
+    },
+    cancel,
+  };
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1707,6 +1707,69 @@ button:disabled {
   box-shadow: 0 0 0 3px rgba(111, 140, 255, 0.14);
 }
 
+.home-page .launch-field-input[aria-invalid="true"] {
+  border-color: rgba(248, 113, 113, 0.62);
+}
+
+.launch-field-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+}
+
+.home-page .launch-field-error {
+  display: block;
+  min-width: 0;
+  max-width: 72%;
+  height: 1rem;
+  color: #fca5a5;
+  font-size: 0.78rem;
+  line-height: 1rem;
+  overflow: hidden;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.launch-field-input-shell {
+  position: relative;
+}
+
+.workspace-validation-input .launch-field-input {
+  padding-right: 44px;
+}
+
+.workspace-validation-spinner {
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  width: 15px;
+  height: 15px;
+  margin-top: -8px;
+  border: 2px solid rgba(203, 213, 225, 0.28);
+  border-top-color: #cbd5e1;
+  border-radius: 50%;
+  pointer-events: none;
+  animation: workspace-validation-spin 0.7s linear infinite;
+}
+
+@keyframes workspace-validation-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workspace-validation-spinner {
+    animation: none;
+  }
+}
+
 .home-page .launch-provider-list .choice-chip.active {
   border-color: rgba(143, 169, 255, 0.48);
   background: rgba(111, 140, 255, 0.24);

--- a/src/withmate-ipc-channels.ts
+++ b/src/withmate-ipc-channels.ts
@@ -75,6 +75,7 @@ export const WITHMATE_ARCHIVE_CHARACTER_CHANNEL = "withmate:archive-character";
 export const WITHMATE_RESOLVE_LAUNCH_CHARACTER_CHANNEL = "withmate:resolve-launch-character";
 export const WITHMATE_START_CHARACTER_AUTHORING_SESSION_CHANNEL = "withmate:start-character-authoring-session";
 export const WITHMATE_PICK_DIRECTORY_CHANNEL = "withmate:pick-directory";
+export const WITHMATE_VALIDATE_WORKSPACE_DIRECTORY_CHANNEL = "withmate:validate-workspace-directory";
 export const WITHMATE_PICK_FILE_CHANNEL = "withmate:pick-file";
 export const WITHMATE_PICK_FILES_CHANNEL = "withmate:pick-files";
 export const WITHMATE_PICK_SESSION_FILES_CHANNEL = "withmate:pick-session-files";

--- a/src/withmate-window-api.ts
+++ b/src/withmate-window-api.ts
@@ -48,6 +48,7 @@ import type {
   MarkdownLinkContextMenuResult,
 } from "./markdown-link-context-menu.js";
 import type { AppBootStatus } from "./app-boot-state.js";
+import type { WorkspaceDirectoryValidationResult } from "./workspace-directory-validation.js";
 import type { AppDatabaseDiagnostics } from "./app-database-diagnostics-state.js";
 import type { MemoryV6Diagnostics } from "./memory-v6/memory-diagnostics-state.js";
 import type { MemoryV6ReviewApi } from "./memory-v6/memory-review-state.js";
@@ -269,6 +270,7 @@ export type WithMateWindowPromptTemplateApi = {
 };
 
 export type WithMateWindowPickerApi = {
+  validateWorkspaceDirectory(targetPath: string): Promise<WorkspaceDirectoryValidationResult>;
   pickDirectory(initialPath?: string | null): Promise<string | null>;
   pickFile(initialPath?: string | null): Promise<string | null>;
   pickFiles(initialPath?: string | null): Promise<string[]>;

--- a/src/workspace-directory-validation.ts
+++ b/src/workspace-directory-validation.ts
@@ -1,0 +1,34 @@
+export type WorkspaceDirectoryValidationFailureReason =
+  | "empty"
+  | "not-absolute"
+  | "missing"
+  | "not-directory"
+  | "unavailable";
+
+export type WorkspaceDirectoryValidationResult =
+  | { valid: true }
+  | {
+      valid: false;
+      reason: WorkspaceDirectoryValidationFailureReason;
+    };
+
+export function resolveWorkspaceDirectoryValidationMessage(
+  result: WorkspaceDirectoryValidationResult,
+): string {
+  if (result.valid) {
+    return "";
+  }
+
+  switch (result.reason) {
+    case "empty":
+      return "";
+    case "not-absolute":
+      return "Enter an absolute path.";
+    case "missing":
+      return "Path not found.";
+    case "not-directory":
+      return "Not a directory.";
+    case "unavailable":
+      return "Directory unavailable.";
+  }
+}


### PR DESCRIPTION
## 概要
- HomeのSession作成dialogでWorkspaceパスを直接入力・貼り付け可能にする
- debounce後にmain processでdirectoryの存在・種別・利用可能性を検証する
- stale responseを破棄し、Browseと手入力で同じvalidation境界を使用する
- エラー表示でlayoutを変えず、短い英語のmicrocopyを表示する

## 検証
- npm test（2347件: 2346 pass / 1 skip）
- npm run typecheck
- npm run build
- git diff --check