### PR TITLE
fix(markdown): リンクコピーのWindowsパスを正規化

### DIFF
--- a/docs/design/message-rich-text.md
+++ b/docs/design/message-rich-text.md
@@ -14,7 +14,7 @@ Session message と Markdown file preview に同じ rich text renderer を使い
 - ローカル path link に `#L10` などの fragment が付いている場合は、少なくとも path 本体を開けるように fragment を無視して扱う。`:10` または `:10:4` 形式は、指定された path が存在しない場合だけ行番号または行番号と列番号として扱う
 - Markdown file preview の相対 link と相対 image は、その file の親 directory と同じ認可済み root の中で解決する
 - OS の既定アプリで file を開けない場合は理由を表示し、通常の Open から Explorer 表示へ自動で切り替えない
-- render 済み link の context menu は「リンクをコピー」を提供し、表示 label ではなく通常の Open と同じ `href` target を clipboard へ渡す。encoded URL / path は decode・normalizeしない
+- render 済み link の context menu は「リンクをコピー」を提供する。protocol-relativeを含む外部 URL は表示 label ではなく `href` target を保ち、local / `file:` / Windows absolute path は通常の Open と同じ Main process の path 解決境界で decode・filesystem path 変換して clipboard へ渡す。最終的な copy target に制御文字を含む場合は clipboard を更新せず失敗として通知する
 - HTTP / HTTPS、`mailto:`、workspace 相対 path、`file:`、Windows absolute pathをcopy対象とし、unsafe schemeで除去されたlinkと同一pageの`#` anchorは対象にしない
 - context menuはmouseの右clickに加え、focusしたlinkからShift+F10またはContext Menu keyで到達できるnative menuとする。dismissはcopy成功として通知しない
 - detached preview の navigation と root authorization は `docs/adr/020-file-preview-window-navigation.md` を正本とする

--- a/scripts/tests/markdown-link-context-menu-service.test.ts
+++ b/scripts/tests/markdown-link-context-menu-service.test.ts
@@ -24,7 +24,7 @@ function createHarness(writeText: (target: string) => void = () => undefined) {
   };
 }
 
-test("Markdown link context menuは選択時だけtargetをそのままclipboardへ渡す", async () => {
+test("Markdown link context menuは選択時だけ解決したtargetをclipboardへ渡す", async () => {
   const copied: string[] = [];
   const harness = createHarness((target) => copied.push(target));
   const request = {
@@ -44,7 +44,79 @@ test("Markdown link context menuは選択時だけtargetをそのままclipboard
 
   harness.getMenuTemplate()[0]?.click?.();
   assert.deepEqual(await resultPromise, { status: "copied" });
-  assert.deepEqual(copied, [request.target]);
+  assert.deepEqual(copied, ["docs/candidate-source final.json"]);
+});
+
+test("Markdown link context menuはpercent-encodedされたWindows pathをfilesystem pathとしてcopyする", async () => {
+  const copied: string[] = [];
+  const harness = createHarness((target) => copied.push(target));
+  const resultPromise = harness.service.showContextMenu({} as never, {
+    target: "C:%5Cworkspace%5Csession-files%5Creport%20仕様.md#intro",
+    point: { x: 120, y: 240 },
+  });
+
+  harness.getMenuTemplate()[0]?.click?.();
+
+  assert.deepEqual(await resultPromise, { status: "copied" });
+  assert.deepEqual(copied, ["C:\\workspace\\session-files\\report 仕様.md"]);
+});
+
+test("Markdown link context menuはdecode後に制御文字を含むlocal pathをcopyしない", async () => {
+  const copied: string[] = [];
+  const harness = createHarness((target) => copied.push(target));
+  const resultPromise = harness.service.showContextMenu({} as never, {
+    target: "docs/report%0D%0Apowershell.exe",
+    point: { x: 120, y: 240 },
+  });
+
+  harness.getMenuTemplate()[0]?.click?.();
+
+  assert.deepEqual(await resultPromise, {
+    status: "failed",
+    message: "リンクをコピーできませんでした。",
+  });
+  assert.deepEqual(copied, []);
+});
+
+test("Markdown link context menuはraw制御文字を含む外部URLをcopyしない", async () => {
+  const copied: string[] = [];
+  const harness = createHarness((target) => copied.push(target));
+  const resultPromise = harness.service.showContextMenu({} as never, {
+    target: "https://example.test/report\r\npowershell.exe",
+    point: { x: 120, y: 240 },
+  });
+
+  harness.getMenuTemplate()[0]?.click?.();
+
+  assert.deepEqual(await resultPromise, {
+    status: "failed",
+    message: "リンクをコピーできませんでした。",
+  });
+  assert.deepEqual(copied, []);
+});
+
+test("Markdown link context menuはdismiss後のclickと選択後の再clickでclipboardを更新しない", async () => {
+  const dismissedCopies: string[] = [];
+  const dismissed = createHarness((target) => dismissedCopies.push(target));
+  const dismissedResult = dismissed.service.showContextMenu({} as never, {
+    target: "docs/dismissed.md",
+    point: { x: 1, y: 2 },
+  });
+  dismissed.getPopupOptions()?.callback?.();
+  dismissed.getMenuTemplate()[0]?.click?.();
+  assert.deepEqual(await dismissedResult, { status: "dismissed" });
+  assert.deepEqual(dismissedCopies, []);
+
+  const selectedCopies: string[] = [];
+  const selected = createHarness((target) => selectedCopies.push(target));
+  const selectedResult = selected.service.showContextMenu({} as never, {
+    target: "docs/selected.md",
+    point: { x: 1, y: 2 },
+  });
+  selected.getMenuTemplate()[0]?.click?.();
+  selected.getMenuTemplate()[0]?.click?.();
+  assert.deepEqual(await selectedResult, { status: "copied" });
+  assert.deepEqual(selectedCopies, ["docs/selected.md"]);
 });
 
 test("Markdown link context menuはdismissとcopy失敗を成功扱いしない", async () => {

--- a/scripts/tests/open-path.test.ts
+++ b/scripts/tests/open-path.test.ts
@@ -5,6 +5,7 @@ import {
   openLocalPathWithDefaultApp,
   revealLocalPathInFileManager,
   resolveForwardSlashUncPathCandidate,
+  resolveMarkdownLinkCopyTarget,
   resolveOpenPathTarget,
   resolveProtocolRelativeExternalFallback,
   resolveProtocolRelativeExternalFallbackAfterLocalOpen,
@@ -200,6 +201,84 @@ describe("resolveOpenPathTarget", () => {
     });
   });
 
+});
+
+describe("resolveMarkdownLinkCopyTarget", () => {
+  it("local linkをdecodeしてfragmentを除いたfilesystem pathにする", () => {
+    assert.equal(
+      resolveMarkdownLinkCopyTarget("docs/my%20file-%E4%BB%95%E6%A7%98.md#intro"),
+      "docs/my file-仕様.md",
+    );
+    assert.equal(
+      resolveMarkdownLinkCopyTarget("C:%5Cworkspace%5Csession-files%5Creport%20%E4%BB%95%E6%A7%98.md#intro"),
+      "C:\\workspace\\session-files\\report 仕様.md",
+    );
+  });
+
+  it("file URLとUNCをfilesystem pathにする", () => {
+    assert.equal(
+      resolveMarkdownLinkCopyTarget("file:///C:/workspace/my%20file.md#intro"),
+      "C:\\workspace\\my file.md",
+    );
+    assert.equal(
+      resolveMarkdownLinkCopyTarget("file://server/share/my%20file.md#intro"),
+      "\\\\server\\share\\my file.md",
+    );
+    assert.equal(
+      resolveMarkdownLinkCopyTarget("%5C%5Cserver%5Cshare%5C%E4%BB%95%E6%A7%98%20file.md#intro"),
+      "\\\\server\\share\\仕様 file.md",
+    );
+    assert.equal(
+      resolveMarkdownLinkCopyTarget("file:/C:/workspace/my%20file.md#intro"),
+      "C:\\workspace\\my file.md",
+    );
+    assert.equal(
+      resolveMarkdownLinkCopyTarget("FILE:/C:/workspace/my%20file.md#intro"),
+      "C:\\workspace\\my file.md",
+    );
+    assert.equal(
+      resolveMarkdownLinkCopyTarget("file:////server/share/my%20file.md#intro"),
+      "\\\\server\\share\\my file.md",
+    );
+  });
+
+  it("decode後のlocal pathに制御文字があれば拒否する", () => {
+    for (const target of [
+      "docs/report%00.txt",
+      "docs/report%09.txt",
+      "docs/report%0D%0Apowershell.txt",
+      "docs/report%7F.txt",
+      "file:/C:/workspace/report%0A.txt",
+    ]) {
+      assert.throws(
+        () => resolveMarkdownLinkCopyTarget(target),
+        /control characters/i,
+      );
+    }
+  });
+
+  it("外部URLはencodeとquery・fragmentを保つ", () => {
+    assert.equal(
+      resolveMarkdownLinkCopyTarget("//example.test/docs/my%20file.md?raw=%2F#intro"),
+      "//example.test/docs/my%20file.md?raw=%2F#intro",
+    );
+    assert.equal(
+      resolveMarkdownLinkCopyTarget("https://example.test/docs/my%20file.md?raw=%2F#intro"),
+      "https://example.test/docs/my%20file.md?raw=%2F#intro",
+    );
+    assert.equal(
+      resolveMarkdownLinkCopyTarget("mailto:alice+docs@example.test?subject=%E4%BB%95%E6%A7%98"),
+      "mailto:alice+docs@example.test?subject=%E4%BB%95%E6%A7%98",
+    );
+    assert.equal(
+      resolveMarkdownLinkCopyTarget("https://example.test/report%0D%0Apowershell.exe"),
+      "https://example.test/report%0D%0Apowershell.exe",
+    );
+    assert.throws(
+      () => resolveMarkdownLinkCopyTarget("https://example.test/report\r\npowershell.exe"),
+      /control characters/i,
+    );
+  });
 });
 
 describe("openLocalPathWithDefaultApp", () => {

--- a/src-electron/markdown-link-context-menu-service.ts
+++ b/src-electron/markdown-link-context-menu-service.ts
@@ -4,6 +4,7 @@ import type {
   MarkdownLinkContextMenuRequest,
   MarkdownLinkContextMenuResult,
 } from "../src/markdown-link-context-menu.js";
+import { resolveMarkdownLinkCopyTarget } from "./open-path.js";
 
 type LinkContextMenu = Pick<Menu, "popup">;
 
@@ -20,7 +21,7 @@ export class MarkdownLinkContextMenuService {
 
   private copyTarget(target: string): MarkdownLinkContextMenuResult {
     try {
-      this.deps.writeText(target);
+      this.deps.writeText(resolveMarkdownLinkCopyTarget(target));
       return { status: "copied" };
     } catch {
       return { status: "failed", message: LINK_COPY_FAILED_MESSAGE };
@@ -43,11 +44,16 @@ export class MarkdownLinkContextMenuService {
           resolve(result);
         }
       };
+      const copyAndSettle = () => {
+        if (!settled) {
+          settle(this.copyTarget(request.target));
+        }
+      };
 
       try {
         const menu = this.deps.buildMenu([{
           label: "リンクをコピー",
-          click: () => settle(this.copyTarget(request.target)),
+          click: copyAndSettle,
         }]);
         menu.popup({
           window,

--- a/src-electron/open-path.ts
+++ b/src-electron/open-path.ts
@@ -47,7 +47,8 @@ function isWindowsFileUrl(url: URL): boolean {
   if (hostname && hostname !== "localhost") {
     return true;
   }
-  return /^\/[a-zA-Z]:\//.test(url.pathname);
+  return /^\/[a-zA-Z]:\//.test(url.pathname)
+    || /^\/\/[^/]+\/[^/]+(?:\/|$)/.test(url.pathname);
 }
 
 function isSupportedExternalUrlScheme(scheme: string): boolean {
@@ -130,7 +131,7 @@ export function resolveOpenPathTarget(target: string, options: OpenPathOptions =
     };
   }
 
-  if (/^file:\/\//i.test(trimmed)) {
+  if (/^file:/i.test(trimmed)) {
     const fileUrl = new URL(trimmed);
     fileUrl.hash = "";
     fileUrl.search = "";
@@ -185,6 +186,17 @@ export function resolveOpenPathTarget(target: string, options: OpenPathOptions =
     type: "local-path",
     targetPath: localTarget,
   };
+}
+
+export function resolveMarkdownLinkCopyTarget(target: string): string {
+  const resolvedTarget = resolveOpenPathTarget(target);
+  const copyTarget = resolvedTarget.type === "local-path"
+    ? resolvedTarget.targetPath
+    : target;
+  if (/[\u0000-\u001f\u007f]/.test(copyTarget)) {
+    throw new Error("Markdown link copy target contains control characters.");
+  }
+  return copyTarget;
 }
 
 function isMissingLocalPathError(error: unknown): boolean {


### PR DESCRIPTION
## 概要

Markdownリンクのコピー時に、Windowsローカルパスをfilesystem pathへ正規化します。

## 変更内容

- local / `file:` / Windows absolute pathのURL decodeとfilesystem path変換をMain processの共通境界へ集約
- protocol-relativeを含む外部URLは元の`href` targetを保持
- 最終copy targetにC0/DEL制御文字が含まれる場合はclipboard更新前に拒否
- dismiss後や複数clickによるclipboardの重複更新を防止
- Windows path、`file:`表記揺れ、UNC、非ASCII、空白、fragment、外部URLの回帰testを追加

## 検証

- `npx tsx --test scripts/tests/open-path.test.ts scripts/tests/markdown-link-context-menu-service.test.ts scripts/tests/message-rich-text.test.ts scripts/tests/main-ipc-registration.test.ts scripts/tests/preload-api.test.ts`
- `npm run typecheck`
- `tsx --test --test-reporter=dot scripts/tests/*.test.ts scripts/tests/*.test.tsx`