### PR TITLE
fix: File Preview Windowのタイトルをファイル名にする

### DIFF
--- a/scripts/tests/aux-window-service.test.ts
+++ b/scripts/tests/aux-window-service.test.ts
@@ -182,6 +182,7 @@ test("AuxWindowService は同じ file preview resource を再利用し close 後
   const payload = {
     resource: { sessionId: "session-1", rootId: "workspace", relativePath: "src/file.ts" },
     ownerSessionId: "session-1",
+    windowTitle: "src/file.ts",
   };
 
   const first = await service.openFilePreviewWindow(payload);
@@ -192,7 +193,10 @@ test("AuxWindowService は同じ file preview resource を再利用し close 後
   assert.equal(first.window, reused.window);
   assert.equal(stubs.length, 1);
   assert.equal(stubs[0]?.getFocusCount(), 1);
-  assert.deepEqual(service.getFilePreviewPayload("preview-1"), payload);
+  assert.deepEqual(service.getFilePreviewPayload("preview-1"), {
+    ...payload,
+    windowTitle: "file.ts",
+  });
   assert.equal(service.isFilePreviewWindow(first.window, "session-1"), true);
   assert.deepEqual(service.getFilePreviewWindowResource(first.window, "session-1"), payload.resource);
   assert.equal(service.isFilePreviewTokenWindow(first.window, "preview-1"), true);
@@ -200,6 +204,7 @@ test("AuxWindowService は同じ file preview resource を再利用し close 後
   const otherPayload = {
     resource: { sessionId: "session-1", rootId: "workspace", relativePath: "src/other.ts" },
     ownerSessionId: "session-1",
+    windowTitle: "src/other.ts",
   };
   const other = await service.openFilePreviewWindow(otherPayload);
   assert.equal(other.disposition, "created");
@@ -212,9 +217,9 @@ test("AuxWindowService は同じ file preview resource を再利用し close 後
   assert.notEqual(reopened.window, first.window);
   assert.deepEqual(previewLoads, ["preview-1", "preview-2", "preview-3"]);
   assert.deepEqual(createdOptions, [
-    { ...FILE_PREVIEW_WINDOW_DEFAULT_BOUNDS, title: "Preview - src/file.ts" },
-    { ...FILE_PREVIEW_WINDOW_DEFAULT_BOUNDS, title: "Preview - src/other.ts" },
-    { ...FILE_PREVIEW_WINDOW_DEFAULT_BOUNDS, title: "Preview - src/file.ts" },
+    { ...FILE_PREVIEW_WINDOW_DEFAULT_BOUNDS, title: "file.ts" },
+    { ...FILE_PREVIEW_WINDOW_DEFAULT_BOUNDS, title: "other.ts" },
+    { ...FILE_PREVIEW_WINDOW_DEFAULT_BOUNDS, title: "file.ts" },
   ]);
   service.closeFilePreviewWindowsForSession("session-1");
   assert.equal(reopened.window.isDestroyed(), true);
@@ -224,9 +229,11 @@ test("AuxWindowService は同じ file preview resource を再利用し close 後
 
 test("AuxWindowService は file preview entry load 失敗時に registry と window を残さない", async () => {
   const stubs: ReturnType<typeof createWindowStub>[] = [];
+  const createdOptions: Array<Record<string, unknown>> = [];
   let loadShouldFail = true;
   const service = new AuxWindowService({
-    createWindow() {
+    createWindow(options) {
+      createdOptions.push(options);
       const stub = createWindowStub();
       stubs.push(stub);
       return stub.window;
@@ -249,6 +256,7 @@ test("AuxWindowService は file preview entry load 失敗時に registry と win
   const payload = {
     resource: { sessionId: "session-1", rootId: "workspace", relativePath: "src/file.ts" },
     ownerSessionId: "session-1",
+    windowTitle: "",
   };
 
   await assert.rejects(() => service.openFilePreviewWindow(payload), /entry load failed/);
@@ -259,13 +267,20 @@ test("AuxWindowService は file preview entry load 失敗時に registry と win
   const reopened = await service.openFilePreviewWindow(payload);
   assert.equal(reopened.disposition, "created");
   assert.equal(stubs.length, 2);
+  assert.deepEqual(createdOptions, [
+    { ...FILE_PREVIEW_WINDOW_DEFAULT_BOUNDS, title: "File Preview" },
+    { ...FILE_PREVIEW_WINDOW_DEFAULT_BOUNDS, title: "File Preview" },
+  ]);
+  assert.equal(service.getFilePreviewPayload("preview-1")?.windowTitle, "File Preview");
 });
 
 test("AuxWindowService は absolute file preview を path 単位で再利用し close 後に破棄する", async () => {
   const stubs: ReturnType<typeof createWindowStub>[] = [];
+  const createdOptions: Array<Record<string, unknown>> = [];
   let tokenSequence = 0;
   const service = new AuxWindowService({
-    createWindow() {
+    createWindow(options) {
+      createdOptions.push(options);
       const stub = createWindowStub();
       stubs.push(stub);
       return stub.window;
@@ -285,6 +300,7 @@ test("AuxWindowService は absolute file preview を path 単位で再利用し 
   const payload = {
     resource: { sessionId: "session-1", absolutePath: "C:\\outside\\notes.md" },
     ownerSessionId: "session-1",
+    windowTitle: "C:\\Users\\private\\notes.md",
   };
 
   const first = await service.openFilePreviewWindow(payload);
@@ -298,6 +314,11 @@ test("AuxWindowService は absolute file preview を path 単位で再利用し 
   const reopened = await service.openFilePreviewWindow(payload);
   assert.equal(reopened.disposition, "created");
   assert.equal(stubs.length, 2);
+  assert.deepEqual(createdOptions, [
+    { ...FILE_PREVIEW_WINDOW_DEFAULT_BOUNDS, title: "notes.md" },
+    { ...FILE_PREVIEW_WINDOW_DEFAULT_BOUNDS, title: "notes.md" },
+  ]);
+  assert.equal(service.getFilePreviewPayload("absolute-preview-2")?.windowTitle, "notes.md");
 });
 
 test("AuxWindowService は大小文字だけが異なる absolute path を別 Preview として扱う", async () => {
@@ -325,10 +346,12 @@ test("AuxWindowService は大小文字だけが異なる absolute path を別 Pr
   const upper = await service.openFilePreviewWindow({
     resource: { sessionId: "session-1", absolutePath: "C:\\case-sensitive\\Report.md" },
     ownerSessionId: "session-1",
+    windowTitle: "Report.md",
   });
   const lower = await service.openFilePreviewWindow({
     resource: { sessionId: "session-1", absolutePath: "C:\\case-sensitive\\report.md" },
     ownerSessionId: "session-1",
+    windowTitle: "report.md",
   });
 
   assert.equal(upper.disposition, "created");
@@ -362,10 +385,12 @@ test("AuxWindowService は literal backslash を含む canonical path を separa
   const literalBackslash = await service.openFilePreviewWindow({
     resource: { sessionId: "session-1", absolutePath: "/tmp/a\\b" },
     ownerSessionId: "session-1",
+    windowTitle: "a\\b",
   });
   const separatorPath = await service.openFilePreviewWindow({
     resource: { sessionId: "session-1", absolutePath: "/tmp/a/b" },
     ownerSessionId: "session-1",
+    windowTitle: "b",
   });
 
   assert.equal(literalBackslash.disposition, "created");
@@ -402,6 +427,7 @@ test("AuxWindowService は entry load 中に閉じた Session を opened 扱い�
   const opening = service.openFilePreviewWindow({
     resource: { sessionId: "session-1", absolutePath: "C:\\outside\\notes.md" },
     ownerSessionId: "session-1",
+    windowTitle: "notes.md",
   });
 
   service.closeFilePreviewWindowsForSession("session-1");
@@ -440,6 +466,7 @@ test("AuxWindowService は共有 entry load 中に閉じた Session を reused �
   const payload = {
     resource: { sessionId: "session-1", absolutePath: "C:\\outside\\notes.md" },
     ownerSessionId: "session-1",
+    windowTitle: "notes.md",
   };
   const firstOpening = service.openFilePreviewWindow(payload);
   const reusedOpening = service.openFilePreviewWindow(payload);
@@ -473,6 +500,7 @@ test("AuxWindowService は close 済み Session の遅延 file preview admission
   const payload = {
     resource: { sessionId: "aux-1", rootId: "workspace", relativePath: "src/file.ts" },
     ownerSessionId: "session-1",
+    windowTitle: "file.ts",
   };
 
   service.closeFilePreviewWindowsForSession("aux-1");

--- a/scripts/tests/file-preview-window-title.test.tsx
+++ b/scripts/tests/file-preview-window-title.test.tsx
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { JSDOM } from "jsdom";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import FilePreviewApp from "../../src/FilePreviewApp.js";
+import {
+  FILE_PREVIEW_WINDOW_TITLE_FALLBACK,
+  resolveSessionFilePreviewWindowTitle,
+  type SessionFileDescriptor,
+} from "../../src/file-explorer/file-explorer-contract.js";
+import type { WithMateWindowApi } from "../../src/withmate-window-api.js";
+
+test("resolveSessionFilePreviewWindowTitle は basename だけを返し不正な名前を fallback する", () => {
+  assert.equal(resolveSessionFilePreviewWindowTitle("C:\\Users\\private\\notes.md"), "notes.md");
+  assert.equal(resolveSessionFilePreviewWindowTitle("/home/private/notes.md"), "notes.md");
+  assert.equal(resolveSessionFilePreviewWindowTitle(""), FILE_PREVIEW_WINDOW_TITLE_FALLBACK);
+  assert.equal(resolveSessionFilePreviewWindowTitle(".."), FILE_PREVIEW_WINDOW_TITLE_FALLBACK);
+  assert.equal(resolveSessionFilePreviewWindowTitle("unsafe\nname.md"), FILE_PREVIEW_WINDOW_TITLE_FALLBACK);
+});
+
+test("FilePreviewApp は payload hydrate 後も document title を対象ファイル名に同期する", async () => {
+  const previousActEnvironment = (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT;
+  const previousWindow = globalThis.window;
+  const previousDocument = globalThis.document;
+  const previousNavigator = globalThis.navigator;
+  const previousNode = globalThis.Node;
+  const dom = new JSDOM(
+    "<!doctype html><html><head><title>File Preview</title></head><body><div id=\"root\"></div></body></html>",
+    { pretendToBeVisual: true, url: "http://localhost/file-preview.html?token=preview-1" },
+  );
+  const resource = { sessionId: "session-1", absolutePath: "C:\\outside\\notes.md" };
+  const descriptor: SessionFileDescriptor = {
+    ...resource,
+    name: "notes.md",
+    kind: "text",
+    byteLength: 0,
+    modifiedAt: "2026-08-14T00:00:00.000Z",
+    mimeType: "text/plain",
+    suggestedEncoding: "utf-8",
+    revision: "empty-r1",
+  };
+  const api = {
+    async getSessionFilePreviewWindowPayload() {
+      return { resource, ownerSessionId: "session-1", windowTitle: "notes.md" };
+    },
+    async inspectSessionFile() {
+      return descriptor;
+    },
+    async listSessionFileRoots() {
+      return [];
+    },
+    async readSessionFileChunk() {
+      throw new Error("Empty preview must not request a file chunk.");
+    },
+  } as unknown as WithMateWindowApi;
+
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  Object.defineProperty(dom.window, "withmate", { configurable: true, value: api });
+  Object.defineProperty(globalThis, "window", { configurable: true, value: dom.window });
+  Object.defineProperty(globalThis, "document", { configurable: true, value: dom.window.document });
+  Object.defineProperty(globalThis, "navigator", { configurable: true, value: dom.window.navigator });
+  Object.defineProperty(globalThis, "Node", { configurable: true, value: dom.window.Node });
+
+  let root: Root | null = null;
+  try {
+    root = createRoot(dom.window.document.getElementById("root") as HTMLElement);
+    await act(async () => {
+      root?.render(<FilePreviewApp />);
+    });
+    for (let index = 0; index < 20 && dom.window.document.title !== "notes.md"; index += 1) {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+    assert.equal(dom.window.document.title, "notes.md");
+  } finally {
+    if (root) {
+      await act(async () => {
+        root?.unmount();
+      });
+    }
+    Object.defineProperty(globalThis, "window", { configurable: true, value: previousWindow });
+    Object.defineProperty(globalThis, "document", { configurable: true, value: previousDocument });
+    Object.defineProperty(globalThis, "navigator", { configurable: true, value: previousNavigator });
+    Object.defineProperty(globalThis, "Node", { configurable: true, value: previousNode });
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+      previousActEnvironment;
+    dom.window.close();
+  }
+});

--- a/scripts/tests/main-ipc-registration.test.ts
+++ b/scripts/tests/main-ipc-registration.test.ts
@@ -554,6 +554,7 @@ test("File Explorer IPC は owning Session window からだけ利用でき、Aux
     getSessionFilePreviewWindowPayload: () => ({
       resource: currentPreviewResource,
       ownerSessionId: "session-1",
+      windowTitle: "current.md",
     }),
     listSessionFileRoots: async () => [{ id: "workspace", kind: "workspace", label: "Workspace", displayPath: "C:/repo" }],
     listSessionDirectory: async (request: unknown) => {
@@ -690,6 +691,7 @@ test("File Explorer IPC は owning Session window からだけ利用でき、Aux
     {
       resource: currentPreviewResource,
       ownerSessionId: "session-1",
+      windowTitle: "current.md",
     },
   );
   assert.equal(

--- a/src-electron/aux-window-service.ts
+++ b/src-electron/aux-window-service.ts
@@ -4,8 +4,8 @@ import type {
   SessionFileResourceRequest,
 } from "../src/file-explorer/file-explorer-contract.js";
 import {
-  getSessionFileResourceDisplayPath,
   isSessionFileAbsoluteResource,
+  resolveSessionFilePreviewWindowTitle,
 } from "../src/file-explorer/file-explorer-contract.js";
 import type { ChatEntryMode, HomeEntryMode, WindowLike } from "./window-entry-loader.js";
 import {
@@ -305,13 +305,17 @@ export class AuxWindowService<TWindow extends BaseWindowLike> {
     }
 
     const token = this.deps.generateDiffToken();
+    const storedPayload = {
+      ...payload,
+      windowTitle: resolveSessionFilePreviewWindowTitle(payload.windowTitle),
+    };
     const window = this.deps.createWindow({
       ...FILE_PREVIEW_WINDOW_DEFAULT_BOUNDS,
-      title: `Preview - ${getSessionFileResourceDisplayPath(payload.resource)}`,
+      title: storedPayload.windowTitle,
     });
     this.filePreviewResourceTokens.set(resourceKey, token);
     this.filePreviewWindows.set(token, window);
-    this.filePreviewStore.set(token, payload);
+    this.filePreviewStore.set(token, storedPayload);
     window.once("ready-to-show", () => window.show());
     window.on("closed", () => {
       this.filePreviewResourceTokens.delete(resourceKey);

--- a/src-electron/main.ts
+++ b/src-electron/main.ts
@@ -72,6 +72,7 @@ import type {
   SessionFilePreviewWindowOpenRequest,
   SessionFilePreviewWindowOpenResult,
 } from "../src/file-explorer/file-explorer-contract.js";
+import { resolveSessionFilePreviewWindowTitle } from "../src/file-explorer/file-explorer-contract.js";
 import { AuditLogStorage } from "./audit-log-storage.js";
 import { AuditLogService } from "./audit-log-service.js";
 import { AppSettingsStorage } from "./app-settings-storage.js";
@@ -3921,12 +3922,16 @@ async function openSessionFilePreviewWindow(
     };
   }
   try {
-    await explorer.inspectFile(resource);
+    const descriptor = await explorer.inspectFile(resource);
     const ownerSessionId = await getSessionFileExplorerOwnerSessionId(resource.sessionId);
     if (!ownerSessionId) {
       throw new Error("The owning Session could not be resolved.");
     }
-    const { disposition } = await requireMainWindowFacade().openFilePreviewWindow({ resource, ownerSessionId });
+    const { disposition } = await requireMainWindowFacade().openFilePreviewWindow({
+      resource,
+      ownerSessionId,
+      windowTitle: resolveSessionFilePreviewWindowTitle(descriptor.name),
+    });
     return { status: "opened", targetType: "preview-window", disposition, resource };
   } catch (error) {
     return {

--- a/src/FilePreviewApp.tsx
+++ b/src/FilePreviewApp.tsx
@@ -55,6 +55,12 @@ export default function FilePreviewApp() {
   }, [api]);
 
   useEffect(() => {
+    if (payload) {
+      document.title = payload.windowTitle;
+    }
+  }, [payload]);
+
+  useEffect(() => {
     let active = true;
     if (!api || !payload || !isSessionFileRootResource(payload.resource)) {
       setDiffScopes([]);

--- a/src/file-explorer/file-explorer-contract.ts
+++ b/src/file-explorer/file-explorer-contract.ts
@@ -79,7 +79,18 @@ export type SessionFilePreviewWindowOpenRequest =
 export type SessionFilePreviewWindowPayload = {
   resource: SessionFileResourceRequest;
   ownerSessionId: string;
+  windowTitle: string;
 };
+
+export const FILE_PREVIEW_WINDOW_TITLE_FALLBACK = "File Preview";
+
+export function resolveSessionFilePreviewWindowTitle(fileName: string | null | undefined): string {
+  const normalizedPath = fileName?.trim().replaceAll("\\", "/") ?? "";
+  const candidate = normalizedPath.split("/").at(-1)?.trim() ?? "";
+  return candidate && candidate !== "." && candidate !== ".." && !/[\u0000-\u001f\u007f]/u.test(candidate)
+    ? candidate
+    : FILE_PREVIEW_WINDOW_TITLE_FALLBACK;
+}
 
 export type SessionFilePreviewWindowOpenResult =
   | {


### PR DESCRIPTION
## 概要
- File Preview Windowのタイトルをプレビュー対象のファイル名へ変更
- resource previewとabsolute path previewのタイトルをbasenameへ正規化
- renderer hydrate後もpayloadのタイトルをdocument.titleへ同期
- 空・不正なファイル名はFile Previewへフォールバック

## 検証
- targeted test 48件
- npm run typecheck
- npm run build