### PR TITLE
チャットのコードブロックへコピー操作を追加

### DIFF
--- a/scripts/tests/message-rich-text.test.ts
+++ b/scripts/tests/message-rich-text.test.ts
@@ -11,6 +11,7 @@ import {
   handleMarkdownLinkClick,
   handleMarkdownLinkContextMenu,
   MessageRichText,
+  resolveCodeBlockText,
   resolveMessageMarkdownRenderMode,
 } from "../../src/MessageRichText.js";
 
@@ -203,6 +204,160 @@ test("MessageRichText は inline code と link を優先しつつ bold を併用
   assert.match(html, /<code class="message-inline-code">\*\*literal\*\*<\/code>/);
   assert.match(html, /<strong class="message-inline-strong">/);
   assert.match(html, /<a href="src\/App\.tsx">file<\/a>/);
+});
+
+test("MessageRichText は fenced code blockだけにaccessibleなcopy操作を表示する", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(MessageRichText, {
+      text: [
+        "plain `inline` text",
+        "",
+        "````markdown",
+        "outer",
+        "```ts",
+        "const nested = true;",
+        "```",
+        "",
+        "````",
+        "",
+        "    indented code",
+      ].join("\n"),
+    }),
+  );
+  const dom = new JSDOM(html);
+  const copyButtons = dom.window.document.querySelectorAll<HTMLButtonElement>(".message-code-copy-button");
+
+  assert.equal(copyButtons.length, 1);
+  assert.equal(copyButtons[0]?.getAttribute("aria-label"), "コードをコピー");
+  assert.equal(copyButtons[0]?.getAttribute("title"), "コードをコピー");
+  assert.match(
+    dom.window.document.querySelector(".message-code-block")?.textContent ?? "",
+    /outer\n```ts\nconst nested = true;\n```\n/,
+  );
+  assert.equal(dom.window.document.querySelector(".message-inline-code")?.textContent, "inline");
+});
+
+test("resolveCodeBlockText は改行をLFへ揃えparser由来の末尾改行だけを除く", () => {
+  assert.equal(resolveCodeBlockText("first\r\nsecond\rthird\n\n"), "first\nsecond\nthird\n");
+  assert.equal(resolveCodeBlockText("without trailing newline"), "without trailing newline");
+});
+
+test("code block copy操作はhover・focus・disabledの視認状態を持つ", async () => {
+  const styles = await readFile(new URL("../../src/styles.css", import.meta.url), "utf8");
+  const buttonRule = styles.match(/\.message-code-copy-button\s*{(?<body>[^}]*)}/)?.groups?.body ?? "";
+  const hoverRule = styles.match(/\.message-code-copy-button:hover:not\(:disabled\)\s*{(?<body>[^}]*)}/)?.groups?.body ?? "";
+  const focusRule = styles.match(/\.message-code-copy-button:focus-visible\s*{(?<body>[^}]*)}/)?.groups?.body ?? "";
+  const disabledRule = styles.match(/\.message-code-copy-button:disabled\s*{(?<body>[^}]*)}/)?.groups?.body ?? "";
+
+  assert.match(buttonRule, /color:\s*rgba\(255, 255, 255, 0\.94\);/);
+  assert.match(buttonRule, /border-radius:\s*999px;/);
+  assert.match(hoverRule, /border-color:/);
+  assert.match(hoverRule, /background:/);
+  assert.match(hoverRule, /transform:\s*translateY\(-1px\);/);
+  assert.match(focusRule, /outline:\s*2px solid var\(--teal\);/);
+  assert.match(disabledRule, /opacity:\s*0\.64;/);
+});
+
+test("MessageRichText のcode block copyは本文だけをclipboardへ渡してfeedbackを表示する", async () => {
+  const dom = new JSDOM("<div id=\"root\"></div>", {
+    pretendToBeVisual: true,
+    url: "https://example.test/",
+  });
+  const restore = installDomGlobals(dom);
+  const container = dom.window.document.getElementById("root");
+  const root: Root | null = container ? createRoot(container) : null;
+  const copied: string[] = [];
+  let resolveWrite: (() => void) | undefined;
+  Object.defineProperty(dom.window.navigator, "clipboard", {
+    configurable: true,
+    value: {
+      writeText: async (text: string) => {
+        copied.push(text);
+        await new Promise<void>((resolve) => {
+          resolveWrite = resolve;
+        });
+      },
+    },
+  });
+
+  try {
+    await act(async () => {
+      root?.render(React.createElement(MessageRichText, {
+        forceFullRender: true,
+        text: ["```ts", "const first = 1;", "", "```"].join("\n"),
+      }));
+    });
+    const button = container?.querySelector<HTMLButtonElement>(".message-code-copy-button");
+    assert.ok(button);
+
+    await act(async () => {
+      button.click();
+      button.click();
+      await Promise.resolve();
+    });
+
+    assert.deepEqual(copied, ["const first = 1;\n"]);
+    assert.equal(button.disabled, true);
+
+    await act(async () => {
+      resolveWrite?.();
+      await Promise.resolve();
+    });
+
+    assert.equal(button.disabled, false);
+    assert.equal(container?.querySelector(".message-copy-toast")?.textContent, "コードをコピーしました。");
+    assert.equal(container?.querySelector(".message-copy-toast")?.getAttribute("role"), "status");
+  } finally {
+    await act(async () => {
+      root?.unmount();
+    });
+    restore();
+    dom.window.close();
+  }
+});
+
+test("MessageRichText のcode block copy失敗はerror feedbackを表示する", async () => {
+  const dom = new JSDOM("<div id=\"root\"></div>", {
+    pretendToBeVisual: true,
+    url: "https://example.test/",
+  });
+  const restore = installDomGlobals(dom);
+  const container = dom.window.document.getElementById("root");
+  const root: Root | null = container ? createRoot(container) : null;
+  Object.defineProperty(dom.window.navigator, "clipboard", {
+    configurable: true,
+    value: {
+      writeText: async () => {
+        throw new Error("clipboard denied");
+      },
+    },
+  });
+
+  try {
+    await act(async () => {
+      root?.render(React.createElement(MessageRichText, {
+        forceFullRender: true,
+        text: ["```", "copy me", "```"].join("\n"),
+      }));
+    });
+    const button = container?.querySelector<HTMLButtonElement>(".message-code-copy-button");
+    assert.ok(button);
+
+    await act(async () => {
+      button.click();
+      await Promise.resolve();
+    });
+
+    const feedback = container?.querySelector(".message-copy-toast");
+    assert.equal(feedback?.textContent, "コードのコピーに失敗しました。");
+    assert.ok(feedback?.classList.contains("error"));
+  } finally {
+    await act(async () => {
+      root?.unmount();
+    });
+    restore();
+    dom.window.close();
+  }
 });
 
 test("handleMarkdownLinkClick は Markdown link を既定ナビゲーションではなく openPath 経路へ流す", () => {

--- a/src/MessageRichText.tsx
+++ b/src/MessageRichText.tsx
@@ -6,6 +6,7 @@ import {
   useEffect,
   useId,
   useMemo,
+  useRef,
   useState,
   type MouseEvent,
   type ReactNode,
@@ -64,6 +65,16 @@ type HastNode = {
   tagName?: string;
   properties?: Record<string, unknown>;
   children?: HastNode[];
+  position?: {
+    start?: {
+      offset?: number;
+    };
+  };
+};
+
+type MessageCopyFeedback = {
+  message: string;
+  tone: "error" | "success";
 };
 
 const htmlLineBreakPattern = /^<br[ \t]*\/?>$/i;
@@ -121,6 +132,66 @@ function extractTextContent(node: ReactNode): string {
     return extractTextContent(node.props.children);
   }
   return "";
+}
+
+export function resolveCodeBlockText(node: ReactNode): string {
+  return extractTextContent(node).replace(/\r\n?/g, "\n").replace(/\n$/, "");
+}
+
+function isFencedCodeBlock(node: HastNode | undefined, markdown: string): boolean {
+  const startOffset = node?.position?.start?.offset;
+  if (typeof startOffset !== "number") {
+    return false;
+  }
+  const openingLine = markdown.slice(startOffset).split(/\r?\n/, 1)[0];
+  return /^[ ]{0,3}(?:`{3,}|~{3,})/.test(openingLine);
+}
+
+type CodeBlockCopyButtonProps = {
+  code: string;
+  onCopyResult: (feedback: MessageCopyFeedback) => void;
+};
+
+function CodeBlockCopyButton({ code, onCopyResult }: CodeBlockCopyButtonProps) {
+  const [isCopying, setIsCopying] = useState(false);
+  const copyInFlightRef = useRef(false);
+
+  const handleCopy = async () => {
+    if (copyInFlightRef.current) {
+      return;
+    }
+    copyInFlightRef.current = true;
+    setIsCopying(true);
+    try {
+      const writeText = navigator.clipboard?.writeText?.bind(navigator.clipboard);
+      if (!writeText) {
+        throw new Error("Clipboard API is unavailable.");
+      }
+      await writeText(code);
+      onCopyResult({ message: "コードをコピーしました。", tone: "success" });
+    } catch {
+      onCopyResult({ message: "コードのコピーに失敗しました。", tone: "error" });
+    } finally {
+      copyInFlightRef.current = false;
+      setIsCopying(false);
+    }
+  };
+
+  return (
+    <button
+      className="message-code-copy-button"
+      type="button"
+      aria-label="コードをコピー"
+      title="コードをコピー"
+      disabled={isCopying}
+      onClick={() => void handleCopy()}
+    >
+      <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+        <path d="M8.5 15.5H7A2.5 2.5 0 0 1 4.5 13V7A2.5 2.5 0 0 1 7 4.5h6A2.5 2.5 0 0 1 15.5 7v1.5" />
+        <rect x="8.5" y="8.5" width="11" height="11" rx="3" />
+      </svg>
+    </button>
+  );
 }
 
 function resolveCodeLanguage(className?: string) {
@@ -316,7 +387,13 @@ function createFootnoteLabelIdPlugin(footnoteLabelId: string) {
   };
 }
 
-function MermaidDiagram({ source }: { source: string }) {
+function MermaidDiagram({
+  source,
+  onCopyResult,
+}: {
+  source: string;
+  onCopyResult?: (feedback: MessageCopyFeedback) => void;
+}) {
   const reactId = useId();
   const diagramId = useMemo(() => `message-mermaid-${reactId.replace(/[^a-zA-Z0-9_-]/g, "")}`, [reactId]);
   const diagramSource = source.trim();
@@ -355,15 +432,27 @@ function MermaidDiagram({ source }: { source: string }) {
   }, [diagramId, diagramSource]);
 
   if (renderState.status === "ready") {
-    return <div className="message-mermaid" dangerouslySetInnerHTML={{ __html: renderState.svg }} />;
+    return (
+      <div className="message-code-block-shell mermaid">
+        <div className="message-mermaid" dangerouslySetInnerHTML={{ __html: renderState.svg }} />
+        {onCopyResult ? (
+          <CodeBlockCopyButton code={resolveCodeBlockText(source)} onCopyResult={onCopyResult} />
+        ) : null}
+      </div>
+    );
   }
 
   return (
-    <div className="message-mermaid fallback">
-      {renderState.status === "error" ? <p className="message-mermaid-error">{renderState.message}</p> : null}
-      <pre className="message-code-block">
-        <code className="message-inline-code language-mermaid">{source}</code>
-      </pre>
+    <div className="message-code-block-shell mermaid">
+      <div className="message-mermaid fallback">
+        {renderState.status === "error" ? <p className="message-mermaid-error">{renderState.message}</p> : null}
+        <pre className="message-code-block">
+          <code className="message-inline-code language-mermaid">{source}</code>
+        </pre>
+      </div>
+      {onCopyResult ? (
+        <CodeBlockCopyButton code={resolveCodeBlockText(source)} onCopyResult={onCopyResult} />
+      ) : null}
     </div>
   );
 }
@@ -414,20 +503,6 @@ const markdownComponents: Components = {
       {children}
     </ol>
   ),
-  pre: ({ children, node, ...props }) => {
-    const child = Children.toArray(children)[0];
-    if (isValidElement<{ className?: string; children?: ReactNode }>(child)) {
-      const language = resolveCodeLanguage(child.props.className);
-      if (language === "mermaid") {
-        return <MermaidDiagram source={extractTextContent(child.props.children)} />;
-      }
-    }
-    return (
-      <pre {...props} className={mergeClassName("message-code-block", props.className)}>
-        {children}
-      </pre>
-    );
-  },
   code: ({ children, className: codeClassName, node, ...props }) => {
     const renderedChildren = typeof children === "string" && children.endsWith("\n")
       ? children.slice(0, -1)
@@ -587,6 +662,8 @@ function createMarkdownComponents(
   onOpenPath?: (target: string) => void,
   options?: {
     enableMermaid?: boolean;
+    markdown?: string;
+    onCodeBlockCopyResult?: (feedback: MessageCopyFeedback) => void;
     onLinkContextMenuResult?: (result: MarkdownLinkContextMenuResult) => void;
     resolveImageSource?: (target: string) => Promise<string | null>;
   },
@@ -594,15 +671,36 @@ function createMarkdownComponents(
   const enableMermaid = options?.enableMermaid ?? true;
   return {
     ...markdownComponents,
-    ...(enableMermaid
-      ? {}
-      : {
-          pre: ({ children, node, ...props }) => (
-            <pre {...props} className={mergeClassName("message-code-block", props.className)}>
-              {children}
-            </pre>
-          ),
-        }),
+    pre: ({ children, node, ...props }) => {
+      const isFenced = isFencedCodeBlock(node, options?.markdown ?? "");
+      const child = Children.toArray(children)[0];
+      if (enableMermaid && isValidElement<{ className?: string; children?: ReactNode }>(child)) {
+        const language = resolveCodeLanguage(child.props.className);
+        if (language === "mermaid") {
+          return (
+            <MermaidDiagram
+              source={extractTextContent(child.props.children)}
+              onCopyResult={isFenced ? options?.onCodeBlockCopyResult : undefined}
+            />
+          );
+        }
+      }
+
+      const content = (
+        <pre {...props} className={mergeClassName("message-code-block", props.className)}>
+          {children}
+        </pre>
+      );
+      return isFenced && options?.onCodeBlockCopyResult ? (
+        <div className="message-code-block-shell">
+          {content}
+          <CodeBlockCopyButton
+            code={resolveCodeBlockText(children)}
+            onCopyResult={options.onCodeBlockCopyResult}
+          />
+        </div>
+      ) : content;
+    },
     a: ({ children, href, node, ...props }) => {
       const target = href?.trim() ?? "";
       const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
@@ -648,10 +746,7 @@ function MessageMarkdownPreview({
   const footnotePrefix = useMemo(() => `message-footnote-${reactId.replace(/[^a-zA-Z0-9_-]/g, "")}-`, [reactId]);
   const footnoteLabelId = `${footnotePrefix}footnote-label`;
   const shouldDefer = !forceFullRender && shouldDeferRichMarkdownRender();
-  const [linkCopyFeedback, setLinkCopyFeedback] = useState<{
-    message: string;
-    tone: "error" | "success";
-  } | null>(null);
+  const [copyFeedback, setCopyFeedback] = useState<MessageCopyFeedback | null>(null);
   const [renderState, setRenderState] = useState<{ text: string; mode: MarkdownRenderMode }>(() => ({
     text,
     mode: shouldDefer ? "light" : "full",
@@ -659,19 +754,24 @@ function MessageMarkdownPreview({
   const renderMode = resolveMessageMarkdownRenderMode(forceFullRender, text, renderState, shouldDefer);
   const isFullRender = renderMode === "full";
   const handleLinkContextMenuResult = useCallback((result: MarkdownLinkContextMenuResult) => {
-    setLinkCopyFeedback(result.status === "copied"
+    setCopyFeedback(result.status === "copied"
       ? { message: "リンクをコピーしました。", tone: "success" }
       : result.status === "failed"
         ? { message: result.message, tone: "error" }
         : null);
   }, []);
+  const handleCodeBlockCopyResult = useCallback((feedback: MessageCopyFeedback) => {
+    setCopyFeedback(feedback);
+  }, []);
   const components = useMemo(
     () => createMarkdownComponents(onOpenPath, {
       enableMermaid: isFullRender,
+      markdown: text,
+      onCodeBlockCopyResult: handleCodeBlockCopyResult,
       onLinkContextMenuResult: handleLinkContextMenuResult,
       resolveImageSource,
     }),
-    [handleLinkContextMenuResult, isFullRender, onOpenPath, resolveImageSource],
+    [handleCodeBlockCopyResult, handleLinkContextMenuResult, isFullRender, onOpenPath, resolveImageSource, text],
   );
   const rehypePlugins = useMemo<PluggableList>(
     () => (isFullRender ? [rehypeKatex, createFootnoteLabelIdPlugin(footnoteLabelId)] : []),
@@ -703,12 +803,12 @@ function MessageMarkdownPreview({
   }, [shouldDefer, text]);
 
   useEffect(() => {
-    if (!linkCopyFeedback) {
+    if (!copyFeedback) {
       return;
     }
-    const timeout = window.setTimeout(() => setLinkCopyFeedback(null), 2_400);
+    const timeout = window.setTimeout(() => setCopyFeedback(null), 2_400);
     return () => window.clearTimeout(timeout);
-  }, [linkCopyFeedback]);
+  }, [copyFeedback]);
 
   return (
     <div className={`${className} rich-text`.trim()} data-markdown-render-mode={renderMode}>
@@ -721,14 +821,14 @@ function MessageMarkdownPreview({
       >
         {text}
       </ReactMarkdown>
-      {linkCopyFeedback ? (
+      {copyFeedback ? (
         <span
-          className={`message-link-copy-toast ${linkCopyFeedback.tone}`}
+          className={`message-copy-toast message-link-copy-toast ${copyFeedback.tone}`}
           role="status"
           aria-live="polite"
           aria-atomic="true"
         >
-          {linkCopyFeedback.message}
+          {copyFeedback.message}
         </span>
       ) : null}
     </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -6549,6 +6549,74 @@ button:disabled {
   white-space: pre;
 }
 
+.message-code-block-shell {
+  position: relative;
+  min-width: 0;
+}
+
+.message-code-block-shell > .message-code-block {
+  padding-right: 52px;
+}
+
+.message-code-copy-button {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 1;
+  display: inline-grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  padding: 0;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 999px;
+  background: rgba(30, 41, 59, 0.72);
+  color: rgba(255, 255, 255, 0.94);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 4px 12px rgba(0, 0, 0, 0.18);
+  cursor: pointer;
+  transition:
+    transform 140ms ease,
+    border-color 140ms ease,
+    background 140ms ease,
+    box-shadow 140ms ease;
+}
+
+.message-code-copy-button svg {
+  width: 16px;
+  height: 16px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.7;
+}
+
+.message-code-copy-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  border-color: rgba(255, 255, 255, 0.58);
+  background: rgba(51, 65, 85, 0.92);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    0 6px 16px rgba(0, 0, 0, 0.24);
+}
+
+.message-code-copy-button:active:not(:disabled) {
+  transform: scale(0.94);
+}
+
+.message-code-copy-button:focus-visible {
+  outline: 2px solid var(--teal);
+  outline-offset: 2px;
+}
+
+.message-code-copy-button:disabled {
+  transform: none;
+  opacity: 0.64;
+  cursor: progress;
+}
+
 .message-code-block .message-inline-code {
   display: inline;
   padding: 0;
@@ -6572,6 +6640,10 @@ button:disabled {
   padding: 0;
   border: 0;
   background: transparent;
+}
+
+.message-code-block-shell.mermaid > .message-mermaid {
+  padding-top: 42px;
 }
 
 .message-mermaid svg {
@@ -10671,7 +10743,7 @@ button:disabled {
   color: #933c3c;
 }
 
-.message-link-copy-toast {
+.message-copy-toast {
   position: fixed;
   right: 18px;
   bottom: 18px;
@@ -10685,11 +10757,11 @@ button:disabled {
   box-shadow: var(--shadow);
 }
 
-.message-link-copy-toast.success {
+.message-copy-toast.success {
   border-color: var(--teal);
 }
 
-.message-link-copy-toast.error {
+.message-copy-toast.error {
   border-color: var(--danger, #fca5a5);
 }
 


### PR DESCRIPTION
## 概要

- fenced code block右上へ本文コピー操作を追加
- 表示装飾と言語ラベルを除外し、改行と末尾改行を決定的に処理
- 既存のCopy feedbackへ成功・失敗を統合し、連打による重複writeを防止
- 円形のicon-only controlへaccessible name、hover、focus、disabled状態を追加
- CommonMarkの長い外側fenceにnested fenceを含むfixtureを追加

## 検証

- `npx tsx --test scripts/tests/message-rich-text.test.ts`（49件成功）
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## 未実施

- 分離起動による実画面の目視確認

Closes #297
