### PR TITLE
fix: Markdown内のHTML改行を安全に描画する

### DIFF
--- a/scripts/tests/message-rich-text.test.ts
+++ b/scripts/tests/message-rich-text.test.ts
@@ -109,6 +109,68 @@ test("MessageRichText は **bold** を strong として render する", () => {
   assert.match(html, /<strong class="message-inline-strong">message<\/strong>/);
 });
 
+test("MessageRichText は属性なしの正しい HTML br 記法を改行として render する", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(MessageRichText, {
+      text: "first<br>second<br/>third<br />fourth<BR>fifth",
+    }),
+  );
+  const dom = new JSDOM(html);
+
+  assert.equal(dom.window.document.querySelectorAll("br").length, 4);
+  assert.equal(
+    dom.window.document.querySelector(".message-paragraph")?.textContent,
+    "first\nsecond\nthird\nfourth\nfifth",
+  );
+});
+
+test("MessageRichText は対象外の raw HTML を element として render しない", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(MessageRichText, {
+      text: [
+        "<script>alert('x')</script>",
+        "<img src=x onerror=alert(1)>",
+        "<br onclick=alert(1)>",
+      ].join("\n"),
+    }),
+  );
+  const dom = new JSDOM(html);
+
+  assert.equal(dom.window.document.querySelector("script, img, br"), null);
+  assert.match(dom.window.document.body.textContent, /<script>alert\('x'\)<\/script>/);
+  assert.match(dom.window.document.body.textContent, /<img src=x onerror=alert\(1\)>/);
+  assert.match(dom.window.document.body.textContent, /<br onclick=alert\(1\)>/);
+});
+
+test("MessageRichText は plain text と code literal 内の HTML br 文字列を改変しない", () => {
+  const markdown = [
+    "invalid </br> closing",
+    "",
+    "plain &lt;/br&gt; text",
+    "",
+    "`inline </br> code`",
+    "",
+    "```txt",
+    "fenced </br> code",
+    "```",
+  ].join("\n");
+  const previewHtml = renderToStaticMarkup(React.createElement(MessageRichText, { text: markdown }));
+  const previewDom = new JSDOM(previewHtml);
+  const sourceHtml = renderToStaticMarkup(React.createElement(MessageRichText, {
+    text: "source </br> text",
+    displayMode: "source",
+  }));
+  const sourceDom = new JSDOM(sourceHtml);
+
+  assert.equal(previewDom.window.document.querySelector("br"), null);
+  assert.match(previewDom.window.document.body.textContent, /invalid <\/br> closing/);
+  assert.match(previewDom.window.document.body.textContent, /plain <\/br> text/);
+  assert.match(previewDom.window.document.querySelector("code")?.textContent ?? "", /inline <\/br> code/);
+  assert.match(previewDom.window.document.querySelector("pre")?.textContent ?? "", /fenced <\/br> code/);
+  assert.equal(sourceDom.window.document.querySelector("br"), null);
+  assert.equal(sourceDom.window.document.querySelector("pre")?.textContent, "source </br> text");
+});
+
 test("MessageRichText の Source は元 Markdown を変換せず plain text で描画する", () => {
   const source = [
     "[link label](https://example.test/path)",
@@ -464,6 +526,41 @@ test("MessageRichText は browser 初回 render を light markdown にして後�
 
     assert.equal(container.querySelector("[data-markdown-render-mode]")?.getAttribute("data-markdown-render-mode"), "full");
     assert.notEqual(container.querySelector("table.message-table"), null);
+  } finally {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    restoreGlobals();
+    dom.window.close();
+  }
+});
+
+test("MessageRichText は light から full へ切り替わっても HTML br の改行を維持する", async () => {
+  const dom = new JSDOM("<!doctype html><div id=\"root\"></div>", {
+    pretendToBeVisual: true,
+    url: "http://localhost/",
+  });
+  const restoreGlobals = installDomGlobals(dom);
+  const container = dom.window.document.getElementById("root");
+  let root: Root | null = null;
+
+  try {
+    assert.ok(container);
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(React.createElement(MessageRichText, { text: "first<br />second" }));
+    });
+
+    assert.equal(container.querySelector("[data-markdown-render-mode]")?.getAttribute("data-markdown-render-mode"), "light");
+    assert.equal(container.querySelectorAll("br").length, 1);
+
+    await act(async () => {
+      await waitForAnimationFrame(dom.window);
+      await waitForAnimationFrame(dom.window);
+    });
+
+    assert.equal(container.querySelector("[data-markdown-render-mode]")?.getAttribute("data-markdown-render-mode"), "full");
+    assert.equal(container.querySelectorAll("br").length, 1);
   } finally {
     if (root) {
       await act(async () => root?.unmount());

--- a/src/MessageRichText.tsx
+++ b/src/MessageRichText.tsx
@@ -14,7 +14,9 @@ import ReactMarkdown, { defaultUrlTransform, type Components, type UrlTransform 
 import rehypeKatex from "rehype-katex";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
-import type { PluggableList } from "unified";
+import type { Root } from "mdast";
+import type { Node, Parent } from "unist";
+import type { Plugin, PluggableList } from "unified";
 
 import { getWithMateApi } from "./renderer-withmate-api.js";
 import { toLocalFileUrl } from "./local-file-url.js";
@@ -62,6 +64,33 @@ type HastNode = {
   tagName?: string;
   properties?: Record<string, unknown>;
   children?: HastNode[];
+};
+
+const htmlLineBreakPattern = /^<br[ \t]*\/?>$/i;
+
+const remarkHtmlLineBreaks: Plugin<[], Root> = () => (tree) => {
+  function visit(node: Node) {
+    if (!("children" in node) || !Array.isArray(node.children)) {
+      return;
+    }
+
+    const parent = node as Parent;
+    for (let index = 0; index < parent.children.length; index += 1) {
+      const child = parent.children[index];
+      if (
+        child.type === "html"
+        && "value" in child
+        && typeof child.value === "string"
+        && htmlLineBreakPattern.test(child.value)
+      ) {
+        parent.children[index] = { type: "break", position: child.position };
+        continue;
+      }
+      visit(child);
+    }
+  }
+
+  visit(tree);
 };
 
 let mermaidModulePromise: Promise<typeof import("mermaid")> | null = null;
@@ -649,7 +678,11 @@ function MessageMarkdownPreview({
     [footnoteLabelId, isFullRender],
   );
   const remarkPlugins = useMemo<PluggableList>(
-    () => (isFullRender ? [remarkGfm, [remarkMath, { singleDollarTextMath: false }]] : []),
+    () => (
+      isFullRender
+        ? [remarkGfm, [remarkMath, { singleDollarTextMath: false }], remarkHtmlLineBreaks]
+        : [remarkHtmlLineBreaks]
+    ),
     [isFullRender],
   );
 


### PR DESCRIPTION
## 概要

- Markdown本文の br 開始タグを改行として描画
- raw HTML全般は有効化せず、属性付きタグや終了タグは文字列表示を維持
- light / full rendererと共有consumerで表示を統一
- plain text、source表示、inline code、fenced codeを回帰テストで保護

## 検証

- npx tsx --test scripts/tests/message-rich-text.test.ts
- npm run typecheck
- npm run build

Closes #294