### PR TITLE
SystemPromptにフォルダコンテキストを追加

### DIFF
--- a/docs/design/prompt-composition.md
+++ b/docs/design/prompt-composition.md
@@ -1,7 +1,7 @@
 # Prompt Composition
 
 - 作成日: 2026-03-13
-- 更新日: 2026-08-09
+- 更新日: 2026-08-15
 - 対象: WithMate における coding plane の prompt 合成
 
 ## Goal
@@ -50,13 +50,15 @@ coding plane に渡す turn prompt は、次のレイヤーを基本にする。
 1. `CharacterRuntimeSnapshot.definitionMarkdown`
 2. `Output Boundary`
 3. `Tool Call Presence`
-4. `Character Affect Context`
-5. 必要最小限の WithMate run marker
-6. `Conversation Timing`
-7. ユーザー入力
-8. 添付 reference
+4. `Folder Context`
+5. `Character Affect Context`
+6. 必要最小限の WithMate run marker
+7. `Conversation Timing`
+8. ユーザー入力
+9. 添付 reference
 
 通常 session / companion の Character snapshot は session / companion 開始時点の保存済み値を使い、catalog の現在値へ追従しない。`character-authoring` session は turn 開始時に最新の `character.md` から runtime snapshot を作り直す。app 共通 system prompt は挿入しない。
+`Folder Context` は毎 turn system 側へ置き、実行 workspace、Main Process が解決した SessionFolder、実効 Additional Directories 一覧だけを明示する。Character、`Output Boundary`、`Tool Call Presence` の安定した section の後ろ、turn ごとに変動する `Character Affect Context` の前に置き、folder 値が変わっても固定 system prefix の再利用を保ちやすくする。各 directory の利用方針は repository instruction、filesystem access grant は provider adapter と既存 allowlist が所有し、Folder Context に説明文を重ねない。
 provider に渡す `Character Definition Snapshot` では、snapshot の取得時点説明を prompt 本体には入れない。保存済み snapshot の frontmatter は除外し、Character 名と説明を metadata として示したうえで、`character.md` 本文だけを markdown block として囲む。Character section の固定説明は、話し方への反映と coding agent 境界の guard に絞る。
 通常 session / companion では Character section の直後に `Output Boundary` を置き、Character 定義の適用先をユーザー向け自然言語レスポンスへ限定する。コード、設定、テスト、ドキュメント、コミットメッセージ案、PR本文案、生成ファイル、diff、artifact summary は、ユーザーが明示しない限り Character の口調・設定・台詞・メタ説明を混ぜず、repository instruction、既存文体、対象ファイルの目的を優先する。
 通常 session / companion では `Output Boundary` の直後に `Tool Call Presence` を置き、tool call や command 実行前に短い自然言語レスポンスを返すことで、Character が無言のまま作業へ入ったように見える体験を避ける。
@@ -78,6 +80,7 @@ Mate Core / Bond Profile / Work Style は provider instruction file へ同期し
 
 ### current runtime
 
+論理 prompt では `Folder Context` section を Character、`Output Boundary`、`Tool Call Presence` の後ろ、`Character Affect Context` の前に置く。Character section がない場合は system 側の先頭になる。`Workspace` は `resolveRunWorkspacePath` の実行値、`SessionFolder` は `session-files.ts` を経由して Main Process が解決した値、`Additional Directories` は実行 workspace を基準に `normalizeAllowedAdditionalDirectories` で正規化した値を使う。空の Additional Directories は `なし`、取得できない path は `利用不可` と明示する。
 論理 prompt では `Character Definition Snapshot` section を system 側に置く。
 通常 session / companion では `Output Boundary` section も system 側に置く。`character-authoring` session では置かない。
 通常 session / companion では `Tool Call Presence` section も system 側に置く。`character-authoring` session では置かない。
@@ -98,6 +101,18 @@ Character Contextを取得できたturnでは、`Character Affect Context` secti
 - transport payload summary
 
 ## Section Formats
+
+### `# Workspace` / `# SessionFolder` / `# Additional Directories`
+
+- source:
+  - `Workspace`: `resolveRunWorkspacePath` の実行 workspace
+  - `SessionFolder`: Main Process が `resolveSessionFilesDirectory` で解決した managed directory
+  - `Additional Directories`: 実行 workspace を基準に正規化した実効 additional directory 一覧
+- 形式:
+  - 3つの見出しと値を system 側へ固定順で置く。Character section がない場合は先頭になる
+  - 値以外の利用方針や認可説明は入れず、repository instruction と provider adapter の責務を重複させない
+  - 値の表示は provider の filesystem access grant を拡大しない。Additional Directories の認可は provider adapter と既存 allowlist が所有する
+  - 値がない場合は path を推測せず、`利用不可` または `なし` を表示する
 
 ### `# User Input`
 
@@ -186,8 +201,10 @@ Character Contextを取得できたturnでは、`Character Affect Context` secti
 
 - 固定的な Mate 定義は provider instruction sync 側へ移す
 - turn prompt の可変部分は `# User Input` と添付 reference に寄せる
+- `CharacterRuntimeSnapshot`、`Output Boundary`、`Tool Call Presence` を system 側の先頭に保ち、その直後に `Folder Context` を置く
+- `Folder Context` は同じ Session で通常は安定するが、実行 workspace や Additional Directories が変わっても固定 prefix の後ろで差分になるようにする
 
-Mate 定義全文と Memory section を毎 turn prompt から外すことで、短い依頼での token 消費を抑え、provider 側の prompt cache を阻害しにくくする。ただし provider instruction file が provider context として読まれる場合、token 消費が完全にゼロになるわけではない。
+固定 Character section と Folder Context を user input / timing / Affect より前に置き、provider が再利用できる prefix を保つ。Folder Context は固定 Character section の後ろへ置くことで、folder 値の変更が固定 prefix 全体を無効化しにくい。Mate 定義全文と Memory section を毎 turn prompt から外すことで、短い依頼での token 消費も抑える。ただし provider instruction file が provider context として読まれる場合、token 消費が完全にゼロになるわけではない。
 
 ## Responsibility Split
 
@@ -250,7 +267,7 @@ Session Window の composer では、参照対象は最終的に textarea 内の
 - `logicalPrompt`
   - `systemText`
     - provider instruction projection の要約
-    - app 共通 system prompt は空
+    - `Folder Context` と Character の system section
   - `inputText`
     - `# Conversation Timing`
     - `# User Input`

--- a/scripts/tests/companion-runtime-service.test.ts
+++ b/scripts/tests/companion-runtime-service.test.ts
@@ -121,6 +121,9 @@ describe("CompanionRuntimeService", () => {
       getProviderCodingAdapter() {
         return adapter;
       },
+      resolveSessionFolderPath(sessionId) {
+        return `F:/user-data/session-files/${sessionId}`;
+      },
       createAuditLog(input) {
         createdAuditLogs.push(input);
         return { ...input, id: 7 };
@@ -165,6 +168,7 @@ describe("CompanionRuntimeService", () => {
     assert.equal(runInput.session.approvalMode, "on-request");
     assert.equal(runInput.session.codexSandboxMode, "read-only");
     assert.equal(runInput.executionWorkspacePath, "F:/repo/.withmate/companion-worktree");
+    assert.equal(runInput.sessionFolderPath, "F:/user-data/session-files/companion-session-1");
     assert.equal(result.runState, "idle");
     assert.equal(result.threadId, "thread-1");
     assert.equal(result.model, "gpt-5.4");

--- a/scripts/tests/provider-prompt.test.ts
+++ b/scripts/tests/provider-prompt.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import path from "node:path";
 import { describe, it } from "node:test";
 
 import { buildNewSession } from "../../src/app-state.js";
@@ -75,6 +76,47 @@ function createCharacterRuntimeSnapshot(overrides?: Partial<CharacterRuntimeSnap
 }
 
 describe("composeProviderPrompt", () => {
+  it("実行 workspace を基準に Workspace / SessionFolder / Additional Directories を system 側へ置く", () => {
+    const session = buildNewSession({
+      id: "session-1",
+      taskTitle: "task",
+      workspaceLabel: "workspace",
+      workspacePath: "stored-workspace",
+      branch: "",
+      characterId: "character-1",
+      character: "Test",
+      characterIconPath: "",
+      characterThemeColors,
+      approvalMode: "untrusted",
+      allowedAdditionalDirectories: [
+        "execution-workspace/nested",
+        "external/docs",
+        "external",
+      ],
+    });
+    const prompt = composeProviderPrompt({
+      session,
+      executionWorkspacePath: "execution-workspace",
+      sessionFolderPath: "F:/user-data/session-files/session-1",
+      sessionMemory: createDefaultSessionMemory(session),
+      projectMemoryEntries: [],
+      providerCatalog,
+      userMessage: "実行して",
+      appSettings: createDefaultAppSettings(),
+      attachments: [],
+    });
+
+    assert.match(prompt.systemBodyText, /^# Workspace\n\nexecution-workspace/);
+    assert.match(prompt.systemBodyText, /# SessionFolder\n\nF:\/user-data\/session-files\/session-1/);
+    assert.match(prompt.systemBodyText, /# Additional Directories\n\n- /);
+    assert.doesNotMatch(prompt.systemBodyText, /雑多な作業ファイル|filesystem access grant|sandbox|approval policy/);
+    assert.equal(prompt.systemBodyText.includes(path.resolve("execution-workspace", "nested")), false);
+    assert.equal(prompt.systemBodyText.includes(`- ${path.resolve("external")}`), true);
+    assert.deepEqual(prompt.additionalDirectories, [path.resolve("external")]);
+    assertSectionOrder(prompt.systemBodyText, ["# Workspace", "# SessionFolder", "# Additional Directories"]);
+    assert.equal(prompt.logicalPrompt.systemText, prompt.systemBodyText);
+  });
+
   it("Conversation Timingをinput側のUser Input直前へ置き、system側へ入れない", () => {
     const session = buildNewSession({
       taskTitle: "task",
@@ -209,7 +251,9 @@ describe("composeProviderPrompt", () => {
       attachments: [],
     });
 
-    assert.equal(prompt.systemBodyText, "");
+    assert.match(prompt.systemBodyText, /# Workspace/);
+    assert.match(prompt.systemBodyText, /# SessionFolder/);
+    assert.match(prompt.systemBodyText, /# Additional Directories\n\nなし/);
     assert.doesNotMatch(prompt.systemBodyText, /# Character/);
     assert.equal(prompt.logicalPrompt.systemText, prompt.systemBodyText);
     assert.doesNotMatch(prompt.logicalPrompt.systemText, /# Character/);
@@ -255,11 +299,11 @@ describe("composeProviderPrompt", () => {
 
     assert.equal(prompt.inputBodyText, "");
     assert.equal(prompt.logicalPrompt.inputText, "");
-    assert.equal(prompt.logicalPrompt.composedText, "");
+    assert.equal(prompt.logicalPrompt.composedText, prompt.systemBodyText);
     assert.doesNotMatch(prompt.inputBodyText, /# User Input/);
   });
 
-  it("共通 system prompt を空文字にする", () => {
+  it("Character がなくても folder context を system prompt に残す", () => {
     const session = buildNewSession({
       taskTitle: "task",
       workspaceLabel: "workspace",
@@ -277,30 +321,35 @@ describe("composeProviderPrompt", () => {
       sessionMemory: createDefaultSessionMemory(session),
       projectMemoryEntries: [],
       providerCatalog,
-      userMessage: "system prompt が空でも user input は残ることを確認する",
+      userMessage: "folder context が system 側でも user input は残ることを確認する",
       appSettings: createDefaultAppSettings(),
       attachments: [],
     });
 
-    assert.equal(prompt.systemBodyText, "");
+    assert.match(prompt.systemBodyText, /# Workspace/);
+    assert.match(prompt.systemBodyText, /# SessionFolder/);
+    assert.match(prompt.systemBodyText, /# Additional Directories\n\nなし/);
     assert.equal(prompt.logicalPrompt.systemText, prompt.systemBodyText);
-    assert.equal(prompt.logicalPrompt.systemText, "");
+    assert.doesNotMatch(prompt.inputBodyText, /# Workspace|# SessionFolder|# Additional Directories/);
     assert.doesNotMatch(prompt.inputBodyText, /# Character/);
     assert.doesNotMatch(prompt.inputBodyText, /あなたは丁寧に説明する。/);
     assert.doesNotMatch(prompt.logicalPrompt.composedText, /# Character/);
     assert.doesNotMatch(prompt.logicalPrompt.composedText, /あなたは丁寧に説明する。/);
     assert.equal(prompt.logicalPrompt.inputText, prompt.inputBodyText);
-    assert.equal(prompt.inputBodyText, "# User Input\n\nsystem prompt が空でも user input は残ることを確認する");
+    assert.equal(prompt.inputBodyText, "# User Input\n\nfolder context が system 側でも user input は残ることを確認する");
     assert.equal(
       prompt.logicalPrompt.composedText,
       prompt.logicalPrompt.systemText
         ? `${prompt.logicalPrompt.systemText}\n\n${prompt.logicalPrompt.inputText}`
         : prompt.logicalPrompt.inputText,
     );
-    assert.match(prompt.logicalPrompt.composedText, /system prompt が空でも user input は残ることを確認する/);
+    assert.match(prompt.logicalPrompt.composedText, /folder context が system 側でも user input は残ることを確認する/);
     assertSectionOrder(prompt.logicalPrompt.composedText, [
+      "# Workspace",
+      "# SessionFolder",
+      "# Additional Directories",
       "# User Input",
-      "system prompt が空でも user input は残ることを確認する",
+      "folder context が system 側でも user input は残ることを確認する",
     ]);
   });
 
@@ -370,6 +419,9 @@ describe("composeProviderPrompt", () => {
       "# Character Definition Snapshot",
       "# Output Boundary",
       "# Tool Call Presence",
+      "# Workspace",
+      "# SessionFolder",
+      "# Additional Directories",
       "# User Input",
       "続けて",
     ]);
@@ -415,6 +467,9 @@ describe("composeProviderPrompt", () => {
     assert.doesNotMatch(prompt.systemBodyText, /生成ファイル、diff、artifact summary/);
     assertSectionOrder(prompt.logicalPrompt.composedText, [
       "# Character Definition Snapshot",
+      "# Workspace",
+      "# SessionFolder",
+      "# Additional Directories",
       "# User Input",
       "character.md を改善して",
     ]);
@@ -480,6 +535,9 @@ describe("composeProviderPrompt", () => {
       "# Character Definition Snapshot",
       "# Output Boundary",
       "# Tool Call Presence",
+      "# Workspace",
+      "# SessionFolder",
+      "# Additional Directories",
       "# Character Affect Context",
       "# User Input",
     ]);

--- a/scripts/tests/session-runtime-service.test.ts
+++ b/scripts/tests/session-runtime-service.test.ts
@@ -597,12 +597,15 @@ describe("SessionRuntimeService", () => {
     };
     let composeSessionName = "";
     let runSessionName = "";
+    let composedSessionFolderPath = "";
+    let runSessionFolderPath = "";
     let notifiedSession: Session | null = null;
     let notifiedLastNonEmptyAssistantMessageText = "";
 
     const adapter: ProviderCodingAdapter = {
       composePrompt(input) {
         composeSessionName = input.session.characterRuntimeSnapshot?.name ?? "";
+        composedSessionFolderPath = input.sessionFolderPath ?? "";
         return {
           systemBodyText: "system",
           inputBodyText: "input",
@@ -618,6 +621,7 @@ describe("SessionRuntimeService", () => {
       invalidateAllSessionThreads() {},
       runSessionTurn(input) {
         runSessionName = input.session.characterRuntimeSnapshot?.name ?? "";
+        runSessionFolderPath = input.sessionFolderPath ?? "";
         return Promise.resolve(createPartialResult({
           threadId: "thread-1",
           assistantText: "途中の案内\n\n完了したよ。",
@@ -648,6 +652,9 @@ describe("SessionRuntimeService", () => {
       },
       getProviderCodingAdapter() {
         return adapter;
+      },
+      resolveSessionFolderPath(sessionId) {
+        return `F:/user-data/session-files/${sessionId}`;
       },
       getSessionMemory() {
         return createSessionMemory(staleSession.id);
@@ -687,6 +694,8 @@ describe("SessionRuntimeService", () => {
 
     assert.equal(composeSessionName, "Fresh");
     assert.equal(runSessionName, "Fresh");
+    assert.equal(composedSessionFolderPath, `F:/user-data/session-files/${freshSession.id}`);
+    assert.equal(runSessionFolderPath, composedSessionFolderPath);
     assert.equal(result.characterRuntimeSnapshot?.name, "Fresh");
     assert.equal(notifiedSession, result);
     assert.equal(notifiedLastNonEmptyAssistantMessageText, "完了したよ。");

--- a/src-electron/companion-runtime-service.ts
+++ b/src-electron/companion-runtime-service.ts
@@ -34,6 +34,7 @@ export type CompanionRuntimeServiceDeps = {
   updateCompanionSession(session: CompanionSession): Awaitable<CompanionSession>;
   resolveComposerPreview(session: Session, userMessage: string): Promise<ComposerPreview>;
   resolveProviderSession?: (session: Session) => Session;
+  resolveSessionFolderPath?: (sessionId: string) => string;
   getAppSettings: () => AppSettings;
   resolveProviderCatalog(providerId: string | null | undefined, revision?: number | null): {
     snapshot: ModelCatalogSnapshot;
@@ -379,6 +380,7 @@ export class CompanionRuntimeService {
       return {
         session: turnProviderSession,
         executionWorkspacePath: turnSession.worktreePath,
+        sessionFolderPath: this.deps.resolveSessionFolderPath?.(turnProviderSession.id),
         sessionMemory,
         projectMemoryEntries: [],
         character,

--- a/src-electron/main.ts
+++ b/src-electron/main.ts
@@ -2436,6 +2436,7 @@ function requireSessionRuntimeService(): SessionRuntimeService {
       ),
       resolveComposerPreview,
       resolveProviderSession: (session) => appendSessionFilesDirectory(app.getPath("userData"), session),
+      resolveSessionFolderPath: (sessionId) => resolveSessionFilesDirectory(app.getPath("userData"), sessionId),
       getAppSettings: () => requireAppSettingsStorage().getSettings(),
       resolveProviderCatalog,
       getProviderCodingAdapter,
@@ -2652,6 +2653,13 @@ function requireAuxiliarySessionRuntimeService(): SessionRuntimeService {
           auxiliarySession?.parentSessionId ?? session.id,
         );
       },
+      resolveSessionFolderPath: (sessionId) => {
+        const auxiliarySession = requireAuxiliarySessionService().getAuxiliarySession(sessionId);
+        return resolveSessionFilesDirectory(
+          app.getPath("userData"),
+          auxiliarySession?.parentSessionId ?? sessionId,
+        );
+      },
       getAppSettings: () => requireAppSettingsStorage().getSettings(),
       resolveProviderCatalog,
       getProviderCodingAdapter,
@@ -2735,6 +2743,7 @@ function requireCompanionRuntimeService(): CompanionRuntimeService {
       updateCompanionSession: (session) => requireCompanionStorage().updateSession(session),
       resolveComposerPreview,
       resolveProviderSession: (session) => appendSessionFilesDirectory(app.getPath("userData"), session),
+      resolveSessionFolderPath: (sessionId) => resolveSessionFilesDirectory(app.getPath("userData"), sessionId),
       getAppSettings: () => requireAppSettingsStorage().getSettings(),
       resolveProviderCatalog,
       getProviderCodingAdapter,

--- a/src-electron/provider-prompt.ts
+++ b/src-electron/provider-prompt.ts
@@ -1,4 +1,8 @@
-import type { RunSessionTurnInput, ProviderPromptComposition } from "./provider-runtime.js";
+import {
+  resolveRunWorkspacePath,
+  type ProviderPromptComposition,
+  type RunSessionTurnInput,
+} from "./provider-runtime.js";
 import { normalizeAllowedAdditionalDirectories } from "./additional-directories.js";
 import { buildCharacterRuntimePromptSection } from "../src/character/character-runtime-snapshot.js";
 import type { ConversationTimingContext } from "./conversation-timing.js";
@@ -122,7 +126,36 @@ function buildToolCallPresenceSection(enabled: boolean): string {
   ].join("\n");
 }
 
+function buildFolderContextSection(
+  input: RunSessionTurnInput,
+  workspacePath: string,
+  additionalDirectories: readonly string[],
+): string {
+  const sessionFolderPath = input.sessionFolderPath?.trim()
+    || (input.session.workspaceLabel.trim() === "SessionFolder" ? workspacePath : "");
+
+  return [
+    "# Workspace",
+    "",
+    workspacePath.trim() || "利用不可",
+    "",
+    "# SessionFolder",
+    "",
+    sessionFolderPath || "利用不可",
+    "",
+    "# Additional Directories",
+    "",
+    additionalDirectories.length > 0 ? additionalDirectories.map((directoryPath) => `- ${directoryPath}`).join("\n") : "なし",
+  ].join("\n");
+}
+
 export function composeProviderPrompt(input: RunSessionTurnInput): ProviderPromptComposition {
+  const workspacePath = resolveRunWorkspacePath(input);
+  const additionalDirectories = normalizeAllowedAdditionalDirectories(
+    workspacePath,
+    input.session.allowedAdditionalDirectories,
+  );
+  const folderContextBody = buildFolderContextSection(input, workspacePath, additionalDirectories);
   const isCharacterAuthoringSession = input.session.sessionKind === "character-authoring";
   const characterPromptBody = buildCharacterRuntimePromptSection(input.session.characterRuntimeSnapshot, {
     includeRuntimeBoundary: !isCharacterAuthoringSession,
@@ -134,7 +167,13 @@ export function composeProviderPrompt(input: RunSessionTurnInput): ProviderPromp
     !isCharacterAuthoringSession && characterPromptBody.trim().length > 0,
   );
   const characterAffectContextBody = buildCharacterAffectContextSection(input.characterContext);
-  const systemPromptBody = [characterPromptBody, outputBoundaryBody, toolCallPresenceBody, characterAffectContextBody]
+  const systemPromptBody = [
+    characterPromptBody,
+    outputBoundaryBody,
+    toolCallPresenceBody,
+    folderContextBody,
+    characterAffectContextBody,
+  ]
     .filter((section) => section.trim().length > 0)
     .join("\n\n");
   const referencedImages = input.attachments.filter((attachment) => attachment.kind === "image");
@@ -164,10 +203,7 @@ export function composeProviderPrompt(input: RunSessionTurnInput): ProviderPromp
       composedText: composedPromptText,
     },
     imagePaths: referencedImages.map((attachment) => attachment.absolutePath),
-    additionalDirectories: normalizeAllowedAdditionalDirectories(
-      input.session.workspacePath,
-      input.session.allowedAdditionalDirectories,
-    ),
+    additionalDirectories,
   };
 }
 

--- a/src-electron/provider-runtime.ts
+++ b/src-electron/provider-runtime.ts
@@ -39,6 +39,7 @@ export type ProviderPromptComposition = {
 export type RunSessionTurnInput = {
   session: Session;
   executionWorkspacePath?: string;
+  sessionFolderPath?: string;
   sessionMemory: SessionMemory;
   projectMemoryEntries: ProjectMemoryEntry[];
   character?: CharacterProfile;

--- a/src-electron/session-runtime-service.ts
+++ b/src-electron/session-runtime-service.ts
@@ -57,6 +57,7 @@ export type SessionRuntimeServiceDeps = {
   resolveRuntimeSessionForTurn?: (session: Session) => Awaitable<Session>;
   resolveComposerPreview(session: Session, userMessage: string): Promise<ComposerPreview>;
   resolveProviderSession?: (session: Session) => Session;
+  resolveSessionFolderPath?: (sessionId: string) => string;
   resolveSessionCharacter?: (session: Session) => Promise<CharacterProfile | null>;
   getAppSettings: () => AppSettings;
   resolveProviderCatalog(providerId: string | null | undefined, revision?: number | null): {
@@ -890,6 +891,7 @@ export class SessionRuntimeService {
     try {
       promptForAudit = providerAdapter.composePrompt({
         session: providerSession,
+        sessionFolderPath: this.deps.resolveSessionFolderPath?.(providerSession.id),
         sessionMemory,
         projectMemoryEntries,
         character: sessionCharacter ?? undefined,
@@ -1060,6 +1062,7 @@ export class SessionRuntimeService {
       const effectiveTurnSession = this.deps.resolveProviderSession?.(turnSession) ?? turnSession;
       const providerPromise = providerAdapter.runSessionTurn({
         session: effectiveTurnSession,
+        sessionFolderPath: this.deps.resolveSessionFolderPath?.(effectiveTurnSession.id),
         sessionMemory,
         projectMemoryEntries,
         providerCatalog: provider,


### PR DESCRIPTION
## 概要
- SystemPrompt に `Workspace` / `SessionFolder` / `Additional Directories` を追加
- Main Process が解決した SessionFolder を通常 Session / Auxiliary / Companion へ伝播
- 固定 prompt prefix の後ろに Folder Context を配置し、利用方針と認可説明は repository instruction / provider adapter に分離
- logicalPrompt と provider transport で同じ正規化済み Additional Directories を使用

## 検証
- `npm test`
- `npm run typecheck`
- `npm run build`
- provider prompt / runtime / auxiliary / companion の targeted tests
- Codex / Copilot adapter と agent runtime binding の targeted tests