### PR TITLE
fix(session): 長い応答のアバターを画面内に保つ

### DIFF
--- a/scripts/tests/message-avatar-position-style.test.ts
+++ b/scripts/tests/message-avatar-position-style.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("長い assistant message の avatar stack は message list 内で row に拘束して追従する", async () => {
+  const [componentSource, stylesSource] = await Promise.all([
+    readFile("src/session-components.tsx", "utf8"),
+    readFile("src/styles.css", "utf8"),
+  ]);
+
+  assert.match(componentSource, /directDomUpdatesMode:\s*"position"/);
+  assert.match(
+    stylesSource,
+    /\.session-message-list\s*{[\s\S]*?overflow:\s*auto;[\s\S]*?}/,
+  );
+  assert.match(
+    stylesSource,
+    /\.message-avatar-stack\s*{[\s\S]*?position:\s*sticky;[\s\S]*?top:\s*8px;[\s\S]*?}/,
+  );
+  assert.match(
+    stylesSource,
+    /@media \(max-width:\s*760px\)\s*{[\s\S]*?\.message-avatar-stack\s*{\s*position:\s*static;\s*}/,
+  );
+});

--- a/scripts/tests/session-message-column.test.ts
+++ b/scripts/tests/session-message-column.test.ts
@@ -983,9 +983,12 @@ test("SessionMessageColumn は上側rowの可変高再計測後も表示位置�
     );
     const rowAboveViewport = renderedRows.find((row) => {
       const start = Number.parseFloat(
-        row.style.transform.match(/translate3d\(0,\s*([^p]+)px/)?.[1]
-          ?? row.style.transform.match(/translateY\(([^p]+)px\)/)?.[1]
-          ?? "0",
+        row.style.top
+          || (
+            row.style.transform.match(/translate3d\(0,\s*([^p]+)px/)?.[1]
+            ?? row.style.transform.match(/translateY\(([^p]+)px\)/)?.[1]
+            ?? "0"
+          ),
       );
       return start < messageList.scrollTop;
     });

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -2554,7 +2554,7 @@ export function SessionMessageColumn({
       messages.length * SESSION_MESSAGE_ESTIMATED_ROW_HEIGHT - SESSION_MESSAGE_FALLBACK_VIEWPORT_HEIGHT,
     ),
     directDomUpdates: true,
-    directDomUpdatesMode: "transform",
+    directDomUpdatesMode: "position",
   });
   messageVirtualizer.shouldAdjustScrollPositionOnItemSizeChange = (item, _delta, instance) => (
     shouldAdjustSessionMessageScrollPosition({

--- a/src/styles.css
+++ b/src/styles.css
@@ -6146,6 +6146,8 @@ button:disabled {
 }
 
 .message-avatar-stack {
+  position: sticky;
+  top: 8px;
   display: grid;
   justify-items: center;
   align-content: start;
@@ -11559,6 +11561,10 @@ button:disabled {
   .composer-box,
   .choice-card {
     grid-template-columns: 1fr;
+  }
+
+  .message-avatar-stack {
+    position: static;
   }
 
   .home-settings-rail {


### PR DESCRIPTION
## 概要

長いassistant responseをスクロールしている間、対応するCharacter avatar stackをmessage viewport内へ追従させます。avatarは自身のmessage row下端で拘束され、前後のmessageへ誤帰属しません。

## 原因

message avatarは通常flowの先頭に固定されていたため、長いresponseの本文を読み進めるとviewport外へ流れていました。また、virtual rowのtransform配置はstickyの基準座標をずらすため、CSSのsticky指定だけでは自然な上端位置へ追従できませんでした。

## 変更内容

- assistant messageのavatar stackをrow内のsticky要素に変更
- virtual rowのdirect DOM配置をtransform modeからposition modeへ変更
- 760px以下の1カラムlayoutではstickyを解除
- sticky、scroll container、narrow layoutのstyle contractを追加
- 可変row高の既存testをposition modeにも対応

pending rowのavatar構造、artifact toggle、Auxiliary group、selection/copy/quoteのDOM構造は変更していません。

## 検証

- targeted test: 34件成功
  - message virtualization
  - 可変row高とscroll位置補正
  - selection/copy/quote
  - artifact、Auxiliary、pending
  - avatar sticky style contract
- `npm run typecheck`: 成功
- `npm run build`: 成功
- Chromium visual/geometry check:
  - 長短message
  - viewport上端と下端
  - row境界
  - artifact toggle付きavatar stack
  - Auxiliary group
  - pending row
  - narrow layout

buildでは既存の`::highlight`およびchunk size警告のみ確認しています。