### PR TITLE
fix(markdown): Markdownプレビューの可読性を改善

### DIFF
--- a/scripts/tests/message-rich-text.test.ts
+++ b/scripts/tests/message-rich-text.test.ts
@@ -643,6 +643,31 @@ test("MessageRichText は2桁番号とnested listをsemanticなordered listと�
   );
 });
 
+test("MessageRichText は2文字ずつのindentをnested unordered listとしてrenderする", () => {
+  const markdown = [
+    "- aaa",
+    "  - bbbb with **inline** text and viewportで折り返す長い本文",
+    "    - cccc",
+    "",
+    "  child paragraph",
+  ].join("\n");
+  const html = renderToStaticMarkup(React.createElement(MessageRichText, { text: markdown }));
+  const dom = new JSDOM(html);
+  const rootList = dom.window.document.querySelector("ul.message-list");
+  const rootItem = rootList?.querySelector(":scope > li");
+  const nestedList = rootItem?.querySelector(":scope > ul.message-list");
+  const nestedItem = nestedList?.querySelector(":scope > li");
+  const deepestList = nestedItem?.querySelector(":scope > ul.message-list");
+
+  assert.ok(rootList);
+  assert.equal(rootItem?.querySelector(":scope > .message-paragraph")?.textContent, "aaa");
+  assert.match(nestedItem?.textContent ?? "", /bbbb with inline text and viewportで折り返す長い本文/);
+  assert.equal(nestedItem?.querySelector("strong.message-inline-strong")?.textContent, "inline");
+  assert.equal(deepestList?.querySelector(":scope > li")?.textContent, "cccc");
+  assert.equal(rootItem?.querySelectorAll(":scope > .message-paragraph").length, 2);
+  assert.equal(rootItem?.querySelectorAll(":scope > .message-paragraph")[1]?.textContent, "child paragraph");
+});
+
 test("Markdown ordered list は2桁marker用の論理方向余白を持ち、独立scroll領域にしない", async () => {
   const styles = await readFile(new URL("../../src/styles.css", import.meta.url), "utf8");
   const orderedListRule = styles.match(/\.message-list\.ordered\s*{(?<body>[^}]*)}/)?.groups?.body ?? "";
@@ -979,6 +1004,39 @@ test("MessageRichText は slash / backslash 形式の Windows absolute image pat
   assert.match(html, /src="file:\/\/\/C:\/workspace\/image-folder\/sample\.png"/);
 });
 
+test("MessageRichText は heading 階層と thematic break の semantic HTML を保持する", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(MessageRichText, {
+      text: [
+        "# ATX H1",
+        "## ATX H2",
+        "### ATX H3",
+        "#### ATX H4",
+        "##### ATX H5",
+        "###### ATX H6",
+        "",
+        "---",
+        "",
+        "Setext H1",
+        "=========",
+        "",
+        "Setext H2",
+        "---------",
+      ].join("\n"),
+    }),
+  );
+
+  assert.match(html, /<h1 class="message-heading level-1">ATX H1<\/h1>/);
+  assert.match(html, /<h2 class="message-heading level-2">ATX H2<\/h2>/);
+  assert.match(html, /<h3 class="message-heading level-3">ATX H3<\/h3>/);
+  assert.match(html, /<h4 class="message-heading level-4">ATX H4<\/h4>/);
+  assert.match(html, /<h5 class="message-heading level-5">ATX H5<\/h5>/);
+  assert.match(html, /<h6 class="message-heading level-6">ATX H6<\/h6>/);
+  assert.match(html, /<hr class="message-divider"\/>/);
+  assert.match(html, /<h1 class="message-heading level-1">Setext H1<\/h1>/);
+  assert.match(html, /<h2 class="message-heading level-2">Setext H2<\/h2>/);
+});
+
 test("MessageRichText は先頭空白付き Markdown 行でも停止せずに render できる", { timeout: 2_000 }, () => {
   const input = ["  # title", "", "  - item", "  1. first", "", "  ```ts", "const answer = 42;", "  ```"].join("\n");
   const html = renderToStaticMarkup(
@@ -987,7 +1045,7 @@ test("MessageRichText は先頭空白付き Markdown 行でも停止せずに re
     }),
   );
 
-  assert.match(html, /<h3 class="message-heading level-1">title<\/h3>/);
+  assert.match(html, /<h1 class="message-heading level-1">title<\/h1>/);
   assert.match(html, /<ul class="message-list">\s*<li>item<\/li>\s*<\/ul>/);
   assert.match(html, /<ol class="message-list ordered">\s*<li>first<\/li>\s*<\/ol>/);
   assert.match(html, /<pre class="message-code-block"><code class="message-inline-code language-ts">const answer = 42;<\/code><\/pre>/);
@@ -1002,7 +1060,7 @@ test("MessageRichText は先頭空白付き Markdown を既存 block と inline 
     }),
   );
 
-  assert.match(html, /<h3 class="message-heading level-1"><strong class="message-inline-strong">title<\/strong><\/h3>/);
+  assert.match(html, /<h1 class="message-heading level-1"><strong class="message-inline-strong">title<\/strong><\/h1>/);
   assert.match(
     html,
     /<ul class="message-list">\s*<li><a href="src\/App\.tsx">file<\/a><\/li>\s*<li><code class="message-inline-code">literal<\/code><\/li>\s*<\/ul>/,

--- a/scripts/tests/session-context-pane-style.test.ts
+++ b/scripts/tests/session-context-pane-style.test.ts
@@ -305,6 +305,51 @@ test("Markdown preview は暗いsurface上のlinkとMermaid errorへ高contrast�
   );
 });
 
+test("Markdown preview はchatと同じ本文line-heightとblock間隔を使う", async () => {
+  const stylesSource = await readFile("src/styles.css", "utf8");
+
+  assert.match(
+    stylesSource,
+    /\.message-body\.rich-text,\s*\.session-file-markdown\.rich-text\s*{[\s\S]*?display:\s*grid;[\s\S]*?gap:\s*8px;[\s\S]*?line-height:\s*1\.6;/,
+  );
+  assert.match(stylesSource, /\.message-paragraph\s*{[\s\S]*?margin:\s*0;[\s\S]*?line-height:\s*1\.6;/);
+});
+
+test("Markdown heading と thematic break は階層と全幅の区切りを視認できる", async () => {
+  const stylesSource = await readFile("src/styles.css", "utf8");
+
+  assert.match(stylesSource, /\.message-heading\.level-1\s*{[\s\S]*?font-size:\s*1\.25rem;/);
+  assert.match(stylesSource, /\.message-heading\.level-2\s*{[\s\S]*?font-size:\s*1\.125rem;/);
+  assert.match(stylesSource, /\.message-heading\.level-3\s*{[\s\S]*?font-size:\s*1\.05rem;/);
+  assert.match(stylesSource, /\.message-heading\.level-4\s*{[\s\S]*?font-size:\s*1rem;/);
+  assert.match(stylesSource, /\.message-heading\.level-5\s*{[\s\S]*?font-size:\s*0\.95rem;/);
+  assert.match(stylesSource, /\.message-heading\.level-6\s*{[\s\S]*?font-size:\s*0\.9rem;/);
+  assert.match(
+    stylesSource,
+    /\.message-divider\s*{[\s\S]*?width:\s*100%;[\s\S]*?border:\s*0;[\s\S]*?border-block-start:\s*1px solid var\(--line\);/,
+  );
+});
+
+test("Markdown list はlogical paddingと階層ごとのmarkerを持つ", async () => {
+  const stylesSource = await readFile("src/styles.css", "utf8");
+
+  assert.match(
+    stylesSource,
+    /\.message-list\s*{[\s\S]*?padding-inline-start:\s*1\.5em;[\s\S]*?list-style-position:\s*outside;/,
+  );
+  assert.match(stylesSource, /\.message-list:not\(\.ordered\)\s*{\s*list-style-type:\s*disc;/);
+  assert.match(
+    stylesSource,
+    /\.message-list \.message-list:not\(\.ordered\)\s*{\s*list-style-type:\s*circle;/,
+  );
+  assert.match(
+    stylesSource,
+    /\.message-list \.message-list \.message-list:not\(\.ordered\)\s*{\s*list-style-type:\s*square;/,
+  );
+  assert.match(stylesSource, /\.message-list\s*>\s*li::marker\s*{\s*color:\s*currentColor;/);
+  assert.doesNotMatch(stylesSource, /\.message-list\s*{[^}]*padding-left:/);
+});
+
 test("Markdown preview は中央本文を固定幅にせずcontent領域を使う", async () => {
   const stylesSource = await readFile("src/styles.css", "utf8");
 

--- a/src/MessageRichText.tsx
+++ b/src/MessageRichText.tsx
@@ -459,34 +459,37 @@ function MermaidDiagram({
 
 const markdownComponents: Components = {
   h1: ({ children, className: headingClassName, node, ...props }) => (
-    <h3 {...props} className={mergeClassName("message-heading level-1", headingClassName)}>
+    <h1 {...props} className={mergeClassName("message-heading level-1", headingClassName)}>
+      {children}
+    </h1>
+  ),
+  h2: ({ children, className: headingClassName, node, ...props }) => (
+    <h2 {...props} className={mergeClassName("message-heading level-2", headingClassName)}>
+      {children}
+    </h2>
+  ),
+  h3: ({ children, className: headingClassName, node, ...props }) => (
+    <h3 {...props} className={mergeClassName("message-heading level-3", headingClassName)}>
       {children}
     </h3>
   ),
-  h2: ({ children, className: headingClassName, node, ...props }) => (
-    <h4 {...props} className={mergeClassName("message-heading level-2", headingClassName)}>
+  h4: ({ children, className: headingClassName, node, ...props }) => (
+    <h4 {...props} className={mergeClassName("message-heading level-4", headingClassName)}>
       {children}
     </h4>
   ),
-  h3: ({ children, className: headingClassName, node, ...props }) => (
-    <h5 {...props} className={mergeClassName("message-heading level-3", headingClassName)}>
-      {children}
-    </h5>
-  ),
-  h4: ({ children, className: headingClassName, node, ...props }) => (
-    <h5 {...props} className={mergeClassName("message-heading level-3", headingClassName)}>
-      {children}
-    </h5>
-  ),
   h5: ({ children, className: headingClassName, node, ...props }) => (
-    <h5 {...props} className={mergeClassName("message-heading level-3", headingClassName)}>
+    <h5 {...props} className={mergeClassName("message-heading level-5", headingClassName)}>
       {children}
     </h5>
   ),
   h6: ({ children, className: headingClassName, node, ...props }) => (
-    <h5 {...props} className={mergeClassName("message-heading level-3", headingClassName)}>
+    <h6 {...props} className={mergeClassName("message-heading level-6", headingClassName)}>
       {children}
-    </h5>
+    </h6>
+  ),
+  hr: ({ className: dividerClassName, node, ...props }) => (
+    <hr {...props} className={mergeClassName("message-divider", dividerClassName)} />
   ),
   p: ({ children, className: paragraphClassName, node, ...props }) => (
     <p {...props} className={mergeClassName("message-paragraph", paragraphClassName)}>

--- a/src/styles.css
+++ b/src/styles.css
@@ -6462,9 +6462,11 @@ button:disabled {
   margin: 0;
 }
 
-.message-body.rich-text {
+.message-body.rich-text,
+.session-file-markdown.rich-text {
   display: grid;
   gap: 8px;
+  line-height: 1.6;
 }
 
 .message-source-text {
@@ -6487,19 +6489,72 @@ button:disabled {
 }
 
 .message-heading.level-1 {
-  font-size: 1.02rem;
+  font-size: 1.25rem;
+  font-weight: 700;
 }
 
-.message-heading.level-2,
+.message-heading.level-2 {
+  font-size: 1.125rem;
+  font-weight: 700;
+}
+
 .message-heading.level-3 {
-  font-size: 0.94rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.message-heading.level-4 {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.message-heading.level-5 {
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.message-heading.level-6 {
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.message-divider {
+  width: 100%;
+  margin: 4px 0;
+  border: 0;
+  border-block-start: 1px solid var(--line);
 }
 
 .message-list {
   margin: 0;
   padding-inline-start: 1.5em;
+  list-style-position: outside;
   display: grid;
   gap: 6px;
+}
+
+.message-list:not(.ordered) {
+  list-style-type: disc;
+}
+
+.message-list .message-list:not(.ordered) {
+  list-style-type: circle;
+}
+
+.message-list .message-list .message-list:not(.ordered) {
+  list-style-type: square;
+}
+
+.message-list > li::marker {
+  color: currentColor;
+}
+
+.message-list .message-list {
+  margin-block-start: 6px;
+}
+
+.message-list > li > .message-paragraph + .message-paragraph {
+  margin-block-start: 6px;
 }
 
 .message-list.ordered {


### PR DESCRIPTION
## 概要

- 共有 MessageRichText の見出しを h1〜h6 の semantic HTML として保持
- Markdown の thematic break を全幅の視認できる区切り線として描画
- 本文間隔と nested list の marker / 階層表示を改善
- renderer と CSS の契約を targeted test で固定

## 検証

- npx tsx --test scripts/tests/message-rich-text.test.ts scripts/tests/session-context-pane-style.test.ts
- npm test
- npm run typecheck
- npm run build

Closes #308