### PR TITLE
fix(notification): 通知から対象Session Windowを確実に開く

### DIFF
--- a/docs/adr/006-windows-session-turn-notifications.md
+++ b/docs/adr/006-windows-session-turn-notifications.md
@@ -24,7 +24,7 @@ Session のターン完了まで時間がかかる場合、ユーザーは WithM
 - Session ID から安定した Windows notification ID を生成する。同一 Session の未処理通知がある場合は閉じ、プロセス再起動をまたぐ場合も Windows の Tag と Group によって新しい完了通知へ置き換える。
 - Windows の system timeout 後も元の notification instance を Session 単位で保持する。同じ Session の新しい通知へ置き換える場合、または Session の単体削除、cutoff 一括削除、Sessions を含む DB 初期化が成功した場合は、その instance の `close()` を呼び、Action Center からの撤去を試みる。削除されなかった Session と、実行中のため一括削除から除外された Session の通知は閉じない。
 - 通知の撤去失敗は記録するが、完了済みの Session 削除を失敗へ変更しない。削除結果を巻き戻せず、通知の再試行にも利用できる追加 API がないため、一括削除では削除済みの全 Session について通知撤去を先に試み、その後に workspace の cleanup へ進む。
-- Electron の通知 instance が click を受け取れる間は、クリック時点で対象 Session が存在すれば Session Window を開き、削除済みまたは読み込み・表示に失敗した場合は Home Window を開く。
+- Electron の通知 instance が click を受け取れる間は、Session ごとに現在追跡中の最新 instance の最初の click だけを受け付ける。同じ click の多重発火、置き換え・撤去済み instance の遅延 click は無視する。`timedOut` で閉じた instance だけは Action Center からの click に備えて保持し、その他の close reason と reason が通知されない close では追跡を終了する。受け付けたクリック時点で対象 Session が存在すれば Session Window を開き、削除済みまたは読み込み・表示に失敗した場合は Home Window を開く。
 - WithMate のプロセス終了後、または通知 instance が破棄された後に Action Center から通知をクリックした場合、Windows によるアプリ起動は許容するが、対象 Session への復帰は保証しない。
 - 通知可否の判定、icon 読み込み、通知生成、表示、click 処理の失敗は記録するが、ターン結果を失敗へ変更せず、通知の再試行もしない。
 

--- a/docs/manual-test-checklist.md
+++ b/docs/manual-test-checklist.md
@@ -189,3 +189,5 @@ npm run electron:start
 | MT-066 | Copilot selected agent visibility | provider を `GitHub Copilot` にした session で custom agent を選択し、composer の `Agent` ボタンを見る | `Agent` ボタン自体が現在値を表示し、`Default Agent` と custom agent 名を見分けられる |
 | MT-067 | Window error recovery | Home / Character Editor / Session / Diff のいずれかで renderer render error を再現する | window-level fallback が出て、`再試行` で再描画を試せる。復帰しない場合も `再読み込み` が使える |
 | MT-067A | Right pane error recovery | `Session Window` の right pane だけで render error を再現する | pane 専用 fallback が出て、`右ペインを再描画` と `Window を再読み込み` の両方が表示される |
+| MT-068 | Windows notification Session activation | Windows で通常の完了通知と返答 preview 通知をそれぞれ発生させる。WithMate 以外を前面にした状態で、対象 Session Window が通常表示、最小化、非表示、未作成の各状態から live toast または Action Center の通知をクリックする | 既存 Window は同じ位置のまま可視化され、最小化時は復元されて前面へ focus する。未作成なら対象 Session の Window が1つだけ新規表示される。別 Session WindowやHomeが開かず、同じ通知を再度activateしても追加のWindowは開かない |
+| MT-068A | Windows notification stale / fallback | 同じ Session の通知を連続して発生させ、置き換え前の通知が操作可能なら古い通知と最新通知を順にクリックする。続けて通知後に対象 Session を削除する場合と、開く処理を失敗させる開発用条件を確認する | 古い通知や同じ通知の多重activationはSessionを再openせず、最新通知の最初のactivationだけが対象を開く。削除済みまたはopen失敗ではHomeが表示・focusされ、失敗が記録される |

--- a/scripts/tests/session-turn-notification-service.test.ts
+++ b/scripts/tests/session-turn-notification-service.test.ts
@@ -56,6 +56,10 @@ class FakeNotification implements SessionTurnNotificationHandle {
   timeout(): void {
     this.closeListener?.("timedOut");
   }
+
+  closeWithoutReason(): void {
+    this.closeListener?.();
+  }
 }
 
 function createSession(overrides?: Partial<Session>): Session {
@@ -540,6 +544,55 @@ describe("SessionTurnNotificationService", () => {
 
     assert.equal(openFailureHarness.homeOpenCount, 1);
     assert.equal(openFailureHarness.warnings[0]?.event, "target-open-failed");
+  });
+
+  it("同じ通知の click が多重発火しても対象 Session は一度だけ開く", async () => {
+    const harness = createHarness();
+    harness.service.notifyTurnCompleted(harness.session);
+
+    harness.notifications[0]?.click();
+    harness.notifications[0]?.click();
+    await flushAsyncListeners();
+
+    assert.deepEqual(harness.openedSessions, [harness.session.id]);
+    assert.equal(harness.homeOpenCount, 0);
+  });
+
+  it("置き換え済み通知の遅延 click は無視し、現在の通知だけが対象 Session を開く", async () => {
+    const harness = createHarness();
+    harness.service.notifyTurnCompleted(harness.session);
+    harness.service.notifyTurnCompleted(harness.session);
+
+    harness.notifications[0]?.click();
+    harness.notifications[1]?.click();
+    await flushAsyncListeners();
+
+    assert.deepEqual(harness.openedSessions, [harness.session.id]);
+    assert.equal(harness.homeOpenCount, 0);
+  });
+
+  it("system timeout 後も現在の通知なら Action Center から対象 Session を開く", async () => {
+    const harness = createHarness();
+    harness.service.notifyTurnCompleted(harness.session);
+
+    harness.notifications[0]?.timeout();
+    harness.notifications[0]?.click();
+    await flushAsyncListeners();
+
+    assert.deepEqual(harness.openedSessions, [harness.session.id]);
+    assert.equal(harness.homeOpenCount, 0);
+  });
+
+  it("reason 不明の close 後に遅延 click が届いても対象を開かない", async () => {
+    const harness = createHarness();
+    harness.service.notifyTurnCompleted(harness.session);
+
+    harness.notifications[0]?.closeWithoutReason();
+    harness.notifications[0]?.click();
+    await flushAsyncListeners();
+
+    assert.deepEqual(harness.openedSessions, []);
+    assert.equal(harness.homeOpenCount, 0);
   });
 
   it("delivery failure 後は active notification から外し、次の通知時に閉じ直さない", () => {

--- a/scripts/tests/session-window-bridge.test.ts
+++ b/scripts/tests/session-window-bridge.test.ts
@@ -28,11 +28,16 @@ function createSession(overrides?: Partial<Session>): Session {
 
 class StubWindow implements SessionWindowLike {
   destroyed = false;
+  delayClosedEvent = false;
   minimized = false;
+  visible = false;
+  focused = false;
   showCount = 0;
   focusCount = 0;
   restoreCount = 0;
   closeCount = 0;
+  destroyCount = 0;
+  readonly activationOperations: string[] = [];
   private readonly readyListeners: Array<() => void> = [];
   private readonly closeListeners: Array<(event: SessionWindowCloseEvent) => void> = [];
   private readonly closedListeners: Array<() => void> = [];
@@ -47,15 +52,22 @@ class StubWindow implements SessionWindowLike {
 
   restore(): void {
     this.minimized = false;
+    this.visible = true;
     this.restoreCount += 1;
+    this.activationOperations.push("restore");
   }
 
   focus(): void {
+    this.focused = true;
     this.focusCount += 1;
+    this.activationOperations.push("focus");
   }
 
   show(): void {
+    this.visible = true;
+    this.focused = true;
     this.showCount += 1;
+    this.activationOperations.push("show");
   }
 
   close(): void {
@@ -78,8 +90,20 @@ class StubWindow implements SessionWindowLike {
     }
 
     this.destroyed = true;
-    for (const listener of this.closedListeners) {
-      listener();
+    if (!this.delayClosedEvent) {
+      this.emitClosed();
+    }
+  }
+
+  destroy(): void {
+    this.destroyCount += 1;
+    if (this.destroyed) {
+      return;
+    }
+
+    this.destroyed = true;
+    if (!this.delayClosedEvent) {
+      this.emitClosed();
     }
   }
 
@@ -107,6 +131,22 @@ class StubWindow implements SessionWindowLike {
     for (const listener of this.readyListeners.splice(0)) {
       listener();
     }
+  }
+
+  emitClosed(): void {
+    for (const listener of this.closedListeners.splice(0)) {
+      listener();
+    }
+  }
+
+  resetActivation(options: { minimized: boolean; visible: boolean }): void {
+    this.minimized = options.minimized;
+    this.visible = options.visible;
+    this.focused = false;
+    this.showCount = 0;
+    this.focusCount = 0;
+    this.restoreCount = 0;
+    this.activationOperations.splice(0);
   }
 }
 
@@ -151,40 +191,66 @@ describe("SessionWindowBridge", () => {
     assert.equal(window.showCount, 1);
   });
 
-  it("既存 window を再利用し、minimize されていれば restore して focus する", async () => {
-    const session = createSession();
-    const createdWindow = new StubWindow();
-    createdWindow.minimized = true;
-    let createCount = 0;
+  it("既存 window は通常・最小化・非表示の各状態から可視化して focus する", async (t) => {
+    const cases = [
+      {
+        name: "通常",
+        minimized: false,
+        visible: true,
+        expectedOperations: ["show", "focus"],
+      },
+      {
+        name: "最小化",
+        minimized: true,
+        visible: false,
+        expectedOperations: ["restore", "show", "focus"],
+      },
+      {
+        name: "非表示",
+        minimized: false,
+        visible: false,
+        expectedOperations: ["show", "focus"],
+      },
+    ] as const;
 
-    const bridge = new SessionWindowBridge({
-      createWindow() {
-        createCount += 1;
-        return createdWindow;
-      },
-      async loadChatEntry() {},
-      getSession() {
-        return session;
-      },
-      isRunInFlight() {
-        return false;
-      },
-      getAllowQuitWithInFlightRuns() {
-        return false;
-      },
-      confirmCloseWhileRunning() {
-        return false;
-      },
-      broadcastOpenSessionWindowIds() {},
-    });
+    for (const testCase of cases) {
+      await t.test(testCase.name, async () => {
+        const session = createSession();
+        const createdWindow = new StubWindow();
+        let createCount = 0;
+        const bridge = new SessionWindowBridge({
+          createWindow() {
+            createCount += 1;
+            return createdWindow;
+          },
+          async loadChatEntry() {},
+          getSession() {
+            return session;
+          },
+          isRunInFlight() {
+            return false;
+          },
+          getAllowQuitWithInFlightRuns() {
+            return false;
+          },
+          confirmCloseWhileRunning() {
+            return false;
+          },
+          broadcastOpenSessionWindowIds() {},
+        });
 
-    const first = await bridge.openSessionWindow(session.id);
-    const second = await bridge.openSessionWindow(session.id);
+        const first = await bridge.openSessionWindow(session.id);
+        first.emitReady();
+        first.resetActivation(testCase);
+        const second = await bridge.openSessionWindow(session.id);
 
-    assert.equal(first, second);
-    assert.equal(createCount, 1);
-    assert.equal(createdWindow.restoreCount, 1);
-    assert.equal(createdWindow.focusCount, 1);
+        assert.equal(first, second);
+        assert.equal(createCount, 1);
+        assert.equal(createdWindow.visible, true);
+        assert.equal(createdWindow.focused, true);
+        assert.deepEqual(createdWindow.activationOperations, testCase.expectedOperations);
+      });
+    }
   });
 
   it("V4 以前の session でも履歴閲覧用に window を開ける", async () => {
@@ -219,6 +285,127 @@ describe("SessionWindowBridge", () => {
 
     assert.equal(createCount, 1);
     assert.deepEqual(loadedChatMode, { kind: "agent", sessionId: legacySession.id });
+  });
+
+  it("entry load 失敗時は失敗した window の claim を破棄し、次回 open で作り直す", async () => {
+    const session = createSession();
+    const windows: StubWindow[] = [];
+    let loadCount = 0;
+    const bridge = new SessionWindowBridge({
+      createWindow() {
+        const window = new StubWindow();
+        windows.push(window);
+        return window;
+      },
+      async loadChatEntry() {
+        loadCount += 1;
+        if (loadCount === 1) {
+          throw new Error("load failed");
+        }
+      },
+      getSession() {
+        return session;
+      },
+      isRunInFlight() {
+        return false;
+      },
+      getAllowQuitWithInFlightRuns() {
+        return false;
+      },
+      confirmCloseWhileRunning() {
+        return false;
+      },
+      broadcastOpenSessionWindowIds() {},
+    });
+
+    await assert.rejects(bridge.openSessionWindow(session.id), /load failed/);
+    assert.equal(bridge.getWindow(session.id), null);
+    assert.equal(windows[0]?.destroyCount, 1);
+
+    const recoveredWindow = await bridge.openSessionWindow(session.id);
+
+    assert.equal(windows.length, 2);
+    assert.equal(loadCount, 2);
+    assert.equal(recoveredWindow, windows[1]);
+  });
+
+  it("entry load 中に重なった open は同じ load 結果を共有する", async () => {
+    const session = createSession();
+    let createCount = 0;
+    let rejectLoad: ((error: Error) => void) | null = null;
+    const bridge = new SessionWindowBridge({
+      createWindow() {
+        createCount += 1;
+        return new StubWindow();
+      },
+      loadChatEntry() {
+        return new Promise<void>((_resolve, reject) => {
+          rejectLoad = reject;
+        });
+      },
+      getSession() {
+        return session;
+      },
+      isRunInFlight() {
+        return false;
+      },
+      getAllowQuitWithInFlightRuns() {
+        return false;
+      },
+      confirmCloseWhileRunning() {
+        return false;
+      },
+      broadcastOpenSessionWindowIds() {},
+    });
+
+    const firstOpen = bridge.openSessionWindow(session.id);
+    const secondOpen = bridge.openSessionWindow(session.id);
+    assert.ok(rejectLoad);
+    rejectLoad(new Error("load failed"));
+
+    const results = await Promise.allSettled([firstOpen, secondOpen]);
+
+    assert.equal(createCount, 1);
+    assert.deepEqual(results.map(({ status }) => status), ["rejected", "rejected"]);
+    assert.equal(bridge.getWindow(session.id), null);
+  });
+
+  it("古い window の遅延 closed は同じ Session の新しい window claim を解放しない", async () => {
+    const session = createSession();
+    const windows: StubWindow[] = [];
+    const bridge = new SessionWindowBridge({
+      createWindow() {
+        const window = new StubWindow();
+        windows.push(window);
+        return window;
+      },
+      async loadChatEntry() {},
+      getSession() {
+        return session;
+      },
+      isRunInFlight() {
+        return false;
+      },
+      getAllowQuitWithInFlightRuns() {
+        return false;
+      },
+      confirmCloseWhileRunning() {
+        return false;
+      },
+      broadcastOpenSessionWindowIds() {},
+    });
+
+    const oldWindow = await bridge.openSessionWindow(session.id);
+    oldWindow.delayClosedEvent = true;
+    oldWindow.close();
+    const currentWindow = await bridge.openSessionWindow(session.id);
+
+    oldWindow.emitClosed();
+    const reopenedWindow = await bridge.openSessionWindow(session.id);
+
+    assert.equal(windows.length, 2);
+    assert.equal(reopenedWindow, currentWindow);
+    assert.equal(bridge.getWindow(session.id), currentWindow);
   });
 
   it("running 中の close は確認ダイアログで継続可否を決める", async () => {

--- a/src-electron/session-turn-notification-service.ts
+++ b/src-electron/session-turn-notification-service.ts
@@ -189,11 +189,13 @@ export class SessionTurnNotificationService<TIcon> {
     notification: SessionTurnNotificationHandle,
   ): void {
     notification.onClick(() => {
-      this.clearIfCurrent(sessionId, notification);
+      if (!this.clearIfCurrent(sessionId, notification)) {
+        return;
+      }
       void this.openNotificationTarget(sessionId);
     });
     notification.onClose((reason) => {
-      if (reason === "userCanceled" || reason === "applicationHidden") {
+      if (reason !== "timedOut") {
         this.clearIfCurrent(sessionId, notification);
       }
     });
@@ -288,10 +290,16 @@ export class SessionTurnNotificationService<TIcon> {
     }
   }
 
-  private clearIfCurrent(sessionId: string, notification: SessionTurnNotificationHandle): void {
-    if (this.trackedNotifications.get(sessionId) === notification) {
-      this.trackedNotifications.delete(sessionId);
+  private clearIfCurrent(
+    sessionId: string,
+    notification: SessionTurnNotificationHandle,
+  ): boolean {
+    if (this.trackedNotifications.get(sessionId) !== notification) {
+      return false;
     }
+
+    this.trackedNotifications.delete(sessionId);
+    return true;
   }
 
   private async openNotificationTarget(sessionId: string): Promise<void> {

--- a/src-electron/session-window-bridge.ts
+++ b/src-electron/session-window-bridge.ts
@@ -12,6 +12,7 @@ export type SessionWindowLike = {
   focus(): void;
   show(): void;
   close(): void;
+  destroy(): void;
   once(event: "ready-to-show", listener: () => void): void;
   on(event: "close", listener: (event: SessionWindowCloseEvent) => void): void;
   on(event: "closed", listener: () => void): void;
@@ -29,7 +30,8 @@ export type SessionWindowBridgeDeps<TWindow extends SessionWindowLike> = {
 
 export class SessionWindowBridge<TWindow extends SessionWindowLike> {
   private readonly sessionWindows = new Map<string, TWindow>();
-  private readonly allowCloseSessionWindows = new Set<string>();
+  private readonly openingSessionWindows = new Map<string, Promise<TWindow>>();
+  private readonly allowCloseSessionWindows = new Set<TWindow>();
 
   constructor(private readonly deps: SessionWindowBridgeDeps<TWindow>) {}
 
@@ -60,12 +62,18 @@ export class SessionWindowBridge<TWindow extends SessionWindowLike> {
   }
 
   async openSessionWindow(sessionId: string): Promise<TWindow> {
+    const openingWindow = this.openingSessionWindows.get(sessionId);
+    if (openingWindow) {
+      return openingWindow;
+    }
+
     const existingWindow = this.getWindow(sessionId);
     if (existingWindow) {
       if (existingWindow.isMinimized()) {
         existingWindow.restore();
       }
 
+      existingWindow.show();
       existingWindow.focus();
       return existingWindow;
     }
@@ -75,23 +83,32 @@ export class SessionWindowBridge<TWindow extends SessionWindowLike> {
     this.broadcast();
     window.once("ready-to-show", () => window.show());
     window.on("close", (event) => this.handleWindowClose(sessionId, window, event));
-    window.on("closed", () => this.handleWindowClosed(sessionId));
+    window.on("closed", () => this.releaseWindowClaim(sessionId, window));
 
-    await this.deps.loadChatEntry(window, { kind: "agent", sessionId });
+    const openingPromise = this.loadSessionWindow(sessionId, window);
+    this.openingSessionWindows.set(sessionId, openingPromise);
 
-    return window;
+    try {
+      return await openingPromise;
+    } finally {
+      if (this.openingSessionWindows.get(sessionId) === openingPromise) {
+        this.openingSessionWindows.delete(sessionId);
+      }
+    }
   }
 
   closeSessionWindow(sessionId: string): void {
     const window = this.sessionWindows.get(sessionId);
     if (!window || window.isDestroyed()) {
       this.sessionWindows.delete(sessionId);
-      this.allowCloseSessionWindows.delete(sessionId);
+      if (window) {
+        this.allowCloseSessionWindows.delete(window);
+      }
       this.broadcast();
       return;
     }
 
-    this.allowCloseSessionWindows.add(sessionId);
+    this.allowCloseSessionWindows.add(window);
     window.close();
   }
 
@@ -100,8 +117,22 @@ export class SessionWindowBridge<TWindow extends SessionWindowLike> {
       this.closeSessionWindow(sessionId);
     }
     this.sessionWindows.clear();
+    this.openingSessionWindows.clear();
     this.allowCloseSessionWindows.clear();
     this.broadcast();
+  }
+
+  private async loadSessionWindow(sessionId: string, window: TWindow): Promise<TWindow> {
+    try {
+      await this.deps.loadChatEntry(window, { kind: "agent", sessionId });
+      return window;
+    } catch (error) {
+      this.releaseWindowClaim(sessionId, window);
+      if (!window.isDestroyed()) {
+        window.destroy();
+      }
+      throw error;
+    }
   }
 
   private handleWindowClose(sessionId: string, window: TWindow, event: SessionWindowCloseEvent): void {
@@ -109,8 +140,8 @@ export class SessionWindowBridge<TWindow extends SessionWindowLike> {
       return;
     }
 
-    if (this.allowCloseSessionWindows.has(sessionId)) {
-      this.allowCloseSessionWindows.delete(sessionId);
+    if (this.allowCloseSessionWindows.has(window)) {
+      this.allowCloseSessionWindows.delete(window);
       return;
     }
 
@@ -124,12 +155,16 @@ export class SessionWindowBridge<TWindow extends SessionWindowLike> {
       return;
     }
 
-    this.allowCloseSessionWindows.add(sessionId);
+    this.allowCloseSessionWindows.add(window);
     window.close();
   }
 
-  private handleWindowClosed(sessionId: string): void {
-    this.allowCloseSessionWindows.delete(sessionId);
+  private releaseWindowClaim(sessionId: string, window: TWindow): void {
+    this.allowCloseSessionWindows.delete(window);
+    if (this.sessionWindows.get(sessionId) !== window) {
+      return;
+    }
+
     this.sessionWindows.delete(sessionId);
     this.broadcast();
   }


### PR DESCRIPTION
## 概要

Windows通知のクリックから対象Session Windowを確実に開けるよう、main processのWindow再利用と通知instance管理を修正します。

## 変更内容

- 既存Session Windowを通常・最小化・非表示の各状態からshow / restore / focus
- Window未作成時は新規作成し、entry load失敗時は壊れたclaimを破棄してHome fallbackを維持
- load中の重複openで同じ結果を共有し、古いWindowの遅延closedが新しい登録を削除しないようinstance単位で管理
- 同じ通知の多重clickと置き換え済み通知の遅延clickを無視
- 明示的なtimedOutだけ通知追跡を維持し、reason不明を含むその他のclose後clickを無視
- 通知契約のADRとWindows手動確認項目を更新

## 検証

- `npx tsx --test scripts/tests/main-window-facade.test.ts scripts/tests/session-window-bridge.test.ts scripts/tests/session-turn-notification-service.test.ts`（33件成功）
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## 手動確認

Windows foreground制約を含むlive toast / Action Centerからの前面化は未確認です。`MT-068` / `MT-068A`に、通常表示・最小化・非表示・未作成・stale通知・fallbackの確認手順を追加しています。