### PR TITLE
fix(session): チャット末尾への追随を安定化する

### DIFF
--- a/scripts/tests/session-chat-layout-hooks.test.tsx
+++ b/scripts/tests/session-chat-layout-hooks.test.tsx
@@ -460,8 +460,10 @@ test("useSessionMessageListFollowing は末尾表示中だけ更新とresizeへ�
       messageList.dispatchEvent(new dom.window.WheelEvent("wheel", { bubbles: true, deltaY: -120 }));
       messageList.scrollTop -= 2;
       messageList.dispatchEvent(new dom.window.Event("scroll", { bubbles: true }));
+      await new Promise<void>((resolve) => dom.window.requestAnimationFrame(() => resolve()));
     });
     assert.equal(following.textContent, "false");
+    assert.equal(messageList.scrollTop, 798, "停止後は予約済みの末尾補正でも読書位置を動かさない");
 
     await act(async () => {
       root?.render(React.createElement(Harness, { enabled: true, scrollSignature: "stream-while-reading" }));

--- a/scripts/tests/session-chat-layout-hooks.test.tsx
+++ b/scripts/tests/session-chat-layout-hooks.test.tsx
@@ -312,7 +312,7 @@ test("ActionDock compact height は展開時の外枠高ではなく compact row
   }
 });
 
-test("useSessionMessageListFollowing は上方向scrollで追従を止め、非表示からの復帰時に戻す", async () => {
+test("useSessionMessageListFollowing は末尾表示中だけ更新とresizeへ追従する", async () => {
   const previousActEnvironment = (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
     .IS_REACT_ACT_ENVIRONMENT;
   const previousWindow = globalThis.window;
@@ -320,6 +320,7 @@ test("useSessionMessageListFollowing は上方向scrollで追従を止め、非�
   const previousHTMLElement = globalThis.HTMLElement;
   const previousNode = globalThis.Node;
   const previousNavigator = globalThis.navigator;
+  const previousResizeObserver = globalThis.ResizeObserver;
   const dom = new JSDOM("<!doctype html><html><body><div id=\"root\"></div></body></html>", {
     pretendToBeVisual: true,
   });
@@ -332,12 +333,45 @@ test("useSessionMessageListFollowing は上方向scrollで追従を止め、非�
 
   let root: Root | null = null;
   let scrollToBottomCount = 0;
+  let scrollHeight = 1_000;
+  let clientHeight = 200;
+  const resizeObservers: TestResizeObserver[] = [];
+
+  class TestResizeObserver {
+    readonly targets = new Set<Element>();
+
+    constructor(readonly callback: ResizeObserverCallback) {
+      resizeObservers.push(this);
+    }
+
+    observe(target: Element): void {
+      this.targets.add(target);
+    }
+
+    disconnect(): void {
+      this.targets.clear();
+    }
+
+    unobserve(target: Element): void {
+      this.targets.delete(target);
+    }
+  }
+
+  Object.defineProperty(globalThis, "ResizeObserver", {
+    configurable: true,
+    value: TestResizeObserver,
+  });
+  Object.defineProperty(dom.window, "ResizeObserver", {
+    configurable: true,
+    value: TestResizeObserver,
+  });
 
   function Harness({ enabled, scrollSignature }: { enabled: boolean; scrollSignature: string }) {
     const {
       messageListRef,
       isMessageListFollowing,
       handleMessageListScroll,
+      followMessageListLatest,
     } = useSessionMessageListFollowing({
       ownerKey: "session-1",
       scrollSignature,
@@ -345,24 +379,47 @@ test("useSessionMessageListFollowing は上方向scrollで追従を止め、非�
     });
 
     return React.createElement(
-      "div",
-      {
-        ref: messageListRef,
-        onScroll: handleMessageListScroll,
-        hidden: !enabled,
-        "data-testid": "message-list",
-      },
-      React.createElement("div", {
-        className: "message-list-bottom-anchor",
-        ref: (element: HTMLDivElement | null) => {
-          if (element) {
-            element.scrollIntoView = () => {
-              scrollToBottomCount += 1;
-            };
-          }
+      React.Fragment,
+      null,
+      React.createElement(
+        "div",
+        {
+          ref: messageListRef,
+          onScroll: handleMessageListScroll,
+          hidden: !enabled,
+          "data-testid": "message-list",
         },
-      }),
-      React.createElement("output", { "data-testid": "following" }, String(isMessageListFollowing)),
+        React.createElement("div", {
+          className: "session-message-list-window",
+        }, React.createElement("div", {
+          className: "message-list-bottom-anchor",
+          ref: (element: HTMLDivElement | null) => {
+            if (element) {
+              element.scrollIntoView = () => {
+                scrollToBottomCount += 1;
+                const owner = element.closest<HTMLElement>("[data-testid=\"message-list\"]");
+                if (owner) {
+                  owner.scrollTop = Math.max(0, owner.scrollHeight - owner.clientHeight);
+                }
+              };
+            }
+          },
+        })),
+        React.createElement("input", { "data-testid": "elicitation-input" }),
+        React.createElement("textarea", { "data-testid": "elicitation-textarea" }),
+        React.createElement(
+          "select",
+          { "data-testid": "elicitation-select" },
+          React.createElement("option", null, "option"),
+        ),
+        React.createElement("output", { "data-testid": "following" }, String(isMessageListFollowing)),
+        React.createElement("button", {
+          type: "button",
+          onClick: followMessageListLatest,
+          "data-testid": "jump",
+        }),
+      ),
+      React.createElement("button", { type: "button", "data-testid": "outside-action" }),
     );
   }
 
@@ -378,71 +435,122 @@ test("useSessionMessageListFollowing は上方向scrollで追従を止め、非�
     assert.ok(following);
     assert.equal(scrollToBottomCount, 1);
 
-    Object.defineProperty(messageList, "scrollHeight", { configurable: true, value: 1_000 });
-    Object.defineProperty(messageList, "clientHeight", { configurable: true, value: 200 });
+    Object.defineProperty(messageList, "scrollHeight", { configurable: true, get: () => scrollHeight });
+    Object.defineProperty(messageList, "clientHeight", { configurable: true, get: () => clientHeight });
+    messageList.scrollTop = scrollHeight - clientHeight;
+    messageList.addEventListener("keydown", (event) => event.stopPropagation());
+    for (const [testId, key, shiftKey] of [
+      ["elicitation-input", "ArrowUp", false],
+      ["elicitation-textarea", "Home", false],
+      ["elicitation-select", " ", true],
+    ] as const) {
+      const formControl = dom.window.document.querySelector<HTMLElement>(`[data-testid="${testId}"]`);
+      assert.ok(formControl);
+      await act(async () => {
+        formControl.dispatchEvent(new dom.window.KeyboardEvent("keydown", {
+          bubbles: true,
+          key,
+          shiftKey,
+        }));
+      });
+      assert.equal(following.textContent, "true", `${key} のフォーム操作では追従を止めない`);
+    }
+
     await act(async () => {
       messageList.dispatchEvent(new dom.window.WheelEvent("wheel", { bubbles: true, deltaY: -120 }));
-      messageList.scrollTop = 800;
-      messageList.dispatchEvent(new dom.window.Event("scroll", { bubbles: true }));
-      messageList.scrollTop = 760;
+      messageList.scrollTop -= 2;
       messageList.dispatchEvent(new dom.window.Event("scroll", { bubbles: true }));
     });
     assert.equal(following.textContent, "false");
 
     await act(async () => {
-      messageList.scrollTop = 780;
+      root?.render(React.createElement(Harness, { enabled: true, scrollSignature: "stream-while-reading" }));
+    });
+    assert.equal(messageList.scrollTop, 798, "stream更新で読書位置を動かさない");
+
+    const outsideAction = dom.window.document.querySelector<HTMLButtonElement>(
+      "[data-testid=\"outside-action\"]",
+    );
+    assert.ok(outsideAction);
+    await act(async () => {
+      const pointerDown = new dom.window.Event("pointerdown", { bubbles: true });
+      Object.defineProperty(pointerDown, "pointerId", { value: 7 });
+      outsideAction.dispatchEvent(pointerDown);
+      const pointerUp = new dom.window.Event("pointerup");
+      Object.defineProperty(pointerUp, "pointerId", { value: 7 });
+      dom.window.dispatchEvent(pointerUp);
+      messageList.scrollTop = scrollHeight - clientHeight;
       messageList.dispatchEvent(new dom.window.Event("scroll", { bubbles: true }));
     });
-    assert.equal(
-      following.textContent,
-      "false",
-      "上方向wheel中のrow計測補正を末尾へ戻るuser intentとして扱わない",
-    );
+    assert.equal(following.textContent, "false", "message list外のpointer操作では追従を再開しない");
 
     await act(async () => {
-      root?.render(React.createElement(Harness, { enabled: true, scrollSignature: "while-reading" }));
+      const pointerDown = new dom.window.Event("pointerdown", { bubbles: true });
+      Object.defineProperty(pointerDown, "pointerId", { value: 8 });
+      messageList.dispatchEvent(pointerDown);
+      const pointerUp = new dom.window.Event("pointerup");
+      Object.defineProperty(pointerUp, "pointerId", { value: 8 });
+      dom.window.dispatchEvent(pointerUp);
+      messageList.dispatchEvent(new dom.window.Event("scroll", { bubbles: true }));
     });
-    assert.equal(scrollToBottomCount, 1);
+    assert.equal(following.textContent, "true", "message list内で開始したpointer操作は追従を再開できる");
+
+    await act(async () => {
+      messageList.dispatchEvent(new dom.window.WheelEvent("wheel", { bubbles: true, deltaY: -120 }));
+      messageList.scrollTop = scrollHeight - clientHeight - 2;
+      messageList.dispatchEvent(new dom.window.Event("scroll", { bubbles: true }));
+    });
+    assert.equal(following.textContent, "false");
 
     await act(async () => {
       messageList.dispatchEvent(new dom.window.WheelEvent("wheel", { bubbles: true, deltaY: 120 }));
-      messageList.scrollTop = 780;
+      messageList.scrollTop = scrollHeight - clientHeight - 1;
       messageList.dispatchEvent(new dom.window.Event("scroll", { bubbles: true }));
     });
-    assert.equal(following.textContent, "true");
+    assert.equal(following.textContent, "true", "1pxのlayout誤差は末尾として許容する");
 
-    Object.defineProperty(messageList, "scrollHeight", { configurable: true, value: 900 });
+    scrollHeight = 1_120;
     await act(async () => {
-      messageList.scrollTop = 680;
-      messageList.dispatchEvent(new dom.window.Event("scroll", { bubbles: true }));
+      root?.render(React.createElement(Harness, { enabled: true, scrollSignature: "stream-growing" }));
     });
-    assert.equal(
-      following.textContent,
-      "true",
-      "上側rowの縮小補正でbottom gapが変わらない場合は末尾追従を維持する",
-    );
+    assert.equal(messageList.scrollTop, 920, "stream本文の伸長へ追従する");
 
+    scrollHeight = 1_260;
     await act(async () => {
-      root?.render(React.createElement(Harness, { enabled: true, scrollSignature: "at-bottom-update" }));
+      for (const observer of resizeObservers) {
+        observer.callback([], observer as unknown as ResizeObserver);
+      }
     });
-    assert.equal(scrollToBottomCount, 2);
+    assert.equal(messageList.scrollTop, 1_060, "message高さの非同期変化へ追従する");
+
+    clientHeight = 140;
+    await act(async () => {
+      for (const observer of resizeObservers) {
+        observer.callback([], observer as unknown as ResizeObserver);
+      }
+    });
+    assert.equal(messageList.scrollTop, 1_120, "ActionDock resize後のviewport末尾へ追従する");
 
     await act(async () => {
-      messageList.scrollTop = 300;
+      messageList.scrollTop = scrollHeight - clientHeight - 2;
       messageList.dispatchEvent(new dom.window.Event("scroll", { bubbles: true }));
     });
     assert.equal(following.textContent, "false");
+
+    await act(async () => {
+      dom.window.document.querySelector<HTMLButtonElement>("[data-testid=\"jump\"]")?.click();
+    });
+    assert.equal(following.textContent, "true");
+    assert.equal(messageList.scrollTop, scrollHeight - clientHeight);
 
     await act(async () => {
       root?.render(React.createElement(Harness, { enabled: false, scrollSignature: "preview-update" }));
     });
-    assert.equal(scrollToBottomCount, 2);
-
     await act(async () => {
       root?.render(React.createElement(Harness, { enabled: true, scrollSignature: "preview-update" }));
     });
-    assert.equal(scrollToBottomCount, 3);
     assert.equal(following.textContent, "true");
+    assert.equal(messageList.scrollTop, scrollHeight - clientHeight);
   } finally {
     await act(async () => root?.unmount());
     dom.window.close();
@@ -451,6 +559,10 @@ test("useSessionMessageListFollowing は上方向scrollで追従を止め、非�
     Object.defineProperty(globalThis, "HTMLElement", { configurable: true, value: previousHTMLElement });
     Object.defineProperty(globalThis, "Node", { configurable: true, value: previousNode });
     Object.defineProperty(globalThis, "navigator", { configurable: true, value: previousNavigator });
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      value: previousResizeObserver,
+    });
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
       previousActEnvironment;
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1460,7 +1460,7 @@ export default function AgentSessionWindowApp() {
     messageListRef,
     isMessageListFollowing,
     handleMessageListScroll,
-    handleJumpToMessageListBottom,
+    followMessageListLatest,
   } = useSessionMessageListFollowing({
     ownerKey: activeRunSessionId,
     scrollSignature: messageListScrollSignature,
@@ -3763,7 +3763,7 @@ export default function AgentSessionWindowApp() {
         onOpenPromptTemplates: handleOpenPromptTemplates,
         onAddAdditionalDirectory: () => void (activeAuxiliarySession ? handleAddAuxiliaryAdditionalDirectory() : handleAddAdditionalDirectory()),
         onToggleAdditionalDirectoryList: handleToggleAdditionalDirectoryList,
-        onJumpToMessageListBottom: handleJumpToMessageListBottom,
+        onJumpToMessageListBottom: followMessageListLatest,
         onSelectCustomAgent: (value) => {
           const agent = value ? availableCustomAgents.find((entry) => entry.name === value) ?? null : null;
           if (activeAuxiliarySession) {

--- a/src/CompanionReviewApp.tsx
+++ b/src/CompanionReviewApp.tsx
@@ -1233,7 +1233,7 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
     messageListRef,
     isMessageListFollowing,
     handleMessageListScroll,
-    handleJumpToMessageListBottom,
+    followMessageListLatest,
   } = useSessionMessageListFollowing({
     ownerKey: activeRunSessionId,
     scrollSignature: companionMessageListScrollSignature,
@@ -3165,7 +3165,7 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
         onToggleSkillPicker: handleToggleSkillPicker,
         onAddAdditionalDirectory: () => void (activeAuxiliarySession ? handleAddAuxiliaryAdditionalDirectory() : handleAddAdditionalDirectory()),
         onToggleAdditionalDirectoryList: handleToggleAdditionalDirectoryList,
-        onJumpToMessageListBottom: handleJumpToMessageListBottom,
+        onJumpToMessageListBottom: followMessageListLatest,
         onSelectCustomAgent: (value) => {
           const agent = value ? availableCustomAgents.find((entry) => entry.name === value) ?? null : null;
           if (activeAuxiliarySession) {

--- a/src/session-chat-layout-hooks.ts
+++ b/src/session-chat-layout-hooks.ts
@@ -31,10 +31,7 @@ const SESSION_ACTION_DOCK_MAX_HEIGHT_RATIO = 0.4;
 const SESSION_CENTRAL_SURFACE_MIN_HEIGHT = 280;
 const SESSION_VERTICAL_SPLITTER_TOTAL_HEIGHT = 40;
 const SESSION_MESSAGE_BOTTOM_EPSILON = 1;
-// ResizeObserver corrections can emit scroll events after a wheel event, but before the virtualizer settles.
-const SESSION_MESSAGE_WHEEL_INTENT_SETTLE_MS = 180;
-
-type SessionMessageWheelIntent = "toward-history" | "toward-bottom" | null;
+const SESSION_MESSAGE_SCROLL_INTENT_SETTLE_MS = 180;
 
 function scrollMessageListElementToBottom(messageListElement: HTMLDivElement): void {
   const bottomAnchor = messageListElement.querySelector<HTMLElement>(".message-list-bottom-anchor");
@@ -424,22 +421,23 @@ export type UseSessionMessageListFollowingArgs = {
   ownerKey: string | null;
   scrollSignature: string;
   enabled?: boolean;
-  bottomThreshold?: number;
+  bottomTolerance?: number;
 };
 
 export function useSessionMessageListFollowing({
   ownerKey,
   scrollSignature,
   enabled = true,
-  bottomThreshold = 80,
+  bottomTolerance = SESSION_MESSAGE_BOTTOM_EPSILON,
 }: UseSessionMessageListFollowingArgs) {
   const messageListRef = useRef<HTMLDivElement | null>(null);
   const messageListSignatureRef = useRef("");
   const messageListOwnerKeyRef = useRef<string | null>(null);
   const messageListEnabledRef = useRef(enabled);
-  const previousMessageListBottomGapRef = useRef<number | null>(null);
-  const messageListWheelIntentRef = useRef<SessionMessageWheelIntent>(null);
-  const messageListWheelIntentTimerRef = useRef<number | null>(null);
+  const isMessageListFollowingRef = useRef(true);
+  const canResumeMessageListFollowingRef = useRef(false);
+  const messageListScrollIntentTimerRef = useRef<number | null>(null);
+  const messageListPointerIdRef = useRef<number | null>(null);
   const [isMessageListFollowing, setIsMessageListFollowing] = useState(true);
 
   useLayoutEffect(() => {
@@ -449,33 +447,83 @@ export function useSessionMessageListFollowing({
       return;
     }
 
-    const clearWheelIntentTimer = () => {
-      if (messageListWheelIntentTimerRef.current !== null) {
-        ownerWindow.clearTimeout(messageListWheelIntentTimerRef.current);
-        messageListWheelIntentTimerRef.current = null;
+    const clearScrollIntentTimer = () => {
+      if (messageListScrollIntentTimerRef.current !== null) {
+        ownerWindow.clearTimeout(messageListScrollIntentTimerRef.current);
+        messageListScrollIntentTimerRef.current = null;
       }
     };
+    const keepResumeIntentUntilScrollSettles = () => {
+      canResumeMessageListFollowingRef.current = true;
+      clearScrollIntentTimer();
+      messageListScrollIntentTimerRef.current = ownerWindow.setTimeout(() => {
+        canResumeMessageListFollowingRef.current = false;
+        messageListScrollIntentTimerRef.current = null;
+      }, SESSION_MESSAGE_SCROLL_INTENT_SETTLE_MS);
+    };
     const handleWheel = (event: WheelEvent) => {
-      if (event.deltaY === 0) {
+      if (event.deltaY < 0) {
+        canResumeMessageListFollowingRef.current = false;
+        isMessageListFollowingRef.current = false;
+        setIsMessageListFollowing(false);
         return;
       }
-
-      messageListWheelIntentRef.current = event.deltaY < 0 ? "toward-history" : "toward-bottom";
-      if (event.deltaY < 0) {
-        setIsMessageListFollowing(false);
+      if (event.deltaY > 0) {
+        keepResumeIntentUntilScrollSettles();
       }
-      clearWheelIntentTimer();
-      messageListWheelIntentTimerRef.current = ownerWindow.setTimeout(() => {
-        messageListWheelIntentRef.current = null;
-        messageListWheelIntentTimerRef.current = null;
-      }, SESSION_MESSAGE_WHEEL_INTENT_SETTLE_MS);
+    };
+    const handlePointerDown = (event: PointerEvent) => {
+      messageListPointerIdRef.current = event.pointerId;
+      canResumeMessageListFollowingRef.current = true;
+    };
+    const handlePointerEnd = (event: PointerEvent) => {
+      if (messageListPointerIdRef.current !== event.pointerId) {
+        return;
+      }
+      messageListPointerIdRef.current = null;
+      keepResumeIntentUntilScrollSettles();
+    };
+    const handlePointerCancel = (event: PointerEvent) => {
+      if (messageListPointerIdRef.current !== event.pointerId) {
+        return;
+      }
+      messageListPointerIdRef.current = null;
+      canResumeMessageListFollowingRef.current = false;
+      clearScrollIntentTimer();
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target;
+      if (
+        target instanceof ownerWindow.HTMLElement
+        && target.closest("input, textarea, select, [contenteditable]:not([contenteditable=\"false\"])")
+      ) {
+        return;
+      }
+      if (["ArrowUp", "PageUp", "Home"].includes(event.key) || (event.key === " " && event.shiftKey)) {
+        canResumeMessageListFollowingRef.current = false;
+        isMessageListFollowingRef.current = false;
+        setIsMessageListFollowing(false);
+        return;
+      }
+      if (["ArrowDown", "PageDown", "End"].includes(event.key) || event.key === " ") {
+        keepResumeIntentUntilScrollSettles();
+      }
     };
 
     messageListElement.addEventListener("wheel", handleWheel, { passive: true });
+    messageListElement.addEventListener("pointerdown", handlePointerDown, { passive: true });
+    ownerWindow.addEventListener("pointerup", handlePointerEnd, { passive: true });
+    ownerWindow.addEventListener("pointercancel", handlePointerCancel, { passive: true });
+    messageListElement.addEventListener("keydown", handleKeyDown);
     return () => {
       messageListElement.removeEventListener("wheel", handleWheel);
-      clearWheelIntentTimer();
-      messageListWheelIntentRef.current = null;
+      messageListElement.removeEventListener("pointerdown", handlePointerDown);
+      ownerWindow.removeEventListener("pointerup", handlePointerEnd);
+      ownerWindow.removeEventListener("pointercancel", handlePointerCancel);
+      messageListElement.removeEventListener("keydown", handleKeyDown);
+      clearScrollIntentTimer();
+      canResumeMessageListFollowingRef.current = false;
+      messageListPointerIdRef.current = null;
     };
   }, [enabled, ownerKey]);
 
@@ -486,11 +534,20 @@ export function useSessionMessageListFollowing({
     }
 
     scrollMessageListElementToBottom(messageListElement);
-    previousMessageListBottomGapRef.current = Math.max(
-      0,
-      messageListElement.scrollHeight - messageListElement.clientHeight - messageListElement.scrollTop,
-    );
   }, []);
+
+  const followMessageListLatest = useCallback(() => {
+    canResumeMessageListFollowingRef.current = false;
+    isMessageListFollowingRef.current = true;
+    setIsMessageListFollowing(true);
+    scrollMessageListToBottom();
+
+    const ownerWindow = messageListRef.current?.ownerDocument.defaultView;
+    if (!ownerWindow) {
+      return;
+    }
+    ownerWindow.requestAnimationFrame(scrollMessageListToBottom);
+  }, [scrollMessageListToBottom]);
 
   useLayoutEffect(() => {
     const currentSignature = scrollSignature;
@@ -502,8 +559,6 @@ export function useSessionMessageListFollowing({
     if (!enabled) {
       messageListOwnerKeyRef.current = ownerKey;
       messageListSignatureRef.current = currentSignature;
-      previousMessageListBottomGapRef.current = null;
-      messageListWheelIntentRef.current = null;
       return;
     }
 
@@ -511,30 +566,20 @@ export function useSessionMessageListFollowing({
     if (!messageListElement) {
       messageListOwnerKeyRef.current = ownerKey;
       messageListSignatureRef.current = currentSignature;
-      previousMessageListBottomGapRef.current = null;
-      messageListWheelIntentRef.current = null;
       return;
     }
 
     if (!wasEnabled) {
       messageListOwnerKeyRef.current = ownerKey;
       messageListSignatureRef.current = currentSignature;
-      previousMessageListBottomGapRef.current = Math.max(
-        0,
-        messageListElement.scrollHeight - messageListElement.clientHeight - messageListElement.scrollTop,
-      );
-      messageListWheelIntentRef.current = null;
-      setIsMessageListFollowing(true);
-      scrollMessageListToBottom();
+      followMessageListLatest();
       return;
     }
 
     if (!wasSameOwner) {
       messageListOwnerKeyRef.current = ownerKey;
       messageListSignatureRef.current = currentSignature;
-      messageListWheelIntentRef.current = null;
-      setIsMessageListFollowing(true);
-      scrollMessageListToBottom();
+      followMessageListLatest();
       return;
     }
 
@@ -544,10 +589,30 @@ export function useSessionMessageListFollowing({
 
     messageListSignatureRef.current = currentSignature;
 
-    if (isMessageListFollowing) {
+    if (isMessageListFollowingRef.current) {
       scrollMessageListToBottom();
     }
-  }, [enabled, isMessageListFollowing, ownerKey, scrollMessageListToBottom, scrollSignature]);
+  }, [enabled, followMessageListLatest, ownerKey, scrollMessageListToBottom, scrollSignature]);
+
+  useLayoutEffect(() => {
+    const messageListElement = messageListRef.current;
+    const ownerWindow = messageListElement?.ownerDocument.defaultView;
+    if (!enabled || !messageListElement || !ownerWindow?.ResizeObserver) {
+      return;
+    }
+
+    const observer = new ownerWindow.ResizeObserver(() => {
+      if (isMessageListFollowingRef.current) {
+        scrollMessageListToBottom();
+      }
+    });
+    observer.observe(messageListElement);
+    const messageListContent = messageListElement.querySelector<HTMLElement>(".session-message-list-window");
+    if (messageListContent) {
+      observer.observe(messageListContent);
+    }
+    return () => observer.disconnect();
+  }, [enabled, ownerKey, scrollMessageListToBottom, scrollSignature]);
 
   const handleMessageListScroll = useCallback(() => {
     const messageListElement = messageListRef.current;
@@ -558,35 +623,22 @@ export function useSessionMessageListFollowing({
     const currentScrollTop = messageListElement.scrollTop;
     const maxScrollTop = Math.max(0, messageListElement.scrollHeight - messageListElement.clientHeight);
     const bottomGap = Math.max(0, maxScrollTop - currentScrollTop);
-    const previousBottomGap = previousMessageListBottomGapRef.current ?? bottomGap;
-    previousMessageListBottomGapRef.current = bottomGap;
-    const isMovingAwayFromBottom = bottomGap > previousBottomGap + SESSION_MESSAGE_BOTTOM_EPSILON;
-    const isAtBottom = bottomGap <= SESSION_MESSAGE_BOTTOM_EPSILON;
-    const wheelIntent = messageListWheelIntentRef.current;
+    const isAtBottom = bottomGap <= bottomTolerance;
+    const nextFollowing = isAtBottom
+      ? isMessageListFollowingRef.current || canResumeMessageListFollowingRef.current
+      : false;
+    isMessageListFollowingRef.current = nextFollowing;
+    setIsMessageListFollowing((current) => current === nextFollowing ? current : nextFollowing);
+  }, [bottomTolerance]);
 
-    setIsMessageListFollowing((current) => {
-      if (wheelIntent === "toward-history") {
-        return false;
-      }
-      if (!current) {
-        return wheelIntent === "toward-bottom" ? bottomGap <= bottomThreshold : isAtBottom;
-      }
-      return isAtBottom || (!isMovingAwayFromBottom && bottomGap <= bottomThreshold);
-    });
-  }, [bottomThreshold]);
-
-  const handleJumpToMessageListBottom = useCallback(() => {
-    messageListWheelIntentRef.current = null;
-    setIsMessageListFollowing(true);
-    scrollMessageListToBottom();
-    window.requestAnimationFrame(scrollMessageListToBottom);
-  }, [scrollMessageListToBottom]);
+  const handleJumpToMessageListBottom = followMessageListLatest;
 
   return {
     messageListRef,
     isMessageListFollowing,
     handleMessageListScroll,
     handleJumpToMessageListBottom,
+    followMessageListLatest,
   };
 }
 

--- a/src/session-chat-layout-hooks.ts
+++ b/src/session-chat-layout-hooks.ts
@@ -546,7 +546,11 @@ export function useSessionMessageListFollowing({
     if (!ownerWindow) {
       return;
     }
-    ownerWindow.requestAnimationFrame(scrollMessageListToBottom);
+    ownerWindow.requestAnimationFrame(() => {
+      if (isMessageListFollowingRef.current) {
+        scrollMessageListToBottom();
+      }
+    });
   }, [scrollMessageListToBottom]);
 
   useLayoutEffect(() => {


### PR DESCRIPTION
## 概要

- 利用者が末尾を表示している間だけ、message追加・stream更新・message高さ変化・ActionDock resizeへ追随する
- 過去方向へのscroll後は追随を停止し、末尾方向の明示操作または「末尾へ移動」でのみ再開する
- 後続の送信時追随設定から接続できる `followMessageListLatest` APIをscroll ownerへ追加する
- Agent SessionとCompanionで同じscroll ownerを利用する

## 安全境界

- 長いassistant応答のavatar sticky配置は変更しない
- Session送信のlatch、draft保持、最新state収束、client request ID相関は変更しない
- Settings schema、保存、UIは追加しない
- フォーム要素内のscroll系キー操作を追随intentから除外する
- message list内で開始したpointer IDだけを追跡し、list外操作による意図しない追随再開を防ぐ

## 検証

- `npx tsx --test scripts/tests/session-chat-layout-hooks.test.tsx scripts/tests/session-message-column.test.ts`
- `npx tsx --test scripts/tests/message-avatar-position-style.test.ts scripts/tests/session-submit-coordinator.test.ts scripts/tests/session-app-render.test.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## Validation gap

分離profileで現行buildの起動までは確認したが、Windows操作helperのnative pipeが利用できず、実画面での追随・停止・再開操作は未確認。

Closes #282