### PR TITLE
fix(chat): エラー表示を共通領域へ移す

### DIFF
--- a/scripts/tests/app-settings-storage.test.ts
+++ b/scripts/tests/app-settings-storage.test.ts
@@ -12,6 +12,33 @@ import {
 import { AppSettingsStorage } from "../../src-electron/app-settings-storage.js";
 
 describe("AppSettingsStorage", () => {
+  it("保存済みの旧 path error 既定値を読み込み時に現在の既定値へ移行する", async () => {
+    const tempDirectory = await mkdtemp(path.join(os.tmpdir(), "withmate-app-settings-"));
+    const dbPath = path.join(tempDirectory, "withmate.db");
+
+    try {
+      const initialStorage = new AppSettingsStorage(dbPath);
+      initialStorage.close();
+
+      const legacyDatabase = new DatabaseSync(dbPath);
+      const legacyCatalog = createDefaultAppSettings().userMicrocopyCatalog;
+      legacyCatalog["composer.error.path_not_found"] = ["指定したパスが見つかりません: {path}"];
+      legacyDatabase
+        .prepare("UPDATE app_settings SET setting_value = ? WHERE setting_key = ?")
+        .run(JSON.stringify(legacyCatalog), "user_microcopy_catalog");
+      legacyDatabase.close();
+
+      const migratedStorage = new AppSettingsStorage(dbPath);
+      assert.deepEqual(
+        migratedStorage.getSettings().userMicrocopyCatalog["composer.error.path_not_found"],
+        ["Path not found: {path}"],
+      );
+      migratedStorage.close();
+    } finally {
+      await rm(tempDirectory, { recursive: true, force: true });
+    }
+  });
+
   it("legacy right pane visibility を canonical side pane へ一度だけ移行する", async () => {
     const tempDirectory = await mkdtemp(path.join(os.tmpdir(), "withmate-app-settings-"));
     const dbPath = path.join(tempDirectory, "withmate.db");

--- a/scripts/tests/chat-window.test.ts
+++ b/scripts/tests/chat-window.test.ts
@@ -96,6 +96,67 @@ test("ChatWindow は preview と compact ActionDock の間に recovery actions �
   assert.ok(html.indexOf("Retry Actions") < html.indexOf("session-action-dock-slot"));
 });
 
+test("ChatWindow は ActionDock の展開状態に依存しない共通エラー領域を描画する", () => {
+  const props = createChatWindowProps();
+  props.isActionDockExpanded = false;
+  props.composerProps = {
+    ...props.composerProps,
+    composerSendability: {
+      primaryFeedback: "Path not found: C:/missing",
+      secondaryFeedback: ["Expected a file: C:/directory"],
+      feedbackTone: "blocked",
+      shouldShowFeedback: true,
+    },
+  };
+  props.errorNotices = [{
+    id: "composer-sendability",
+    message: "Path not found: C:/missing",
+    details: ["Expected a file: C:/directory"],
+    relatedControl: "composer",
+  }];
+
+  const html = renderToStaticMarkup(React.createElement(ChatWindow, props));
+
+  assert.match(html, /class="chat-error-surface" role="region" aria-label="チャットエラー"/);
+  assert.match(html, /class="chat-error-notice" role="alert"/);
+  assert.match(html, /Path not found: C:\/missing/);
+  assert.match(html, /Expected a file: C:\/directory/);
+  assert.match(html, /<textarea[^>]*aria-describedby="[^"]+-notice-0"[^>]*aria-invalid="true"/);
+  assert.doesNotMatch(html, /class="composer-sendability-feedback blocked"/);
+  assert.match(html, /id="session-action-dock"[^>]*class="session-action-dock-slot is-compact"/);
+  assert.ok(html.indexOf("session-central-surface") < html.indexOf("chat-error-surface"));
+  assert.ok(html.indexOf("chat-error-surface") < html.indexOf("session-action-dock-slot"));
+});
+
+test("ChatWindow の共通エラー領域は owner が指定したdismissと回復操作を表示する", () => {
+  const props = createChatWindowProps();
+  props.errorNotices = [{
+    id: "workspace-unavailable",
+    message: "Workspaceを利用できません。",
+    dismissLabel: "Workspaceエラーを閉じる",
+    onDismiss: noop,
+    actionLabel: "再確認",
+    onAction: noop,
+  }];
+
+  const html = renderToStaticMarkup(React.createElement(ChatWindow, props));
+
+  assert.match(html, />再確認<\/button>/);
+  assert.match(html, /aria-label="Workspaceエラーを閉じる"/);
+});
+
+test("chat work surface は共通エラーの有無に関係なく中央contentへ可変領域を割り当てる", async () => {
+  const styles = await readFile(new URL("../../src/styles.css", import.meta.url), "utf8");
+  const stackRule = styles.match(/\.session-message-stack\s*\{([^}]*)\}/)?.[1] ?? "";
+  const errorRule = styles.match(/\.chat-error-surface\s*\{([^}]*)\}/)?.[1] ?? "";
+  const centralRule = styles.match(/\.session-central-surface\s*\{([^}]*)\}/)?.[1] ?? "";
+
+  assert.match(stackRule, /grid-template-rows:\s*minmax\(0, 1fr\) auto auto/);
+  assert.match(errorRule, /grid-row:\s*3/);
+  assert.match(errorRule, /padding:\s*0 12px 12px/);
+  assert.match(centralRule, /grid-row:\s*1/);
+});
+
 test("ChatWindow は preview を保持したまま Skill 候補を中央 work surface に重ねる", () => {
   const props = createChatWindowProps();
   props.mainContent = React.createElement("div", null, "File Preview");

--- a/scripts/tests/companion-chat-projection.test.ts
+++ b/scripts/tests/companion-chat-projection.test.ts
@@ -313,6 +313,26 @@ test("buildCompanionChatWindowProps は retry actions を共通 chat layout に�
   assert.match(html, />編集<\/button>/);
 });
 
+test("buildCompanionChatWindowProps は composer error を共通領域へ投影する", () => {
+  const props = buildCompanionChatWindowProps(createProjectionInput({
+    composerSendability: {
+      primaryFeedback: "Path not found: C:/missing",
+      secondaryFeedback: [],
+      feedbackTone: "blocked",
+      shouldShowFeedback: true,
+    },
+    isActionDockExpanded: false,
+  }));
+
+  assert.deepEqual(props.errorNotices, [{
+    id: "composer-sendability",
+    message: "Path not found: C:/missing",
+    details: [],
+    relatedControl: "composer",
+  }]);
+  assert.equal(props.isActionDockExpanded, false);
+});
+
 test("buildCompanionChatWindowProps は retry draft 上書き確認を共通 composer に渡す", () => {
   const props = buildCompanionChatWindowProps(createProjectionInput({
     retryBanner: {

--- a/scripts/tests/composer-preview-config.test.ts
+++ b/scripts/tests/composer-preview-config.test.ts
@@ -23,28 +23,28 @@ test("resolveComposerPreviewDisplay は存在しない @path エラーを microc
   const preview = resolveComposerPreviewDisplay(
     {
       attachments: [],
-      errors: ["@ のパスが見つからないよ: missing.txt"],
+      errors: ["Path not found: missing.txt"],
     },
     {
-      "composer.error.path_not_found": ["添付パスを確認してください: {path}"],
+      "composer.error.path_not_found": ["Missing attachment: {path}"],
     },
   );
 
-  assert.deepEqual(preview.errors, ["添付パスを確認してください: missing.txt"]);
+  assert.deepEqual(preview.errors, ["Missing attachment: missing.txt"]);
 });
 
 test("resolveComposerPreviewDisplay は未対応エラーをそのまま返す", () => {
   const preview = resolveComposerPreviewDisplay(
     {
       attachments: [],
-      errors: ["ワークスペース外のパスは追加ディレクトリで許可してから添付してね: ../secret.txt"],
+      errors: ["Path is outside the workspace. Add its directory before attaching: ../secret.txt"],
     },
     {
-      "composer.error.path_not_found": ["添付パスを確認してください: {path}"],
+      "composer.error.path_not_found": ["Missing attachment: {path}"],
     },
   );
 
   assert.deepEqual(preview.errors, [
-    "ワークスペース外のパスは追加ディレクトリで許可してから添付してね: ../secret.txt",
+    "Path is outside the workspace. Add its directory before attaching: ../secret.txt",
   ]);
 });

--- a/scripts/tests/microcopy-state.test.ts
+++ b/scripts/tests/microcopy-state.test.ts
@@ -29,6 +29,21 @@ describe("microcopy-state", () => {
     assert.equal("unknown" in catalog, false);
   });
 
+  it("normalizeUserMicrocopyCatalog は旧 path error 既定値だけを現在の既定値へ移行する", () => {
+    const migrated = normalizeUserMicrocopyCatalog({
+      "composer.error.path_not_found": ["指定したパスが見つかりません: {path}"],
+    });
+    const customized = normalizeUserMicrocopyCatalog({
+      "composer.error.path_not_found": ["Custom path error: {path}"],
+    });
+
+    assert.deepEqual(
+      migrated["composer.error.path_not_found"],
+      BUILT_IN_MICROCOPY_CATALOG["composer.error.path_not_found"],
+    );
+    assert.deepEqual(customized["composer.error.path_not_found"], ["Custom path error: {path}"]);
+  });
+
   it("resolveMicrocopy は同じ seed で安定して variant を選ぶ", () => {
     const userCatalog = normalizeUserMicrocopyCatalog({
       "chat.pending.response_waiting": ["A", "B", "C"],

--- a/scripts/tests/session-chat-projection.test.ts
+++ b/scripts/tests/session-chat-projection.test.ts
@@ -103,6 +103,7 @@ function createProjectionInput(overrides: Partial<AgentSessionChatProjectionInpu
     liveRunAssistantText: "",
     hasLiveRunAssistantText: false,
     liveRunErrorMessage: "",
+    inlinePathFeedback: "",
     isMessageListFollowing: true,
     retryBanner: null,
     isRetryActionDisabled: false,
@@ -197,6 +198,7 @@ function createProjectionInput(overrides: Partial<AgentSessionChatProjectionInpu
     onResolveLiveApproval: noop,
     onResolveLiveElicitation: noop,
     onOpenInlinePath: noop,
+    onDismissInlinePathFeedback: noop,
     getChangedFilesEmptyText: () => "ファイル変更はありません",
     onCopyMessageText: noop,
     onQuoteMessageText: noop,
@@ -293,6 +295,38 @@ test("buildAgentSessionChatWindowProps は retry actions を共通 chat layout �
   assert.match(html, /retry-banner failed/);
   assert.match(html, />再送<\/button>/);
   assert.match(html, />編集<\/button>/);
+});
+
+test("buildAgentSessionChatWindowProps は composer とpath操作のエラーを共通領域へ投影する", () => {
+  const onDismissInlinePathFeedback = () => {};
+  const props = buildAgentSessionChatWindowProps(createProjectionInput({
+    inlinePathFeedback: "The local path was not found.",
+    onDismissInlinePathFeedback,
+    composerSendability: {
+      primaryFeedback: "Path not found: C:/missing",
+      secondaryFeedback: ["C:/missing"],
+      feedbackTone: "blocked",
+      shouldShowFeedback: true,
+    },
+    isActionDockExpanded: false,
+  }));
+
+  assert.deepEqual(props.errorNotices, [
+    {
+      id: "composer-sendability",
+      message: "Path not found: C:/missing",
+      details: ["C:/missing"],
+      relatedControl: "composer",
+    },
+    {
+      id: "inline-path-open",
+      message: "The local path was not found.",
+      dismissLabel: "パスを開いた結果を閉じる",
+      onDismiss: onDismissInlinePathFeedback,
+    },
+  ]);
+  assert.equal(props.isActionDockExpanded, false);
+  assert.equal("inlinePathFeedback" in props.messageColumnProps, false);
 });
 
 test("buildAgentSessionChatWindowProps は Auxiliary mode で parent header 操作だけ隠す", () => {

--- a/scripts/tests/session-composer-feedback.test.ts
+++ b/scripts/tests/session-composer-feedback.test.ts
@@ -90,7 +90,7 @@ describe("session composer feedback", () => {
       draftText: "",
     });
 
-    assert.equal(getComposerSendBlockedMessage(state), "送信できない状態だよ。");
+    assert.equal(getComposerSendBlockedMessage(state), "Message cannot be sent.");
   });
 
   it("send blocked message は送信可能なら null を返す", () => {

--- a/src-electron/companion-runtime-service.ts
+++ b/src-electron/companion-runtime-service.ts
@@ -357,7 +357,7 @@ export class CompanionRuntimeService {
       ?? buildProviderSession(requestedSession);
     const composerPreview = await this.deps.resolveComposerPreview(providerSession, request.userMessage);
     if (composerPreview.errors.length > 0) {
-      throw new Error(composerPreview.errors[0] ?? "添付の解決に失敗したよ。");
+      throw new Error(composerPreview.errors[0] ?? "Failed to resolve attachment.");
     }
 
     const currentTimestampLabel = this.deps.currentTimestampLabel ?? defaultCurrentTimestampLabel;

--- a/src-electron/composer-attachments.ts
+++ b/src-electron/composer-attachments.ts
@@ -54,14 +54,14 @@ async function resolveAttachmentCandidate(
 ): Promise<ComposerAttachment> {
   const absolutePath = resolveCandidatePath(session.workspacePath, candidate.path);
   if (!absolutePath) {
-    throw new Error("空のパスは添付できないよ。");
+    throw new Error("Attachment path is empty.");
   }
 
   let stats;
   try {
     stats = await stat(absolutePath);
   } catch {
-    throw new Error(`${candidate.source === "text" ? "@" : "添付"} のパスが見つからないよ: ${candidate.path}`);
+    throw new Error(`Path not found: ${candidate.path}`);
   }
 
   const kind =
@@ -69,11 +69,11 @@ async function resolveAttachmentCandidate(
     (stats.isDirectory() ? "folder" : inferFileKindFromPath(absolutePath));
 
   if (kind === "folder" && !stats.isDirectory()) {
-    throw new Error(`フォルダとして指定したパスがフォルダじゃないよ: ${candidate.path}`);
+    throw new Error(`Expected a directory: ${candidate.path}`);
   }
 
   if ((kind === "file" || kind === "image") && !stats.isFile()) {
-    throw new Error(`ファイルとして指定したパスがファイルじゃないよ: ${candidate.path}`);
+    throw new Error(`Expected a file: ${candidate.path}`);
   }
 
   const workspaceRelativePath = toWorkspaceRelativePath(session.workspacePath, absolutePath);
@@ -82,7 +82,7 @@ async function resolveAttachmentCandidate(
     session.allowedAdditionalDirectories,
   );
   if (workspaceRelativePath === null && !isPathWithinAnyDirectory(absolutePath, allowedAdditionalDirectories)) {
-    throw new Error(`ワークスペース外のパスは追加ディレクトリで許可してから添付してね: ${candidate.path}`);
+    throw new Error(`Path is outside the workspace. Add its directory before attaching: ${candidate.path}`);
   }
   const displayPath = toDisplayPath(session.workspacePath, absolutePath);
 
@@ -111,7 +111,7 @@ export async function resolveComposerPreview(
       return { attachment: await resolveAttachmentCandidate(session, candidate) } as const;
     } catch (error) {
       return {
-        error: error instanceof Error ? error.message : "添付の解決に失敗したよ。",
+        error: error instanceof Error ? error.message : "Failed to resolve attachment.",
       } as const;
     }
   }));
@@ -120,7 +120,7 @@ export async function resolveComposerPreview(
     if ("error" in resolved) {
       const errorMessage = typeof resolved.error === "string"
         ? resolved.error
-        : "添付の解決に失敗したよ。";
+        : "Failed to resolve attachment.";
       errors.push(errorMessage);
       continue;
     }

--- a/src-electron/session-runtime-service.ts
+++ b/src-electron/session-runtime-service.ts
@@ -849,7 +849,7 @@ export class SessionRuntimeService {
     const composerPreview = await this.deps.resolveComposerPreview(providerSession, request.userMessage);
     throwIfRunCanceled(runAbortController.signal);
     if (composerPreview.errors.length > 0) {
-      throw new Error(composerPreview.errors[0] ?? "添付の解決に失敗したよ。");
+      throw new Error(composerPreview.errors[0] ?? "Failed to resolve attachment.");
     }
 
     const appSettings = this.deps.getAppSettings();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -506,7 +506,12 @@ export default function AgentSessionWindowApp() {
   } | null>(null);
   const [fileRootDiffLoadingScope, setFileRootDiffLoadingScope] = useState<FileRootGitChangeScope | null>(null);
   const [previewChatActivity, setPreviewChatActivity] = useState(() => endPreviewChatActivity());
-  const [inlinePathFeedback, setInlinePathFeedback] = useState("");
+  const [inlinePathError, setInlinePathError] = useState<{
+    ownerSessionId: string;
+    target: string;
+    message: string;
+  } | null>(null);
+  const inlinePathOperationRevisionRef = useRef(new StateMutationRevision());
   const [liveRunState, setLiveRunStateBase] = useState<OwnedLiveSessionRunState>({ ownerSessionId: null, state: null });
   const liveRunRevisionRef = useRef(0);
   const setLiveRunState = useCallback((update: SetStateAction<OwnedLiveSessionRunState>) => {
@@ -1103,17 +1108,17 @@ export default function AgentSessionWindowApp() {
     }
 
     if (isSelectedSessionReadOnly) {
-      return "この session は旧バージョンのため閲覧専用です。追加メッセージを送る場合は新しいセッションを作成してください。";
+      return "This session is read-only. Create a new session to send messages.";
     }
 
     if (!isSelectedProviderEnabled) {
-      return "この provider は Settings の Coding Agent Providers で無効になっているよ。Home の Settings で有効化してね。";
+      return "Provider is disabled. Enable it in Settings.";
     }
 
     return "";
   }, [isSelectedProviderEnabled, isSelectedSessionReadOnly, selectedSession]);
   const composerBlockedReason = pendingSubmitSessionId === selectedSession?.id
-    ? "送信処理を開始しているよ。少し待ってね。"
+    ? "Message submission is in progress."
     : sessionExecutionBlockedReason;
 
   useEffect(() => {
@@ -1872,7 +1877,6 @@ export default function AgentSessionWindowApp() {
       isAgentPickerOpen,
       isSkillPickerOpen,
       isRetryDraftReplacePending,
-      composerSendability.feedbackTone === "blocked",
     ],
   });
   const {
@@ -2746,15 +2750,30 @@ export default function AgentSessionWindowApp() {
     if (!withmateApi || !activeRunSessionId) {
       return;
     }
+    const ownerSessionId = activeRunSessionId;
+    inlinePathOperationRevisionRef.current.advance();
+    const operationRevision = inlinePathOperationRevisionRef.current.capture();
     try {
       const result = await withmateApi.openSessionFilePreviewWindow({
         kind: "link",
-        sessionId: activeRunSessionId,
+        sessionId: ownerSessionId,
         target,
       });
-      setInlinePathFeedback(result.status === "opened" ? "" : result.message);
+      if (!inlinePathOperationRevisionRef.current.isCurrent(operationRevision)) {
+        return;
+      }
+      setInlinePathError(result.status === "opened"
+        ? null
+        : { ownerSessionId, target, message: result.message });
     } catch (error) {
-      setInlinePathFeedback(error instanceof Error ? error.message : "The path could not be opened.");
+      if (!inlinePathOperationRevisionRef.current.isCurrent(operationRevision)) {
+        return;
+      }
+      setInlinePathError({
+        ownerSessionId,
+        target,
+        message: error instanceof Error ? error.message : "The path could not be opened.",
+      });
     }
   };
 
@@ -3638,7 +3657,9 @@ export default function AgentSessionWindowApp() {
         liveRunAssistantText,
         hasLiveRunAssistantText,
         liveRunErrorMessage: selectedSessionLiveRun?.errorMessage ?? "",
-        inlinePathFeedback,
+        inlinePathFeedback: inlinePathError?.ownerSessionId === renderedSession.id
+          ? inlinePathError.message
+          : "",
         pendingMessageGroupId: resolvePendingAuxiliaryMessageGroupId(activeAuxiliarySession),
         isMessageListFollowing,
         retryBanner: activeAuxiliarySession ? null : retryBanner,
@@ -3743,7 +3764,10 @@ export default function AgentSessionWindowApp() {
         onResolveLiveApproval: (request, decision) => void handleResolveLiveApproval(request, decision),
         onResolveLiveElicitation: (request, response) => void handleResolveLiveElicitation(request, response),
         onOpenInlinePath: handleOpenInlinePath,
-        onDismissInlinePathFeedback: () => setInlinePathFeedback(""),
+        onDismissInlinePathFeedback: () => {
+          inlinePathOperationRevisionRef.current.advance();
+          setInlinePathError((current) => current?.ownerSessionId === renderedSession.id ? null : current);
+        },
         getChangedFilesEmptyText,
         onCopyMessageText: handleCopyMessageText,
         onQuoteMessageText: handleQuoteMessageText,

--- a/src/CompanionReviewApp.tsx
+++ b/src/CompanionReviewApp.tsx
@@ -1295,7 +1295,7 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
     ],
   );
   const companionComposerBlockedReason = snapshot?.session.status !== "active"
-    ? "この Companion は active ではないよ。"
+    ? "This Companion session is not active."
     : "";
   const retryBanner = useMemo<RetryBannerState | null>(() => {
     if (!snapshot || !shouldShowRetryBanner({
@@ -1389,7 +1389,6 @@ export default function CompanionReviewApp({ viewMode: forcedViewMode }: Compani
       isSkillPickerOpen,
       isAdditionalDirectoryListOpen,
       isRetryDraftReplacePending,
-      companionComposerSendability.shouldShowFeedback,
     ],
   });
   const {

--- a/src/chat/chat-window.tsx
+++ b/src/chat/chat-window.tsx
@@ -2,6 +2,7 @@ import {
   memo,
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -34,13 +35,26 @@ import { focusRovingItemByKey } from "../a11y.js";
 
 type ChatScreenProps = ComponentProps<typeof SessionChatScreen>;
 
+export type ChatErrorNotice = {
+  id: string;
+  message: string;
+  details?: readonly string[];
+  relatedControl?: "composer";
+  dismissLabel?: string;
+  onDismiss?: () => void;
+  actionLabel?: string;
+  onAction?: () => void;
+  isActionDisabled?: boolean;
+};
+
 export type ChatWindowProps = Omit<
   ChatScreenProps,
-  "header" | "messageColumn" | "actionDock" | "isHeaderVisible"
+  "header" | "messageColumn" | "actionDock" | "isHeaderVisible" | "errorSurface"
 > & {
   isHeaderExpanded: boolean;
   headerProps: SessionHeaderProps;
   messageColumnProps: SessionMessageColumnProps;
+  errorNotices?: readonly ChatErrorNotice[];
   recoveryActions?: ChatScreenProps["recoveryActions"];
   isActionDockExpanded: boolean;
   composerProps: SessionComposerExpandedProps;
@@ -262,6 +276,7 @@ export function ChatWindow({
   isHeaderExpanded,
   headerProps,
   messageColumnProps,
+  errorNotices = [],
   recoveryActions,
   isActionDockExpanded,
   composerProps,
@@ -270,6 +285,7 @@ export function ChatWindow({
   ...screenProps
 }: ChatWindowProps) {
   const [messageViewMode, setMessageViewMode] = useState<MessageViewMode>("preview");
+  const errorSurfaceId = useId();
   const skillButtonRef = useRef<HTMLButtonElement | null>(null);
   const wasSkillPickerOpenRef = useRef(false);
   const showMessageViewModeControls = messageColumnProps.onQuoteMessageText !== undefined;
@@ -286,12 +302,53 @@ export function ChatWindow({
     wasSkillPickerOpenRef.current = isOpen;
   }, [skillPickerProps?.isOpen]);
 
+  const visibleErrorNotices = errorNotices.filter((notice) => notice.message.trim());
+  const renderedErrorNotices = visibleErrorNotices.map((notice, index) => ({
+    ...notice,
+    domId: `${errorSurfaceId}-notice-${index}`,
+  }));
+  const composerErrorDescriptionIds = renderedErrorNotices
+    .filter((notice) => notice.relatedControl === "composer")
+    .map((notice) => notice.domId)
+    .join(" ");
+
   return (
     <SessionChatScreen
       {...screenProps}
       header={<SessionHeader {...headerProps} />}
       isHeaderVisible={isHeaderExpanded}
       isActionDockExpanded={isActionDockExpanded}
+      errorSurface={renderedErrorNotices.length > 0 ? (
+        <div className="chat-error-surface" role="region" aria-label="チャットエラー">
+          {renderedErrorNotices.map((notice) => (
+            <div key={notice.id} id={notice.domId} className="chat-error-notice" role="alert">
+              <div className="chat-error-copy">
+                <p>{notice.message}</p>
+                {notice.details && notice.details.length > 0 ? (
+                  <ul>
+                    {notice.details.map((detail, index) => <li key={`${notice.id}-detail-${index}`}>{detail}</li>)}
+                  </ul>
+                ) : null}
+              </div>
+              {notice.actionLabel && notice.onAction ? (
+                <button type="button" onClick={notice.onAction} disabled={notice.isActionDisabled}>
+                  {notice.actionLabel}
+                </button>
+              ) : null}
+              {notice.onDismiss ? (
+                <button
+                  className="chat-error-dismiss"
+                  type="button"
+                  onClick={notice.onDismiss}
+                  aria-label={notice.dismissLabel ?? "エラー表示を閉じる"}
+                >
+                  ×
+                </button>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
       recoveryActions={recoveryActions}
       workSurfaceOverlay={skillPickerProps ? <ChatSkillPickerPanel {...skillPickerProps} /> : null}
       messageColumn={(
@@ -311,6 +368,7 @@ export function ChatWindow({
           >
             <SessionComposerExpanded
               {...composerProps}
+              externalErrorDescriptionIds={composerErrorDescriptionIds || undefined}
               skillButtonRef={skillButtonRef}
               showMessageViewModeControls={showMessageViewModeControls}
               messageViewMode={messageViewMode}

--- a/src/chat/companion-chat-projection.tsx
+++ b/src/chat/companion-chat-projection.tsx
@@ -33,6 +33,7 @@ import {
   buildLiveSessionCommonComposerDockInput,
   buildLiveSessionCommonContextPaneProps,
   buildLiveSessionCommonMessageColumnProps,
+  buildLiveSessionErrorNotices,
   buildLiveSessionRecoveryActions,
 } from "./live-session-projection.js";
 
@@ -397,6 +398,9 @@ export function buildCompanionChatWindowProps(input: CompanionChatProjectionInpu
     onActivateDockPriority: input.onActivateDockPriority,
     headerProps,
     messageColumnProps: chatBodyProps.messageColumnProps,
+    errorNotices: buildLiveSessionErrorNotices({
+      composerFeedback: input.composerSendability,
+    }),
     recoveryActions,
     isActionDockExpanded: input.isActionDockExpanded,
     headerSplitterProps: {

--- a/src/chat/live-session-projection.tsx
+++ b/src/chat/live-session-projection.tsx
@@ -5,6 +5,7 @@ import {
   type LiveSessionMessageColumnProps,
 } from "./chat-window-adapter.js";
 import { buildLiveSessionRetryBanner } from "./retry-banner-adapter.js";
+import type { ChatErrorNotice } from "./chat-window.js";
 
 export type LiveSessionRecoveryActionsInput = {
   retryBanner: SessionRetryBannerProps["retryBanner"];
@@ -19,6 +20,31 @@ export type LiveSessionRecoveryActionsInput = {
 
 export function buildLiveSessionRecoveryActions(input: LiveSessionRecoveryActionsInput) {
   return buildLiveSessionRetryBanner(input);
+}
+
+export function buildLiveSessionErrorNotices(input: {
+  composerFeedback: {
+    primaryFeedback: string;
+    secondaryFeedback: readonly string[];
+    shouldShowFeedback: boolean;
+  };
+  additionalNotices?: readonly ChatErrorNotice[];
+}): ChatErrorNotice[] {
+  const feedbackMessages = input.composerFeedback.shouldShowFeedback
+    ? [input.composerFeedback.primaryFeedback, ...input.composerFeedback.secondaryFeedback]
+      .map((message) => message.trim())
+      .filter(Boolean)
+    : [];
+  const composerNotice: ChatErrorNotice[] = feedbackMessages.length > 0
+    ? [{
+        id: "composer-sendability",
+        message: feedbackMessages[0],
+        details: feedbackMessages.slice(1),
+        relatedControl: "composer",
+      }]
+    : [];
+
+  return [...composerNotice, ...(input.additionalNotices ?? [])];
 }
 
 export function buildLiveSessionCommonComposerDockInput(

--- a/src/chat/live-session-window-props.tsx
+++ b/src/chat/live-session-window-props.tsx
@@ -20,6 +20,7 @@ type LiveSessionWindowShellPropsInput = {
   onActivateDockPriority: () => void;
   headerProps: ChatWindowProps["headerProps"];
   messageColumnProps: ChatWindowProps["messageColumnProps"];
+  errorNotices?: ChatWindowProps["errorNotices"];
   recoveryActions?: ChatWindowProps["recoveryActions"];
   mainContent?: ReactNode;
   isActionDockExpanded: boolean;
@@ -58,6 +59,7 @@ export function buildLiveSessionWindowShellProps(
       ...input.messageColumnProps,
       isContentActive: input.mainContent === undefined,
     },
+    errorNotices: input.errorNotices,
     recoveryActions: input.recoveryActions,
     mainContent: input.mainContent,
     isActionDockExpanded: input.isActionDockExpanded,

--- a/src/chat/session-chat-projection.tsx
+++ b/src/chat/session-chat-projection.tsx
@@ -26,6 +26,7 @@ import {
   buildLiveSessionCommonComposerDockInput,
   buildLiveSessionCommonContextPaneProps,
   buildLiveSessionCommonMessageColumnProps,
+  buildLiveSessionErrorNotices,
   buildLiveSessionRecoveryActions,
 } from "./live-session-projection.js";
 
@@ -405,9 +406,18 @@ export function buildAgentSessionChatWindowProps(input: AgentSessionChatProjecti
     headerProps,
     messageColumnProps: {
       ...chatBodyProps.messageColumnProps,
-      inlinePathFeedback: input.inlinePathFeedback,
-      onDismissInlinePathFeedback: input.onDismissInlinePathFeedback,
     },
+    errorNotices: buildLiveSessionErrorNotices({
+      composerFeedback: input.composerSendability,
+      additionalNotices: input.inlinePathFeedback.trim()
+        ? [{
+            id: "inline-path-open",
+            message: input.inlinePathFeedback,
+            dismissLabel: "パスを開いた結果を閉じる",
+            onDismiss: input.onDismissInlinePathFeedback,
+          }]
+        : [],
+    }),
     recoveryActions,
     mainContent: input.mainContent,
     isActionDockExpanded: input.isActionDockExpanded,

--- a/src/composer-preview-config.ts
+++ b/src/composer-preview-config.ts
@@ -4,7 +4,7 @@ import {
   type MicrocopyCatalog,
 } from "./microcopy-state.js";
 
-const TEXT_PATH_NOT_FOUND_ERROR_PATTERN = /^@ のパスが見つからないよ: (.+)$/;
+const TEXT_PATH_NOT_FOUND_ERROR_PATTERN = /^Path not found: (.+)$/;
 
 export function createEmptyComposerPreview(): ComposerPreview {
   return { attachments: [], errors: [] };

--- a/src/microcopy-state.ts
+++ b/src/microcopy-state.ts
@@ -37,7 +37,7 @@ export const BUILT_IN_MICROCOPY_CATALOG: Record<MicrocopySlot, string[]> = {
   "retry.interrupted.title": ["前回の依頼は中断されたままです"],
   "retry.failed.title": ["前回の依頼は完了できませんでした"],
   "retry.canceled.title": ["この依頼は途中で停止しました"],
-  "composer.error.path_not_found": ["指定したパスが見つかりません: {path}"],
+  "composer.error.path_not_found": ["Path not found: {path}"],
   "empty.latest_command.waiting": ["最初の command を待機中"],
   "empty.latest_command": ["直近 run の command 記録はありません"],
   "empty.changed_files": ["ファイル変更はありません"],
@@ -45,6 +45,11 @@ export const BUILT_IN_MICROCOPY_CATALOG: Record<MicrocopySlot, string[]> = {
 };
 
 const MICROCOPY_SLOT_SET = new Set<string>(MICROCOPY_SLOTS);
+const LEGACY_PATH_NOT_FOUND_DEFAULT = ["指定したパスが見つかりません: {path}"];
+
+function isExactVariantList(value: string[], expected: readonly string[]): boolean {
+  return value.length === expected.length && value.every((entry, index) => entry === expected[index]);
+}
 
 function cloneCatalog(catalog: Record<MicrocopySlot, string[]>): Record<MicrocopySlot, string[]> {
   return Object.fromEntries(
@@ -87,10 +92,15 @@ export function normalizeUserMicrocopyCatalog(value: unknown): Record<MicrocopyS
       continue;
     }
 
-    normalized[slot as MicrocopySlot] = normalizeMicrocopyVariants(
+    const typedSlot = slot as MicrocopySlot;
+    const normalizedVariants = normalizeMicrocopyVariants(
       variants,
-      BUILT_IN_MICROCOPY_CATALOG[slot as MicrocopySlot],
+      BUILT_IN_MICROCOPY_CATALOG[typedSlot],
     );
+    normalized[typedSlot] = typedSlot === "composer.error.path_not_found"
+      && isExactVariantList(normalizedVariants, LEGACY_PATH_NOT_FOUND_DEFAULT)
+      ? [...BUILT_IN_MICROCOPY_CATALOG[typedSlot]]
+      : normalizedVariants;
   }
 
   return normalized;

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -848,6 +848,7 @@ export type SessionChatScreenProps = {
   messageColumn: ReactNode;
   mainContent?: ReactNode;
   workSurfaceOverlay?: ReactNode;
+  errorSurface?: ReactNode;
   recoveryActions?: ReactNode;
   actionDock: ReactNode;
   actionDockSplitter: ReactNode;
@@ -893,6 +894,7 @@ export function SessionChatScreen({
   messageColumn,
   mainContent,
   workSurfaceOverlay = null,
+  errorSurface = null,
   recoveryActions = null,
   actionDock,
   actionDockSplitter,
@@ -969,6 +971,7 @@ export function SessionChatScreen({
             {recoveryActions}
           </div>
         ) : null}
+        {errorSurface}
       </section>
 
       {splitter}
@@ -2194,8 +2197,6 @@ export type SessionMessageColumnProps = {
   getChangedFilesEmptyText: (artifactKey: string, artifactHasSnapshotRisk: boolean) => string;
   onCopyMessageText?: (text: string) => void;
   onQuoteMessageText?: (text: string) => void;
-  inlinePathFeedback?: string;
-  onDismissInlinePathFeedback?: () => void;
   isContentActive?: boolean;
   messageViewMode?: MessageViewMode;
 };
@@ -2527,8 +2528,6 @@ export function SessionMessageColumn({
   getChangedFilesEmptyText,
   onCopyMessageText,
   onQuoteMessageText,
-  inlinePathFeedback = "",
-  onDismissInlinePathFeedback,
   isContentActive = true,
   messageViewMode = "preview",
 }: SessionMessageColumnProps) {
@@ -2997,14 +2996,6 @@ export function SessionMessageColumn({
 
   return (
     <div className="session-message-column">
-      {inlinePathFeedback ? (
-        <div className="session-inline-path-feedback" role="alert">
-          <span>{inlinePathFeedback}</span>
-          {onDismissInlinePathFeedback ? (
-            <button type="button" onClick={onDismissInlinePathFeedback} aria-label="Dismiss path open result">×</button>
-          ) : null}
-        </div>
-      ) : null}
       <SessionContentFindBar
         open={findOpen}
         query={findQuery}
@@ -3500,6 +3491,7 @@ export type SessionComposerExpandedProps = {
   isComposerDisabled: boolean;
   isSendDisabled: boolean;
   composerSendability: SessionComposerSendabilityView;
+  externalErrorDescriptionIds?: string;
   sendButtonTitle?: string;
   isComposerBlockedFeedbackActive: boolean;
   approvalOptions: Array<{ value: ApprovalMode; label: string }>;
@@ -3577,6 +3569,7 @@ export function SessionComposerExpanded({
   isComposerDisabled,
   isSendDisabled,
   composerSendability,
+  externalErrorDescriptionIds,
   sendButtonTitle,
   isComposerBlockedFeedbackActive,
   approvalOptions,
@@ -3955,10 +3948,12 @@ export function SessionComposerExpanded({
             onCompositionStart={onDraftCompositionStart}
             onCompositionEnd={onDraftCompositionEnd}
             disabled={isComposerDisabled}
-            aria-describedby={composerSendability.shouldShowFeedback ? "composer-sendability-feedback" : undefined}
+            aria-describedby={externalErrorDescriptionIds || (
+              composerSendability.shouldShowFeedback ? "composer-sendability-feedback" : undefined
+            )}
             aria-invalid={composerSendability.feedbackTone === "blocked" ? true : undefined}
           />
-          {composerSendability.shouldShowFeedback ? (
+          {composerSendability.shouldShowFeedback && !externalErrorDescriptionIds ? (
             <div
               id="composer-sendability-feedback"
               className={`composer-sendability-feedback ${composerSendability.feedbackTone ?? "helper"}`}

--- a/src/session-composer-feedback.ts
+++ b/src/session-composer-feedback.ts
@@ -15,8 +15,8 @@ export type TextComposerSubmitPreflightResult =
   | { status: "blocked"; reason: "empty"; feedback: string }
   | { status: "blocked"; reason: "running" };
 
-export const BLANK_DRAFT_FEEDBACK = "メッセージを入力してください。";
-export const COMPOSER_SEND_BLOCKED_FALLBACK = "送信できない状態だよ。";
+export const BLANK_DRAFT_FEEDBACK = "Message is empty.";
+export const COMPOSER_SEND_BLOCKED_FALLBACK = "Message cannot be sent.";
 
 export function buildComposerSendabilityState({
   runState,
@@ -121,7 +121,7 @@ export function getComposerSendButtonTitle(state: ComposerSendabilityState): str
     return "メッセージを送信";
   }
 
-  return state.primaryFeedback || (state.isBlankDraft ? BLANK_DRAFT_FEEDBACK : "送信できない状態だよ。");
+  return state.primaryFeedback || (state.isBlankDraft ? BLANK_DRAFT_FEEDBACK : COMPOSER_SEND_BLOCKED_FALLBACK);
 }
 
 export function getComposerSendBlockedMessage(

--- a/src/styles.css
+++ b/src/styles.css
@@ -4148,15 +4148,70 @@ button:disabled {
 
 .session-message-stack {
   display: grid;
-  grid-template-rows: minmax(0, 1fr) auto;
+  grid-template-rows: minmax(0, 1fr) auto auto;
   gap: 0;
   min-height: 0;
   min-width: 0;
 }
 
 .session-recovery-actions-slot {
+  grid-row: 2;
   min-width: 0;
   padding: 0 12px 12px;
+}
+
+.chat-error-surface {
+  display: grid;
+  grid-row: 3;
+  gap: 6px;
+  min-width: 0;
+  padding: 0 12px 12px;
+}
+
+.chat-error-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  min-width: 0;
+  padding: 8px 10px;
+  border: 1px solid rgba(248, 113, 113, 0.24);
+  border-radius: 9px;
+  background: rgba(248, 113, 113, 0.1);
+  color: #fecaca;
+  font-size: 0.8rem;
+}
+
+.chat-error-copy {
+  display: grid;
+  flex: 1 1 auto;
+  gap: 4px;
+  min-width: 0;
+}
+
+.chat-error-copy p,
+.chat-error-copy li {
+  margin: 0;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.chat-error-copy ul {
+  display: grid;
+  gap: 3px;
+  margin: 0;
+  padding-left: 18px;
+}
+
+.chat-error-notice > button {
+  flex: 0 0 auto;
+}
+
+.chat-error-dismiss {
+  min-width: auto;
+  padding: 0 2px;
+  border: 0;
+  background: transparent;
+  color: inherit;
 }
 
 .session-message-column {
@@ -4167,6 +4222,7 @@ button:disabled {
 
 .session-central-surface {
   display: grid;
+  grid-row: 1;
   min-width: 0;
   min-height: 0;
 }
@@ -4409,34 +4465,8 @@ button:disabled {
   }
 }
 
-.session-message-column:has(.session-content-find),
-.session-message-column:has(.session-inline-path-feedback) {
+.session-message-column:has(.session-content-find) {
   grid-template-rows: auto minmax(0, 1fr);
-}
-
-.session-message-column:has(.session-content-find):has(.session-inline-path-feedback) {
-  grid-template-rows: auto auto minmax(0, 1fr);
-}
-
-.session-inline-path-feedback {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  margin-bottom: 6px;
-  padding: 7px 10px;
-  border: 1px solid rgba(251, 191, 36, 0.26);
-  border-radius: 9px;
-  background: rgba(120, 53, 15, 0.18);
-  color: #fde68a;
-  font-size: 0.76rem;
-}
-
-.session-inline-path-feedback button {
-  border: 0;
-  background: transparent;
-  color: inherit;
-  cursor: pointer;
 }
 
 .session-context-pane {


### PR DESCRIPTION
## 概要

- ActionDock内のチャット操作エラーを、ActionDock直上の共通エラー領域へ移動
- エラーの可視性をActionDockの展開状態から分離
- パス操作エラーの所有Sessionとdismiss条件を明確化
- 添付・送信不可エラーを簡潔な英文へ統一し、旧既定microcopyのみ移行
- Cancel/error後に保持されたassistant本文のCopy/Quote契約を維持

## 検証

- targeted tests: 131 passed
- npm run typecheck
- npm run build
- 分離起動による表示確認

Closes #278