### PR TITLE
fix: Session Workspaceの利用可否確認をSession専用IPCへ分離する

### DIFF
--- a/scripts/tests/main-ipc-registration.test.ts
+++ b/scripts/tests/main-ipc-registration.test.ts
@@ -52,6 +52,7 @@ import {
   WITHMATE_OPEN_SESSION_CHANNEL,
   WITHMATE_OPEN_SETTINGS_WINDOW_CHANNEL,
   WITHMATE_PICK_IMAGE_FILE_CHANNEL,
+  WITHMATE_VALIDATE_SESSION_WORKSPACE_CHANNEL,
   WITHMATE_VALIDATE_WORKSPACE_DIRECTORY_CHANNEL,
   WITHMATE_RESET_APP_DATABASE_CHANNEL,
   WITHMATE_RESOLVE_LAUNCH_CHARACTER_CHANNEL,
@@ -245,6 +246,41 @@ test("workspace validation IPC は Home window だけから validation service �
     /only available from the Home window/,
   );
   assert.deepEqual(validatedPaths, ["C:\\workspace"]);
+});
+
+test("Session workspace validation IPC は対象 Session window の保存済み path だけを検証する", async () => {
+  const { ipcMain, handlers } = createIpcMainStub();
+  const sessionWindow = createWindowStub("http://localhost:5173/?mode=session&sessionId=session-1");
+  const otherWindow = createWindowStub("http://localhost:5173/?mode=session&sessionId=session-2");
+  let eventWindow = sessionWindow;
+  const resolvedSessionIds: string[] = [];
+  const validatedPaths: unknown[] = [];
+  const { deps } = createDeps({
+    resolveEventWindow: () => eventWindow,
+    resolveSessionWindow: (sessionId: string) => sessionId === "session-1" ? sessionWindow : otherWindow,
+    getSession: async (sessionId: string) => {
+      resolvedSessionIds.push(sessionId);
+      return sessionId === "session-1" ? { workspacePath: "C:\\session-workspace" } : null;
+    },
+    validateWorkspaceDirectory: async (targetPath: unknown) => {
+      validatedPaths.push(targetPath);
+      return { valid: true };
+    },
+  });
+  registerMainIpcHandlers(ipcMain, deps);
+  const handler = handlers.get(WITHMATE_VALIDATE_SESSION_WORKSPACE_CHANNEL);
+
+  assert.deepEqual(await handler?.({}, "session-1"), { valid: true });
+  assert.deepEqual(resolvedSessionIds, ["session-1"]);
+  assert.deepEqual(validatedPaths, ["C:\\session-workspace"]);
+
+  eventWindow = otherWindow;
+  await assert.rejects(
+    () => handler?.({}, "session-1") as Promise<unknown>,
+    /only available from the target Session window/,
+  );
+  assert.deepEqual(resolvedSessionIds, ["session-1"]);
+  assert.deepEqual(validatedPaths, ["C:\\session-workspace"]);
 });
 
 test("Session/Companion 作成 IPC は Home だけを許可し、作成直前に同じ workspace validation を通す", async () => {

--- a/scripts/tests/preload-api.test.ts
+++ b/scripts/tests/preload-api.test.ts
@@ -193,6 +193,10 @@ test("createWithMateWindowApi は invoke 系 API を domain ごとに束ねる",
     channel: "withmate:validate-workspace-directory",
     args: ["C:/workspace"],
   });
+  assert.deepEqual(await api.validateSessionWorkspace("session-1"), {
+    channel: "withmate:validate-session-workspace",
+    args: ["session-1"],
+  });
   assert.deepEqual(await api.pickSessionFiles("session-1"), {
     channel: "withmate:pick-session-files",
     args: ["session-1"],
@@ -423,6 +427,7 @@ test("createWithMateWindowApi は current public API の key を揃えて expose
     "openSettingsWindow",
     "openMemoryV6ReviewWindow",
     "openTerminalAtPath",
+    "validateSessionWorkspace",
     "validateWorkspaceDirectory",
     "pickDirectory",
     "pickFile",

--- a/src-electron/main-ipc-registration.ts
+++ b/src-electron/main-ipc-registration.ts
@@ -162,6 +162,7 @@ import {
   WITHMATE_GET_SESSION_AUDIT_LOG_OPERATION_DETAIL_CHANNEL,
   WITHMATE_GET_SESSION_BACKGROUND_ACTIVITY_CHANNEL,
   WITHMATE_GET_SESSION_CHANNEL,
+  WITHMATE_VALIDATE_SESSION_WORKSPACE_CHANNEL,
   WITHMATE_LIST_SESSION_FILE_ROOTS_CHANNEL,
   WITHMATE_LIST_SESSION_DIRECTORY_CHANNEL,
   WITHMATE_INSPECT_SESSION_FILE_CHANNEL,
@@ -599,6 +600,7 @@ type MainIpcSessionQueryDeps = Pick<
   | "listOpenSessionWindowIds"
   | "listOpenCompanionReviewWindowIds"
   | "getSession"
+  | "validateWorkspaceDirectory"
   | "getSessionFileExplorerOwnerSessionId"
   | "listSessionFileRoots"
   | "listSessionDirectory"
@@ -1344,6 +1346,20 @@ function registerSessionQueryHandlers(ipcMain: IpcHandleRegistrar, deps: MainIpc
       return null;
     }
     return deps.getSession(sessionId);
+  });
+  ipcMain.handle(WITHMATE_VALIDATE_SESSION_WORKSPACE_CHANNEL, async (event, sessionId: string) => {
+    if (typeof sessionId !== "string" || !sessionId) {
+      throw new TypeError("Session ID is invalid.");
+    }
+    const window = deps.resolveEventWindow(event);
+    if (!window || deps.resolveSessionWindow(sessionId) !== window) {
+      throw new Error("Session workspace validation IPC is only available from the target Session window.");
+    }
+    const session = await deps.getSession(sessionId);
+    if (!session) {
+      return { valid: false, reason: "unavailable" };
+    }
+    return deps.validateWorkspaceDirectory(session.workspacePath);
   });
   ipcMain.handle(WITHMATE_LIST_SESSION_FILE_ROOTS_CHANNEL, async (event, sessionId: string) => {
     if (typeof sessionId !== "string" || !sessionId) {

--- a/src-electron/preload-api.ts
+++ b/src-electron/preload-api.ts
@@ -69,6 +69,7 @@ import {
   WITHMATE_GET_SESSION_AUDIT_LOG_OPERATION_DETAIL_CHANNEL,
   WITHMATE_GET_SESSION_BACKGROUND_ACTIVITY_CHANNEL,
   WITHMATE_GET_SESSION_CHANNEL,
+  WITHMATE_VALIDATE_SESSION_WORKSPACE_CHANNEL,
   WITHMATE_LIST_SESSION_FILE_ROOTS_CHANNEL,
   WITHMATE_LIST_SESSION_DIRECTORY_CHANNEL,
   WITHMATE_INSPECT_SESSION_FILE_CHANNEL,
@@ -309,6 +310,9 @@ function createSessionApi(ipcRenderer: IpcRendererLike): WithMateWindowSessionAp
     },
     getSession(sessionId) {
       return ipcRenderer.invoke(WITHMATE_GET_SESSION_CHANNEL, sessionId);
+    },
+    validateSessionWorkspace(sessionId) {
+      return ipcRenderer.invoke(WITHMATE_VALIDATE_SESSION_WORKSPACE_CHANNEL, sessionId);
     },
     listSessionFileRoots(sessionId) {
       return ipcRenderer.invoke(WITHMATE_LIST_SESSION_FILE_ROOTS_CHANNEL, sessionId);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -736,7 +736,7 @@ export default function AgentSessionWindowApp() {
     const requestId = workspaceAvailabilityRequestIdRef.current + 1;
     workspaceAvailabilityRequestIdRef.current = requestId;
     setWorkspaceAvailability(beginSessionWorkspaceAvailabilityCheck(sessionId, workspacePath, requestId));
-    const result = await withmateApi.validateWorkspaceDirectory(workspacePath)
+    const result = await withmateApi.validateSessionWorkspace(sessionId)
       .catch(() => ({ valid: false, reason: "unavailable" } as const));
     if (workspaceAvailabilityRequestIdRef.current !== requestId) {
       return false;

--- a/src/withmate-ipc-channels.ts
+++ b/src/withmate-ipc-channels.ts
@@ -9,6 +9,7 @@ export const WITHMATE_OPEN_COMPANION_REVIEW_WINDOW_CHANNEL = "withmate:open-comp
 export const WITHMATE_OPEN_COMPANION_MERGE_WINDOW_CHANNEL = "withmate:open-companion-merge-window";
 export const WITHMATE_LIST_SESSION_SUMMARIES_CHANNEL = "withmate:list-session-summaries";
 export const WITHMATE_GET_SESSION_CHANNEL = "withmate:get-session";
+export const WITHMATE_VALIDATE_SESSION_WORKSPACE_CHANNEL = "withmate:validate-session-workspace";
 export const WITHMATE_LIST_SESSION_FILE_ROOTS_CHANNEL = "withmate:list-session-file-roots";
 export const WITHMATE_LIST_SESSION_DIRECTORY_CHANNEL = "withmate:list-session-directory";
 export const WITHMATE_INSPECT_SESSION_FILE_CHANNEL = "withmate:inspect-session-file";

--- a/src/withmate-window-api.ts
+++ b/src/withmate-window-api.ts
@@ -142,6 +142,7 @@ export type WithMateWindowCatalogApi = {
 export type WithMateWindowSessionApi = {
   listSessionSummaries(): Promise<SessionSummary[]>;
   getSession(sessionId: string): Promise<Session | null>;
+  validateSessionWorkspace(sessionId: string): Promise<WorkspaceDirectoryValidationResult>;
   listSessionFileRoots(sessionId: string): Promise<SessionFileRoot[]>;
   listSessionDirectory(request: SessionDirectoryRequest): Promise<SessionDirectoryEntry[]>;
   inspectSessionFile(request: SessionFileResourceRequest): Promise<SessionFileDescriptor>;


### PR DESCRIPTION
## 概要
- PR #404 で Session Window から Home 専用の Workspace validation IPC を呼んでいたため、実在する Workspace も送信元検証で拒否されていた問題を修正
- Session 専用 IPC は `sessionId` だけを受け取り、main process が対象 Session Window の ownership を確認してから保存済み `workspacePath` を検証
- Home の任意 path 検証 IPC は Home Window 専用のまま維持
- 起動時、Recheck、送信直前の確認を同じ Session 専用経路へ統一

## 検証
- 修正前: Session 専用 channel が存在せず、追加した IPC 境界テストが失敗することを確認
- `npm run typecheck`
- Session / IPC / preload 関連 targeted test: 94 passed
- `npm test`: 2442 passed, 1 skipped, 0 failed
- authorization owner binding の独立 targeted review: blocking finding なし

## 残課題
- 既存の `updateSession` 全量更新境界では `workspacePath` の不変性と sender ownership が固定されていない。provider 実行を含む別責務へ波及するため、本修正には混ぜず Session mutation 境界の独立した変更対象とする。