### PR TITLE
fix(session): 狭い幅でもヘッダーを1行に保つ

### DIFF
--- a/scripts/tests/session-context-pane-style.test.ts
+++ b/scripts/tests/session-context-pane-style.test.ts
@@ -215,6 +215,21 @@ test("Header と ActionDock は中央・左右ペインの外側に全幅 dock �
   assert.doesNotMatch(companionProjectionSource, /isHeaderResizing|onStartHeaderResize/);
 });
 
+test("固定高のSession Headerは操作群を折り返さずタイトルを残り幅へ収める", async () => {
+  const stylesSource = await readFile("src/styles.css", "utf8");
+  const controlsRule = stylesSource.match(/\.session-window-controls\s*{([^}]*)}/)?.[1] ?? "";
+  const titleRule = stylesSource.match(/\.session-title-shell\s*{([^}]*)}/)?.[1] ?? "";
+
+  assert.match(stylesSource, /\.session-page \.session-top-bar\s*{\s*container-type:\s*inline-size;/);
+  assert.match(controlsRule, /flex:\s*0 0 auto;/);
+  assert.match(controlsRule, /flex-wrap:\s*nowrap;/);
+  assert.match(titleRule, /flex:\s*1 1 0;/);
+  assert.match(
+    stylesSource,
+    /@container \(max-width:\s*960px\)\s*{[\s\S]*?\.session-window-controls\s*{[\s\S]*?gap:\s*4px;[\s\S]*?\.session-window-control-group-label\s*{[\s\S]*?font-size:\s*0\.6rem;[\s\S]*?\.session-page \.session-window-control-group \.drawer-toggle\s*{[\s\S]*?font-size:\s*0\.75rem;/,
+  );
+});
+
 test("Session 四辺の開閉は共通 motion を使い、resize 中と reduced-motion で補間を止める", async () => {
   const stylesSource = await readFile("src/styles.css", "utf8");
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -620,6 +620,7 @@ button:disabled {
 }
 
 .session-page .session-top-bar {
+  container-type: inline-size;
   padding: 10px 14px;
   overflow: visible;
 }
@@ -643,8 +644,8 @@ button:disabled {
   align-items: center;
   justify-content: flex-end;
   gap: 8px;
-  row-gap: 8px;
-  flex-wrap: wrap;
+  flex: 0 0 auto;
+  flex-wrap: nowrap;
   min-width: 0;
 }
 
@@ -743,6 +744,32 @@ button:disabled {
 .session-header-more-menu button:disabled {
   cursor: not-allowed;
   opacity: 0.48;
+}
+
+@container (max-width: 960px) {
+  .session-window-controls {
+    gap: 4px;
+  }
+
+  .session-window-control-group {
+    gap: 3px;
+  }
+
+  .session-window-control-group-label {
+    padding: 0;
+    font-size: 0.6rem;
+    letter-spacing: 0.03em;
+  }
+
+  .session-page .session-window-control-group .drawer-toggle {
+    padding: 6px 7px;
+    font-size: 0.75rem;
+  }
+
+  .session-header-more > summary {
+    width: 30px;
+    height: 30px;
+  }
 }
 
 .sr-only {
@@ -3754,7 +3781,7 @@ button:disabled {
   align-items: center;
   gap: 12px;
   min-width: 0;
-  flex: 1 1 auto;
+  flex: 1 1 0;
 }
 
 .session-title-editor {


### PR DESCRIPTION
## 概要

- 固定高のSession Header内で操作群を折り返さず、タイトルを残り幅へ省略表示するように変更
- ヘッダー幅960px以下では、ラベル・操作の意味を維持したまま間隔と文字サイズを圧縮
- 固定高Headerの配置契約を検出する回帰テストを追加

## 原因

Header Dockは1行分の64px固定高である一方、`.session-window-controls`が`flex-wrap: wrap`を許可していました。タイトルと操作群の合計幅が不足すると操作群の2行目が固定高領域から下へ描画され、splitterや中央surfaceと重なっていました。

## 確認した状態

- header visible / hidden
- ActionDock compact / expanded
- 通常Session / active Auxiliary Session
- 長いSession title
- title編集時のSave / Cancel
- running / read-only由来のdisabled状態

## 検証

- `npx tsx --test scripts/tests/session-context-pane-style.test.ts scripts/tests/chat-header-actions.test.tsx scripts/tests/chat-window.test.ts scripts/tests/chat-layout-preference.test.ts scripts/tests/action-dock-state.test.ts`（55件成功）
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- Electron 43 / Chromiumで1064px内容幅と、製品最小Window幅900px相当の884px内容幅を計測
  - 長いタイトル、Workspace / Session / Auxiliary操作、Return to main、more操作が1行かつHeader境界内
  - 884px内容幅でタイトル領域を約172px確保
  - title編集時のSave / CancelがHeader境界内

## 未確認

- macOS / Linuxでの実描画
- 製品最小Window幅未満になる高倍率zoom