### PR TITLE
fix: Session送信の二重dispatchとdraft消失を防ぐ

### DIFF
--- a/scripts/tests/main-ipc-registration.test.ts
+++ b/scripts/tests/main-ipc-registration.test.ts
@@ -903,6 +903,45 @@ test("registerMainIpcHandlers は Mate 未作成時でも session runtime IPC �
   assert.deepEqual(calls, ["runSessionTurn:session-1,[object Object]"]);
 });
 
+test("run-session-turn IPC拒否ログは本文を含めずclient request IDを相関情報として渡す", async () => {
+  const { ipcMain, handlers } = createIpcMainStub();
+  const errors: Array<{ channel: string; clientRequestId?: string }> = [];
+  const { deps } = createDeps({
+    runSessionTurn: async () => {
+      throw new Error("このセッションはまだ実行中だよ。");
+    },
+    logIpcError: (input: { channel: string; clientRequestId?: string }) => {
+      errors.push(input);
+    },
+  });
+  registerMainIpcHandlers(ipcMain, deps);
+
+  await assert.rejects(
+    () => handlers.get(WITHMATE_RUN_SESSION_TURN_CHANNEL)?.({}, "session-1", {
+      userMessage: "ログへ出してはいけない本文",
+      clientRequestId: "7c26d875-9117-4ad5-97b5-e9af775b94bc",
+    }) as Promise<unknown>,
+    /まだ実行中/,
+  );
+
+  assert.deepEqual(errors.map(({ channel, clientRequestId }) => ({ channel, clientRequestId })), [{
+    channel: WITHMATE_RUN_SESSION_TURN_CHANNEL,
+    clientRequestId: "7c26d875-9117-4ad5-97b5-e9af775b94bc",
+  }]);
+  assert.doesNotMatch(JSON.stringify(errors), /ログへ出してはいけない本文/);
+
+  await assert.rejects(
+    () => handlers.get(WITHMATE_RUN_SESSION_TURN_CHANNEL)?.({}, "session-1", {
+      userMessage: "please use secretprompt",
+      clientRequestId: "secretprompt",
+      submitSource: "secretprompt",
+    }) as Promise<unknown>,
+    /まだ実行中/,
+  );
+  assert.equal(errors.at(-1)?.clientRequestId, undefined);
+  assert.doesNotMatch(JSON.stringify(errors.at(-1)), /secretprompt/);
+});
+
 test("Memory V6 Review IPC は memory-review window からだけ呼び出せる", async () => {
   const { ipcMain, handlers } = createIpcMainStub();
   const reviewWindow = createWindowStub("http://localhost:5173/?mode=memory-review");

--- a/scripts/tests/main-session-persistence-facade.test.ts
+++ b/scripts/tests/main-session-persistence-facade.test.ts
@@ -14,6 +14,14 @@ test("MainSessionPersistenceFacade は upsert/replaceAll を SessionPersistenceS
           calls.push(`upsert:${session.id}`);
           return session as never;
         },
+        upsertTerminalSession(session) {
+          calls.push(`terminal:${session.id}`);
+          return session as never;
+        },
+        upsertSessionPreservingPin(session) {
+          calls.push(`preserve-pin:${session.id}`);
+          return session as never;
+        },
         replaceAllSessions(sessions) {
           calls.push(`replace:${sessions.length}`);
           return sessions as never;
@@ -23,9 +31,11 @@ test("MainSessionPersistenceFacade は upsert/replaceAll を SessionPersistenceS
   });
 
   await facade.upsertSession({ id: "s-1" } as never);
+  await facade.upsertTerminalSession({ id: "s-1" } as never);
+  await facade.upsertSessionPreservingPin({ id: "s-1" } as never);
   await facade.replaceAllSessions([{ id: "s-1" }] as never);
 
-  assert.deepEqual(calls, ["upsert:s-1", "replace:1"]);
+  assert.deepEqual(calls, ["upsert:s-1", "terminal:s-1", "preserve-pin:s-1", "replace:1"]);
 });
 
 test("MainSessionPersistenceFacade は running session を詳細 hydrate して interrupted に変換する", async () => {

--- a/scripts/tests/session-persistence-service.test.ts
+++ b/scripts/tests/session-persistence-service.test.ts
@@ -125,6 +125,67 @@ describe("SessionPersistenceService", () => {
     assert.deepEqual(broadcasts, [[session.id]]);
   });
 
+  it("pin変更の後にstaleなrunning・retry・terminal保存が続いても最新のpinを維持する", async () => {
+    const runningSession = createSession({
+      id: "pin-during-run",
+      status: "running",
+      runState: "running",
+      isPinned: false,
+    });
+    let cachedSessions = [runningSession];
+    let storedSession = runningSession;
+    const service = new SessionPersistenceService({
+      getSessions: () => cachedSessions,
+      setSessions: (next) => { cachedSessions = next; },
+      getSession: (sessionId) => cachedSessions.find((session) => session.id === sessionId) ?? null,
+      isSessionRunInFlight: () => true,
+      upsertStoredSession: (next) => {
+        storedSession = next;
+        return next;
+      },
+      replaceStoredSessions: () => undefined,
+      setStoredSessionPinned: (sessionId, isPinned) => {
+        storedSession = { ...storedSession, isPinned };
+        return { ...projectSessionSummary(storedSession), id: sessionId, isPinned };
+      },
+      listStoredSessions: () => [storedSession],
+      getAppSettings: () => normalizeAppSettings({}),
+      getModelCatalogSnapshot: createSnapshot,
+      syncSessionDependencies: () => undefined,
+      clearSessionContextTelemetry: () => undefined,
+      clearSessionBackgroundActivities: () => undefined,
+      invalidateProviderSessionThread: () => undefined,
+      closeSessionWindow: () => undefined,
+      broadcastSessions: () => undefined,
+    });
+    const staleCompletedSession = createSession({
+      ...runningSession,
+      status: "idle",
+      runState: "idle",
+      isPinned: false,
+      messages: [...runningSession.messages, { role: "assistant", text: "done" }],
+    });
+
+    const pinWrite = service.setSessionPinned(runningSession.id, true);
+    const staleRunningWrite = service.upsertSessionPreservingPin({
+      ...runningSession,
+      threadId: "thread-stale",
+      isPinned: false,
+    });
+    const staleRetryWrite = service.upsertSessionPreservingPin({
+      ...runningSession,
+      threadId: "",
+      isPinned: false,
+    });
+    const terminalWrite = service.upsertTerminalSession(staleCompletedSession);
+    await Promise.all([pinWrite, staleRunningWrite, staleRetryWrite, terminalWrite]);
+
+    assert.equal(storedSession.isPinned, true);
+    assert.equal(storedSession.runState, "idle");
+    assert.equal(storedSession.messages.at(-1)?.text, "done");
+    assert.equal(cachedSessions[0]?.isPinned, true);
+  });
+
   it("createSession は有効な provider と model を解決して保存する", async () => {
     const storedSessions: Session[] = [];
     const syncedSessionIds: string[] = [];

--- a/scripts/tests/session-runtime-service.test.ts
+++ b/scripts/tests/session-runtime-service.test.ts
@@ -32,6 +32,7 @@ import {
   SessionRuntimeService,
   hasMeaningfulPartialRunResult,
   isRetryableStaleThreadSessionError,
+  preserveSessionTurnRequestMetadata,
   type SessionRuntimeServiceDeps,
 } from "../../src-electron/session-runtime-service.js";
 import type { ConversationTimingContext } from "../../src-electron/conversation-timing.js";
@@ -181,7 +182,10 @@ describe("SessionRuntimeService", () => {
     let contextVersion = 0;
     let auditId = 0;
     const appraisalCorrelations: string[] = [];
+    const requestCorrelations: string[] = [];
     const callOrder: string[] = [];
+    let blockCompletedAudit = false;
+    let releaseCompletedAudit: (() => void) | null = null;
     const adapter: ProviderCodingAdapter = {
       composePrompt() {
         return {
@@ -221,6 +225,10 @@ describe("SessionRuntimeService", () => {
         return sessionId === storedSession.id ? storedSession : null;
       },
       upsertSession(next) {
+        storedSession = next;
+        return next;
+      },
+      upsertTerminalSession(next) {
         if (next.status === "idle" && next.messages.at(-1)?.role === "assistant") {
           callOrder.push("completed-upsert");
         }
@@ -260,10 +268,23 @@ describe("SessionRuntimeService", () => {
         callOrder.push("appraised");
       },
       createAuditLog(input) {
+        const requestMetadata = input.providerMetadata.find((entry) => entry.kind === "session_turn_request");
+        const clientRequestId = requestMetadata?.payload && "clientRequestId" in requestMetadata.payload
+          ? requestMetadata.payload.clientRequestId
+          : null;
+        if (typeof clientRequestId === "string") {
+          requestCorrelations.push(clientRequestId);
+        }
         auditId += 1;
         return { ...createAuditLogBase(input), id: auditId };
       },
-      updateAuditLog() {},
+      updateAuditLog(_id, input) {
+        if (blockCompletedAudit && input.phase === "completed") {
+          return new Promise<void>((resolve) => {
+            releaseCompletedAudit = resolve;
+          });
+        }
+      },
       setLiveSessionRun() {},
       getLiveSessionRun() {
         return null;
@@ -284,12 +305,24 @@ describe("SessionRuntimeService", () => {
       currentTimestampLabel,
     });
 
-    await service.runSessionTurn(storedSession.id, { userMessage: "first" });
+    await service.runSessionTurn(storedSession.id, {
+      userMessage: "first",
+      clientRequestId: "7c26d875-9117-4ad5-97b5-e9af775b94b1",
+      submitSource: "composer",
+    });
     callOrder.push("first-returned");
-    await service.runSessionTurn(storedSession.id, { userMessage: "second" });
+    await service.runSessionTurn(storedSession.id, {
+      userMessage: "second",
+      clientRequestId: "7c26d875-9117-4ad5-97b5-e9af775b94b2",
+      submitSource: "retry",
+    });
     callOrder.push("second-returned");
 
     assert.equal(contextVersion, 2);
+    assert.deepEqual(requestCorrelations, [
+      "7c26d875-9117-4ad5-97b5-e9af775b94b1",
+      "7c26d875-9117-4ad5-97b5-e9af775b94b2",
+    ]);
     assert.deepEqual(appraisalCorrelations, [
       `turn:${storedSession.id}:audit:1`,
       `turn:${storedSession.id}:audit:2`,
@@ -304,6 +337,46 @@ describe("SessionRuntimeService", () => {
       "appraised",
       "second-returned",
     ]);
+
+    blockCompletedAudit = true;
+    const completingRun = service.runSessionTurn(storedSession.id, {
+      userMessage: "third",
+      clientRequestId: "7c26d875-9117-4ad5-97b5-e9af775b94b3",
+    });
+    for (let attempt = 0; attempt < 20 && !releaseCompletedAudit; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    assert.ok(releaseCompletedAudit, "provider完了後のaudit終了処理へ到達すること");
+    await assert.rejects(
+      service.runSessionTurn(storedSession.id, {
+        userMessage: "cleanup中の再送",
+        clientRequestId: "7c26d875-9117-4ad5-97b5-e9af775b94b4",
+      }),
+      /まだ実行中/,
+    );
+    blockCompletedAudit = false;
+    releaseCompletedAudit();
+    await completingRun;
+  });
+
+  it("terminal audit fallback はsession turn correlationだけを保持する", () => {
+    const correlation = {
+      provider: "codex",
+      kind: "session_turn_request",
+      source: "session-runtime-service.run-session-turn",
+      summary: "Session turn request correlation",
+      payload: { clientRequestId: "7c26d875-9117-4ad5-97b5-e9af775b94bc", submitSource: "composer" },
+    };
+    assert.deepEqual(preserveSessionTurnRequestMetadata([
+      correlation,
+      {
+        provider: "codex",
+        kind: "provider_detail",
+        source: "provider",
+        summary: "detail",
+        payload: { secret: "drop" },
+      },
+    ]), [correlation]);
   });
 
   it("HTTP runtime未初期化でもpendingをcompleted Sessionより先に永続化し、保存失敗時はcompletedにしない", async () => {
@@ -1360,7 +1433,11 @@ describe("SessionRuntimeService", () => {
       currentTimestampLabel,
     });
 
-    const result = await service.runSessionTurn(session.id, { userMessage: "お願いします" });
+    const result = await service.runSessionTurn(session.id, {
+      userMessage: "お願いします",
+      clientRequestId: "7c26d875-9117-4ad5-97b5-e9af775b94bc",
+      submitSource: "composer",
+    });
 
     assert.equal(result.runState, "idle");
     assert.equal(result.status, "idle");
@@ -1371,6 +1448,11 @@ describe("SessionRuntimeService", () => {
     assert.equal(storedSessions[1]?.messages.at(-1)?.text, "完了したよ。");
     assert.equal(persistedAudit?.phase, "completed");
     assert.equal(persistedAudit?.assistantText, "");
+    assert.equal(persistedAudit?.providerMetadata[0]?.kind, "session_turn_request");
+    assert.equal(
+      persistedAudit?.providerMetadata[0]?.payload.clientRequestId,
+      "7c26d875-9117-4ad5-97b5-e9af775b94bc",
+    );
     assert.equal(auditUpdates.at(-1)?.phase, "completed");
     assert.equal(auditUpdates.at(-1)?.operations.length, 0);
     assert.equal(auditUpdates.at(-1)?.assistantText, "完了したよ。");

--- a/scripts/tests/session-submit-coordinator.test.ts
+++ b/scripts/tests/session-submit-coordinator.test.ts
@@ -1,0 +1,272 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  LatestRequestRevision,
+  SessionSubmitCoordinator,
+  StateMutationRevision,
+  convergeRejectedLiveRunState,
+  convergeRejectedSessionSnapshot,
+  convergeResolvedSessionProjection,
+  fingerprintSessionDraft,
+  mergeRefetchedSessionProjection,
+  mergeRejectedSessionDraft,
+  recoverRejectedSessionSnapshot,
+} from "../../src/session-submit-coordinator.js";
+import type { LiveSessionRunState } from "../../src/runtime-state.js";
+import {
+  normalizeSessionTurnClientRequestId,
+  normalizeSessionTurnCorrelation,
+  normalizeSessionTurnSubmitSource,
+} from "../../src/runtime-state.js";
+import type { Session } from "../../src/session-state.js";
+
+function createSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "session-1",
+    taskTitle: "test",
+    status: "idle",
+    updatedAt: "2026-08-13T01:00:00.000Z",
+    isPinned: false,
+    provider: "codex",
+    catalogRevision: 1,
+    workspaceLabel: "workspace",
+    workspacePath: "C:\\workspace",
+    branch: "main",
+    sessionKind: "default",
+    accessMode: "active",
+    sourceSchemaVersion: 5,
+    characterId: "character-1",
+    character: "Character",
+    characterIconPath: "",
+    characterThemeColors: { primary: "#000000", secondary: "#000000", accent: "#000000" },
+    characterRuntimeSnapshot: null,
+    runState: "idle",
+    approvalMode: "on-request",
+    codexSandboxMode: "workspace-write",
+    model: "model",
+    reasoningEffort: "medium",
+    customAgentName: "",
+    allowedAdditionalDirectories: [],
+    threadId: "thread-1",
+    messages: [],
+    stream: [],
+    ...overrides,
+  };
+}
+
+function createLiveRun(overrides: Partial<LiveSessionRunState> = {}): LiveSessionRunState {
+  return {
+    sessionId: "session-1",
+    threadId: "",
+    assistantText: "",
+    reasoningText: "",
+    steps: [],
+    backgroundTasks: [],
+    usage: null,
+    errorMessage: "",
+    approvalRequest: null,
+    elicitationRequest: null,
+    ...overrides,
+  };
+}
+
+test("SessionSubmitCoordinator は preview 待機中の同一session rapid submitを一件だけ通す", async () => {
+  const coordinator = new SessionSubmitCoordinator();
+  let releasePreview: (() => void) | null = null;
+  const preview = new Promise<void>((resolve) => {
+    releasePreview = resolve;
+  });
+  let dispatchCount = 0;
+
+  const submit = async () => {
+    const lease = coordinator.tryAcquire("session-1");
+    if (!lease) {
+      return "blocked" as const;
+    }
+    try {
+      await preview;
+      dispatchCount += 1;
+      return "dispatched" as const;
+    } finally {
+      lease.release();
+    }
+  };
+
+  const first = submit();
+  const second = await submit();
+  assert.equal(second, "blocked");
+  assert.equal(dispatchCount, 0);
+  assert.equal(coordinator.isClaimed("session-1"), true);
+  assert.ok(releasePreview);
+  releasePreview();
+  assert.equal(await first, "dispatched");
+  assert.equal(dispatchCount, 1);
+  assert.equal(coordinator.isClaimed("session-1"), false);
+});
+
+test("LatestRequestRevision は逆順で完了した古いsession refetchを失効させる", () => {
+  const revisions = new LatestRequestRevision();
+  const older = revisions.start();
+  const newer = revisions.start();
+
+  assert.equal(revisions.isCurrent(newer), true);
+  assert.equal(revisions.isCurrent(older), false);
+});
+
+test("StateMutationRevision はrefetch待機中の楽観またはsubscription更新を検知する", () => {
+  const revisions = new StateMutationRevision();
+  const refetchStartedAt = revisions.capture();
+  assert.equal(revisions.isCurrent(refetchStartedAt), true);
+
+  revisions.advance();
+  assert.equal(revisions.isCurrent(refetchStartedAt), false);
+});
+
+test("session refetch は局所的なpin projectionを維持して権威ある本体状態を反映する", () => {
+  const current = createSession({
+    isPinned: true,
+    runState: "running",
+    messages: [{ role: "user", text: "optimistic" }],
+  });
+  const refreshed = createSession({
+    isPinned: false,
+    runState: "idle",
+    messages: [{ role: "user", text: "accepted" }, { role: "assistant", text: "done" }],
+  });
+
+  assert.deepEqual(mergeRefetchedSessionProjection(current, refreshed, true), {
+    ...refreshed,
+    isPinned: true,
+  });
+  assert.equal(mergeRefetchedSessionProjection(current, refreshed, false), refreshed);
+});
+
+test("turn成功応答は実行中に進んだpin projectionを維持して最新本体を反映する", () => {
+  const current = createSession({ isPinned: true, runState: "running" });
+  const saved = createSession({
+    isPinned: false,
+    runState: "idle",
+    messages: [{ role: "user", text: "accepted" }, { role: "assistant", text: "done" }],
+  });
+
+  assert.deepEqual(convergeResolvedSessionProjection(current, saved, true), {
+    ...saved,
+    isPinned: true,
+  });
+  assert.equal(convergeResolvedSessionProjection(current, saved, false), saved);
+});
+
+test("mergeRejectedSessionDraft は拒否された入力と送信後の追加入力を両方保持する", () => {
+  assert.equal(mergeRejectedSessionDraft("送信した内容", ""), "送信した内容");
+  assert.equal(
+    mergeRejectedSessionDraft("送信した内容", "あとから入力した内容"),
+    "送信した内容\n\nあとから入力した内容",
+  );
+  assert.equal(mergeRejectedSessionDraft("送信した内容", "送信した内容"), "送信した内容");
+});
+
+test("fingerprintSessionDraft は本文を含めず同じdraftを安定して識別する", () => {
+  const first = fingerprintSessionDraft("secret prompt");
+  assert.equal(first, fingerprintSessionDraft("secret prompt"));
+  assert.notEqual(first, fingerprintSessionDraft("different prompt"));
+  assert.doesNotMatch(first, /secret|prompt/);
+});
+
+test("normalizeSessionTurnClientRequestId はログへ安全に渡せる相関IDだけを受理する", () => {
+  assert.equal(
+    normalizeSessionTurnClientRequestId("7c26d875-9117-4ad5-97b5-e9af775b94bc"),
+    "7c26d875-9117-4ad5-97b5-e9af775b94bc",
+  );
+  assert.equal(normalizeSessionTurnClientRequestId("session-turn-mewz2-k4j8n"), null);
+  assert.equal(normalizeSessionTurnClientRequestId("turn-123:abc"), null);
+  assert.equal(normalizeSessionTurnClientRequestId(""), null);
+  assert.equal(normalizeSessionTurnClientRequestId("本文 を含む"), null);
+  assert.equal(normalizeSessionTurnClientRequestId("x".repeat(129)), null);
+  assert.equal(normalizeSessionTurnSubmitSource("composer"), "composer");
+  assert.equal(normalizeSessionTurnSubmitSource("本文"), null);
+  assert.deepEqual(normalizeSessionTurnCorrelation({
+    userMessage: "secretprompt",
+    clientRequestId: "session-turn-secretprompt-abc",
+    submitSource: "本文" as "composer",
+  }), {
+    clientRequestId: null,
+    submitSource: null,
+  });
+  assert.deepEqual(normalizeSessionTurnCorrelation({
+    userMessage: "please use 7c26d875-9117-4ad5-97b5-e9af775b94bc",
+    clientRequestId: "7c26d875-9117-4ad5-97b5-e9af775b94bc",
+    submitSource: "composer",
+  }), {
+    clientRequestId: null,
+    submitSource: "composer",
+  });
+});
+
+test("convergeRejectedSessionSnapshot は古い楽観snapshotを最新取得結果へ置き換える", () => {
+  const before = createSession();
+  const optimistic = createSession({
+    status: "running",
+    runState: "running",
+    updatedAt: "2026-08-13T01:00:01.000Z",
+    messages: [{ role: "user", text: "rejected" }],
+  });
+  const refreshed = createSession({
+    updatedAt: "2026-08-13T01:00:02.000Z",
+    messages: [{ role: "user", text: "accepted earlier" }, { role: "assistant", text: "done" }],
+  });
+
+  assert.equal(convergeRejectedSessionSnapshot(optimistic, optimistic, refreshed, true, false), refreshed);
+  assert.equal(convergeRejectedSessionSnapshot(before, optimistic, refreshed, false, false), before);
+  const pinnedProjection = { ...optimistic, isPinned: true };
+  assert.deepEqual(convergeRejectedSessionSnapshot(pinnedProjection, optimistic, refreshed, true, true), {
+    ...refreshed,
+    isPinned: true,
+  });
+  const newerSubscription = createSession({
+    updatedAt: optimistic.updatedAt,
+    messages: [{ role: "user", text: "newer subscription" }],
+  });
+  assert.equal(convergeRejectedSessionSnapshot(newerSubscription, optimistic, refreshed, false, false), newerSubscription);
+});
+
+test("recoverRejectedSessionSnapshot はpin projectionを保持して楽観bodyだけをerrorへ収束する", () => {
+  const optimistic = createSession({ status: "running", runState: "running" });
+  assert.deepEqual(recoverRejectedSessionSnapshot(optimistic, optimistic, true), {
+    ...optimistic,
+    status: "idle",
+    runState: "error",
+  });
+  const pinnedProjection = { ...optimistic, isPinned: true };
+  assert.deepEqual(recoverRejectedSessionSnapshot(pinnedProjection, optimistic, true), {
+    ...optimistic,
+    isPinned: true,
+    status: "idle",
+    runState: "error",
+  });
+
+  const newer = createSession({ runState: "idle" });
+  assert.equal(recoverRejectedSessionSnapshot(newer, optimistic, false), newer);
+});
+
+test("convergeRejectedLiveRunState は楽観pendingだけを最新取得結果へ収束し、空またはnullの購読更新も巻き戻さない", () => {
+  const refreshed = createLiveRun({ threadId: "thread-latest", assistantText: "latest" });
+  assert.deepEqual(
+    convergeRejectedLiveRunState(
+      { ownerSessionId: "session-1", state: createLiveRun() },
+      "session-1",
+      refreshed,
+      3,
+      3,
+    ),
+    { ownerSessionId: "session-1", state: refreshed },
+  );
+
+  const subscriptionProgress = createLiveRun({ assistantText: "newer subscription" });
+  const current = { ownerSessionId: "session-1", state: subscriptionProgress };
+  assert.equal(convergeRejectedLiveRunState(current, "session-1", refreshed, 3, 4), current);
+  const completed = { ownerSessionId: "session-1", state: null };
+  assert.equal(convergeRejectedLiveRunState(completed, "session-1", refreshed, 3, 4), completed);
+  const emptySubscription = { ownerSessionId: "session-1", state: createLiveRun() };
+  assert.equal(convergeRejectedLiveRunState(emptySubscription, "session-1", refreshed, 3, 4), emptySubscription);
+});

--- a/src-electron/main-ipc-registration.ts
+++ b/src-electron/main-ipc-registration.ts
@@ -1,6 +1,7 @@
 import type { BrowserWindow, IpcMain, IpcMainInvokeEvent } from "electron";
 
 import type { RendererLogInput } from "../src/app-log-types.js";
+import { normalizeSessionTurnCorrelation } from "../src/runtime-state.js";
 import type {
   MarkdownLinkContextMenuRequest,
   MarkdownLinkContextMenuResult,
@@ -272,6 +273,7 @@ type LogIpcErrorInput = {
   channel: string;
   durationMs: number;
   error: unknown;
+  clientRequestId?: string;
 };
 
 type IpcHandleRegistrar = {
@@ -1683,10 +1685,14 @@ function createErrorLoggingIpcMain(ipcMain: IpcMain, deps: MainIpcRegistrationDe
         try {
           return await handler(event, ...args);
         } catch (error) {
+          const clientRequestId = channel === WITHMATE_RUN_SESSION_TURN_CHANNEL
+            ? normalizeSessionTurnCorrelation(args[1] as RunSessionTurnRequest).clientRequestId ?? undefined
+            : undefined;
           deps.logIpcError?.({
             channel,
             durationMs: Date.now() - startedAt,
             error,
+            clientRequestId,
           });
           throw error;
         }

--- a/src-electron/main-session-persistence-facade.ts
+++ b/src-electron/main-session-persistence-facade.ts
@@ -51,6 +51,14 @@ export class MainSessionPersistenceFacade {
     return this.deps.getSessionPersistenceService().upsertSession(session);
   }
 
+  async upsertTerminalSession(session: Session): Promise<Session> {
+    return this.deps.getSessionPersistenceService().upsertTerminalSession(session);
+  }
+
+  async upsertSessionPreservingPin(session: Session): Promise<Session> {
+    return this.deps.getSessionPersistenceService().upsertSessionPreservingPin(session);
+  }
+
   async replaceAllSessions(nextSessions: Session[], options?: ReplaceAllSessionsOptions): Promise<Session[]> {
     return this.deps.getSessionPersistenceService().replaceAllSessions(nextSessions, options);
   }

--- a/src-electron/main.ts
+++ b/src-electron/main.ts
@@ -789,6 +789,23 @@ function attachWindowLogHandlers(window: BrowserWindow): void {
       },
     });
   });
+  window.webContents.on("did-start-navigation", (_event, url, isInPlace, isMainFrame) => {
+    if (!isMainFrame) {
+      return;
+    }
+    writeAppLog({
+      level: "info",
+      kind: "renderer.navigation-started",
+      process: "main",
+      message: "Renderer main-frame navigation started",
+      windowId: window.id,
+      data: {
+        url,
+        isInPlace,
+        windowTitle: readWindowTitle(window),
+      },
+    });
+  });
 }
 
 function readWindowTitle(window: BrowserWindow): string {
@@ -807,16 +824,23 @@ function readWindowUrl(window: BrowserWindow): string {
   }
 }
 
-function writeIpcErrorLog(input: { channel: string; durationMs: number; error: unknown }): void {
+function writeIpcErrorLog(input: {
+  channel: string;
+  durationMs: number;
+  error: unknown;
+  clientRequestId?: string;
+}): void {
   writeAppLog({
     level: "error",
     kind: "ipc.error",
     process: "main",
     message: `IPC failed: ${input.channel}`,
+    requestId: input.clientRequestId,
     data: {
       channel: input.channel,
       durationMs: input.durationMs,
       success: false,
+      clientRequestId: input.clientRequestId,
     },
     error: appLogService.errorToLogError(input.error),
   });
@@ -2266,7 +2290,8 @@ function requireSessionRuntimeService(): SessionRuntimeService {
   if (!sessionRuntimeService) {
     sessionRuntimeService = new SessionRuntimeService({
       getSession: getRuntimeSession,
-      upsertSession: (session) => requireMainSessionPersistenceFacade().upsertSession(session),
+      upsertSession: (session) => requireMainSessionPersistenceFacade().upsertSessionPreservingPin(session),
+      upsertTerminalSession: (session) => requireMainSessionPersistenceFacade().upsertTerminalSession(session),
       resolveRuntimeSessionForTurn: (session) => resolveCharacterAuthoringRuntimeSessionForTurn(
         session,
         (characterId) => requireCharacterService().createRuntimeSnapshot(characterId),

--- a/src-electron/session-persistence-service.ts
+++ b/src-electron/session-persistence-service.ts
@@ -299,6 +299,22 @@ export class SessionPersistenceService {
     return this.enqueueSessionMutation(() => this.upsertSessionNow(nextSession, operation));
   }
 
+  async upsertTerminalSession(nextSession: Session): Promise<Session> {
+    return this.enqueueSessionMutation(() => this.upsertSessionPreservingPinNow(nextSession));
+  }
+
+  async upsertSessionPreservingPin(nextSession: Session): Promise<Session> {
+    return this.enqueueSessionMutation(() => this.upsertSessionPreservingPinNow(nextSession));
+  }
+
+  private upsertSessionPreservingPinNow(nextSession: Session): Promise<Session> {
+    const currentSession = this.deps.getSession(nextSession.id);
+    return this.upsertSessionNow({
+      ...nextSession,
+      isPinned: currentSession?.isPinned ?? nextSession.isPinned,
+    }, "upsert");
+  }
+
   private async upsertSessionNow(
     nextSession: Session,
     operation: "create" | "upsert",

--- a/src-electron/session-runtime-service.ts
+++ b/src-electron/session-runtime-service.ts
@@ -14,6 +14,7 @@ import {
   type SessionContextTelemetry,
   type SessionMemory,
 } from "../src/app-state.js";
+import { normalizeSessionTurnCorrelation } from "../src/runtime-state.js";
 import { type CharacterProfile } from "../src/character-state.js";
 import { buildLiveRunAuditOperations } from "../src/live-run-audit-operations.js";
 import { getProviderAppSettings, type AppSettings } from "../src/provider-settings-state.js";
@@ -51,6 +52,7 @@ function logSessionRunStuckInvestigation(
 export type SessionRuntimeServiceDeps = {
   getSession(sessionId: string): Awaitable<Session | null>;
   upsertSession(session: Session): Awaitable<Session>;
+  upsertTerminalSession?(session: Session): Awaitable<Session>;
   resolveRuntimeSessionForTurn?: (session: Session) => Awaitable<Session>;
   resolveComposerPreview(session: Session, userMessage: string): Promise<ComposerPreview>;
   resolveProviderSession?: (session: Session) => Session;
@@ -489,6 +491,8 @@ function buildRunningAuditEntry(params: {
   session: Pick<Session, "provider" | "model" | "reasoningEffort" | "approvalMode" | "codexSandboxMode" | "threadId" | "messages">;
   logicalPrompt: CreateAuditLogInput["logicalPrompt"];
   threadId?: string;
+  clientRequestId?: string | null;
+  submitSource?: RunSessionTurnRequest["submitSource"];
 }): CreateAuditLogInput {
   return {
     sessionId: params.sessionId,
@@ -506,7 +510,18 @@ function buildRunningAuditEntry(params: {
     assistantText: "",
     operations: [],
     rawItemsJson: "[]",
-    providerMetadata: [],
+    providerMetadata: params.clientRequestId
+      ? [{
+          provider: params.session.provider,
+          kind: "session_turn_request",
+          source: "session-runtime-service.run-session-turn",
+          summary: "Session turn request correlation",
+          payload: {
+            clientRequestId: params.clientRequestId,
+            submitSource: params.submitSource ?? null,
+          },
+        }]
+      : [],
     usage: null,
     errorMessage: "",
   };
@@ -601,6 +616,12 @@ function buildTerminalAuditEntry(params: {
   };
 }
 
+export function preserveSessionTurnRequestMetadata(
+  providerMetadata: CreateAuditLogInput["providerMetadata"],
+): NonNullable<CreateAuditLogInput["providerMetadata"]> {
+  return (providerMetadata ?? []).filter((entry) => entry.kind === "session_turn_request");
+}
+
 function buildMinimalTerminalAuditEntry(params: {
   baseEntry: CreateAuditLogInput;
   phase: CreateAuditLogInput["phase"];
@@ -609,6 +630,7 @@ function buildMinimalTerminalAuditEntry(params: {
   threadId?: string | null;
   errorMessage?: string;
 }): CreateAuditLogInput {
+  const correlationMetadata = preserveSessionTurnRequestMetadata(params.baseEntry.providerMetadata);
   return {
     ...params.baseEntry,
     phase: params.phase,
@@ -623,7 +645,7 @@ function buildMinimalTerminalAuditEntry(params: {
     assistantText: "",
     operations: [],
     rawItemsJson: "[]",
-    providerMetadata: [],
+    providerMetadata: correlationMetadata,
     usage: null,
     errorMessage: params.errorMessage ?? "",
   };
@@ -643,18 +665,21 @@ function buildDegradedCompletedAuditEntry(params: {
     phase: "completed",
     operations: [],
     rawItemsJson: "",
-    providerMetadata: [{
-      provider: params.completedAuditEntry.provider,
-      kind: "audit_persistence_degraded",
-      source: "session-runtime-service.completed-audit-update",
-      summary: "Completed audit persistence degraded",
-      payload: {
-        message,
-        operationCount: params.completedAuditEntry.operations.length,
-        hadRawItems: params.completedAuditEntry.rawItemsJson.trim() !== "",
-        hadProviderMetadata: (params.completedAuditEntry.providerMetadata ?? []).length > 0,
+    providerMetadata: [
+      ...preserveSessionTurnRequestMetadata(params.completedAuditEntry.providerMetadata),
+      {
+        provider: params.completedAuditEntry.provider,
+        kind: "audit_persistence_degraded",
+        source: "session-runtime-service.completed-audit-update",
+        summary: "Completed audit persistence degraded",
+        payload: {
+          message,
+          operationCount: params.completedAuditEntry.operations.length,
+          hadRawItems: params.completedAuditEntry.rawItemsJson.trim() !== "",
+          hadProviderMetadata: (params.completedAuditEntry.providerMetadata ?? []).length > 0,
+        },
       },
-    }],
+    ],
   };
 }
 
@@ -666,6 +691,10 @@ export class SessionRuntimeService {
   private readonly sessionRunControllers = new Map<string, AbortController>();
 
   constructor(private readonly deps: SessionRuntimeServiceDeps) {}
+
+  private upsertTerminalSession(session: Session): Awaitable<Session> {
+    return this.deps.upsertTerminalSession?.(session) ?? this.deps.upsertSession(session);
+  }
 
   hasInFlightRuns(): boolean {
     return this.inFlightSessionRuns.size > 0
@@ -726,7 +755,20 @@ export class SessionRuntimeService {
   }
 
   async runSessionTurn(sessionId: string, request: RunSessionTurnRequest): Promise<Session> {
-    if (this.isRunInFlight(sessionId)) {
+    const { clientRequestId, submitSource } = normalizeSessionTurnCorrelation(request);
+    const alreadyInFlight = this.isRunInFlight(sessionId);
+    logSessionRunStuckInvestigation("runtime.requested", {
+      sessionId,
+      clientRequestId,
+      submitSource,
+      isRunInFlight: alreadyInFlight,
+    });
+    if (alreadyInFlight) {
+      logSessionRunStuckInvestigation("runtime.rejected", {
+        sessionId,
+        clientRequestId,
+        reason: "session-run-in-flight",
+      });
       throw new Error("このセッションはまだ実行中だよ。");
     }
     this.startingSessionRuns.add(sessionId);
@@ -758,6 +800,7 @@ export class SessionRuntimeService {
     request: RunSessionTurnRequest,
     runAbortController: AbortController,
   ): Promise<Session> {
+    const { clientRequestId, submitSource } = normalizeSessionTurnCorrelation(request);
     const observedAt = (this.deps.currentDate ?? (() => new Date()))();
     const investigationStartedAt = Date.now();
     const storedSession = await this.deps.getSession(sessionId);
@@ -781,6 +824,7 @@ export class SessionRuntimeService {
     throwIfRunCanceled(runAbortController.signal);
     logSessionRunStuckInvestigation("runtime.start", {
       sessionId,
+      clientRequestId,
       provider: session.provider,
       runState: session.runState,
       status: session.status,
@@ -880,6 +924,8 @@ export class SessionRuntimeService {
         createdAt: new Date().toISOString(),
         session: runningSession,
         logicalPrompt: promptForAudit.logicalPrompt,
+        clientRequestId,
+        submitSource: submitSource ?? undefined,
       });
       const runningAuditCreateStartedAt = Date.now();
       runningAuditLog = await this.deps.createAuditLog(runningAuditEntry);
@@ -899,7 +945,7 @@ export class SessionRuntimeService {
         this.deps.setLiveSessionRun(sessionId, null);
       }
       if (setupRunningSessionSaved) {
-        await Promise.resolve(this.deps.upsertSession({
+        await Promise.resolve(this.upsertTerminalSession({
           ...runningSession!,
           updatedAt: currentTimestampLabel(),
           status: "idle",
@@ -1076,6 +1122,7 @@ export class SessionRuntimeService {
           result = await runProviderTurn(activeRunningSession);
           logSessionRunStuckInvestigation("runtime.provider-turn.done", {
             sessionId,
+            clientRequestId,
             elapsedMs: Date.now() - investigationStartedAt,
             assistantChars: result.assistantText.length,
             operationCount: result.operations.length,
@@ -1114,6 +1161,8 @@ export class SessionRuntimeService {
             session: activeRunningSession,
             logicalPrompt: promptForAudit.logicalPrompt,
             threadId: "",
+            clientRequestId,
+            submitSource: submitSource ?? undefined,
           });
           const resetAuditSignature = buildRunningAuditProgressSignature(resetAuditEntry);
           await flushAuditWrites();
@@ -1176,7 +1225,7 @@ export class SessionRuntimeService {
       }
 
       const completedSessionUpsertStartedAt = Date.now();
-      const storedCompletedSession = await this.deps.upsertSession(completedSession);
+      const storedCompletedSession = await this.upsertTerminalSession(completedSession);
       logSessionRunStuckInvestigation("runtime.completed-session-upsert.done", {
         sessionId,
         durationMs: Date.now() - completedSessionUpsertStartedAt,
@@ -1502,7 +1551,7 @@ export class SessionRuntimeService {
       };
 
       const failedSessionUpsertStartedAt = Date.now();
-      const storedFailedSession = await this.deps.upsertSession(failedSession);
+      const storedFailedSession = await this.upsertTerminalSession(failedSession);
       logSessionRunStuckInvestigation("runtime.terminal-session-upsert.done", {
         sessionId,
         durationMs: Date.now() - failedSessionUpsertStartedAt,
@@ -1535,6 +1584,7 @@ export class SessionRuntimeService {
       this.deps.broadcastLiveSessionRun(sessionId);
       logSessionRunStuckInvestigation("runtime.finally.done", {
         sessionId,
+        clientRequestId,
         elapsedMs: Date.now() - investigationStartedAt,
         activeRunState: activeRunningSession.runState,
         activeStatus: activeRunningSession.status,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,13 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ClipboardEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ClipboardEvent,
+  type SetStateAction,
+} from "react";
 
 import {
   type ComposerPreview,
@@ -165,13 +174,24 @@ import {
 } from "./file-explorer/preview-chat-activity.js";
 import {
   applyOptimisticSessionRunUpdate,
-  applyResolvedSessionRunUpdate,
   createOwnedPendingLiveSessionRunState,
   replaceLiveRunAfterResolvedRequest,
-  rollbackOptimisticSessionRunUpdate,
   resolveSessionRunErrorMessage,
   type OwnedLiveSessionRunState,
 } from "./session-live-run-state.js";
+import {
+  LatestRequestRevision,
+  SessionSubmitCoordinator,
+  StateMutationRevision,
+  convergeRejectedLiveRunState,
+  convergeRejectedSessionSnapshot,
+  convergeResolvedSessionProjection,
+  createSessionTurnClientRequestId,
+  fingerprintSessionDraft,
+  mergeRefetchedSessionProjection,
+  mergeRejectedSessionDraft,
+  recoverRejectedSessionSnapshot,
+} from "./session-submit-coordinator.js";
 import { buildAgentSessionChatWindowProps } from "./chat/session-chat-projection.js";
 import { getWithMateApi, isDesktopRuntime } from "./renderer-withmate-api.js";
 import { resolveOpenPathFeedback, showOpenPathFeedback } from "./open-path-result.js";
@@ -448,10 +468,21 @@ function buildLiveRunScrollSignature(liveRun: LiveSessionRunState | null): strin
 export default function AgentSessionWindowApp() {
   const desktopRuntime = isDesktopRuntime();
   const withmateApi = getWithMateApi();
-  const [sessions, setSessions] = useState<Session[]>([]);
+  const [sessions, setSessionsBase] = useState<Session[]>([]);
+  const sessionMutationRevisionRef = useRef(new StateMutationRevision());
+  const sessionProjectionRevisionRef = useRef(new StateMutationRevision());
+  const setAuthoritativeSessions = useCallback((update: SetStateAction<Session[]>) => {
+    sessionMutationRevisionRef.current.advance();
+    setSessionsBase(update);
+  }, []);
+  const setSessionProjection = useCallback((update: SetStateAction<Session[]>) => {
+    sessionProjectionRevisionRef.current.advance();
+    setSessionsBase(update);
+  }, []);
   const [companionSessions, setCompanionSessions] = useState<CompanionSessionSummary[]>([]);
   const [openCompanionReviewWindowIds, setOpenCompanionReviewWindowIds] = useState<string[]>([]);
   const [draft, setDraft] = useState("");
+  const [pendingSubmitSessionId, setPendingSubmitSessionId] = useState<string | null>(null);
   const [forceComposerBlockedFeedback, setForceComposerBlockedFeedback] = useState(false);
   const [modelCatalog, setModelCatalog] = useState<ModelCatalogSnapshot | null>(null);
   const [titleDraft, setTitleDraft] = useState("");
@@ -476,7 +507,12 @@ export default function AgentSessionWindowApp() {
   const [fileRootDiffLoadingScope, setFileRootDiffLoadingScope] = useState<FileRootGitChangeScope | null>(null);
   const [previewChatActivity, setPreviewChatActivity] = useState(() => endPreviewChatActivity());
   const [inlinePathFeedback, setInlinePathFeedback] = useState("");
-  const [liveRunState, setLiveRunState] = useState<OwnedLiveSessionRunState>({ ownerSessionId: null, state: null });
+  const [liveRunState, setLiveRunStateBase] = useState<OwnedLiveSessionRunState>({ ownerSessionId: null, state: null });
+  const liveRunRevisionRef = useRef(0);
+  const setLiveRunState = useCallback((update: SetStateAction<OwnedLiveSessionRunState>) => {
+    liveRunRevisionRef.current += 1;
+    setLiveRunStateBase(update);
+  }, []);
   const [liveAssistantBridge, setLiveAssistantBridge] = useState<LiveAssistantProjection | null>(null);
   const [providerQuotaTelemetryState, setProviderQuotaTelemetryState] = useState<ProviderOwnedQuotaTelemetry>({
     ownerProviderId: null,
@@ -557,6 +593,8 @@ export default function AgentSessionWindowApp() {
   const mainComposerCaretRef = useRef(0);
   const promptTemplateSelectionRef = useRef({ start: 0, end: 0 });
   const fileRootDiffRequestRevisionRef = useRef(0);
+  const sessionRefetchRevisionRef = useRef(new LatestRequestRevision());
+  const sessionSubmitCoordinatorRef = useRef(new SessionSubmitCoordinator());
   const selectedId = useMemo(() => getSessionIdFromLocation(), []);
 
   useEffect(() => {
@@ -569,20 +607,63 @@ export default function AgentSessionWindowApp() {
     }
 
     if (!selectedId) {
-      setSessions([]);
+      setAuthoritativeSessions([]);
       return () => {
         active = false;
       };
     }
 
     const hydrateSelectedSession = () => {
-      void withmateApi.getSession(selectedId).then((session) => {
-        if (!active) {
-          return;
-        }
-
-        setSessions(session ? [session] : []);
+      const requestRevision = sessionRefetchRevisionRef.current.start();
+      const mutationRevision = sessionMutationRevisionRef.current.capture();
+      const projectionRevision = sessionProjectionRevisionRef.current.capture();
+      withmateApi.reportRendererLog({
+        level: "info",
+        kind: "renderer.session-refetch.started",
+        message: "Session refetch started",
+        data: { sessionId: selectedId },
       });
+      void withmateApi.getSession(selectedId)
+        .then((session) => {
+          if (
+            !active
+            || !sessionRefetchRevisionRef.current.isCurrent(requestRevision)
+            || !sessionMutationRevisionRef.current.isCurrent(mutationRevision)
+          ) {
+            return;
+          }
+
+          setAuthoritativeSessions((current) => session
+            ? [mergeRefetchedSessionProjection(
+              current.find((candidate) => candidate.id === session.id) ?? null,
+              session,
+              !sessionProjectionRevisionRef.current.isCurrent(projectionRevision),
+            )]
+            : []);
+          withmateApi.reportRendererLog({
+            level: "info",
+            kind: "renderer.session-refetch.completed",
+            message: "Session refetch completed",
+            data: {
+              sessionId: selectedId,
+              found: !!session,
+              runState: session?.runState ?? null,
+              status: session?.status ?? null,
+            },
+          });
+        })
+        .catch((error) => {
+          withmateApi.reportRendererLog({
+            level: "error",
+            kind: "renderer.session-refetch.failed",
+            message: "Session refetch failed",
+            data: { sessionId: selectedId },
+            error: {
+              name: error instanceof Error ? error.name : "UnknownError",
+              message: error instanceof Error ? error.message : String(error),
+            },
+          });
+        });
     };
 
     hydrateSelectedSession();
@@ -599,7 +680,7 @@ export default function AgentSessionWindowApp() {
       active = false;
       unsubscribe();
     };
-  }, [selectedId, withmateApi]);
+  }, [selectedId, setAuthoritativeSessions, withmateApi]);
 
   useEffect(() => {
     return startCompanionSessionSummariesSubscription({
@@ -1031,7 +1112,9 @@ export default function AgentSessionWindowApp() {
 
     return "";
   }, [isSelectedProviderEnabled, isSelectedSessionReadOnly, selectedSession]);
-  const composerBlockedReason = sessionExecutionBlockedReason;
+  const composerBlockedReason = pendingSubmitSessionId === selectedSession?.id
+    ? "送信処理を開始しているよ。少し待ってね。"
+    : sessionExecutionBlockedReason;
 
   useEffect(() => {
     if (!selectedSession || isEditingTitle) {
@@ -1942,14 +2025,31 @@ export default function AgentSessionWindowApp() {
     setForceComposerBlockedFeedback(true);
   };
 
-  const sendMessage = async (messageText: string, options?: { clearDraft?: boolean; collapseActionDock?: boolean }) => {
+  const sendMessage = async (
+    messageText: string,
+    options?: { clearDraft?: boolean; collapseActionDock?: boolean; submitSource?: "composer" | "retry" },
+  ) => {
     if (!withmateApi || !selectedSession) {
       return;
     }
 
+    const sessionId = selectedSession.id;
+    const submitLease = sessionSubmitCoordinatorRef.current.tryAcquire(sessionId);
+    if (!submitLease) {
+      setForceComposerBlockedFeedback(true);
+      return;
+    }
+    setPendingSubmitSessionId(sessionId);
+
+    const clientRequestId = createSessionTurnClientRequestId();
+    const draftFingerprint = fingerprintSessionDraft(messageText);
+
     const investigationStartedAt = Date.now();
     logSessionRunStuckInvestigation("renderer.send.start", {
-      sessionId: selectedSession.id,
+      sessionId,
+      clientRequestId,
+      submitSource: options?.submitSource ?? "composer",
+      draftFingerprint,
       runState: selectedSession.runState,
       status: selectedSession.status,
       messageCount: selectedSession.messages.length,
@@ -1957,107 +2057,163 @@ export default function AgentSessionWindowApp() {
       draftChars: messageText.length,
     });
 
-    if (composerBlockedReason) {
-      setForceComposerBlockedFeedback(true);
-      return;
-    }
-
-    if (isSelectedSessionReadOnly) {
-      setForceComposerBlockedFeedback(true);
-      return;
-    }
-
-    const previewRequest = createComposerPreviewRequest({
-      api: withmateApi,
-      mode: "session",
-      sessionId: selectedSession.id,
-    });
-    if (!previewRequest) {
-      return;
-    }
-
-    const nextMessage = messageText.trim();
-    const preview = await previewRequest(messageText);
-    const displayPreview = resolveComposerPreviewDisplay(preview, appSettings.userMicrocopyCatalog);
-    logSessionRunStuckInvestigation("renderer.composer-preview.done", {
-      sessionId: selectedSession.id,
-      elapsedMs: Date.now() - investigationStartedAt,
-      attachmentCount: preview.attachments.length,
-      errorCount: preview.errors.length,
-    });
-    setComposerPreview(displayPreview);
-    const { blockedMessage } = resolveComposerSendPreflight({
-      runState: selectedSessionRunState,
-      blockedReason: composerBlockedReason,
-      inputErrors: displayPreview.errors,
-      draftText: messageText,
-    });
-    if (blockedMessage) {
-      setForceComposerBlockedFeedback(true);
-      return;
-    }
-
-    if (options?.collapseActionDock) {
-      setIsActionDockPinnedExpanded(false);
-    }
-    if (options?.clearDraft ?? true) {
-      applyComposerDraftClearCommand({
-        setDraft,
-      });
-    }
-    const updatedSession = applyOptimisticSessionRunUpdate({
-      session: selectedSession,
-      userMessage: nextMessage,
-      updatedAt: currentTimestampLabel(),
-      status: "running",
-      updateLiveRunState: (update) => setLiveRunState(update),
-      applyRunningSession: (runningSession) => setSessions([runningSession]),
-    });
-    if (isCentralPreviewActive) {
-      setPreviewChatActivity((current) => acknowledgePreviewChatMessageCount(
-        current,
-        updatedSession.id,
-        updatedSession.messages.length,
-      ));
-    }
-    logSessionRunStuckInvestigation("renderer.optimistic-running-applied", {
-      sessionId: updatedSession.id,
-      elapsedMs: Date.now() - investigationStartedAt,
-      messageCount: updatedSession.messages.length,
-      runState: updatedSession.runState,
-      status: updatedSession.status,
-    });
-
     try {
-      const request: RunSessionTurnRequest = {
-        userMessage: messageText,
-      };
-      const savedSession = await withmateApi.runSessionTurn(selectedSession.id, request);
-      logSessionRunStuckInvestigation("renderer.run-session-turn.resolved", {
-        sessionId: savedSession.id,
+      if (sessionExecutionBlockedReason || isSelectedSessionReadOnly) {
+        setForceComposerBlockedFeedback(true);
+        return;
+      }
+
+      const previewRequest = createComposerPreviewRequest({
+        api: withmateApi,
+        mode: "session",
+        sessionId,
+      });
+      if (!previewRequest) {
+        return;
+      }
+
+      const nextMessage = messageText.trim();
+      const preview = await previewRequest(messageText);
+      const displayPreview = resolveComposerPreviewDisplay(preview, appSettings.userMicrocopyCatalog);
+      logSessionRunStuckInvestigation("renderer.composer-preview.done", {
+        sessionId,
+        clientRequestId,
         elapsedMs: Date.now() - investigationStartedAt,
-        messageCount: savedSession.messages.length,
-        runState: savedSession.runState,
-        status: savedSession.status,
-        hasLiveRun: !!selectedSessionLiveRun,
+        attachmentCount: preview.attachments.length,
+        errorCount: preview.errors.length,
       });
-      applyResolvedSessionRunUpdate({
-        savedSession,
-        applySavedSession: (nextSession) => setSessions([nextSession]),
+      setComposerPreview(displayPreview);
+      const { blockedMessage } = resolveComposerSendPreflight({
+        runState: selectedSessionRunState,
+        blockedReason: sessionExecutionBlockedReason,
+        inputErrors: displayPreview.errors,
+        draftText: messageText,
       });
-    } catch (error) {
-      logSessionRunStuckInvestigation("renderer.run-session-turn.failed", {
+      if (blockedMessage) {
+        setForceComposerBlockedFeedback(true);
+        return;
+      }
+
+      if (options?.collapseActionDock) {
+        setIsActionDockPinnedExpanded(false);
+      }
+      const shouldClearDraft = options?.clearDraft ?? true;
+      if (shouldClearDraft) {
+        setDraft((current) => current === messageText ? "" : current);
+      }
+      const updatedSession = applyOptimisticSessionRunUpdate({
+        session: selectedSession,
+        userMessage: nextMessage,
+        updatedAt: currentTimestampLabel(),
+        status: "running",
+        updateLiveRunState: (update) => setLiveRunState(update),
+        applyRunningSession: (runningSession) => setAuthoritativeSessions([runningSession]),
+      });
+      const optimisticSessionMutationRevision = sessionMutationRevisionRef.current.capture();
+      const optimisticSessionProjectionRevision = sessionProjectionRevisionRef.current.capture();
+      const optimisticLiveRunRevision = liveRunRevisionRef.current;
+      if (isCentralPreviewActive) {
+        setPreviewChatActivity((current) => acknowledgePreviewChatMessageCount(
+          current,
+          updatedSession.id,
+          updatedSession.messages.length,
+        ));
+      }
+      logSessionRunStuckInvestigation("renderer.optimistic-running-applied", {
         sessionId: updatedSession.id,
+        clientRequestId,
         elapsedMs: Date.now() - investigationStartedAt,
         messageCount: updatedSession.messages.length,
-        errorMessage: error instanceof Error ? error.message : String(error),
+        runState: updatedSession.runState,
+        status: updatedSession.status,
       });
-      console.error(error);
-      rollbackOptimisticSessionRunUpdate({
-        sessionId: updatedSession.id,
-        updateLiveRunState: (update) => setLiveRunState(update),
-        restoreSession: () => setSessions([selectedSession]),
-      });
+
+      const request: RunSessionTurnRequest = {
+        userMessage: messageText,
+        clientRequestId,
+        submitSource: options?.submitSource ?? "composer",
+      };
+      try {
+        const savedSession = await withmateApi.runSessionTurn(sessionId, request);
+        logSessionRunStuckInvestigation("renderer.run-session-turn.resolved", {
+          sessionId: savedSession.id,
+          clientRequestId,
+          elapsedMs: Date.now() - investigationStartedAt,
+          messageCount: savedSession.messages.length,
+          runState: savedSession.runState,
+          status: savedSession.status,
+          hasLiveRun: !!selectedSessionLiveRun,
+        });
+        const preserveCurrentPin = !sessionProjectionRevisionRef.current.isCurrent(
+          optimisticSessionProjectionRevision,
+        );
+        setAuthoritativeSessions((current) => [convergeResolvedSessionProjection(
+          current.find((session) => session.id === savedSession.id) ?? null,
+          savedSession,
+          preserveCurrentPin,
+        )]);
+      } catch (error) {
+        logSessionRunStuckInvestigation("renderer.run-session-turn.failed", {
+          sessionId: updatedSession.id,
+          clientRequestId,
+          elapsedMs: Date.now() - investigationStartedAt,
+          messageCount: updatedSession.messages.length,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        });
+        console.error(error);
+        if (shouldClearDraft) {
+          setDraft((current) => mergeRejectedSessionDraft(messageText, current));
+        }
+
+        const [refreshedSessionResult, refreshedLiveRunResult] = await Promise.allSettled([
+          withmateApi.getSession(sessionId),
+          withmateApi.getLiveSessionRun(sessionId),
+        ]);
+        const canReplaceOptimisticBody = sessionMutationRevisionRef.current.isCurrent(
+          optimisticSessionMutationRevision,
+        );
+        const preserveCurrentPin = !sessionProjectionRevisionRef.current.isCurrent(
+          optimisticSessionProjectionRevision,
+        );
+        if (refreshedSessionResult.status === "fulfilled" && canReplaceOptimisticBody) {
+          setAuthoritativeSessions((current) => {
+            const currentSession = current.find((session) => session.id === sessionId) ?? null;
+            const converged = convergeRejectedSessionSnapshot(
+              currentSession,
+              updatedSession,
+              refreshedSessionResult.value,
+              true,
+              preserveCurrentPin,
+            );
+            return converged ? [converged] : [];
+          });
+        } else if (
+          canReplaceOptimisticBody
+          && (
+            refreshedLiveRunResult.status === "rejected"
+            || refreshedLiveRunResult.value === null
+          )
+        ) {
+          setAuthoritativeSessions((current) => {
+            const currentSession = current.find((session) => session.id === sessionId) ?? null;
+            const recovered = recoverRejectedSessionSnapshot(currentSession, updatedSession, true);
+            return recovered ? [recovered] : current;
+          });
+        }
+        if (liveRunRevisionRef.current === optimisticLiveRunRevision) {
+          setLiveRunState((current) => convergeRejectedLiveRunState(
+            current,
+            sessionId,
+            refreshedLiveRunResult.status === "fulfilled" ? refreshedLiveRunResult.value : null,
+            optimisticLiveRunRevision,
+            optimisticLiveRunRevision,
+          ));
+        }
+        throw error;
+      }
+    } finally {
+      submitLease.release();
+      setPendingSubmitSessionId((current) => current === sessionId ? null : current);
     }
   };
 
@@ -2088,6 +2244,7 @@ export default function AgentSessionWindowApp() {
       await sendMessage(draft, {
         clearDraft: true,
         collapseActionDock: appSettings.autoCollapseActionDockOnSend,
+        submitSource: "composer",
       });
     } catch (error) {
       window.alert(resolveSessionRunErrorMessage(error, "送信に失敗したよ。"));
@@ -2240,7 +2397,7 @@ export default function AgentSessionWindowApp() {
     }
 
     const savedSession = await withmateApi.updateSession(nextSession);
-    setSessions([savedSession]);
+    setAuthoritativeSessions([savedSession]);
     return savedSession;
   };
 
@@ -2254,7 +2411,7 @@ export default function AgentSessionWindowApp() {
         sessionId: selectedSession.id,
         isPinned: selectedSession.isPinned !== true,
       });
-      setSessions((current) => current.map((session) => (
+      setSessionProjection((current) => current.map((session) => (
         session.id === saved.id ? { ...session, isPinned: saved.isPinned } : session
       )));
     } catch (error) {
@@ -2505,7 +2662,7 @@ export default function AgentSessionWindowApp() {
     await runRetryResendCommand({
       isDisabled: !!composerBlockedReason || isSelectedSessionReadOnly,
       messageText: lastUserMessage?.text,
-      resendMessage: (messageText) => sendMessage(messageText, { clearDraft: false }),
+      resendMessage: (messageText) => sendMessage(messageText, { clearDraft: false, submitSource: "retry" }),
     });
   };
 

--- a/src/error-boundary.tsx
+++ b/src/error-boundary.tsx
@@ -57,6 +57,13 @@ export class WindowErrorBoundary extends Component<WindowErrorBoundaryProps, Win
   };
 
   private handleReload = () => {
+    getWithMateApi()?.reportRendererLog({
+      level: "warn",
+      kind: "renderer.reload-requested",
+      message: `${this.props.windowLabel} reload requested from error boundary`,
+      url: window.location.href,
+      data: { boundary: "window", windowLabel: this.props.windowLabel },
+    });
     window.location.reload();
   };
 

--- a/src/runtime-state.ts
+++ b/src/runtime-state.ts
@@ -347,11 +347,40 @@ export type ComposerPreview = {
 
 export type RunSessionTurnRequest = {
   userMessage: string;
+  clientRequestId?: string;
+  submitSource?: "composer" | "retry";
   model?: string;
   reasoningEffort?: ModelReasoningEffort;
   approvalMode?: ApprovalMode;
   codexSandboxMode?: CodexSandboxMode;
 };
+
+const SESSION_TURN_CLIENT_REQUEST_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function normalizeSessionTurnClientRequestId(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const normalized = value.trim();
+  return SESSION_TURN_CLIENT_REQUEST_ID_PATTERN.test(normalized) ? normalized : null;
+}
+
+export function normalizeSessionTurnSubmitSource(value: unknown): RunSessionTurnRequest["submitSource"] | null {
+  return value === "composer" || value === "retry" ? value : null;
+}
+
+export function normalizeSessionTurnCorrelation(
+  request: Partial<Pick<RunSessionTurnRequest, "userMessage" | "clientRequestId" | "submitSource">> | null | undefined,
+): { clientRequestId: string | null; submitSource: RunSessionTurnRequest["submitSource"] | null } {
+  const normalizedClientRequestId = normalizeSessionTurnClientRequestId(request?.clientRequestId);
+  const userMessage = typeof request?.userMessage === "string" ? request.userMessage.trim().toLocaleLowerCase() : "";
+  return {
+    clientRequestId: normalizedClientRequestId && !userMessage.includes(normalizedClientRequestId.toLocaleLowerCase())
+      ? normalizedClientRequestId
+      : null,
+    submitSource: normalizeSessionTurnSubmitSource(request?.submitSource),
+  };
+}
 
 export function makeDiffRows(
   rows: Array<[DiffRow["kind"], number | undefined, string | undefined, number | undefined, string | undefined]>,

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -1677,6 +1677,13 @@ export class SessionPaneErrorBoundary extends Component<
   };
 
   private handleReload = () => {
+    getWithMateApi()?.reportRendererLog({
+      level: "warn",
+      kind: "renderer.reload-requested",
+      message: "Session pane reload requested from error boundary",
+      url: window.location.href,
+      data: { boundary: "session-pane" },
+    });
     window.location.reload();
   };
 

--- a/src/session-submit-coordinator.ts
+++ b/src/session-submit-coordinator.ts
@@ -1,0 +1,164 @@
+import type { LiveSessionRunState } from "./runtime-state.js";
+import type { Session } from "./session-state.js";
+import type { OwnedLiveSessionRunState } from "./session-live-run-state.js";
+
+export type SessionSubmitLease = {
+  sessionId: string;
+  release(): void;
+};
+
+export class SessionSubmitCoordinator {
+  private readonly claims = new Map<string, symbol>();
+
+  tryAcquire(sessionId: string): SessionSubmitLease | null {
+    if (this.claims.has(sessionId)) {
+      return null;
+    }
+
+    const claim = Symbol(sessionId);
+    this.claims.set(sessionId, claim);
+    let released = false;
+    return {
+      sessionId,
+      release: () => {
+        if (released) {
+          return;
+        }
+        released = true;
+        if (this.claims.get(sessionId) === claim) {
+          this.claims.delete(sessionId);
+        }
+      },
+    };
+  }
+
+  isClaimed(sessionId: string): boolean {
+    return this.claims.has(sessionId);
+  }
+}
+
+export class LatestRequestRevision {
+  private revision = 0;
+
+  start(): number {
+    this.revision += 1;
+    return this.revision;
+  }
+
+  isCurrent(revision: number): boolean {
+    return revision === this.revision;
+  }
+}
+
+export class StateMutationRevision {
+  private revision = 0;
+
+  capture(): number {
+    return this.revision;
+  }
+
+  advance(): void {
+    this.revision += 1;
+  }
+
+  isCurrent(revision: number): boolean {
+    return revision === this.revision;
+  }
+}
+
+export function createSessionTurnClientRequestId(): string {
+  const randomUuid = globalThis.crypto?.randomUUID?.bind(globalThis.crypto);
+  if (randomUuid) {
+    return randomUuid();
+  }
+
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (token) => {
+    const random = Math.floor(Math.random() * 16);
+    const value = token === "x" ? random : (random & 0x3) | 0x8;
+    return value.toString(16);
+  });
+}
+
+export function fingerprintSessionDraft(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `${value.length}:${(hash >>> 0).toString(16).padStart(8, "0")}`;
+}
+
+export function mergeRejectedSessionDraft(submittedDraft: string, currentDraft: string): string {
+  if (!currentDraft.trim()) {
+    return submittedDraft;
+  }
+  if (currentDraft === submittedDraft) {
+    return currentDraft;
+  }
+  return `${submittedDraft}\n\n${currentDraft}`;
+}
+
+export function mergeRefetchedSessionProjection(
+  current: Session | null,
+  refreshed: Session,
+  preserveCurrentPin: boolean,
+): Session {
+  return preserveCurrentPin && current?.id === refreshed.id
+    ? { ...refreshed, isPinned: current.isPinned }
+    : refreshed;
+}
+
+export function convergeResolvedSessionProjection(
+  current: Session | null,
+  saved: Session,
+  preserveCurrentPin: boolean,
+): Session {
+  return mergeRefetchedSessionProjection(current, saved, preserveCurrentPin);
+}
+
+export function recoverRejectedSessionSnapshot(
+  current: Session | null,
+  optimistic: Session,
+  canReplaceOptimisticBody: boolean,
+): Session | null {
+  if (!canReplaceOptimisticBody || !current || current.id !== optimistic.id) {
+    return current;
+  }
+  return {
+    ...optimistic,
+    isPinned: current.isPinned,
+    status: "idle",
+    runState: "error",
+  };
+}
+
+export function convergeRejectedSessionSnapshot(
+  current: Session | null,
+  optimistic: Session,
+  refreshed: Session | null,
+  canReplaceOptimisticBody: boolean,
+  preserveCurrentPin: boolean,
+): Session | null {
+  if (!canReplaceOptimisticBody || !current || current.id !== optimistic.id) {
+    return current;
+  }
+  return refreshed
+    ? mergeRefetchedSessionProjection(current, refreshed, preserveCurrentPin)
+    : null;
+}
+
+export function convergeRejectedLiveRunState(
+  current: OwnedLiveSessionRunState,
+  sessionId: string,
+  refreshed: LiveSessionRunState | null,
+  optimisticRevision: number,
+  currentRevision: number,
+): OwnedLiveSessionRunState {
+  if (current.ownerSessionId !== sessionId || currentRevision !== optimisticRevision) {
+    return current;
+  }
+  return {
+    ownerSessionId: sessionId,
+    state: refreshed,
+  };
+}


### PR DESCRIPTION
## 概要

Session送信開始時の二重dispatchをrendererの同期latchで防ぎ、拒否時のdraft保持と最新stateへの収束を追加します。

## 変更内容

- preview前にsession単位の同期latchを取得し、rapid submitを一件だけ通す
- `runSessionTurn`拒否時にdraftを保持し、古いsnapshotへrollbackせず最新Session/live stateへ収束する
- session本体とpin projectionのrevisionを分離し、refetch・成功応答・失敗復旧で最新pinを保持する
- main側のrunning/retry/terminal保存で、実行中に変更されたpinをSQLiteへ維持する
- renderer/main/runtime間のrequest correlationを追加し、minimal/degraded auditでも保持する
- reload/navigation/refetchの調査ログを追加する

## 検証

- targeted tests: 124 passed
- `npm test`: 2381 passed / 1 skipped / 0 failed
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- 分離userDataによるrenderer smoke起動
- contract-closure targeted review: approve

Closes #290