### PR TITLE
fix: Session作成画面のスクロール範囲をCharacter一覧へ限定する

### DIFF
--- a/scripts/tests/home-components.test.tsx
+++ b/scripts/tests/home-components.test.tsx
@@ -598,6 +598,8 @@ describe("HomeLaunchDialog", () => {
   it("ダイアログに Character selector が含まれる", () => {
     const html = renderHomeLaunchDialog();
 
+    assert.ok(html.includes("launch-dialog panel home-launch-dialog"));
+    assert.ok(html.includes("launch-section minimal home-launch-character-section"));
     assert.ok(html.includes("Character"));
     assert.ok(html.includes("Mia"));
     assert.ok(!html.includes(">Default</span>"));

--- a/scripts/tests/home-launch-style.test.ts
+++ b/scripts/tests/home-launch-style.test.ts
@@ -29,3 +29,27 @@ test("Workspace validation spinner は debounce 中から遅延なく描画す�
   assert.doesNotMatch(spinnerRule, /opacity:\s*0;/);
   assert.doesNotMatch(spinnerRule, /animation-delay:/);
 });
+
+test("Session 作成画面は Character 一覧だけをスクロール領域にする", async () => {
+  const [componentSource, stylesSource] = await Promise.all([
+    readFile("src/home/HomeLaunchDialog.tsx", "utf8"),
+    readFile("src/styles.css", "utf8"),
+  ]);
+  const panelRule = stylesSource.match(/\.home-launch-dialog \.launch-panel\s*{([^}]*)}/)?.[1];
+  const characterListRule = stylesSource.match(
+    /\.home-launch-character-section \.launch-character-list\s*{([^}]*)}/,
+  )?.[1];
+  const characterFocusRule = stylesSource.match(/\.launch-character-option:focus-visible\s*{([^}]*)}/)?.[1];
+
+  assert.match(componentSource, /dialogClassName="home-launch-dialog"/);
+  assert.match(componentSource, /className="launch-section minimal home-launch-character-section"/);
+  assert.ok(panelRule);
+  assert.match(panelRule, /grid-template-rows:\s*auto auto auto minmax\(0, 1fr\);/);
+  assert.match(panelRule, /overflow:\s*hidden;/);
+  assert.ok(characterListRule);
+  assert.match(characterListRule, /overflow-y:\s*auto;/);
+  assert.match(characterListRule, /overscroll-behavior:\s*contain;/);
+  assert.ok(characterFocusRule);
+  assert.match(characterFocusRule, /outline:\s*2px solid/);
+  assert.match(characterFocusRule, /outline-offset:\s*-3px;/);
+});

--- a/src/home/HomeLaunchDialog.tsx
+++ b/src/home/HomeLaunchDialog.tsx
@@ -82,6 +82,7 @@ export function HomeLaunchDialog({
       onClose={onClose}
       dialogRef={dialogRef}
       onKeyDown={handleDialogKeyDown}
+      dialogClassName="home-launch-dialog"
       footer={
         <LaunchDialogFooter
           feedback={launchFeedback}
@@ -171,7 +172,7 @@ export function HomeLaunchDialog({
         onSelectProvider={onSelectProvider}
       />
 
-      <section className="launch-section minimal">
+      <section className="launch-section minimal home-launch-character-section">
         <div className="launch-field">
           <span className="launch-field-label">Character</span>
           {!charactersLoaded ? (

--- a/src/styles.css
+++ b/src/styles.css
@@ -2063,6 +2063,12 @@ button:disabled {
   padding: 12px 22px 0;
 }
 
+.home-launch-dialog .launch-panel {
+  grid-template-rows: auto auto auto minmax(0, 1fr);
+  min-height: 0;
+  overflow: hidden;
+}
+
 .launch-section {
   padding: 14px;
   border: 1px solid rgba(203, 213, 225, 0.12);
@@ -3494,6 +3500,22 @@ button:disabled {
   gap: 8px;
 }
 
+.home-launch-character-section,
+.home-launch-character-section .launch-field {
+  min-height: 0;
+}
+
+.home-launch-character-section .launch-field {
+  grid-template-rows: auto minmax(0, 1fr);
+}
+
+.home-launch-character-section .launch-character-list {
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  scroll-padding-block: 3px;
+}
+
 .launch-character-option,
 .launch-character-neutral {
   display: grid;
@@ -3518,6 +3540,11 @@ button:disabled {
 .launch-character-option.selected {
   border-color: color-mix(in srgb, var(--character-main) 42%, rgba(203, 213, 225, 0.18));
   background: color-mix(in srgb, var(--character-main-soft) 34%, rgba(255, 255, 255, 0.04));
+}
+
+.launch-character-option:focus-visible {
+  outline: 2px solid rgba(96, 165, 250, 0.88);
+  outline-offset: -3px;
 }
 
 .launch-character-copy {


### PR DESCRIPTION
## 概要

Issue #280 の対応として、Session作成画面のスクロール範囲をCharacter一覧へ限定します。

## 変更内容

- Title、Workspace、Provider、作成操作を固定表示
- Character一覧だけを縦スクロール可能に変更
- Character選択肢のキーボードフォーカスを見やすく調整
- component/styleの回帰テストを追加

## 検証

- npx tsx --test scripts/tests/home-components.test.tsx scripts/tests/home-launch-style.test.ts
- npx tsx --test scripts/tests/a11y.test.ts
- npm run typecheck
- npm run build
- 分離起動で狭いWindow、Character一覧のスクロール、キーボード操作、フォーカス表示を目視確認

Closes #280