### PR TITLE
fix(chat): 通常送信中の共通エラー表示を抑制

### DIFF
--- a/scripts/tests/chat-window.test.ts
+++ b/scripts/tests/chat-window.test.ts
@@ -129,6 +129,29 @@ test("ChatWindow は ActionDock の展開状態に依存しない共通エラー
   assert.ok(html.indexOf("chat-error-surface") < html.indexOf("session-action-dock-slot"));
 });
 
+test("ChatWindow は submit pending を非表示の busy status として通知し、エラー表示しない", () => {
+  const props = createChatWindowProps();
+  props.composerProps = {
+    ...props.composerProps,
+    isComposerDisabled: true,
+    composerSendability: {
+      isBusy: true,
+      busyReason: "Message submission is in progress.",
+      primaryFeedback: "",
+      secondaryFeedback: [],
+      feedbackTone: null,
+      shouldShowFeedback: false,
+    },
+  };
+
+  const html = renderToStaticMarkup(React.createElement(ChatWindow, props));
+
+  assert.match(html, /<textarea[^>]*disabled=""[^>]*aria-busy="true"/);
+  assert.match(html, /class="visually-hidden" role="status"[^>]*>Message submission is in progress\.<\/span>/);
+  assert.doesNotMatch(html, /chat-error-surface/);
+  assert.doesNotMatch(html, /composer-sendability-feedback/);
+});
+
 test("ChatWindow の共通エラー領域は owner が指定したdismissと回復操作を表示する", () => {
   const props = createChatWindowProps();
   props.errorNotices = [{

--- a/scripts/tests/composer-preview-stale-errors.test.ts
+++ b/scripts/tests/composer-preview-stale-errors.test.ts
@@ -15,7 +15,7 @@ test("Agent composer は draft 変更時に stale preview errors を clear す�
   );
   assert.match(
     source,
-    /resolveComposerSendabilityState\(\{\s*runState: selectedSessionRunState,\s*blockedReason: composerBlockedReason,\s*inputErrors: composerPreview\.errors,/,
+    /resolveComposerSendabilityState\(\{\s*runState: selectedSessionRunState,\s*busyReason: composerBusyReason,\s*blockedReason: sessionExecutionBlockedReason,\s*inputErrors: composerPreview\.errors,/,
   );
   assert.match(
     source,

--- a/scripts/tests/session-chat-projection.test.ts
+++ b/scripts/tests/session-chat-projection.test.ts
@@ -361,6 +361,36 @@ test("buildAgentSessionChatWindowProps は composer とpath操作のエラーを
   assert.equal("inlinePathFeedback" in props.messageColumnProps, false);
 });
 
+test("buildAgentSessionChatWindowProps は submit pending の helper feedback を共通エラー領域へ投影しない", () => {
+  const props = buildAgentSessionChatWindowProps(createProjectionInput({
+    composerSendability: {
+      isBusy: true,
+      busyReason: "Message submission is in progress.",
+      primaryFeedback: "Message submission is in progress.",
+      secondaryFeedback: [],
+      feedbackTone: "helper",
+      shouldShowFeedback: true,
+    },
+  }));
+
+  assert.deepEqual(props.errorNotices, []);
+  assert.equal(props.composerProps.composerSendability.feedbackTone, "helper");
+  assert.equal(props.composerProps.composerSendability.isBusy, true);
+});
+
+test("buildAgentSessionChatWindowProps は blank draft の helper feedback を共通エラー領域へ投影しない", () => {
+  const props = buildAgentSessionChatWindowProps(createProjectionInput({
+    composerSendability: {
+      primaryFeedback: "Message is empty.",
+      secondaryFeedback: [],
+      feedbackTone: "helper",
+      shouldShowFeedback: true,
+    },
+  }));
+
+  assert.deepEqual(props.errorNotices, []);
+});
+
 test("buildAgentSessionChatWindowProps は Auxiliary mode で parent header 操作だけ隠す", () => {
   const normalProps = buildAgentSessionChatWindowProps(createProjectionInput());
   const auxiliaryProps = buildAgentSessionChatWindowProps(createProjectionInput({ isAuxiliaryMode: true }));

--- a/scripts/tests/session-composer-feedback.test.ts
+++ b/scripts/tests/session-composer-feedback.test.ts
@@ -26,7 +26,7 @@ describe("session composer feedback", () => {
     assert.equal(getComposerSendButtonTitle(state), BLANK_DRAFT_FEEDBACK);
   });
 
-  it("forced blocked feedback で blank draft 理由を表示する", () => {
+  it("forced feedback で blank draft 理由を helper として表示する", () => {
     const state = withForcedComposerBlockedFeedback(
       buildComposerSendabilityState({
         runState: "idle",
@@ -38,8 +38,63 @@ describe("session composer feedback", () => {
     );
 
     assert.equal(state.shouldShowFeedback, true);
-    assert.equal(state.feedbackTone, "blocked");
+    assert.equal(state.feedbackTone, "helper");
     assert.equal(state.primaryFeedback, BLANK_DRAFT_FEEDBACK);
+  });
+
+  it("送信開始時に draft clear と古い forced feedback が交差しても error feedback にしない", () => {
+    const beforeSend = resolveComposerSendabilityState({
+      runState: "idle",
+      blockedReason: "",
+      inputErrors: [],
+      draftText: "hello",
+      forceBlockedFeedback: true,
+    });
+    const afterDraftClear = resolveComposerSendabilityState({
+      runState: "idle",
+      blockedReason: "",
+      inputErrors: [],
+      draftText: "",
+      forceBlockedFeedback: true,
+    });
+
+    assert.equal(beforeSend.shouldShowFeedback, false);
+    assert.equal(afterDraftClear.primaryFeedback, BLANK_DRAFT_FEEDBACK);
+    assert.equal(afterDraftClear.feedbackTone, "helper");
+  });
+
+  it("submit pending は通常状態では error feedback を出さず、重複操作時だけ helper として表示する", () => {
+    const pending = buildComposerSendabilityState({
+      runState: "idle",
+      busyReason: "Message submission is in progress.",
+      blockedReason: "",
+      inputErrors: [],
+      draftText: "hello",
+    });
+
+    assert.equal(pending.isSendDisabled, true);
+    assert.equal(pending.shouldShowFeedback, false);
+    assert.equal(pending.feedbackTone, null);
+    assert.equal(getComposerSendButtonTitle(pending), "Message submission is in progress.");
+
+    const afterDuplicateSubmit = withForcedComposerBlockedFeedback(pending, true);
+    assert.equal(afterDuplicateSubmit.primaryFeedback, "Message submission is in progress.");
+    assert.equal(afterDuplicateSubmit.feedbackTone, "helper");
+    assert.equal(afterDuplicateSubmit.shouldShowFeedback, true);
+  });
+
+  it("submit pending 中も実際の input error は blocked feedback を維持する", () => {
+    const state = buildComposerSendabilityState({
+      runState: "idle",
+      busyReason: "Message submission is in progress.",
+      blockedReason: "",
+      inputErrors: ["Path not found: C:/missing"],
+      draftText: "hello",
+    });
+
+    assert.equal(state.primaryFeedback, "Path not found: C:/missing");
+    assert.equal(state.feedbackTone, "blocked");
+    assert.equal(state.shouldShowFeedback, true);
   });
 
   it("既存の blocked reason がある時は forced feedback で上書きしない", () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1174,9 +1174,10 @@ export default function AgentSessionWindowApp() {
 
     return "";
   }, [isSelectedProviderEnabled, isSelectedSessionReadOnly, selectedSession, workspaceAvailability]);
-  const composerBlockedReason = pendingSubmitSessionId === selectedSession?.id
+  const composerBusyReason = pendingSubmitSessionId === selectedSession?.id
     ? "Message submission is in progress."
-    : sessionExecutionBlockedReason;
+    : "";
+  const composerBlockedReason = composerBusyReason || sessionExecutionBlockedReason;
   const isSelectedWorkspaceAvailable = selectedSession
     ? isSessionWorkspaceAvailable(
         workspaceAvailability,
@@ -1928,12 +1929,20 @@ export default function AgentSessionWindowApp() {
     () =>
       resolveComposerSendabilityState({
         runState: selectedSessionRunState,
-        blockedReason: composerBlockedReason,
+        busyReason: composerBusyReason,
+        blockedReason: sessionExecutionBlockedReason,
         inputErrors: composerPreview.errors,
         draftText: draft,
         forceBlockedFeedback: forceComposerBlockedFeedback,
       }),
-    [composerBlockedReason, composerPreview.errors, draft, forceComposerBlockedFeedback, selectedSessionRunState],
+    [
+      composerBusyReason,
+      composerPreview.errors,
+      draft,
+      forceComposerBlockedFeedback,
+      selectedSessionRunState,
+      sessionExecutionBlockedReason,
+    ],
   );
   const isSendDisabled = composerSendability.isSendDisabled;
   const composerSendButtonTitle = getComposerSendButtonTitle(composerSendability);
@@ -2299,6 +2308,7 @@ export default function AgentSessionWindowApp() {
     } finally {
       submitLease.release();
       setPendingSubmitSessionId((current) => current === sessionId ? null : current);
+      setForceComposerBlockedFeedback(false);
     }
   };
 
@@ -2410,7 +2420,8 @@ export default function AgentSessionWindowApp() {
       const activeSendability = activeAuxiliarySession
         ? buildComposerSendabilityState({
             runState: activeAuxiliarySession.runState,
-            blockedReason: composerBlockedReason,
+            busyReason: composerBusyReason,
+            blockedReason: sessionExecutionBlockedReason,
             inputErrors: composerPreview.errors,
             draftText: activeAuxiliarySession.composerDraft,
           })
@@ -3513,15 +3524,17 @@ export default function AgentSessionWindowApp() {
   const auxiliaryComposerSendability = useMemo(
     () => buildComposerSendabilityState({
       runState: activeAuxiliarySession?.runState,
-      blockedReason: composerBlockedReason,
+      busyReason: composerBusyReason,
+      blockedReason: sessionExecutionBlockedReason,
       inputErrors: composerPreview.errors,
       draftText: activeAuxiliarySession?.composerDraft ?? "",
     }),
     [
       activeAuxiliarySession?.composerDraft,
       activeAuxiliarySession?.runState,
-      composerBlockedReason,
+      composerBusyReason,
       composerPreview.errors,
+      sessionExecutionBlockedReason,
     ],
   );
   const renderedSession = displayedSession;
@@ -3773,7 +3786,8 @@ export default function AgentSessionWindowApp() {
         isSendDisabled: renderedIsSendDisabled,
         composerSendability: renderedComposerSendability,
         composerSendButtonTitle: renderedComposerButtonTitle,
-        isComposerBlockedFeedbackActive: forceComposerBlockedFeedback && renderedComposerSendability.shouldShowFeedback,
+        isComposerBlockedFeedbackActive:
+          forceComposerBlockedFeedback && renderedComposerSendability.feedbackTone === "blocked",
         approvalChoiceOptions,
         sandboxChoiceOptions,
         modelSelectOptions,

--- a/src/chat/live-session-projection.tsx
+++ b/src/chat/live-session-projection.tsx
@@ -26,12 +26,14 @@ export function buildLiveSessionErrorNotices(input: {
   composerFeedback: {
     primaryFeedback: string;
     secondaryFeedback: readonly string[];
+    feedbackTone: "blocked" | "helper" | null;
     shouldShowFeedback: boolean;
   };
   additionalNotices?: readonly ChatErrorNotice[];
 }): ChatErrorNotice[] {
   const additionalNotices = input.additionalNotices ?? [];
   const feedbackMessages = input.composerFeedback.shouldShowFeedback
+    && input.composerFeedback.feedbackTone === "blocked"
     ? [input.composerFeedback.primaryFeedback, ...input.composerFeedback.secondaryFeedback]
       .map((message) => message.trim())
       .filter(Boolean)

--- a/src/session-components.tsx
+++ b/src/session-components.tsx
@@ -3451,6 +3451,8 @@ type SessionAttachmentItem = {
 };
 
 type SessionComposerSendabilityView = {
+  isBusy?: boolean;
+  busyReason?: string;
   primaryFeedback: string;
   secondaryFeedback: string[];
   feedbackTone: "blocked" | "helper" | null;
@@ -3918,11 +3920,17 @@ export function SessionComposerExpanded({
             onCompositionStart={onDraftCompositionStart}
             onCompositionEnd={onDraftCompositionEnd}
             disabled={isComposerDisabled}
+            aria-busy={composerSendability.isBusy || undefined}
             aria-describedby={externalErrorDescriptionIds || (
               composerSendability.shouldShowFeedback ? "composer-sendability-feedback" : undefined
             )}
             aria-invalid={composerSendability.feedbackTone === "blocked" ? true : undefined}
           />
+          {composerSendability.isBusy && composerSendability.busyReason ? (
+            <span className="visually-hidden" role="status" aria-live="polite" aria-atomic="true">
+              {composerSendability.busyReason}
+            </span>
+          ) : null}
           {composerSendability.shouldShowFeedback && !externalErrorDescriptionIds ? (
             <div
               id="composer-sendability-feedback"

--- a/src/session-composer-feedback.ts
+++ b/src/session-composer-feedback.ts
@@ -1,6 +1,8 @@
 export type ComposerSendabilityState = {
   isRunning: boolean;
   isBlankDraft: boolean;
+  isBusy: boolean;
+  busyReason: string;
   blockedReason: string;
   inputErrors: string[];
   primaryFeedback: string;
@@ -20,24 +22,30 @@ export const COMPOSER_SEND_BLOCKED_FALLBACK = "Message cannot be sent.";
 
 export function buildComposerSendabilityState({
   runState,
+  busyReason = "",
   blockedReason,
   inputErrors,
   draftText,
 }: {
   runState: string | null | undefined;
+  busyReason?: string;
   blockedReason: string;
   inputErrors: string[];
   draftText: string;
 }): ComposerSendabilityState {
   const normalizedBlockedReason = blockedReason.trim();
+  const normalizedBusyReason = busyReason.trim();
   const normalizedInputErrors = inputErrors.map((error) => error.trim()).filter(Boolean);
   const isRunning = runState === "running";
   const isBlankDraft = draftText.trim().length === 0;
+  const isBusy = normalizedBusyReason.length > 0;
 
   if (isRunning) {
     return {
       isRunning,
       isBlankDraft,
+      isBusy,
+      busyReason: normalizedBusyReason,
       blockedReason: normalizedBlockedReason,
       inputErrors: normalizedInputErrors,
       primaryFeedback: "",
@@ -61,13 +69,15 @@ export function buildComposerSendabilityState({
   return {
     isRunning,
     isBlankDraft,
+    isBusy,
+    busyReason: normalizedBusyReason,
     blockedReason: normalizedBlockedReason,
     inputErrors: normalizedInputErrors,
     primaryFeedback,
     secondaryFeedback,
     feedbackTone,
     shouldShowFeedback: !!primaryFeedback || secondaryFeedback.length > 0,
-    isSendDisabled: !!normalizedBlockedReason || normalizedInputErrors.length > 0 || isBlankDraft,
+    isSendDisabled: isBusy || !!normalizedBlockedReason || normalizedInputErrors.length > 0 || isBlankDraft,
   };
 }
 
@@ -79,23 +89,35 @@ export function withForcedComposerBlockedFeedback(
     return state;
   }
 
+  if (state.isBusy) {
+    return {
+      ...state,
+      primaryFeedback: state.busyReason,
+      secondaryFeedback: [],
+      feedbackTone: "helper",
+      shouldShowFeedback: true,
+    };
+  }
+
   return {
     ...state,
     primaryFeedback: BLANK_DRAFT_FEEDBACK,
     secondaryFeedback: [],
-    feedbackTone: "blocked",
+    feedbackTone: "helper",
     shouldShowFeedback: true,
   };
 }
 
 export function resolveComposerSendabilityState({
   runState,
+  busyReason,
   blockedReason,
   inputErrors,
   draftText,
   forceBlockedFeedback,
 }: {
   runState: string | null | undefined;
+  busyReason?: string;
   blockedReason: string;
   inputErrors: string[];
   draftText: string;
@@ -104,6 +126,7 @@ export function resolveComposerSendabilityState({
   return withForcedComposerBlockedFeedback(
     buildComposerSendabilityState({
       runState,
+      busyReason,
       blockedReason,
       inputErrors,
       draftText,
@@ -121,7 +144,9 @@ export function getComposerSendButtonTitle(state: ComposerSendabilityState): str
     return "メッセージを送信";
   }
 
-  return state.primaryFeedback || (state.isBlankDraft ? BLANK_DRAFT_FEEDBACK : COMPOSER_SEND_BLOCKED_FALLBACK);
+  return state.primaryFeedback
+    || state.busyReason
+    || (state.isBlankDraft ? BLANK_DRAFT_FEEDBACK : COMPOSER_SEND_BLOCKED_FALLBACK);
 }
 
 export function getComposerSendBlockedMessage(


### PR DESCRIPTION
## 概要

- submit pendingを実エラーから分離し、通常送信中は共通エラー領域へ表示しない
- rapid submit時のSession単位leaseを維持し、重複操作のfeedbackをhelperとして扱う
- workspace、provider、inputなどの実エラーは従来どおり共通エラー領域へ表示する
- busy状態をdisabled、aria-busy、screen reader向けstatusへ反映する
- success、preflight拒否、例外後にpendingと強制feedbackを解除する

## 検証

- `npx tsx --test scripts/tests/session-composer-feedback.test.ts scripts/tests/session-chat-projection.test.ts scripts/tests/chat-window.test.ts scripts/tests/session-submit-coordinator.test.ts`
- `npm run typecheck` 
- `npm run build` 
- 通常送信直後と応答完了後に共通エラー表示が残らないことを目視確認

## 対象外

- Character affect appraisalによる入力復帰遅延はIssue #296の担当範囲とし、本PRでは`SessionRuntimeService`、通知、audit、IPCの完了順序を変更しない

Closes #301