### PR TITLE
fix(session): チャットスクロールのドリフトを防ぐ

### DIFF
--- a/docs/design/desktop-ui.md
+++ b/docs/design/desktop-ui.md
@@ -247,9 +247,9 @@ Electron デスクトップアプリとして、`Home Window` / `Character Edito
 - 中央 live Git Diff は Split を既定表示とし、Inline へ切り替えられる。両表示は同じ unified patch と検索modelを投影し、Split でも表示rowをvirtualizeする
 - work surface は外側 card を持たず、padding / gap を抑えて message viewport を優先する
 - message list は条件付き follow mode で動かす
-  - viewport bottom gap が 80px 以下で、上方向へ読み始めていないときは末尾追従を許可する
-  - 上方向への scroll を検出した時点で追従を止め、80px 以内でも遅延描画や行高再計測によって末尾側へ戻さない
-  - 80px を超えて上へ読んでいる間も位置を維持する
+  - user の scroll intent と末尾移動は一つの follow owner が決定し、virtual row の再計測は visible anchor の補正だけを担当する
+  - 上方向への wheel intent を scroll event より先に追従停止へ反映し、遅延描画や行高再計測による `scrollTop` 変化を追従再開として扱わない
+  - 追従停止後は、user が末尾方向へ戻すか実際の末尾へ到達するまで位置を維持する
   - `selectedSession.id` 切替時は follow / unread state をリセットする
   - 追従停止中は `新着あり` / `読み返し中` の最小 banner を表示し、`末尾へ移動` で復帰できる
 - pending 中の live activity / streaming response

--- a/scripts/tests/session-chat-layout-hooks.test.tsx
+++ b/scripts/tests/session-chat-layout-hooks.test.tsx
@@ -381,6 +381,7 @@ test("useSessionMessageListFollowing は上方向scrollで追従を止め、非�
     Object.defineProperty(messageList, "scrollHeight", { configurable: true, value: 1_000 });
     Object.defineProperty(messageList, "clientHeight", { configurable: true, value: 200 });
     await act(async () => {
+      messageList.dispatchEvent(new dom.window.WheelEvent("wheel", { bubbles: true, deltaY: -120 }));
       messageList.scrollTop = 800;
       messageList.dispatchEvent(new dom.window.Event("scroll", { bubbles: true }));
       messageList.scrollTop = 760;
@@ -389,15 +390,37 @@ test("useSessionMessageListFollowing は上方向scrollで追従を止め、非�
     assert.equal(following.textContent, "false");
 
     await act(async () => {
+      messageList.scrollTop = 780;
+      messageList.dispatchEvent(new dom.window.Event("scroll", { bubbles: true }));
+    });
+    assert.equal(
+      following.textContent,
+      "false",
+      "上方向wheel中のrow計測補正を末尾へ戻るuser intentとして扱わない",
+    );
+
+    await act(async () => {
       root?.render(React.createElement(Harness, { enabled: true, scrollSignature: "while-reading" }));
     });
     assert.equal(scrollToBottomCount, 1);
 
     await act(async () => {
-      messageList.scrollTop = 800;
+      messageList.dispatchEvent(new dom.window.WheelEvent("wheel", { bubbles: true, deltaY: 120 }));
+      messageList.scrollTop = 780;
       messageList.dispatchEvent(new dom.window.Event("scroll", { bubbles: true }));
     });
     assert.equal(following.textContent, "true");
+
+    Object.defineProperty(messageList, "scrollHeight", { configurable: true, value: 900 });
+    await act(async () => {
+      messageList.scrollTop = 680;
+      messageList.dispatchEvent(new dom.window.Event("scroll", { bubbles: true }));
+    });
+    assert.equal(
+      following.textContent,
+      "true",
+      "上側rowの縮小補正でbottom gapが変わらない場合は末尾追従を維持する",
+    );
 
     await act(async () => {
       root?.render(React.createElement(Harness, { enabled: true, scrollSignature: "at-bottom-update" }));
@@ -418,7 +441,7 @@ test("useSessionMessageListFollowing は上方向scrollで追従を止め、非�
     await act(async () => {
       root?.render(React.createElement(Harness, { enabled: true, scrollSignature: "preview-update" }));
     });
-    assert.equal(scrollToBottomCount, 2);
+    assert.equal(scrollToBottomCount, 3);
     assert.equal(following.textContent, "true");
   } finally {
     await act(async () => root?.unmount());

--- a/scripts/tests/session-message-column.test.ts
+++ b/scripts/tests/session-message-column.test.ts
@@ -1001,25 +1001,18 @@ test("SessionMessageColumn は上側rowの可変高再計測後も表示位置�
   }
 });
 
-test("SessionMessageColumn は上方向scroll中のrow計測補正だけを抑止する", () => {
+test("SessionMessageColumn は上方向scroll中も上側rowのvisible anchorを補正する", () => {
   assert.equal(shouldAdjustSessionMessageScrollPosition({
     itemStart: 1_000,
     scrollOffset: 4_000,
-    scrollDirection: "backward",
-  }), false);
-  assert.equal(shouldAdjustSessionMessageScrollPosition({
-    itemStart: 1_000,
-    scrollOffset: 4_000,
-    scrollDirection: null,
   }), true);
   assert.equal(shouldAdjustSessionMessageScrollPosition({
     itemStart: 5_000,
     scrollOffset: 4_000,
-    scrollDirection: null,
   }), false);
 });
 
-test("SessionMessageColumn は末尾追従中だけappend後も末尾へ追従する", async () => {
+test("SessionMessageColumn はappend時の末尾移動をfollow ownerへ委ねる", async () => {
   const initialMessages = createMessages(20);
   const mounted = await mountSessionMessageColumn({
     messages: initialMessages,
@@ -1043,7 +1036,7 @@ test("SessionMessageColumn は末尾追従中だけappend後も末尾へ追従�
       await new Promise<void>((resolve) => mounted.dom.window.requestAnimationFrame(() => resolve()));
     });
 
-    assert.ok(messageList.scrollTop > followingScrollTop);
+    assert.equal(messageList.scrollTop, followingScrollTop);
     assert.match(mounted.container.textContent ?? "", /appended at end/);
 
     await act(async () => {
@@ -1097,7 +1090,7 @@ test("SessionMessageColumn は同じ仮想範囲内の連続scrollでmessageを�
   }
 });
 
-test("SessionMessageColumn は非表示から復帰したとき仮想リストの末尾へ移動する", async () => {
+test("SessionMessageColumn は非表示から復帰したとき独自に末尾へ移動しない", async () => {
   const mounted = await mountSessionMessageColumn({
     messages: createMessages(100),
   });
@@ -1117,11 +1110,7 @@ test("SessionMessageColumn は非表示から復帰したとき仮想リスト�
       isMessageListFollowing: false,
     });
 
-    assert.equal(
-      messageList.scrollTop,
-      messageList.scrollHeight - messageList.clientHeight,
-    );
-    assert.match(mounted.container.textContent ?? "", /message 100(?:\D|$)/);
+    assert.equal(messageList.scrollTop, 0);
   } finally {
     await mounted.cleanup();
   }

--- a/src/session-chat-layout-hooks.ts
+++ b/src/session-chat-layout-hooks.ts
@@ -31,6 +31,10 @@ const SESSION_ACTION_DOCK_MAX_HEIGHT_RATIO = 0.4;
 const SESSION_CENTRAL_SURFACE_MIN_HEIGHT = 280;
 const SESSION_VERTICAL_SPLITTER_TOTAL_HEIGHT = 40;
 const SESSION_MESSAGE_BOTTOM_EPSILON = 1;
+// ResizeObserver corrections can emit scroll events after a wheel event, but before the virtualizer settles.
+const SESSION_MESSAGE_WHEEL_INTENT_SETTLE_MS = 180;
+
+type SessionMessageWheelIntent = "toward-history" | "toward-bottom" | null;
 
 function scrollMessageListElementToBottom(messageListElement: HTMLDivElement): void {
   const bottomAnchor = messageListElement.querySelector<HTMLElement>(".message-list-bottom-anchor");
@@ -433,8 +437,47 @@ export function useSessionMessageListFollowing({
   const messageListSignatureRef = useRef("");
   const messageListOwnerKeyRef = useRef<string | null>(null);
   const messageListEnabledRef = useRef(enabled);
-  const previousMessageListScrollTopRef = useRef<number | null>(null);
+  const previousMessageListBottomGapRef = useRef<number | null>(null);
+  const messageListWheelIntentRef = useRef<SessionMessageWheelIntent>(null);
+  const messageListWheelIntentTimerRef = useRef<number | null>(null);
   const [isMessageListFollowing, setIsMessageListFollowing] = useState(true);
+
+  useLayoutEffect(() => {
+    const messageListElement = messageListRef.current;
+    const ownerWindow = messageListElement?.ownerDocument.defaultView;
+    if (!enabled || !messageListElement || !ownerWindow) {
+      return;
+    }
+
+    const clearWheelIntentTimer = () => {
+      if (messageListWheelIntentTimerRef.current !== null) {
+        ownerWindow.clearTimeout(messageListWheelIntentTimerRef.current);
+        messageListWheelIntentTimerRef.current = null;
+      }
+    };
+    const handleWheel = (event: WheelEvent) => {
+      if (event.deltaY === 0) {
+        return;
+      }
+
+      messageListWheelIntentRef.current = event.deltaY < 0 ? "toward-history" : "toward-bottom";
+      if (event.deltaY < 0) {
+        setIsMessageListFollowing(false);
+      }
+      clearWheelIntentTimer();
+      messageListWheelIntentTimerRef.current = ownerWindow.setTimeout(() => {
+        messageListWheelIntentRef.current = null;
+        messageListWheelIntentTimerRef.current = null;
+      }, SESSION_MESSAGE_WHEEL_INTENT_SETTLE_MS);
+    };
+
+    messageListElement.addEventListener("wheel", handleWheel, { passive: true });
+    return () => {
+      messageListElement.removeEventListener("wheel", handleWheel);
+      clearWheelIntentTimer();
+      messageListWheelIntentRef.current = null;
+    };
+  }, [enabled, ownerKey]);
 
   const scrollMessageListToBottom = useCallback(() => {
     const messageListElement = messageListRef.current;
@@ -443,9 +486,9 @@ export function useSessionMessageListFollowing({
     }
 
     scrollMessageListElementToBottom(messageListElement);
-    previousMessageListScrollTopRef.current = Math.max(
+    previousMessageListBottomGapRef.current = Math.max(
       0,
-      messageListElement.scrollHeight - messageListElement.clientHeight,
+      messageListElement.scrollHeight - messageListElement.clientHeight - messageListElement.scrollTop,
     );
   }, []);
 
@@ -459,7 +502,8 @@ export function useSessionMessageListFollowing({
     if (!enabled) {
       messageListOwnerKeyRef.current = ownerKey;
       messageListSignatureRef.current = currentSignature;
-      previousMessageListScrollTopRef.current = null;
+      previousMessageListBottomGapRef.current = null;
+      messageListWheelIntentRef.current = null;
       return;
     }
 
@@ -467,21 +511,28 @@ export function useSessionMessageListFollowing({
     if (!messageListElement) {
       messageListOwnerKeyRef.current = ownerKey;
       messageListSignatureRef.current = currentSignature;
-      previousMessageListScrollTopRef.current = null;
+      previousMessageListBottomGapRef.current = null;
+      messageListWheelIntentRef.current = null;
       return;
     }
 
     if (!wasEnabled) {
       messageListOwnerKeyRef.current = ownerKey;
       messageListSignatureRef.current = currentSignature;
-      previousMessageListScrollTopRef.current = messageListElement.scrollTop;
+      previousMessageListBottomGapRef.current = Math.max(
+        0,
+        messageListElement.scrollHeight - messageListElement.clientHeight - messageListElement.scrollTop,
+      );
+      messageListWheelIntentRef.current = null;
       setIsMessageListFollowing(true);
+      scrollMessageListToBottom();
       return;
     }
 
     if (!wasSameOwner) {
       messageListOwnerKeyRef.current = ownerKey;
       messageListSignatureRef.current = currentSignature;
+      messageListWheelIntentRef.current = null;
       setIsMessageListFollowing(true);
       scrollMessageListToBottom();
       return;
@@ -506,17 +557,26 @@ export function useSessionMessageListFollowing({
 
     const currentScrollTop = messageListElement.scrollTop;
     const maxScrollTop = Math.max(0, messageListElement.scrollHeight - messageListElement.clientHeight);
-    const previousScrollTop = previousMessageListScrollTopRef.current ?? maxScrollTop;
-    previousMessageListScrollTopRef.current = currentScrollTop;
     const bottomGap = Math.max(0, maxScrollTop - currentScrollTop);
-    const isScrollingUp = currentScrollTop < previousScrollTop;
+    const previousBottomGap = previousMessageListBottomGapRef.current ?? bottomGap;
+    previousMessageListBottomGapRef.current = bottomGap;
+    const isMovingAwayFromBottom = bottomGap > previousBottomGap + SESSION_MESSAGE_BOTTOM_EPSILON;
     const isAtBottom = bottomGap <= SESSION_MESSAGE_BOTTOM_EPSILON;
-    const nextFollowing = isAtBottom || (!isScrollingUp && bottomGap <= bottomThreshold);
+    const wheelIntent = messageListWheelIntentRef.current;
 
-    setIsMessageListFollowing((current) => (current === nextFollowing ? current : nextFollowing));
+    setIsMessageListFollowing((current) => {
+      if (wheelIntent === "toward-history") {
+        return false;
+      }
+      if (!current) {
+        return wheelIntent === "toward-bottom" ? bottomGap <= bottomThreshold : isAtBottom;
+      }
+      return isAtBottom || (!isMovingAwayFromBottom && bottomGap <= bottomThreshold);
+    });
   }, [bottomThreshold]);
 
   const handleJumpToMessageListBottom = useCallback(() => {
+    messageListWheelIntentRef.current = null;
     setIsMessageListFollowing(true);
     scrollMessageListToBottom();
     window.requestAnimationFrame(scrollMessageListToBottom);

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -500,9 +500,8 @@ const SESSION_MESSAGE_SCROLL_END_THRESHOLD = 80;
 export function shouldAdjustSessionMessageScrollPosition(input: {
   itemStart: number;
   scrollOffset: number;
-  scrollDirection: "forward" | "backward" | null;
 }): boolean {
-  return input.scrollDirection !== "backward" && input.itemStart < input.scrollOffset;
+  return input.itemStart < input.scrollOffset;
 }
 
 type MessageArtifactFoldSection = "files" | "operation";
@@ -2532,7 +2531,6 @@ export function SessionMessageColumn({
   const [findQuery, setFindQuery] = useState("");
   const [currentFindMatch, setCurrentFindMatch] = useState(0);
   const selectionToolbarRef = useRef<HTMLDivElement | null>(null);
-  const wasContentActiveRef = useRef(isContentActive);
   const previousMessageViewModeRef = useRef(messageViewMode);
   const getMessageKey = useCallback(
     (index: number) => messageKeys?.[index] ?? `${sessionId}-${index}`,
@@ -2545,7 +2543,7 @@ export function SessionMessageColumn({
     getItemKey: getMessageKey,
     overscan: SESSION_MESSAGE_OVERSCAN,
     anchorTo: isMessageListFollowing ? "end" : "start",
-    followOnAppend: isMessageListFollowing,
+    followOnAppend: false,
     scrollEndThreshold: SESSION_MESSAGE_SCROLL_END_THRESHOLD,
     initialRect: { width: 0, height: SESSION_MESSAGE_FALLBACK_VIEWPORT_HEIGHT },
     initialOffset: Math.max(
@@ -2559,7 +2557,6 @@ export function SessionMessageColumn({
     shouldAdjustSessionMessageScrollPosition({
       itemStart: item.start,
       scrollOffset: instance.scrollOffset ?? 0,
-      scrollDirection: instance.scrollDirection,
     })
   );
   const virtualMessages = messageVirtualizer.getVirtualItems();
@@ -2865,15 +2862,6 @@ export function SessionMessageColumn({
     pendingMessageGroupEndIndex,
     visibleMessageSignature,
   ]);
-
-  useLayoutEffect(() => {
-    const wasContentActive = wasContentActiveRef.current;
-    wasContentActiveRef.current = isContentActive;
-
-    if (isContentActive && (!wasContentActive || isMessageListFollowing)) {
-      messageVirtualizer.scrollToEnd();
-    }
-  }, [isContentActive, isMessageListFollowing, messageVirtualizer]);
 
   const isArtifactFoldOpen = (artifactKey: string, section: MessageArtifactFoldSection, index?: number) =>
     Boolean(openArtifactFolds[messageArtifactFoldKey(artifactKey, section, index)]);


### PR DESCRIPTION
## 概要

Session Windowでマウスwheel中にvirtual rowの再計測や遅延layoutが発生すると、表示位置がずれたり末尾へ戻ったりする問題を修正します。

## 原因

- row再計測による`scrollTop`補正をuserの末尾方向scrollとして誤認し、follow-to-bottomを再開していた
- 上方向scroll中はviewportより上のrowに対するvisible anchor補正を抑止しており、rowの高さ差分がwheel移動量へ加算されていた
- 末尾移動の書き込み責務がfollow hook、component、virtualizerへ分散していた

## 変更内容

- wheel intentとfollow-to-bottom判定を`useSessionMessageListFollowing`へ集約
- `scrollTop`の増減ではなくbottom gapの変化で末尾から離れたかを判定
- virtual rowの伸縮時はscroll方向にかかわらずvisible anchorを補正
- `SessionMessageColumn`側のappend・preview復帰時の重複した末尾移動を削除
- row成長・縮小、follow復帰、append ownershipのregression testを追加・更新
- message listの設計契約を更新

## 検証

- targeted test: 42 passed
- `npm test`: 2356 passed / 1 skipped / 0 failed
- `npm run typecheck`: passed
- `npm run build`: passed
- 分離Electronで長文Sessionを確認
  - 上方向wheel中のrow成長でvisible anchorを維持
  - bottom gap 20pxのfollow中に上側rowを100px縮小してもgap・anchor・followを維持
  - 縮小直後の末尾content増加にも追従
- `feat/v6.3.21`取り込み後、selection action overlayとの非干渉をtargeted reviewで確認

## 残リスク

実provider通信によるstreamingと、新規画像load・Mermaid描画の個別発火は未実施です。同じResizeObserver経路による連続row伸縮は実Electronで確認しています。